### PR TITLE
Add provider dropdown affordance

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -252,6 +252,26 @@ function IconKey({ className }: { className?: string }) {
   );
 }
 
+function IconChevronDown({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      focusable="false"
+      aria-hidden="true"
+    >
+      <polyline points="4,6 8,10 12,6" />
+    </svg>
+  );
+}
+
 function IconKebab() {
   return (
     <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
@@ -730,10 +750,13 @@ export function App() {
               aria-label="choose provider"
               aria-expanded={modeMenuOpen}
             >
-              <ProviderIcon
-                provider={selectedProvider}
-                className="new-row-provider-icon"
-              />
+              <span className="new-row-provider-slot">
+                <ProviderIcon
+                  provider={selectedProvider}
+                  className="new-row-provider-icon"
+                />
+              </span>
+              <IconChevronDown className="new-row-provider-chevron" />
             </button>
             <button
               className="new-row-action"

--- a/frontend/src/StyleguideView.tsx
+++ b/frontend/src/StyleguideView.tsx
@@ -99,6 +99,26 @@ function IconKey({ className }: { className?: string }) {
   );
 }
 
+function IconChevronDown({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      focusable="false"
+      aria-hidden="true"
+    >
+      <polyline points="4,6 8,10 12,6" />
+    </svg>
+  );
+}
+
 export function StyleguideView() {
   const [dropdownOpen, setDropdownOpen] = useState(true);
 
@@ -160,7 +180,10 @@ export function StyleguideView() {
           </p>
           <div className="new-row new-row-launcher" data-menu="mode">
             <button className="new-row-provider-toggle" type="button" aria-label="choose provider">
-              <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
+              <span className="new-row-provider-slot">
+                <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
+              </span>
+              <IconChevronDown className="new-row-provider-chevron" />
             </button>
             <button className="new-row-action" type="button" aria-label="start default session">
               <span className="row-icon">+</span>
@@ -279,7 +302,10 @@ export function StyleguideView() {
               aria-label="choose provider"
               onClick={() => setDropdownOpen((v) => !v)}
             >
-              <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
+              <span className="new-row-provider-slot">
+                <ProviderIcon provider="anthropic" className="new-row-provider-icon" />
+              </span>
+              <IconChevronDown className="new-row-provider-chevron" />
             </button>
             <button className="new-row-action" type="button" aria-label="start default session">
               <span className="row-icon">+</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -373,8 +373,6 @@ button:disabled {
 
 .new-row-provider-toggle,
 .new-row-action {
-  width: 2.25rem;
-  min-width: 2.25rem;
   height: 2rem;
   display: inline-flex;
   align-items: center;
@@ -384,13 +382,40 @@ button:disabled {
 }
 
 .new-row-provider-toggle {
+  width: 2.75rem;
+  min-width: 2.75rem;
+  display: grid;
+  grid-template-columns: 2rem 0.75rem;
+  padding: 0;
   border-radius: var(--radius-xl) 0 0 var(--radius-xl);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.06);
+}
+
+.new-row-action {
+  width: 2.25rem;
+  min-width: 2.25rem;
 }
 
 .new-row-provider-toggle.is-open {
   background: var(--bg-launch-menu);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   color: var(--text-primary);
+}
+
+.new-row-provider-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.new-row-provider-chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--text-faint);
+  justify-self: center;
+  flex-shrink: 0;
 }
 
 .new-row-action {
@@ -429,7 +454,8 @@ button:disabled {
 }
 
 .new-row:hover .row-icon,
-.new-row:hover .new-row-provider-icon {
+.new-row:hover .new-row-provider-icon,
+.new-row:hover .new-row-provider-chevron {
   color: var(--text-primary);
 }
 
@@ -488,7 +514,7 @@ button:disabled {
 .dropdown-provider {
   top: 100%;
   left: 0;
-  width: 2.25rem;
+  width: 2.75rem;
   min-width: 0;
   box-sizing: border-box;
   padding: 0 0 var(--space-1);
@@ -536,9 +562,11 @@ button:disabled {
 
 .dropdown-provider button {
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   min-height: 32px;
   padding: var(--space-2) 0;
+  display: grid;
+  grid-template-columns: 2rem 0.75rem;
 }
 
 .dropdown-provider-icon {
@@ -546,6 +574,7 @@ button:disabled {
   height: 1rem;
   color: var(--text-muted);
   flex-shrink: 0;
+  justify-self: center;
 }
 
 .dropdown-wrench-icon {


### PR DESCRIPTION
## Summary
- Add a chevron affordance to the provider logo control
- Keep the provider dropdown aligned with the logo column
- Update styleguide launcher examples

## Test
- npm run build