### PR TITLE
agent-images: expose Go on default PATH

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -34,7 +34,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Go — projects whose dev-loop builds a Go server (ambience).
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
-        | tar -C /usr/local -xz
+        | tar -C /usr/local -xz \
+    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # claude-code CLI + playwright npm package. The base image preinstalls

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -40,7 +40,9 @@ RUN apk add --no-cache \
         vim
 
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
-        | tar -C /usr/local -xz
+        | tar -C /usr/local -xz \
+    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \


### PR DESCRIPTION
## Summary
- symlink `go` and `gofmt` into `/usr/local/bin` in session agent images
- apply the same fix to `agent-container`

## Why
The Go archive is present in `410e0f3`, but runtime PATH is the default `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`, so `go` is not found unless callers know `/usr/local/go/bin/go`.

## Checks
- `git diff --check`
- verified `romainecr.azurecr.io/claude-container:410e0f3` has `/usr/local/go/bin/go` but `go` is not on PATH
- verified `romainecr.azurecr.io/codex-container:410e0f3` has Vite but `go` is not on PATH