### PR TITLE
[codex] Handle Codex scrollback keys

### DIFF
--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -76,12 +76,30 @@ export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
     });
     term.open(containerRef.current);
     termRef.current = term;
+    term.attachCustomKeyEventHandler((event) => {
+      if (!mode.startsWith("codex_") || event.type !== "keydown") return true;
+      if (event.altKey || event.ctrlKey || event.metaKey) return true;
+
+      if (event.key === "PageUp") {
+        event.preventDefault();
+        term.scrollPages(-1);
+        return false;
+      }
+      if (event.key === "PageDown") {
+        event.preventDefault();
+        term.scrollPages(1);
+        return false;
+      }
+
+      return true;
+    });
     const onWheel = (event: WheelEvent) => {
       if (!mode.startsWith("codex_") || event.ctrlKey || event.deltaY === 0) return;
       // Codex's TUI enables mouse reporting, which makes xterm forward wheel
       // events into the process instead of scrolling the browser terminal
-      // viewport. Treat ordinary wheel gestures as scrollback navigation in
-      // Codex sessions; keep ctrl+wheel available for browser zoom.
+      // viewport. Treat ordinary wheel and PageUp/PageDown gestures as
+      // scrollback navigation in Codex sessions; keep ctrl+wheel available
+      // for browser zoom.
       event.preventDefault();
       event.stopPropagation();
       term.scrollLines(Math.sign(event.deltaY) * Math.max(1, Math.ceil(Math.abs(event.deltaY) / 30)));


### PR DESCRIPTION
## Summary

Handle PageUp and PageDown locally in the web terminal for Codex sessions, matching the existing wheel scrollback behavior.

## Why

Codex sessions enable mouse reporting, which can cause scroll inputs to be forwarded into the TUI instead of moving xterm scrollback. Alt+T also reaches Codex as Esc+t and toggles transcript mode, so PageUp/PageDown need to be owned by the terminal wrapper instead.

## Validation

- `npm run build` in `frontend/`