### PR TITLE
Remove completion sound preview button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { Terminal, playCompletionSound, type AgentActivity, type TerminalHandle } from "./Terminal";
+import { Terminal, type AgentActivity, type TerminalHandle } from "./Terminal";
 import { authedFetch, bootstrapAuth, logout, startLogin } from "./auth";
 import { ProviderIcon } from "./providerIcons";
 
@@ -1082,14 +1082,6 @@ export function App() {
                   />
                   <span className="setting-value">{Math.round(completionSoundVolume * 100)}%</span>
                 </label>
-                <button
-                  className="setting-test-button"
-                  type="button"
-                  disabled={!completionSoundEnabled}
-                  onClick={() => playCompletionSound(completionSoundVolume)}
-                >
-                  Test sound
-                </button>
               </li>
               <li className="dropdown-divider" role="separator" />
               <li>

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -72,10 +72,6 @@ const completionSound = (() => {
   return { play, unlock };
 })();
 
-export function playCompletionSound(volume: number): void {
-  completionSound.play(volume);
-}
-
 export type AgentActivity = "working" | "waiting";
 
 interface Props {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -713,18 +713,6 @@ button:disabled {
   font-variant-numeric: tabular-nums;
 }
 
-.setting-test-button {
-  justify-content: center;
-  border: 1px solid var(--gray-700) !important;
-  background: var(--bg-sidebar-hover) !important;
-  color: var(--text-primary) !important;
-  padding: var(--space-2) var(--space-3) !important;
-}
-
-.setting-test-button:disabled {
-  opacity: 0.45;
-}
-
 .dropdown-mode button {
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove the temporary completion sound test button from the profile menu
- remove the exported preview playback helper and unused styles
- keep the sound enabled/volume settings and volume recovery behavior

## Checks
- npm run build
- git diff --check