### PR TITLE
Make session names click-to-rename

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -222,7 +222,7 @@ export function App() {
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
   // Inline rename state. `editingId` is the session whose row is currently
   // an <input>; `editingValue` holds the in-progress name. Reset on commit
-  // or cancel. Triggered by double-click on the session-id span.
+  // or cancel. Triggered by clicking the session name.
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
   // One Terminal handle per session — populated by Terminal's forwardRef
@@ -510,7 +510,6 @@ export function App() {
                   key={s.id}
                   className={isActive ? "is-open" : ""}
                   onClick={isEditing ? undefined : () => activate(s.id)}
-                  onDoubleClick={isEditing ? undefined : () => startEditing(s.id, s.name)}
                 >
                   <div className="session-row-top">
                     <span
@@ -523,6 +522,7 @@ export function App() {
                         className="session-name-input"
                         value={editingValue}
                         autoFocus
+                        onClick={(e) => e.stopPropagation()}
                         onChange={(e) => setEditingValue(e.target.value)}
                         onKeyDown={(e) => {
                           if (e.key === "Enter") commitEditing();
@@ -535,7 +535,11 @@ export function App() {
                     ) : (
                       <button
                         className="session-open"
-                        title={s.name ? `${s.id} — double-click to rename` : "double-click to rename"}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          startEditing(s.id, s.name);
+                        }}
+                        title={s.name ? `${s.id} — click to rename` : "click to rename"}
                       >
                         <span className="session-id">{s.name ?? s.id}</span>
                       </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -514,9 +514,11 @@ button:disabled {
   min-width: 0;
   border-radius: 0;
   color: var(--text-secondary);
+  cursor: text;
 }
 
 .sessions li.is-open .session-open { color: var(--text-primary); }
+.session-open:hover:not(:disabled) { color: var(--text-primary); }
 
 .session-id {
   flex: 1;
@@ -837,7 +839,7 @@ button:disabled {
 .session-action.session-remote { background: var(--cyan-bg); color: var(--cyan); }
 .session-action.session-remote:hover:not(:disabled) { background: rgba(34, 211, 238, 0.22); color: var(--cyan-bright); }
 
-/* Inline rename input — replaces the session-id span on double-click. */
+/* Inline rename input — replaces the session-id span after clicking the name. */
 .session-name-input {
   flex: 1;
   background: transparent;


### PR DESCRIPTION
## Summary
- make the session/tab name enter inline rename mode on click
- keep row activation behavior on the rest of the session row
- update cursor and hover styling for the editable label

## Test
- npm run build