### PR TITLE
Unify sidebar surface colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1118,3 +1118,35 @@ button:disabled {
 
 .terminals {
   flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.terminal-body,
+.terminal-waiting {
+  position: absolute;
+  inset: 0;
+}
+
+.terminal-body {
+  padding: var(--space-2);
+  overflow: hidden;
+}
+
+.terminal-body .xterm-viewport {
+  scrollbar-width: none;
+}
+
+.terminal-body .xterm-viewport::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.terminal-waiting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -40,13 +40,18 @@
 
   /* Surfaces */
   --bg-app: #171717;
-  --bg-sidebar: rgba(13, 13, 13, 0.7);
   --bg-elevated: var(--gray-850);
-  --bg-hover: rgba(255, 255, 255, 0.06);
+  --bg-sidebar: rgba(13, 13, 13, 0.88);
+  --bg-sidebar-control: rgba(255, 255, 255, 0.03);
+  --bg-sidebar-raised: #1f1f1f;
+  --bg-sidebar-hover: rgba(255, 255, 255, 0.075);
+  --bg-sidebar-active: rgba(79, 140, 247, 0.10);
+  --bg-sidebar-menu: var(--bg-sidebar-raised);
+  --bg-hover: var(--bg-sidebar-hover);
   --bg-hover-soft: rgba(255, 255, 255, 0.05);
-  --bg-row-rest: rgba(255, 255, 255, 0.025);
-  --bg-launch-menu: #1f1f1f;
-  --bg-active: transparent;
+  --bg-row-rest: var(--bg-sidebar-control);
+  --bg-launch-menu: var(--bg-sidebar-menu);
+  --bg-active: var(--bg-sidebar-active);
   --row-rest-ring: rgba(255, 255, 255, 0.045);
 
   /* Borders */
@@ -288,8 +293,7 @@ button:disabled {
   gap: var(--space-2);
   padding: 14px var(--space-4);
   flex-shrink: 0;
-  background: rgba(0, 0, 0, 0.35);
-  box-shadow: inset 0 -1px 0 #3a3a3a;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .sidebar-brand h1 {
@@ -311,8 +315,7 @@ button:disabled {
   padding-top: 10px;
   padding-bottom: var(--space-3);
   flex-shrink: 0;
-  background: rgba(0, 0, 0, 0.15);
-  box-shadow: inset 0 -1px 0 #3a3a3a;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .sidebar-list {
@@ -396,7 +399,7 @@ button:disabled {
   grid-template-columns: 2rem 0.75rem;
   padding: 0;
   border-radius: var(--radius-xl);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-sidebar-control);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
@@ -404,7 +407,7 @@ button:disabled {
   display: flex;
   align-items: stretch;
   border-radius: var(--radius-xl);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-sidebar-control);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   overflow: hidden;
 }
@@ -415,7 +418,7 @@ button:disabled {
 }
 
 .new-row-provider-toggle.is-open {
-  background: var(--bg-launch-menu);
+  background: var(--bg-sidebar-menu);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   color: var(--text-primary);
   box-shadow: none;
@@ -508,7 +511,7 @@ button:disabled {
   list-style: none;
   margin: 0;
   padding: var(--space-1);
-  background: var(--gray-850);
+  background: var(--bg-sidebar-menu);
   border: 1px solid var(--gray-800);
   border-radius: var(--radius-xl);
   min-width: 14rem;
@@ -526,7 +529,7 @@ button:disabled {
   min-width: 0;
   box-sizing: border-box;
   padding: 0 0 var(--space-1);
-  background: var(--bg-launch-menu);
+  background: var(--bg-sidebar-menu);
   border-color: transparent;
   border-top: 1px solid var(--gray-800);
   border-radius: 0 0 var(--radius-xl) var(--radius-xl);
@@ -541,7 +544,7 @@ button:disabled {
   min-width: 0;
   box-sizing: border-box;
   padding: 0 0 var(--space-1);
-  background: var(--bg-launch-menu);
+  background: var(--bg-sidebar-menu);
   border-color: transparent;
   border-top: 1px solid var(--gray-800);
   border-radius: 0 0 var(--radius-xl) var(--radius-xl);
@@ -571,7 +574,7 @@ button:disabled {
 }
 
 .dropdown button:hover:not(:disabled) {
-  background: var(--gray-900);
+  background: var(--bg-sidebar-hover);
   color: var(--text-primary);
 }
 
@@ -754,7 +757,7 @@ button:disabled {
 }
 
 .session-delete:hover:not(:disabled) {
-  background: var(--gray-850);
+  background: var(--bg-sidebar-hover);
   color: var(--text-primary);
 }
 
@@ -872,7 +875,7 @@ button:disabled {
 }
 
 .profile:hover:not(:disabled) {
-  background: rgba(22, 22, 22, 0.5);           /* gray-900/50 */
+  background: var(--bg-sidebar-hover);
   color: var(--text-primary);
 }
 
@@ -1115,35 +1118,3 @@ button:disabled {
 
 .terminals {
   flex: 1;
-  position: relative;
-  overflow: hidden;
-}
-
-.terminal-body,
-.terminal-waiting {
-  position: absolute;
-  inset: 0;
-}
-
-.terminal-body {
-  padding: var(--space-2);
-  overflow: hidden;
-}
-
-.terminal-body .xterm-viewport {
-  scrollbar-width: none;
-}
-
-.terminal-body .xterm-viewport::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-
-.terminal-waiting {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-}


### PR DESCRIPTION
## Summary
- add a sidebar surface token ladder for base, controls, raised/menu, hover, and active states
- route sidebar brand, launcher, dropdown, row, delete, and profile backgrounds through the shared tokens
- give active session rows a subtle selected surface instead of making them transparent

## Checks
- `npm ci`
- `npm run build`