### PR TITLE
Clarify Pi subscription Anthropic usage

### DIFF
--- a/backend/src/tank_operator/sessions.py
+++ b/backend/src/tank_operator/sessions.py
@@ -120,6 +120,14 @@ CODEX_CREDS_SECRET = os.environ.get("CODEX_CREDS_SECRET", "codex-credentials")
 # Pi-config is a disposable Pi login sandbox. Pi-subscription curates
 # Tank-backed Claude/Codex subscriptions into Pi's auth.json at pod startup so
 # the launcher only needs one Pi option while Pi still sees multiple providers.
+#
+# Product note: keeping this code alive is intentional, but we have not found a
+# strong day-to-day use for Pi when the available hosted providers are only
+# Codex and Claude. Codex's own TUI is the better first-party OpenAI surface,
+# and Anthropic subscription auth inside Pi is third-party harness usage billed
+# through extra usage, not Claude plan limits. Pi's likely value is future
+# multi-provider work: Qwen/Kimi/DeepSeek, OpenRouter, Bedrock/Vertex/Azure
+# gateways, or self-hosted OpenAI-compatible endpoints.
 PI_CONFIG_MODE = "pi_config"
 PI_SUBSCRIPTION_MODE = "pi_subscription"
 # Modes that must reach the real internet directly (no platform.claude.com /

--- a/claude-container/tank-bootstrap.sh
+++ b/claude-container/tank-bootstrap.sh
@@ -219,13 +219,32 @@ if [ "${TANK_SESSION_MODE}" = "pi_config" ]; then
 Run `/login`, choose your provider, and complete the login flow. This mode is
 for manual Pi testing; Tank does not persist Pi's native auth.json.
 EOF
-  exec tmux new-session -s tank 'printf "Run /login in Pi. This sandbox does not persist Pi auth.\\n\\n"; pi; exec bash'
+  exec "${tmux_utf8[@]}" new-session -s tank 'printf "Run /login in Pi. This sandbox does not persist Pi auth.\\n\\n"; pi; exec bash'
 fi
 # Pi-subscription mode: curate all Tank-backed subscription auth into Pi's
 # native ~/.pi/agent/auth.json from existing Claude proxy and Codex credentials.
 if [ "${TANK_SESSION_MODE}" = "pi_subscription" ]; then
   mkdir -p $HOME/.pi/agent
   cp /workspace/AGENTS.md $HOME/.pi/agent/AGENTS.md 2>/dev/null || true
+  cat >> $HOME/.pi/agent/AGENTS.md <<'EOF'
+
+## Tank Pi Subscription
+
+OpenAI Codex is the default Pi provider for Tank subscription sessions.
+Anthropic is available through Tank's Claude proxy, but Pi is a third-party
+harness and Anthropic bills that path against extra usage, not Claude plan
+limits. If extra usage is exhausted, Anthropic models will fail while Codex
+models can continue working.
+EOF
+  if [ ! -f $HOME/.pi/agent/settings.json ]; then
+    cat > $HOME/.pi/agent/settings.json <<'EOF'
+{
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.5"
+}
+EOF
+    chmod 600 $HOME/.pi/agent/settings.json
+  fi
   printf '{}\n' > $HOME/.pi/agent/auth.json
   node <<'NODE'
 const fs = require("fs");
@@ -306,7 +325,7 @@ fs.writeFileSync(modelsPath, JSON.stringify(models, null, 2));
 fs.chmodSync(modelsPath, 0o600);
 NODE
   chmod 600 $HOME/.pi/agent/auth.json
-  exec tmux new-session -s tank 'pi; exec bash'
+  exec "${tmux_utf8[@]}" new-session -s tank 'pi; exec bash'
 fi
 # MCP auth is delegated to the mcp-auth-proxy sidecar — claude reaches
 # in-cluster HTTP MCP servers via 127.0.0.1 ports declared in


### PR DESCRIPTION
## Summary
- launch Pi config/subscription tmux sessions with `tmux -u` to avoid the extended key/UTF-8 warning path
- seed Pi subscription sessions to default to `openai-codex` / `gpt-5.5`
- document that Pi is not currently a strong hosted Codex/Claude value-add; its likely future value is multi-provider/self-hosted model support
- add Pi session context explaining that Anthropic inside Pi is third-party extra-usage billed and can fail independently of Codex

## Validation
- `bash -n claude-container/tank-bootstrap.sh`
- `python3 -m py_compile backend/src/tank_operator/sessions.py`
- `git diff --check`
- `helm template tank-operator ./k8s`