### PR TITLE
sessions: preserve image PATH during bootstrap

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -34,9 +34,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Go — projects whose dev-loop builds a Go server (ambience).
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
-        | tar -C /usr/local -xz \
-    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
-    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+        | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # claude-code CLI + playwright npm package. The base image preinstalls

--- a/backend/src/tank_operator/exec_proxy.py
+++ b/backend/src/tank_operator/exec_proxy.py
@@ -29,7 +29,9 @@ log = logging.getLogger(__name__)
 # but the kube-apiserver URL-encodes every byte of the exec command into
 # ?command=... and rejects oversized request lines with HTTP 400; the
 # script grew past that limit and broke reconnects.
-EXEC_COMMAND = ["bash", "-l", "/opt/tank/bootstrap.sh"]
+# Do not use a login shell here: Alpine's /etc/profile resets PATH to the
+# distro default and masks tool paths exported by the image, including Go.
+EXEC_COMMAND = ["bash", "/opt/tank/bootstrap.sh"]
 
 # Session pods have two containers (mcp-auth-proxy sidecar + claude). The
 # apiserver requires container= when more than one is present, otherwise

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -40,9 +40,7 @@ RUN apk add --no-cache \
         vim
 
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
-        | tar -C /usr/local -xz \
-    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
-    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+        | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \


### PR DESCRIPTION
## Summary
- stop launching the session bootstrap as a login shell
- remove the `/usr/local/bin` Go symlink workaround from the agent images
- document why login-shell startup masks image-exported tool paths

## Root Cause
The Go install and Dockerfile `ENV PATH="/usr/local/go/bin:${PATH}"` did work. A normal process in `claude-container:410e0f3` sees `/usr/local/go/bin` and can run `go`. The tank exec bridge used `bash -l /opt/tank/bootstrap.sh`; login-shell startup resets PATH to Alpine's default, which drops `/usr/local/go/bin` before tmux/agent startup.

## Checks
- `git diff --check`
- `python3 -m py_compile backend/src/tank_operator/exec_proxy.py`
- verified `claude-container:410e0f3` with `bash -c` sees `/usr/local/go/bin` and runs `go version go1.26.2 linux/amd64`
- verified `claude-container:410e0f3` with `bash -lc` resets PATH and loses bare `go`
- verified bootstrap-equivalent `bash -c` command finds both `go` and `vite`