### PR TITLE
agent-images: add Vite CLI

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -11,6 +11,7 @@ FROM mcr.microsoft.com/playwright:v1.49.1-noble
 
 ARG TARGETARCH=amd64
 ARG GO_VERSION=1.26.2
+ARG VITE_VERSION=5.4.21
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
@@ -42,7 +43,7 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # scripts/agent/capture-screenshot.mjs) would fail without this. Browsers
 # are already on disk so we skip re-downloading.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-RUN npm install -g @anthropic-ai/claude-code playwright
+RUN npm install -g @anthropic-ai/claude-code playwright "vite@${VITE_VERSION}"
 
 # NODE_PATH lets bare `import "playwright"` resolve from the global
 # install above without per-script `npm link`. Standard global path on

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -15,6 +15,7 @@ ARG UV_VERSION=0.5.18
 ARG RUFF_VERSION=0.15.12
 ARG PYTEST_VERSION=8.4.2
 ARG GO_VERSION=1.26.2
+ARG VITE_VERSION=5.4.21
 ARG TANK_AGENT=claude
 
 # ripgrep + make round out the bash surface (rg replaces grep for repo
@@ -77,8 +78,8 @@ RUN curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/
     && chmod +x /usr/local/bin/uv /usr/local/bin/uvx
 
 RUN case "${TANK_AGENT}" in \
-        claude) npm install -g @anthropic-ai/claude-code ;; \
-        codex) npm install -g @openai/codex ;; \
+        claude) npm install -g @anthropic-ai/claude-code "vite@${VITE_VERSION}" ;; \
+        codex) npm install -g @openai/codex "vite@${VITE_VERSION}" ;; \
         *) echo "unsupported TANK_AGENT=${TANK_AGENT}; expected claude or codex" >&2; exit 1 ;; \
     esac
 


### PR DESCRIPTION
## Summary
- install a pinned global Vite CLI in Claude/Codex session images
- install the same Vite CLI in the issue-runner agent image

## Checks
- `git diff --check`
- `npm view vite@5.4.21 version`

Docker is not available in the session pod, so local image builds were not run.