### PR TITLE
Split session launcher controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -758,30 +758,32 @@ export function App() {
               </span>
               <IconChevronDown className="new-row-provider-chevron" />
             </button>
-            <button
-              className="new-row-action"
-              onClick={() => createSession(defaultSessionMode)}
-              disabled={busy}
-              aria-label={`Start ${MODE_LABELS[defaultSessionMode]} session`}
-            >
-              <span className="row-icon"><IconPlus /></span>
-            </button>
-            <button
-              className="new-row-action"
-              onClick={() => createSession("api_key")}
-              disabled={busy}
-              aria-label="Start API key session"
-            >
-              <IconKey className="new-row-action-icon" />
-            </button>
-            <button
-              className="new-row-action"
-              onClick={() => createSession(configMode)}
-              disabled={busy}
-              aria-label={`Start ${MODE_LABELS[configMode]} session`}
-            >
-              <IconWrench className="new-row-action-icon" />
-            </button>
+            <div className="new-row-action-group" role="group" aria-label="session actions">
+              <button
+                className="new-row-action"
+                onClick={() => createSession(defaultSessionMode)}
+                disabled={busy}
+                aria-label={`Start ${MODE_LABELS[defaultSessionMode]} session`}
+              >
+                <span className="row-icon"><IconPlus /></span>
+              </button>
+              <button
+                className="new-row-action"
+                onClick={() => createSession("api_key")}
+                disabled={busy}
+                aria-label="Start API key session"
+              >
+                <IconKey className="new-row-action-icon" />
+              </button>
+              <button
+                className="new-row-action"
+                onClick={() => createSession(configMode)}
+                disabled={busy}
+                aria-label={`Start ${MODE_LABELS[configMode]} session`}
+              >
+                <IconWrench className="new-row-action-icon" />
+              </button>
+            </div>
             {modeMenuOpen && (
               <ul className="dropdown dropdown-provider" role="menu">
                 {(["anthropic", "openai"] as Provider[]).map((provider) => {

--- a/frontend/src/StyleguideView.tsx
+++ b/frontend/src/StyleguideView.tsx
@@ -185,15 +185,17 @@ export function StyleguideView() {
               </span>
               <IconChevronDown className="new-row-provider-chevron" />
             </button>
-            <button className="new-row-action" type="button" aria-label="start default session">
-              <span className="row-icon">+</span>
-            </button>
-            <button className="new-row-action" type="button" aria-label="start API key session">
-              <IconKey className="new-row-action-icon" />
-            </button>
-            <button className="new-row-action" type="button" aria-label="start config session">
-              <IconWrench className="new-row-action-icon" />
-            </button>
+            <div className="new-row-action-group" role="group" aria-label="session actions">
+              <button className="new-row-action" type="button" aria-label="start default session">
+                <span className="row-icon">+</span>
+              </button>
+              <button className="new-row-action" type="button" aria-label="start API key session">
+                <IconKey className="new-row-action-icon" />
+              </button>
+              <button className="new-row-action" type="button" aria-label="start config session">
+                <IconWrench className="new-row-action-icon" />
+              </button>
+            </div>
           </div>
         </section>
 
@@ -307,15 +309,17 @@ export function StyleguideView() {
               </span>
               <IconChevronDown className="new-row-provider-chevron" />
             </button>
-            <button className="new-row-action" type="button" aria-label="start default session">
-              <span className="row-icon">+</span>
-            </button>
-            <button className="new-row-action" type="button" aria-label="start API key session">
-              <IconKey className="new-row-action-icon" />
-            </button>
-            <button className="new-row-action" type="button" aria-label="start config session">
-              <IconWrench className="new-row-action-icon" />
-            </button>
+            <div className="new-row-action-group" role="group" aria-label="session actions">
+              <button className="new-row-action" type="button" aria-label="start default session">
+                <span className="row-icon">+</span>
+              </button>
+              <button className="new-row-action" type="button" aria-label="start API key session">
+                <IconKey className="new-row-action-icon" />
+              </button>
+              <button className="new-row-action" type="button" aria-label="start config session">
+                <IconWrench className="new-row-action-icon" />
+              </button>
+            </div>
             {dropdownOpen && (
               <ul className="dropdown dropdown-provider" role="menu">
                 <li>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -343,6 +343,7 @@ button:disabled {
   position: relative;
   display: flex;
   align-items: stretch;
+  gap: 0.25rem;
   border-radius: var(--radius-xl);
   background: transparent;
   transition: background 120ms ease;
@@ -350,16 +351,6 @@ button:disabled {
 
 .new-row-launcher {
   width: max-content;
-}
-
-.new-row:hover,
-.new-row.is-open {
-  background: var(--bg-hover);
-}
-
-.new-row.is-open {
-  background: var(--bg-launch-menu);
-  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
 }
 
 .new-row-main {
@@ -402,9 +393,18 @@ button:disabled {
   display: grid;
   grid-template-columns: 2rem 0.75rem;
   padding: 0;
-  border-radius: var(--radius-xl) 0 0 var(--radius-xl);
+  border-radius: var(--radius-xl);
   background: rgba(255, 255, 255, 0.03);
-  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.new-row-action-group {
+  display: flex;
+  align-items: stretch;
+  border-radius: var(--radius-xl);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
 }
 
 .new-row-action {
@@ -416,6 +416,7 @@ button:disabled {
   background: var(--bg-launch-menu);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   color: var(--text-primary);
+  box-shadow: none;
 }
 
 .new-row-provider-slot {
@@ -435,6 +436,10 @@ button:disabled {
 
 .new-row-action {
   border-radius: 0;
+}
+
+.new-row-action:first-child {
+  border-radius: var(--radius-xl) 0 0 var(--radius-xl);
 }
 
 .new-row-action:last-of-type {


### PR DESCRIPTION
## Summary
- Make the provider selector its own rounded dropdown control
- Group plus, key, and wrench into a separate three-button rounded action cluster
- Update styleguide launcher examples

## Test
- npm run build