### PR TITLE
Report terminal color diagnostics to server

### DIFF
--- a/backend/src/tank_operator/api.py
+++ b/backend/src/tank_operator/api.py
@@ -1,7 +1,8 @@
 import os
+import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from fastapi import Cookie, Depends, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect, status
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
@@ -35,6 +36,7 @@ from .sessions import (
 
 sessions = SessionManager()
 profiles = ProfileStore()
+log = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -58,6 +60,13 @@ class LoginBody(BaseModel):
 class LoginResponse(BaseModel):
     token: str
     user: dict[str, str]
+
+
+class TerminalDebugBody(BaseModel):
+    event: str
+    session_id: str | None = None
+    mode: str | None = None
+    payload: dict[str, Any] = {}
 
 
 @app.get("/healthz")
@@ -130,6 +139,22 @@ async def me(user: User = Depends(current_user)) -> dict:
         "github_login": profile.github_login,
         "installation_id": profile.installation_id,
     }
+
+
+@app.post("/api/debug/terminal")
+async def terminal_debug(
+    body: TerminalDebugBody,
+    user: User = Depends(current_user),
+) -> dict[str, str]:
+    log.info(
+        "terminal debug event=%s user=%s session=%s mode=%s payload=%s",
+        body.event,
+        user.email,
+        body.session_id,
+        body.mode,
+        body.payload,
+    )
+    return {"status": "ok"}
 
 
 # ----------------------------------------------------------------------------

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -161,6 +161,28 @@ function paletteProbeLine(): string {
   ].join("");
 }
 
+function reportTerminalDebug(
+  event: string,
+  sessionId: string,
+  mode: string,
+  payload: Record<string, unknown>,
+): void {
+  const body = JSON.stringify({
+    event,
+    session_id: sessionId,
+    mode,
+    payload,
+  });
+  const blob = new Blob([body], { type: "application/json" });
+  if (navigator.sendBeacon?.("/api/debug/terminal", blob)) return;
+  void fetch("/api/debug/terminal", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive: true,
+  }).catch(() => undefined);
+}
+
 export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
   {
     sessionId,
@@ -250,16 +272,17 @@ export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
     });
     term.open(containerRef.current);
     termRef.current = term;
+    const palette = Object.fromEntries(
+      Object.keys(ANSI_256_OVERRIDES).map((code) => [
+        code,
+        {
+          expected: ANSI_256_OVERRIDES[Number(code)],
+          actual: readXtermAnsiColor(term, Number(code)),
+        },
+      ]),
+    );
+    reportTerminalDebug("palette-audit", sessionId, mode, { palette });
     if (terminalDebugEnabled()) {
-      const palette = Object.fromEntries(
-        Object.keys(ANSI_256_OVERRIDES).map((code) => [
-          code,
-          {
-            expected: ANSI_256_OVERRIDES[Number(code)],
-            actual: readXtermAnsiColor(term, Number(code)),
-          },
-        ]),
-      );
       console.info("[tank-terminal] palette audit", {
         sessionId,
         mode,
@@ -448,6 +471,7 @@ export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
           const colors = ansiColorCodes(text);
           if (colors.length > 0) {
             debugPayloadLogs += 1;
+            reportTerminalDebug("incoming-ansi-colors", sessionId, mode, { colors });
             console.info("[tank-terminal] incoming ansi colors", {
               sessionId,
               mode,


### PR DESCRIPTION
## Summary
- add an authenticated terminal diagnostics endpoint that logs browser-reported xterm color state
- report palette audits and incoming ANSI color codes from the terminal client
- keep browser console diagnostics available for manual probing

## Checks
- npm run build
- python -m compileall backend/src/tank_operator