### PR TITLE
Match Claude standard ANSI accents

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import { Terminal, type AgentActivity, type TerminalHandle } from "./Terminal";
 import { authedFetch, bootstrapAuth, logout, startLogin } from "./auth";
 import { ProviderIcon } from "./providerIcons";
-import { ANSI_256_OVERRIDES } from "./terminalTheme";
+import { ANSI_256_OVERRIDES, ANSI_STANDARD_OVERRIDES } from "./terminalTheme";
 
 type SessionMode =
   | "api_key"
@@ -114,19 +114,19 @@ type AnsiSegment = {
 };
 
 const DEMO_CLAUDE_LINES = [
-  "\x1b[38;5;174m ▐\x1b[48;5;16m▛███▜\x1b[49m▌\x1b[39m   \x1b[1mClaude Code\x1b[0m \x1b[38;5;246mv2.1.126\x1b[39m",
-  "\x1b[38;5;174m▝▜\x1b[48;5;16m█████\x1b[49m▛▘\x1b[39m  \x1b[38;5;246mOpus 4.7 (1M context) · Claude Max\x1b[39m",
-  "\x1b[38;5;174m  ▘▘ ▝▝  \x1b[39m  \x1b[38;5;246m/workspace\x1b[39m",
+  "\x1b[31m ▐\x1b[40m▛███▜\x1b[49m▌\x1b[39m   \x1b[1mClaude Code\x1b[22m \x1b[37mv2.1.126\x1b[39m",
+  "\x1b[31m▝▜\x1b[40m█████\x1b[49m▛▘\x1b[39m  \x1b[37mOpus 4.7 (1M context) · Claude Max\x1b[39m",
+  "\x1b[31m  ▘▘ ▝▝  \x1b[39m  \x1b[37m/workspace\x1b[39m",
   "",
-  "  \x1b[1m\x1b[38;5;174mWelcome to Opus 4.7 xhigh!\x1b[0m\x1b[38;5;246m · /effort to tune speed vs. intelligence\x1b[39m",
+  "  \x1b[1m\x1b[91mWelcome to Opus 4.7 xhigh!\x1b[22m\x1b[37m · /effort to tune speed vs. intelligence\x1b[39m",
   "",
   "",
   "",
-  "                                                                                  \x1b[38;5;246m◉ xhigh · /effort\x1b[39m",
+  "                                                                                  \x1b[37m◉ xhigh · /effort\x1b[39m",
   "\x1b[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────\x1b[39m",
-  "❯\u00a0\x1b[7m \x1b[0m",
+  "❯\u00a0\x1b[7m \x1b[27m",
   "\x1b[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────\x1b[39m",
-  "  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle)\x1b[39m",
+  "  \x1b[95m⏵⏵ bypass permissions on\x1b[37m (shift+tab to cycle)\x1b[39m",
 ];
 
 const DEMO_CODEX_LINES = [
@@ -172,10 +172,14 @@ function ansiColorClass(code: number | undefined, prefix: "fg" | "bg"): string |
 
 function ansiStyle(style: AnsiStyle): CSSProperties | undefined {
   const css: CSSProperties = {};
-  if (style.fg != null && ANSI_256_OVERRIDES[style.fg]) {
+  if (style.fg != null && ANSI_STANDARD_OVERRIDES[style.fg]) {
+    css.color = ANSI_STANDARD_OVERRIDES[style.fg];
+  } else if (style.fg != null && ANSI_256_OVERRIDES[style.fg]) {
     css.color = ANSI_256_OVERRIDES[style.fg];
   }
-  if (style.bg != null && ANSI_256_OVERRIDES[style.bg]) {
+  if (style.bg != null && ANSI_STANDARD_OVERRIDES[style.bg]) {
+    css.backgroundColor = ANSI_STANDARD_OVERRIDES[style.bg];
+  } else if (style.bg != null && ANSI_256_OVERRIDES[style.bg]) {
     css.backgroundColor = ANSI_256_OVERRIDES[style.bg];
   }
   return Object.keys(css).length > 0 ? css : undefined;
@@ -196,6 +200,10 @@ function applyAnsiCodes(style: AnsiStyle, rawCodes: string): AnsiStyle {
     } else if (code === 27) next.inverse = false;
     else if (code === 39) delete next.fg;
     else if (code === 49) delete next.bg;
+    else if (code >= 30 && code <= 37) next.fg = code - 30;
+    else if (code >= 40 && code <= 47) next.bg = code - 40;
+    else if (code >= 90 && code <= 97) next.fg = code - 90 + 8;
+    else if (code >= 100 && code <= 107) next.bg = code - 100 + 8;
     else if (code === 38 && codes[i + 1] === 5) {
       next.fg = codes[i + 2];
       i += 2;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1215,14 +1215,21 @@ button:disabled {
   background: #e4e4e4;
 }
 
+.ansi-fg-1 { color: #d77757; }
 .ansi-fg-5 { color: #800080; }
 .ansi-fg-6 { color: #008080; }
+.ansi-fg-7 { color: #d3d7cf; }
+.ansi-fg-9 { color: #d77757; }
+.ansi-fg-13 { color: #f9b18f; }
 .ansi-fg-174 { color: #d77757; }
 .ansi-fg-211 { color: #f9b18f; }
 .ansi-fg-244 { color: #808080; }
 .ansi-fg-246 { color: #949494; }
+.ansi-bg-0 { background: #2e3436; }
 .ansi-bg-16 { background: #000000; }
 
+.ansi-bg-0.ansi-fg-1,
+.ansi-bg-0 .ansi-fg-1,
 .ansi-bg-16.ansi-fg-174,
 .ansi-bg-16 .ansi-fg-174 {
   color: #d77757;

--- a/frontend/src/terminalTheme.ts
+++ b/frontend/src/terminalTheme.ts
@@ -3,12 +3,20 @@ import type { ITheme } from "@xterm/xterm";
 export const TERMINAL_BACKGROUND = "#171717";
 export const TERMINAL_FOREGROUND = "#e4e4e4";
 
+export const ANSI_STANDARD_OVERRIDES: Record<number, string> = {
+  // Claude Code's current startup screen emits standard red for the logo and
+  // bright red for its welcome accent. Native terminal palettes render these as
+  // warm orange tones, while xterm.js defaults make them look red/pink. The
+  // lower status accent may arrive as bright magenta.
+  1: "#d77757",
+  9: "#d77757",
+  13: "#f9b18f",
+};
+
 export const ANSI_256_OVERRIDES: Record<number, string> = {
-  // Claude Code emits xterm-256 color 174 for its logo and welcome line.
-  // xterm's stock 174 is pink; the native terminal palette Claude is tuned
-  // against renders this as a muted orange.
+  // Keep the 256-color aliases as well; Claude has used these for the same
+  // accents in some startup/onboarding paths.
   174: "#d77757",
-  // Same Claude accent family for the secondary status line.
   211: "#f9b18f",
 };
 
@@ -20,5 +28,8 @@ for (const [code, color] of Object.entries(ANSI_256_OVERRIDES)) {
 export const TERMINAL_THEME: ITheme = {
   background: TERMINAL_BACKGROUND,
   foreground: TERMINAL_FOREGROUND,
+  red: ANSI_STANDARD_OVERRIDES[1],
+  brightRed: ANSI_STANDARD_OVERRIDES[9],
+  brightMagenta: ANSI_STANDARD_OVERRIDES[13],
   extendedAnsi,
 };


### PR DESCRIPTION
## Summary

- map Claude's current standard ANSI startup colors (`31`, `91`, `95`) in the shared xterm theme
- keep the existing 256-color aliases for paths that still emit `174`/`211`
- update the unauthenticated Claude preview fixture and ANSI parser to use the real startup SGR codes

## Testing

- `npm run build`
- Playwright sampled the local unauth preview: logo/welcome computed `rgb(215, 119, 87)`, status accent computed `rgb(249, 177, 143)`

Refs #145