### PR TITLE
Rework session launcher actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ type SessionMode =
   | "codex_subscription"
   | "codex_config";
 type DefaultSessionMode = Extract<SessionMode, "subscription" | "codex_subscription">;
+type Provider = "anthropic" | "openai";
 
 interface Session {
   id: string;
@@ -45,12 +46,22 @@ const MODE_CHIP_ICONS: Partial<Record<SessionMode, "anthropic" | "openai">> = {
   codex_subscription: "openai",
 };
 
-const MODE_MENU_ICONS: Record<SessionMode, "anthropic" | "openai"> = {
+const MODE_MENU_ICONS: Record<SessionMode, Provider> = {
   api_key: "anthropic",
   subscription: "anthropic",
   config: "anthropic",
   codex_subscription: "openai",
   codex_config: "openai",
+};
+
+const PROVIDER_DEFAULT_MODES: Record<Provider, DefaultSessionMode> = {
+  anthropic: "subscription",
+  openai: "codex_subscription",
+};
+
+const PROVIDER_CONFIG_MODES: Record<Provider, SessionMode> = {
+  anthropic: "config",
+  openai: "codex_config",
 };
 
 const MODE_HINTS: Record<SessionMode, string> = {
@@ -241,15 +252,6 @@ function IconKey({ className }: { className?: string }) {
   );
 }
 
-function IconChevron() {
-  return (
-    <svg viewBox="0 0 16 16" width="12" height="12" fill="none"
-         stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="4,6 8,10 12,6" />
-    </svg>
-  );
-}
-
 function IconKebab() {
   return (
     <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
@@ -310,20 +312,6 @@ function ModeChip({ mode }: { mode: SessionMode }) {
         label
       )}
     </span>
-  );
-}
-
-function ModeMenuItem({ mode }: { mode: SessionMode }) {
-  const isConfig = mode === "config" || mode === "codex_config";
-  const isApiKey = mode === "api_key";
-
-  return (
-    <>
-      <ProviderIcon provider={MODE_MENU_ICONS[mode]} className="dropdown-provider-icon" />
-      {isConfig && <IconWrench className="dropdown-wrench-icon" />}
-      {isApiKey && <IconKey className="dropdown-key-icon" />}
-      <span className="sr-only">{MODE_LABELS[mode]}</span>
-    </>
   );
 }
 
@@ -567,6 +555,13 @@ export function App() {
     }
   }
 
+  function setDefaultProvider(provider: Provider) {
+    const mode = PROVIDER_DEFAULT_MODES[provider];
+    setDefaultSessionMode(mode);
+    writeDefaultSessionMode(mode);
+    setModeMenuOpen(false);
+  }
+
   async function renameSession(id: string, nextName: string | null) {
     try {
       const res = await authedFetch(`/api/sessions/${id}`, {
@@ -716,6 +711,9 @@ export function App() {
     return <OnboardingWall user={user} onLogout={logout} />;
   }
 
+  const selectedProvider = MODE_MENU_ICONS[defaultSessionMode];
+  const configMode = PROVIDER_CONFIG_MODES[selectedProvider];
+
   return (
     <div className="shell">
       <aside className="sidebar">
@@ -724,41 +722,62 @@ export function App() {
         </div>
 
         <div className="sidebar-section">
-          <div className={`new-row${modeMenuOpen ? " is-open" : ""}`} data-menu="mode">
+          <div className="new-row new-row-launcher" data-menu="mode">
             <button
-              className="new-row-main"
-              onClick={() => createSession()}
+              className={`new-row-provider-toggle${modeMenuOpen ? " is-open" : ""}`}
+              onClick={() => setModeMenuOpen((v) => !v)}
               disabled={busy}
-              aria-label={`Start ${MODE_LABELS[defaultSessionMode]} session`}
+              aria-label="choose provider"
+              aria-expanded={modeMenuOpen}
             >
-              <span className="row-icon"><IconPlus /></span>
               <ProviderIcon
-                provider={MODE_MENU_ICONS[defaultSessionMode]}
+                provider={selectedProvider}
                 className="new-row-provider-icon"
               />
             </button>
             <button
-              className="new-row-toggle"
-              onClick={() => setModeMenuOpen((v) => !v)}
+              className="new-row-action"
+              onClick={() => createSession(defaultSessionMode)}
               disabled={busy}
-              aria-label="choose auth mode"
-              aria-expanded={modeMenuOpen}
+              aria-label={`Start ${MODE_LABELS[defaultSessionMode]} session`}
             >
-              <IconChevron />
+              <span className="row-icon"><IconPlus /></span>
+            </button>
+            <button
+              className="new-row-action"
+              onClick={() => createSession("api_key")}
+              disabled={busy}
+              aria-label="Start API key session"
+            >
+              <IconKey className="new-row-action-icon" />
+            </button>
+            <button
+              className="new-row-action"
+              onClick={() => createSession(configMode)}
+              disabled={busy}
+              aria-label={`Start ${MODE_LABELS[configMode]} session`}
+            >
+              <IconWrench className="new-row-action-icon" />
             </button>
             {modeMenuOpen && (
-              <ul className="dropdown dropdown-mode" role="menu">
-                {MODE_ORDER.map((m) => (
-                  <li key={m}>
+              <ul className="dropdown dropdown-provider" role="menu">
+                {(["anthropic", "openai"] as Provider[]).map((provider) => {
+                  const mode = PROVIDER_DEFAULT_MODES[provider];
+                  return (
+                    <li key={provider}>
                     <button
-                      onClick={() => createSession(m)}
+                      onClick={() => setDefaultProvider(provider)}
                       disabled={busy}
-                      aria-label={MODE_LABELS[m]}
+                      aria-label={MODE_LABELS[mode]}
                     >
-                      <ModeMenuItem mode={m} />
+                      <ProviderIcon
+                        provider={provider}
+                        className="dropdown-provider-icon"
+                      />
                     </button>
                   </li>
-                ))}
+                  );
+                })}
               </ul>
             )}
           </div>

--- a/frontend/src/StyleguideView.tsx
+++ b/frontend/src/StyleguideView.tsx
@@ -155,16 +155,21 @@ export function StyleguideView() {
         <section style={sectionStyle}>
           <h2 style={headStyle}>new session row</h2>
           <p style={captionStyle}>
-            The plus starts the saved default provider; the chevron opens
-            launch-mode selection.
+            Provider selector first, then default session, API-key fallback,
+            and provider-specific config.
           </p>
-          <div className="new-row" data-menu="mode" style={{ maxWidth: 280 }}>
-            <button className="new-row-main" type="button" aria-label="start default session">
-              <span className="row-icon">+</span>
+          <div className="new-row new-row-launcher" data-menu="mode">
+            <button className="new-row-provider-toggle" type="button" aria-label="choose provider">
               <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
             </button>
-            <button className="new-row-toggle" type="button" aria-label="choose auth mode">
-              ▾
+            <button className="new-row-action" type="button" aria-label="start default session">
+              <span className="row-icon">+</span>
+            </button>
+            <button className="new-row-action" type="button" aria-label="start API key session">
+              <IconKey className="new-row-action-icon" />
+            </button>
+            <button className="new-row-action" type="button" aria-label="start config session">
+              <IconWrench className="new-row-action-icon" />
             </button>
           </div>
         </section>
@@ -264,24 +269,29 @@ export function StyleguideView() {
         <section style={sectionStyle}>
           <h2 style={headStyle}>mode dropdown</h2>
           <p style={captionStyle}>
-            Appears under the launch row when the chevron toggles. Default
-            modes are provider-only; setup modes add the wrench.
+            Provider selection is the only dropdown; action icons stay in the
+            launcher row.
           </p>
-          <div className={`new-row${dropdownOpen ? " is-open" : ""}`} data-menu="mode" style={{ maxWidth: 280 }}>
-            <button className="new-row-main" type="button" aria-label="start default session">
-              <span className="row-icon">+</span>
-              <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
-            </button>
+          <div className="new-row new-row-launcher" data-menu="mode">
             <button
-              className="new-row-toggle"
+              className={`new-row-provider-toggle${dropdownOpen ? " is-open" : ""}`}
               type="button"
-              aria-label="choose auth mode"
+              aria-label="choose provider"
               onClick={() => setDropdownOpen((v) => !v)}
             >
-              ▾
+              <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
+            </button>
+            <button className="new-row-action" type="button" aria-label="start default session">
+              <span className="row-icon">+</span>
+            </button>
+            <button className="new-row-action" type="button" aria-label="start API key session">
+              <IconKey className="new-row-action-icon" />
+            </button>
+            <button className="new-row-action" type="button" aria-label="start config session">
+              <IconWrench className="new-row-action-icon" />
             </button>
             {dropdownOpen && (
-              <ul className="dropdown dropdown-mode" role="menu">
+              <ul className="dropdown dropdown-provider" role="menu">
                 <li>
                   <button type="button" aria-label="Claude">
                     <ProviderIcon provider="anthropic" className="dropdown-provider-icon" />
@@ -289,30 +299,9 @@ export function StyleguideView() {
                   </button>
                 </li>
                 <li>
-                  <button type="button">
-                    <ProviderIcon provider="anthropic" className="dropdown-provider-icon" />
-                    <IconKey className="dropdown-key-icon" />
-                    <span className="sr-only">Claude API key</span>
-                  </button>
-                </li>
-                <li>
-                  <button type="button" aria-label="Claude config">
-                    <ProviderIcon provider="anthropic" className="dropdown-provider-icon" />
-                    <IconWrench className="dropdown-wrench-icon" />
-                    <span className="sr-only">Claude config</span>
-                  </button>
-                </li>
-                <li>
                   <button type="button" aria-label="Codex">
                     <ProviderIcon provider="openai" className="dropdown-provider-icon" />
                     <span className="sr-only">Codex</span>
-                  </button>
-                </li>
-                <li>
-                  <button type="button" aria-label="Codex config">
-                    <ProviderIcon provider="openai" className="dropdown-provider-icon" />
-                    <IconWrench className="dropdown-wrench-icon" />
-                    <span className="sr-only">Codex config</span>
                   </button>
                 </li>
               </ul>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -333,6 +333,10 @@ button:disabled {
   transition: background 120ms ease;
 }
 
+.new-row-launcher {
+  width: max-content;
+}
+
 .new-row:hover,
 .new-row.is-open {
   background: var(--bg-hover);
@@ -367,6 +371,42 @@ button:disabled {
   border-bottom-left-radius: 0;
 }
 
+.new-row-provider-toggle,
+.new-row-action {
+  width: 2.25rem;
+  min-width: 2.25rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.new-row-provider-toggle {
+  border-radius: var(--radius-xl) 0 0 var(--radius-xl);
+}
+
+.new-row-provider-toggle.is-open {
+  background: var(--bg-launch-menu);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  color: var(--text-primary);
+}
+
+.new-row-action {
+  border-radius: 0;
+}
+
+.new-row-action:last-of-type {
+  border-radius: 0 var(--radius-xl) var(--radius-xl) 0;
+}
+
+.new-row-provider-toggle:hover:not(:disabled),
+.new-row-action:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
 .row-icon {
   display: inline-flex;
   align-items: center;
@@ -378,6 +418,13 @@ button:disabled {
   width: 1rem;
   height: 1rem;
   color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.new-row-action-icon {
+  width: 1rem;
+  height: 1rem;
+  color: currentColor;
   flex-shrink: 0;
 }
 
@@ -438,6 +485,21 @@ button:disabled {
   transform-origin: top;
 }
 
+.dropdown-provider {
+  top: 100%;
+  left: 0;
+  width: 2.25rem;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 0 0 var(--space-1);
+  background: var(--bg-launch-menu);
+  border-color: transparent;
+  border-top: 1px solid var(--gray-800);
+  border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+  box-shadow: none;
+  transform-origin: top left;
+}
+
 .dropdown-profile {
   animation-name: dropdown-up-in;
   transform-origin: bottom left;
@@ -470,6 +532,13 @@ button:disabled {
   min-height: 32px;
   gap: var(--space-2);
   padding: var(--space-2) 0.625rem var(--space-2) calc(0.625rem + 1rem + var(--space-2));
+}
+
+.dropdown-provider button {
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: var(--space-2) 0;
 }
 
 .dropdown-provider-icon {


### PR DESCRIPTION
## Summary
- Make the provider logo the only dropdown trigger in the session launcher
- Split default session, API-key fallback, and config into adjacent icon actions
- Update the styleguide launcher examples to match the new control order

## Test
- npm run build