### PR TITLE
Restore Pi credentials ExternalSecret

### DIFF
--- a/backend/src/tank_operator/credentials_seed.py
+++ b/backend/src/tank_operator/credentials_seed.py
@@ -22,8 +22,6 @@ from typing import Any
 
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.secrets.aio import SecretClient
-from kubernetes_asyncio import client
-from kubernetes_asyncio.client.exceptions import ApiException
 
 from .exec_proxy import exec_capture
 from .oauth_gateway import _extract_access_token, _extract_refresh_token
@@ -37,24 +35,6 @@ class CredentialsSeedError(Exception):
     Wrapped to give the API endpoint a clean error type to catch and turn
     into a 400 with a user-readable message.
     """
-
-
-async def _upsert_secret_file(
-    namespace: str, secret_name: str, key: str, value: str
-) -> None:
-    """Create or patch an Opaque Secret containing one stringData file."""
-    core = client.CoreV1Api()
-    body = client.V1Secret(
-        metadata=client.V1ObjectMeta(name=secret_name),
-        type="Opaque",
-        string_data={key: value},
-    )
-    try:
-        await core.patch_namespaced_secret(secret_name, namespace, body)
-    except ApiException as e:
-        if e.status != 404:
-            raise
-        await core.create_namespaced_secret(namespace, body)
 
 
 def _validate(blob: dict[str, Any]) -> None:
@@ -163,7 +143,7 @@ def _validate_pi(blob: dict[str, Any]) -> None:
 
 
 async def harvest_pi_and_save(namespace: str, pod_name: str) -> None:
-    """Read ~/.pi/agent/auth.json out of a pi_config pod and store it."""
+    """Read ~/.pi/agent/auth.json out of a pi_config pod and write it to KV."""
     raw = await exec_capture(
         namespace, pod_name, ["sh", "-c", "cat $HOME/.pi/agent/auth.json"]
     )
@@ -179,18 +159,11 @@ async def harvest_pi_and_save(namespace: str, pod_name: str) -> None:
     _validate_pi(blob)
 
     kv_url = os.environ["AZURE_KEYVAULT_URL"]
-    serialized = json.dumps(blob)
     secret_name = os.environ.get("PI_CREDENTIALS_KV_KEY", "pi-credentials")
     cred = DefaultAzureCredential()
     try:
         async with SecretClient(vault_url=kv_url, credential=cred) as kv:
             log.info("seeding %s/%s with captured pi credentials", kv_url, secret_name)
-            await kv.set_secret(secret_name, serialized)
+            await kv.set_secret(secret_name, json.dumps(blob))
     finally:
         await cred.close()
-    await _upsert_secret_file(
-        namespace=namespace,
-        secret_name=os.environ.get("PI_CREDENTIALS_K8S_SECRET", "pi-credentials"),
-        key=os.environ.get("PI_CREDENTIALS_K8S_KEY", "auth.json"),
-        value=serialized,
-    )

--- a/backend/src/tank_operator/sessions.py
+++ b/backend/src/tank_operator/sessions.py
@@ -432,9 +432,8 @@ class SessionManager:
                     },
                 }
             )
-        # pi_subscription pods mount the Secret written by pi_config's
-        # save-credentials path. It is optional so Pi can still surface a
-        # terminal-side auth error before the first successful /login save.
+        # pi_subscription pods mount the ESO-mirrored pi-credentials Secret.
+        # It is optional for the same first-config flow as Codex.
         if mode == PI_SUBSCRIPTION_MODE:
             container = next(c for c in pod_spec["containers"] if c["name"] == "claude")
             container.setdefault("volumeMounts", []).append(

--- a/k8s/templates/externalsecret-pi.yaml
+++ b/k8s/templates/externalsecret-pi.yaml
@@ -1,0 +1,29 @@
+# Mirrors the `pi-credentials` KV secret into a Secret in the SESSIONS
+# namespace, where pi_subscription pods mount it as
+# /etc/pi-creds/auth.json.
+#
+# Same model as Codex: Pi rotates/updates its auth file in the pod's writable
+# config directory, but no write-back to KV exists yet. Re-seed by launching a
+# Pi config session and clicking Save Credentials.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalSecret.piCredentials.secretName }}
+  namespace: {{ .Values.namespaces.sessions }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.storeName }}
+    kind: {{ .Values.externalSecret.storeKind }}
+  target:
+    name: {{ .Values.externalSecret.piCredentials.secretName }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: {{ .Values.externalSecret.piCredentials.secretKey }}
+      remoteRef:
+        key: {{ .Values.externalSecret.piCredentials.kvKey }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/k8s/templates/rbac.yaml
+++ b/k8s/templates/rbac.yaml
@@ -20,9 +20,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -170,10 +170,9 @@ externalSecret:
     # so this name has to be `auth.json`.
     secretKey: auth.json
     kvKey: codex-credentials
-  # Pi subscription credentials. A config session harvests
-  # ~/.pi/agent/auth.json into KV and also upserts this Secret in the
-  # sessions namespace. There is no always-on ExternalSecret for Pi because
-  # first install should stay healthy before anyone has completed /login.
+  # Pi subscription credentials. Same consume model as Codex: a config
+  # session harvests ~/.pi/agent/auth.json into KV; subscription pods mount
+  # the ESO-mirrored file and copy it into Pi's writable config directory.
   piCredentials:
     secretName: pi-credentials
     secretKey: auth.json


### PR DESCRIPTION
## Summary
- Restore the Pi credentials ExternalSecret so Pi follows the same KV -> ESO -> sessions Secret pattern as Codex.
- Remove the direct Kubernetes Secret upsert from `pi_config` save-credentials.
- Drop the extra orchestrator Secret write RBAC that was only needed for the direct upsert path.

## Validation
- helm template tank-operator ./k8s
- /tmp/tank-backend-venv/bin/python -m pytest backend/tests
- /tmp/tank-backend-venv/bin/python -m compileall backend/src
- git diff --check