### PR TITLE
Enable tmux scrolling for Codex sessions

### DIFF
--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -143,10 +143,11 @@ RUN mkdir -p /home/node/.claude/skills /home/node/.codex/skills \
           ;; \
     esac
 
-# Hide tmux's status bar so the claude TUI gets the full terminal height.
-# tmux is the WS-reconnect-survival wrapper for the claude session
-# (see tank-bootstrap.sh); the status bar would steal one row.
-RUN printf 'set -g status off\nset -g default-terminal "tmux-256color"\n' > /home/node/.tmux.conf \
+# Hide tmux's status bar so the TUI gets the full terminal height.
+# tmux is the WS-reconnect-survival wrapper for agent sessions
+# (see tank-bootstrap.sh); the status bar would steal one row. Mouse mode
+# lets tmux handle wheel scrolling when the browser is attached to tmux.
+RUN printf 'set -g status off\nset -g default-terminal "tmux-256color"\nset -g mouse on\n' > /home/node/.tmux.conf \
     && chown node:node /home/node/.tmux.conf
 
 # Run the agent as a non-root user so claude's safety check accepts

--- a/claude-container/tank-bootstrap.sh
+++ b/claude-container/tank-bootstrap.sh
@@ -201,7 +201,7 @@ EOF
   fi
   cp /etc/codex-creds/auth.json $HOME/.codex/auth.json
   chmod 600 $HOME/.codex/auth.json
-  exec tmux new-session -s tank 'codex; exec bash'
+  exec tmux new-session -s tank 'codex --no-alt-screen; exec bash'
 fi
 # MCP auth is delegated to the mcp-auth-proxy sidecar — claude reaches
 # in-cluster HTTP MCP servers via 127.0.0.1 ports declared in


### PR DESCRIPTION
## Summary
- enable tmux mouse mode in the session image so browser-attached tmux sessions can handle wheel scrolling
- launch Codex subscription sessions with `codex --no-alt-screen`, matching the tmux/no-alt-screen test session that worked

## Checks
- `bash -n claude-container/tank-bootstrap.sh`
- `git diff --check`