### PR TITLE
Show session runtime in sidebar tabs

### DIFF
--- a/backend/src/tank_operator/sessions.py
+++ b/backend/src/tank_operator/sessions.py
@@ -172,6 +172,9 @@ class SessionInfo:
     owner: str
     status: str
     mode: str
+    # ISO timestamp from the Deployment's creation time. The frontend uses
+    # this to show a small "running for" indicator on session rows.
+    created_at: str | None = None
     # User-provided friendly name. None when unset; the frontend falls back
     # to the session id slug. The slug stays canonical in URLs and the
     # Deployment/pod name — this is purely a display label.
@@ -527,7 +530,7 @@ class SessionManager:
         # and injects the real one, refreshing against platform.claude.com
         # behind the scenes when it observes a 401.
         session_id = uuid.uuid4().hex[:10]
-        await self._apps.create_namespaced_deployment(
+        created = await self._apps.create_namespaced_deployment(
             namespace=SESSIONS_NAMESPACE,
             body=self._deployment_manifest(session_id, owner, mode, glimmung_context),
         )
@@ -536,7 +539,17 @@ class SessionManager:
         # for deletion.
         self._activity[session_id] = time.monotonic()
         self._ws_count[session_id] = 0
-        return SessionInfo(id=session_id, pod_name=None, owner=owner, status="Pending", mode=mode)
+        created_at = None
+        if created.metadata and created.metadata.creation_timestamp:
+            created_at = created.metadata.creation_timestamp.isoformat()
+        return SessionInfo(
+            id=session_id,
+            pod_name=None,
+            owner=owner,
+            status="Pending",
+            mode=mode,
+            created_at=created_at,
+        )
 
     async def list(self, owner: str) -> list[SessionInfo]:
         assert self._apps is not None
@@ -554,6 +567,7 @@ class SessionManager:
                 owner=owner,
                 status=_deployment_status(d),
                 mode=d.metadata.labels.get("tank-operator/mode", DEFAULT_SESSION_MODE),
+                created_at=_deployment_created_at(d),
                 name=(d.metadata.annotations or {}).get(NAME_ANNOTATION),
             )
             for d in deployments.items
@@ -587,6 +601,7 @@ class SessionManager:
             owner=owner,
             status=_deployment_status(deployment),
             mode=mode,
+            created_at=_deployment_created_at(deployment),
             name=(deployment.metadata.annotations or {}).get(NAME_ANNOTATION),
         )
 
@@ -630,6 +645,7 @@ class SessionManager:
             owner=owner,
             status=_deployment_status(deployment),
             mode=mode,
+            created_at=_deployment_created_at(deployment),
             name=annotation_value,
         )
 
@@ -765,6 +781,12 @@ def _deployment_status(deployment: Any) -> str:
             if c.type == "Progressing" and c.status == "False":
                 return "Failed"
     return "Pending"
+
+
+def _deployment_created_at(deployment: Any) -> str | None:
+    if not deployment.metadata or not deployment.metadata.creation_timestamp:
+        return None
+    return deployment.metadata.creation_timestamp.isoformat()
 
 
 def _pod_ready(pod: Any) -> bool:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ interface Session {
   owner: string;
   status: string;
   mode: SessionMode;
+  created_at: string | null;
   // User-set friendly name. Null when unset; UI falls back to the id slug.
   name: string | null;
 }
@@ -110,6 +111,7 @@ const DEMO_BASE_SESSIONS: Session[] = [
     owner: "preview",
     status: "Active",
     mode: "subscription",
+    created_at: new Date(Date.now() - 12 * 60 * 1000).toISOString(),
     name: "Claude Code",
   },
   {
@@ -118,6 +120,7 @@ const DEMO_BASE_SESSIONS: Session[] = [
     owner: "preview",
     status: "Active",
     mode: "codex_subscription",
+    created_at: new Date(Date.now() - 68 * 60 * 1000).toISOString(),
     name: "Codex",
   },
   {
@@ -126,6 +129,7 @@ const DEMO_BASE_SESSIONS: Session[] = [
     owner: "preview",
     status: "Active",
     mode: "pi_subscription",
+    created_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
     name: "Pi",
   },
 ];
@@ -312,6 +316,7 @@ function createDemoSession(mode: DefaultSessionMode, index: number): Session {
     owner: "preview",
     status: "Active",
     mode,
+    created_at: new Date().toISOString(),
     name: `${label} ${index}`,
   };
 }
@@ -525,6 +530,29 @@ function sessionDisplayName(session: Session): string {
   return session.name ?? defaultSessionName(session);
 }
 
+function formatRuntime(ms: number): string {
+  const minutes = Math.max(0, Math.floor(ms / 60_000));
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function sessionRuntimeLabel(session: Session, nowMs: number): string | null {
+  if (!session.created_at) return null;
+  const startedMs = Date.parse(session.created_at);
+  if (!Number.isFinite(startedMs)) return null;
+  return formatRuntime(nowMs - startedMs);
+}
+
+function sessionRuntimeTitle(session: Session, nowMs: number): string {
+  const startedMs = session.created_at ? Date.parse(session.created_at) : NaN;
+  const runtime = Number.isFinite(startedMs) ? formatRuntime(nowMs - startedMs) : "unknown";
+  return `running ${runtime}`;
+}
+
 function readGlimmungLaunchContext(): GlimmungLaunchContext | null {
   const params = new URLSearchParams(window.location.search);
   const runId = params.get("glimmung_run_id");
@@ -552,6 +580,7 @@ function clearGlimmungLaunchContext(): void {
 }
 
 const POLL_INTERVAL_MS = 1500;
+const SESSION_RUNTIME_TICK_MS = 30_000;
 
 function shiftArrowSessionDirection(event: KeyboardEvent): -1 | 1 | null {
   if (!event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return null;
@@ -928,6 +957,7 @@ function DemoLanding() {
               const statusDotClass = s.mode.startsWith("codex")
                 ? "status-dot status-codex-waiting"
                 : `status-dot status-${s.status.toLowerCase()}`;
+              const runtimeLabel = sessionRuntimeLabel(s, Date.now());
               return (
                 <li
                   key={s.id}
@@ -943,6 +973,11 @@ function DemoLanding() {
                     <button className="session-open" onClick={() => setActiveDemoSession(s.id)}>
                       <span className="session-id">{sessionDisplayName(s)}</span>
                     </button>
+                    {runtimeLabel && (
+                      <span className="session-runtime" title={sessionRuntimeTitle(s, Date.now())}>
+                        {runtimeLabel}
+                      </span>
+                    )}
                     <button
                       className="session-delete"
                       onClick={(e) => {
@@ -1000,6 +1035,7 @@ export function App() {
   const [booted, setBooted] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [active, setActive] = useState<string | null>(null);
@@ -1077,6 +1113,12 @@ export function App() {
 
   useEffect(() => {
     if (user) void refresh();
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    const t = setInterval(() => setNowMs(Date.now()), SESSION_RUNTIME_TICK_MS);
+    return () => clearInterval(t);
   }, [user]);
 
   useEffect(() => {
@@ -1535,6 +1577,7 @@ export function App() {
               const statusLabel = agentActivity
                 ? `${MODE_LABELS[s.mode]} ${agentActivity}`
                 : s.status;
+              const runtimeLabel = sessionRuntimeLabel(s, nowMs);
               return (
                 <li
                   key={s.id}
@@ -1587,6 +1630,15 @@ export function App() {
                       >
                         <span className="session-id">{sessionDisplayName(s)}</span>
                       </button>
+                    )}
+                    {runtimeLabel && (
+                      <span
+                        className="session-runtime"
+                        title={sessionRuntimeTitle(s, nowMs)}
+                        aria-label={sessionRuntimeTitle(s, nowMs)}
+                      >
+                        {runtimeLabel}
+                      </span>
                     )}
                     <button
                       className="session-delete"

--- a/frontend/src/StyleguideView.tsx
+++ b/frontend/src/StyleguideView.tsx
@@ -251,9 +251,9 @@ export function StyleguideView() {
           <h2 style={headStyle}>session row</h2>
           <p style={captionStyle}>
             One row per session in the sidebar list. Top: status dot + session
-            name + delete affordance. Bottom: mode chip + optional inline
-            actions (remote-control, save-credentials). Active row gets the
-            <code>is-open</code> class; not styled here for brevity.
+            name + compact runtime + delete affordance. Bottom: mode chip +
+            optional inline actions (remote-control, save-credentials). Active
+            row gets the <code>is-open</code> class; not styled here for brevity.
           </p>
           <ul className="sessions" style={{ maxWidth: 360, listStyle: "none", padding: 0, margin: 0 }}>
             <li>
@@ -262,6 +262,7 @@ export function StyleguideView() {
                 <button className="session-open" type="button">
                   <span className="session-id">my-session</span>
                 </button>
+                <span className="session-runtime" title="running 12m">12m</span>
                 <button className="session-delete" aria-label="delete session" type="button">
                   ×
                 </button>
@@ -279,6 +280,7 @@ export function StyleguideView() {
                 <button className="session-open" type="button">
                   <span className="session-id">starting…</span>
                 </button>
+                <span className="session-runtime" title="running less than 1m">&lt;1m</span>
                 <button className="session-delete" aria-label="delete session" type="button">
                   ×
                 </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -850,7 +850,7 @@ button:disabled {
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
-  padding-right: 28px;
+  padding-right: 68px;
 }
 
 .session-row-bottom {
@@ -901,6 +901,24 @@ button:disabled {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-runtime {
+  position: absolute;
+  right: 31px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-faint);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  min-width: 2rem;
+  text-align: right;
+  pointer-events: none;
+}
+
+.sessions li.is-open:not(.is-closing) .session-runtime {
+  color: var(--text-muted);
 }
 
 .session-delete {
@@ -989,6 +1007,7 @@ button:disabled {
 
 .sidebar.is-collapsed .session-open,
 .sidebar.is-collapsed .session-delete,
+.sidebar.is-collapsed .session-runtime,
 .sidebar.is-collapsed .session-row-bottom,
 .sidebar.is-collapsed .session-name-input {
   display: none;


### PR DESCRIPTION
## Summary
- expose session creation timestamps from Kubernetes Deployment metadata
- show compact elapsed runtime labels in sidebar session tabs before the close button
- update the styleguide/demo rows for the new indicator

## Checks
- python -m py_compile backend/src/tank_operator/sessions.py
- npm ci
- npm run build