### PR TITLE
[codex] Add opt-in Codex no-alt-screen sessions

### DIFF
--- a/backend/src/tank_operator/api.py
+++ b/backend/src/tank_operator/api.py
@@ -23,6 +23,7 @@ from .credentials_seed import CredentialsSeedError, harvest_and_save, harvest_co
 from .exec_proxy import bridge
 from .profiles import ProfileStore
 from .sessions import (
+    CODEX_SUBSCRIPTION_MODE,
     DEFAULT_SESSION_MODE,
     SESSION_MODES,
     SESSIONS_NAMESPACE,
@@ -215,6 +216,7 @@ class CreateSessionBody(BaseModel):
     # Body is optional on the wire (POST with no JSON still works) so the
     # default-mode `+ new` button doesn't have to send anything.
     mode: str = DEFAULT_SESSION_MODE
+    codex_no_alt_screen: bool = False
 
 
 class CreateSessionWithContextBody(BaseModel):
@@ -224,6 +226,7 @@ class CreateSessionWithContextBody(BaseModel):
     validation_url: str | None = None
     caller_email: str | None = None
     mode: str = DEFAULT_SESSION_MODE
+    codex_no_alt_screen: bool = False
 
 
 class CreateSessionWithContextResponse(BaseModel):
@@ -237,9 +240,19 @@ async def create_session(
     user: User = Depends(current_user),
 ) -> SessionInfo:
     mode = body.mode if body else DEFAULT_SESSION_MODE
+    codex_no_alt_screen = bool(body.codex_no_alt_screen) if body else False
     if mode not in SESSION_MODES:
         raise HTTPException(status_code=400, detail=f"unknown mode: {mode}")
-    return await sessions.create(owner=user.email, mode=mode)
+    if codex_no_alt_screen and mode != CODEX_SUBSCRIPTION_MODE:
+        raise HTTPException(
+            status_code=400,
+            detail="codex_no_alt_screen is only valid for codex_subscription sessions",
+        )
+    return await sessions.create(
+        owner=user.email,
+        mode=mode,
+        codex_no_alt_screen=codex_no_alt_screen,
+    )
 
 
 @app.post("/api/sessions/with-context", response_model=CreateSessionWithContextResponse)
@@ -256,6 +269,11 @@ async def create_session_with_context(
     """
     if body.mode not in SESSION_MODES:
         raise HTTPException(status_code=400, detail=f"unknown mode: {body.mode}")
+    if body.codex_no_alt_screen and body.mode != CODEX_SUBSCRIPTION_MODE:
+        raise HTTPException(
+            status_code=400,
+            detail="codex_no_alt_screen is only valid for codex_subscription sessions",
+        )
     if body.caller_email and body.caller_email.lower() != user.email.lower():
         raise HTTPException(status_code=403, detail="caller_email does not match session user")
 
@@ -270,6 +288,7 @@ async def create_session_with_context(
         owner=user.email,
         mode=body.mode,
         glimmung_context=context,
+        codex_no_alt_screen=body.codex_no_alt_screen,
     )
     session_url = str(request.base_url).rstrip("/") + f"/?session={created.id}"
     return CreateSessionWithContextResponse(session_url=session_url, session=created)

--- a/backend/src/tank_operator/sessions.py
+++ b/backend/src/tank_operator/sessions.py
@@ -233,6 +233,7 @@ class SessionManager:
         owner: str,
         mode: str,
         glimmung_context: dict[str, Any] | None = None,
+        codex_no_alt_screen: bool = False,
     ) -> dict[str, Any]:
         owner_label = _owner_label(owner)
         selector_labels = {"tank-operator/session-id": session_id}
@@ -301,6 +302,10 @@ class SessionManager:
                         {
                             "name": "TANK_GLIMMUNG_VALIDATION_URL",
                             "value": str((glimmung_context or {}).get("validation_url") or ""),
+                        },
+                        {
+                            "name": "TANK_CODEX_NO_ALT_SCREEN",
+                            "value": "1" if codex_no_alt_screen else "",
                         },
                         # Force claude (and anything else using the
                         # `supports-hyperlinks` npm lib) to emit OSC 8
@@ -456,6 +461,7 @@ class SessionManager:
         owner: str,
         mode: str = DEFAULT_SESSION_MODE,
         glimmung_context: dict[str, Any] | None = None,
+        codex_no_alt_screen: bool = False,
     ) -> SessionInfo:
         assert self._apps is not None
         if mode not in SESSION_MODES:
@@ -477,7 +483,13 @@ class SessionManager:
         session_id = uuid.uuid4().hex[:10]
         await self._apps.create_namespaced_deployment(
             namespace=SESSIONS_NAMESPACE,
-            body=self._deployment_manifest(session_id, owner, mode, glimmung_context),
+            body=self._deployment_manifest(
+                session_id,
+                owner,
+                mode,
+                glimmung_context,
+                codex_no_alt_screen=codex_no_alt_screen,
+            ),
         )
         # Seed activity so the reaper gives the session a full
         # IDLE_TIMEOUT to receive its first WS before being eligible

--- a/backend/tests/test_glimmung_context_sessions.py
+++ b/backend/tests/test_glimmung_context_sessions.py
@@ -49,3 +49,14 @@ def test_plain_session_has_no_glimmung_context_annotation() -> None:
 
     assert GLIMMUNG_CONTEXT_ANNOTATION not in manifest["metadata"]["annotations"]
     assert _claude_env(manifest)["TANK_GLIMMUNG_CONTEXT_JSON"] == ""
+
+
+def test_codex_no_alt_screen_flag_is_stamped_on_session_env() -> None:
+    manifest = SessionManager()._deployment_manifest(
+        "abc123",
+        owner="operator@example.test",
+        mode="codex_subscription",
+        codex_no_alt_screen=True,
+    )
+
+    assert _claude_env(manifest)["TANK_CODEX_NO_ALT_SCREEN"] == "1"

--- a/claude-container/tank-bootstrap.sh
+++ b/claude-container/tank-bootstrap.sh
@@ -201,6 +201,9 @@ EOF
   fi
   cp /etc/codex-creds/auth.json $HOME/.codex/auth.json
   chmod 600 $HOME/.codex/auth.json
+  if [ "${TANK_CODEX_NO_ALT_SCREEN:-}" = "1" ]; then
+    exec tmux new-session -s tank 'codex --no-alt-screen; exec bash'
+  fi
   exec tmux new-session -s tank 'codex; exec bash'
 fi
 # MCP auth is delegated to the mcp-auth-proxy sidecar — claude reaches

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -108,6 +108,14 @@ function writeDefaultSessionMode(mode: DefaultSessionMode): void {
   }
 }
 
+function readCodexNoAltScreenFlag(): boolean {
+  try {
+    return localStorage.getItem("tankCodexNoAltScreen") === "1";
+  } catch {
+    return false;
+  }
+}
+
 function readCompletionSoundEnabled(): boolean {
   try {
     return localStorage.getItem(COMPLETION_SOUND_ENABLED_KEY) !== "0";
@@ -648,7 +656,10 @@ export function App() {
       const res = await authedFetch("/api/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode }),
+        body: JSON.stringify({
+          mode,
+          codex_no_alt_screen: mode === "codex_subscription" && readCodexNoAltScreenFlag(),
+        }),
       });
       if (!res.ok) throw new Error(`create failed: ${res.status}`);
       const created: Session = await res.json();


### PR DESCRIPTION
## Summary

Adds a narrow test path for Codex subscription sessions to launch with `codex --no-alt-screen` without changing the default behavior.

- Accepts `codex_no_alt_screen` on session creation for `codex_subscription` only.
- Stamps `TANK_CODEX_NO_ALT_SCREEN=1` onto the session pod when requested.
- Makes the bootstrap run `codex --no-alt-screen` for that flagged pod.
- Adds a hidden frontend opt-in via `localStorage.setItem("tankCodexNoAltScreen", "1")` for newly created Codex sessions.

## Validation

- `backend`: `pytest tests/test_glimmung_context_sessions.py`
- `frontend`: `npm run build`
- `bash -n claude-container/tank-bootstrap.sh`
- `git diff --check`