### PR TITLE
[codex] sessions: accept glimmung launch context

### DIFF
--- a/backend/src/tank_operator/api.py
+++ b/backend/src/tank_operator/api.py
@@ -217,6 +217,20 @@ class CreateSessionBody(BaseModel):
     mode: str = DEFAULT_SESSION_MODE
 
 
+class CreateSessionWithContextBody(BaseModel):
+    glimmung_run_id: str
+    glimmung_issue_id: str
+    glimmung_pr_id: str | None = None
+    validation_url: str | None = None
+    caller_email: str | None = None
+    mode: str = DEFAULT_SESSION_MODE
+
+
+class CreateSessionWithContextResponse(BaseModel):
+    session_url: str
+    session: SessionInfo
+
+
 @app.post("/api/sessions")
 async def create_session(
     body: CreateSessionBody | None = None,
@@ -226,6 +240,39 @@ async def create_session(
     if mode not in SESSION_MODES:
         raise HTTPException(status_code=400, detail=f"unknown mode: {mode}")
     return await sessions.create(owner=user.email, mode=mode)
+
+
+@app.post("/api/sessions/with-context", response_model=CreateSessionWithContextResponse)
+async def create_session_with_context(
+    body: CreateSessionWithContextBody,
+    request: Request,
+    user: User = Depends(current_user),
+) -> CreateSessionWithContextResponse:
+    """Create a fresh session preloaded with canonical glimmung context.
+
+    Glimmung passes ids, not rendered text. The session pod can then use
+    mcp-glimmung to read the Issue / Run / PR details from the source of
+    truth while still booting with enough context to orient the operator.
+    """
+    if body.mode not in SESSION_MODES:
+        raise HTTPException(status_code=400, detail=f"unknown mode: {body.mode}")
+    if body.caller_email and body.caller_email.lower() != user.email.lower():
+        raise HTTPException(status_code=403, detail="caller_email does not match session user")
+
+    context = {
+        "glimmung_run_id": body.glimmung_run_id,
+        "glimmung_issue_id": body.glimmung_issue_id,
+        "glimmung_pr_id": body.glimmung_pr_id,
+        "validation_url": body.validation_url,
+        "caller_email": user.email,
+    }
+    created = await sessions.create(
+        owner=user.email,
+        mode=body.mode,
+        glimmung_context=context,
+    )
+    session_url = str(request.base_url).rstrip("/") + f"/?session={created.id}"
+    return CreateSessionWithContextResponse(session_url=session_url, session=created)
 
 
 @app.get("/api/sessions")

--- a/backend/src/tank_operator/sessions.py
+++ b/backend/src/tank_operator/sessions.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import hashlib
+import json
 import logging
 import os
 import socket
@@ -131,6 +132,7 @@ NO_CLAUDE_HIJACK_MODES = frozenset(
 # well below that for UI sanity.
 NAME_ANNOTATION = "tank-operator/display-name"
 MAX_NAME_LENGTH = 80
+GLIMMUNG_CONTEXT_ANNOTATION = "tank-operator/glimmung-context"
 
 
 @dataclass
@@ -221,13 +223,22 @@ class SessionManager:
         if self._api is not None:
             await self._api.close()
 
-    def _deployment_manifest(self, session_id: str, owner: str, mode: str) -> dict[str, Any]:
+    def _deployment_manifest(
+        self,
+        session_id: str,
+        owner: str,
+        mode: str,
+        glimmung_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         owner_label = _owner_label(owner)
         selector_labels = {"tank-operator/session-id": session_id}
         deployment_name = f"session-{session_id}"
         argocd_tracking_id = (
             f"{ARGOCD_TRACKING_APP}:apps/Deployment:{SESSIONS_NAMESPACE}/{deployment_name}"
         )
+        context_json = ""
+        if glimmung_context is not None:
+            context_json = json.dumps(glimmung_context, sort_keys=True, separators=(",", ":"))
         pod_spec: dict[str, Any] = {
             "serviceAccountName": SESSION_SERVICE_ACCOUNT,
             # The image's USER is claude (uid 1000). Reasserting it here
@@ -266,6 +277,26 @@ class SessionManager:
                         # via secret) because the value is per-pod,
                         # not a shared secret.
                         {"name": "TANK_SESSION_MODE", "value": mode},
+                        {
+                            "name": "TANK_GLIMMUNG_CONTEXT_JSON",
+                            "value": context_json,
+                        },
+                        {
+                            "name": "TANK_GLIMMUNG_RUN_ID",
+                            "value": str((glimmung_context or {}).get("glimmung_run_id") or ""),
+                        },
+                        {
+                            "name": "TANK_GLIMMUNG_ISSUE_ID",
+                            "value": str((glimmung_context or {}).get("glimmung_issue_id") or ""),
+                        },
+                        {
+                            "name": "TANK_GLIMMUNG_PR_ID",
+                            "value": str((glimmung_context or {}).get("glimmung_pr_id") or ""),
+                        },
+                        {
+                            "name": "TANK_GLIMMUNG_VALIDATION_URL",
+                            "value": str((glimmung_context or {}).get("validation_url") or ""),
+                        },
                         # Force claude (and anything else using the
                         # `supports-hyperlinks` npm lib) to emit OSC 8
                         # hyperlinks. The library's terminal-sniff list
@@ -373,6 +404,12 @@ class SessionManager:
                     },
                 }
             )
+        annotations = {
+            "tank-operator/owner-email": owner,
+            "argocd.argoproj.io/tracking-id": argocd_tracking_id,
+        }
+        if context_json:
+            annotations[GLIMMUNG_CONTEXT_ANNOTATION] = context_json
         return {
             "apiVersion": "apps/v1",
             "kind": "Deployment",
@@ -386,10 +423,7 @@ class SessionManager:
                     "tank-operator/session-id": session_id,
                     "tank-operator/mode": mode,
                 },
-                "annotations": {
-                    "tank-operator/owner-email": owner,
-                    "argocd.argoproj.io/tracking-id": argocd_tracking_id,
-                },
+                "annotations": annotations,
             },
             "spec": {
                 "replicas": 1,
@@ -412,7 +446,12 @@ class SessionManager:
             },
         }
 
-    async def create(self, owner: str, mode: str = DEFAULT_SESSION_MODE) -> SessionInfo:
+    async def create(
+        self,
+        owner: str,
+        mode: str = DEFAULT_SESSION_MODE,
+        glimmung_context: dict[str, Any] | None = None,
+    ) -> SessionInfo:
         assert self._apps is not None
         if mode not in SESSION_MODES:
             raise ValueError(f"unknown session mode: {mode!r}")
@@ -433,7 +472,7 @@ class SessionManager:
         session_id = uuid.uuid4().hex[:10]
         await self._apps.create_namespaced_deployment(
             namespace=SESSIONS_NAMESPACE,
-            body=self._deployment_manifest(session_id, owner, mode),
+            body=self._deployment_manifest(session_id, owner, mode, glimmung_context),
         )
         # Seed activity so the reaper gives the session a full
         # IDLE_TIMEOUT to receive its first WS before being eligible

--- a/backend/tests/test_glimmung_context_sessions.py
+++ b/backend/tests/test_glimmung_context_sessions.py
@@ -1,0 +1,51 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from tank_operator.sessions import GLIMMUNG_CONTEXT_ANNOTATION, SessionManager
+
+
+def _claude_env(manifest: dict) -> dict[str, str]:
+    containers = manifest["spec"]["template"]["spec"]["containers"]
+    claude = next(c for c in containers if c["name"] == "claude")
+    return {e["name"]: e["value"] for e in claude["env"]}
+
+
+def test_glimmung_context_is_stamped_on_session_deployment() -> None:
+    context = {
+        "glimmung_run_id": "run-1",
+        "glimmung_issue_id": "issue-1",
+        "glimmung_pr_id": "pr-1",
+        "validation_url": "https://preview.example.test",
+        "caller_email": "operator@example.test",
+    }
+
+    manifest = SessionManager()._deployment_manifest(
+        "abc123",
+        owner="operator@example.test",
+        mode="subscription",
+        glimmung_context=context,
+    )
+
+    annotations = manifest["metadata"]["annotations"]
+    assert json.loads(annotations[GLIMMUNG_CONTEXT_ANNOTATION]) == context
+
+    env = _claude_env(manifest)
+    assert json.loads(env["TANK_GLIMMUNG_CONTEXT_JSON"]) == context
+    assert env["TANK_GLIMMUNG_RUN_ID"] == "run-1"
+    assert env["TANK_GLIMMUNG_ISSUE_ID"] == "issue-1"
+    assert env["TANK_GLIMMUNG_PR_ID"] == "pr-1"
+    assert env["TANK_GLIMMUNG_VALIDATION_URL"] == "https://preview.example.test"
+
+
+def test_plain_session_has_no_glimmung_context_annotation() -> None:
+    manifest = SessionManager()._deployment_manifest(
+        "abc123",
+        owner="operator@example.test",
+        mode="subscription",
+    )
+
+    assert GLIMMUNG_CONTEXT_ANNOTATION not in manifest["metadata"]["annotations"]
+    assert _claude_env(manifest)["TANK_GLIMMUNG_CONTEXT_JSON"] == ""

--- a/claude-container/tank-bootstrap.sh
+++ b/claude-container/tank-bootstrap.sh
@@ -53,6 +53,33 @@
 if tmux has-session -t tank 2>/dev/null; then
   exec tmux attach-session -t tank
 fi
+if [ -n "${TANK_GLIMMUNG_CONTEXT_JSON:-}" ]; then
+  cat > /workspace/GLIMMUNG_CONTEXT.json <<EOF
+${TANK_GLIMMUNG_CONTEXT_JSON}
+EOF
+  cat > /workspace/GLIMMUNG_CONTEXT.md <<EOF
+# Glimmung Context
+
+This session was launched from glimmung for an attended pickup.
+
+- Run id: ${TANK_GLIMMUNG_RUN_ID:-}
+- Issue id: ${TANK_GLIMMUNG_ISSUE_ID:-}
+- PR id: ${TANK_GLIMMUNG_PR_ID:-}
+- Validation URL: ${TANK_GLIMMUNG_VALIDATION_URL:-}
+
+Use the glimmung MCP server to read the canonical Issue, Run, PR, graph,
+comments, reviews, and signals before making changes. Treat GitHub as a
+syndication surface when glimmung has the richer record.
+EOF
+  cat >> /workspace/CLAUDE.md <<'EOF'
+
+## Glimmung attended pickup
+
+This pod was launched from glimmung. Read `/workspace/GLIMMUNG_CONTEXT.md`
+first, then use the glimmung MCP server to fetch the canonical Issue / Run /
+PR state before acting.
+EOF
+fi
 # Config-mode: short-circuit the regular session bootstrap. The user is
 # here to do `claude /login` once so we can capture credentials.json and
 # write it to KV. No MCP wiring, no onboarding bypass, no credentials

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,6 +133,17 @@ function clearInstallError(): void {
   window.history.replaceState({}, "", url.toString());
 }
 
+function readInitialSessionId(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("session");
+}
+
+function clearInitialSessionId(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("session");
+  window.history.replaceState({}, "", url.toString());
+}
+
 const POLL_INTERVAL_MS = 1500;
 
 function IconPlus() {
@@ -326,6 +337,7 @@ export function App() {
   // callback. Used by the inline "remote control" button to inject the
   // /remote-control slash command into the live WS.
   const terminalRefs = useRef<Map<string, TerminalHandle>>(new Map());
+  const initialSessionId = useRef<string | null>(readInitialSessionId());
 
   useEffect(() => {
     bootstrapAuth()
@@ -393,6 +405,15 @@ export function App() {
       return changed ? next : prev;
     });
   }, [sessions, active]);
+
+  useEffect(() => {
+    const target = initialSessionId.current;
+    if (!target) return;
+    if (!sessions.some((s) => s.id === target)) return;
+    activate(target);
+    initialSessionId.current = null;
+    clearInitialSessionId();
+  }, [sessions]);
 
   function activate(id: string) {
     setActive(id);


### PR DESCRIPTION
## Summary
- add `POST /api/sessions/with-context` for glimmung attended-pickup launches
- stamp glimmung run/issue/PR/validation context into session Deployment annotations and Claude-container env
- write `GLIMMUNG_CONTEXT` files during bootstrap so the LLM starts with canonical glimmung references
- support `?session=<id>` URLs in the frontend so the returned launch URL opens the new session

## Verification
- `uv run --project backend --with pytest pytest backend/tests`
- `uv run --project backend python -c "from tank_operator.api import app; print(len(app.routes))"`
- `npm ci && npm run build`

Part of nelsong6/glimmung#117.