### PR TITLE
Fix session-creation 500: counter doc was missing partition-key field

### DIFF
--- a/backend-go/internal/sessionregistry/write.go
+++ b/backend-go/internal/sessionregistry/write.go
@@ -3,7 +3,9 @@ package sessionregistry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -13,54 +15,102 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
 )
 
-// NextSessionID returns the next monotonic session ID using a per-scope counter
-// document. The counter is a simple integer stored as a Cosmos item.
-func (s *CosmosStore) NextSessionID(ctx context.Context) (string, error) {
-	counterID := "counter:" + s.scope
-	pk := azcosmos.NewPartitionKeyString(counterID)
+// counterPartitionKey is the partition value for the session-counter document.
+// The profiles container is partitioned on /email; the counter has no real
+// owner, so we stamp this sentinel as both the partition value and the doc's
+// email field. Must match the prior Python backend's value so the existing
+// counter row continues to advance monotonically across the rewrite.
+const counterPartitionKey = "__tank_operator_system__"
 
-	for attempt := 0; attempt < 5; attempt++ {
-		resp, err := s.container.ReadItem(ctx, pk, counterID, nil)
-		var current int64
+// NextSessionID returns the next monotonic session ID, allocated from a
+// per-scope counter document. Doc shape matches the Python implementation that
+// previously owned this counter: id=session-counter[:scope], partition value
+// __tank_operator_system__, field next_session_number is the value to return
+// on the NEXT call (i.e. the doc stores "next", not "last allocated").
+func (s *CosmosStore) NextSessionID(ctx context.Context) (string, error) {
+	counterID := compat.SessionCounterDocID(s.scope)
+	pk := azcosmos.NewPartitionKeyString(counterPartitionKey)
+
+	for attempt := 0; attempt < 20; attempt++ {
+		resp, readErr := s.container.ReadItem(ctx, pk, counterID, nil)
+
+		var next int64
 		var etag string
-		if err != nil {
-			current = 0
-			etag = ""
-		} else {
-			var doc struct {
-				Value int64 `json:"value"`
+		exists := false
+		if readErr == nil {
+			var existing struct {
+				NextSessionNumber int64 `json:"next_session_number"`
 			}
-			if jsonErr := json.Unmarshal(resp.Value, &doc); jsonErr == nil {
-				current = doc.Value
+			if err := json.Unmarshal(resp.Value, &existing); err != nil {
+				return "", fmt.Errorf("decode session counter: %w", err)
+			}
+			next = existing.NextSessionNumber
+			if next < 1 {
+				next = 1
 			}
 			etag = string(resp.ETag)
+			exists = true
+		} else if !isNotFound(readErr) {
+			return "", fmt.Errorf("read session counter: %w", readErr)
+		} else {
+			next = 1
 		}
 
-		next := current + 1
-		doc := map[string]any{
-			"id":    counterID,
-			"scope": s.scope,
-			"type":  "session_counter",
-			"value": next,
-		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		doc := buildCounterDoc(s.scope, next, exists, now)
 		raw, err := json.Marshal(doc)
 		if err != nil {
 			return "", err
 		}
 
-		var upsertErr error
-		if etag == "" {
-			_, upsertErr = s.container.CreateItem(ctx, pk, raw, nil)
-		} else {
+		var writeErr error
+		if exists {
 			opts := &azcosmos.ItemOptions{IfMatchEtag: (*azcore.ETag)(&etag)}
-			_, upsertErr = s.container.ReplaceItem(ctx, pk, counterID, raw, opts)
+			_, writeErr = s.container.ReplaceItem(ctx, pk, counterID, raw, opts)
+		} else {
+			_, writeErr = s.container.CreateItem(ctx, pk, raw, nil)
 		}
-		if upsertErr == nil {
+		if writeErr == nil {
 			return fmt.Sprintf("%d", next), nil
 		}
-		// Conflict (412) or already exists (409): retry.
+		if isConflict(writeErr) {
+			continue
+		}
+		return "", fmt.Errorf("allocate session id: %w", writeErr)
 	}
-	return "", fmt.Errorf("could not allocate session ID after retries")
+	return "", fmt.Errorf("could not allocate session ID after 20 retries")
+}
+
+// buildCounterDoc returns the Cosmos document body for the session counter.
+// The email field MUST equal counterPartitionKey because the profiles container
+// is partitioned on /email; a mismatch is a 400 BadRequest on every write.
+func buildCounterDoc(scope string, currentNext int64, exists bool, now string) map[string]any {
+	doc := map[string]any{
+		"id":                  compat.SessionCounterDocID(scope),
+		"type":                "session_counter",
+		"email":               counterPartitionKey,
+		"session_scope":       scope,
+		"next_session_number": currentNext + 1,
+		"updated_at":          now,
+	}
+	if !exists {
+		doc["created_at"] = now
+	}
+	return doc
+}
+
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}
+
+func isConflict(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusConflict ||
+		respErr.StatusCode == http.StatusPreconditionFailed
 }
 
 // Upsert writes or overwrites a session record in the registry.

--- a/backend-go/internal/sessionregistry/write_test.go
+++ b/backend-go/internal/sessionregistry/write_test.go
@@ -1,0 +1,53 @@
+package sessionregistry
+
+import "testing"
+
+// TestCounterDocCarriesPartitionKeyEmail pins the fix for the regression that
+// broke session creation after the Python→Go rewrite: the counter document
+// must carry an `email` field equal to the partition value the request header
+// claims, because the profiles container is partitioned on /email. Without
+// this, Cosmos rejects every write with 400 BadRequest.
+func TestCounterDocCarriesPartitionKeyEmail(t *testing.T) {
+	doc := buildCounterDoc("default", 60, true, "2026-05-11T14:00:00Z")
+
+	if got, want := doc["email"], counterPartitionKey; got != want {
+		t.Fatalf("email field = %q, want partition-key sentinel %q", got, want)
+	}
+	if got, want := doc["id"], "session-counter"; got != want {
+		t.Fatalf("id = %q, want %q (Python convention)", got, want)
+	}
+	if got, want := doc["next_session_number"], int64(61); got != want {
+		t.Fatalf("next_session_number = %v, want %v (stored value is next to allocate, not last allocated)", got, want)
+	}
+	if got, want := doc["type"], "session_counter"; got != want {
+		t.Fatalf("type = %q, want %q", got, want)
+	}
+	if got, want := doc["session_scope"], "default"; got != want {
+		t.Fatalf("session_scope = %q, want %q", got, want)
+	}
+	if _, hasCreated := doc["created_at"]; hasCreated {
+		t.Fatal("created_at present on existing-doc write — should only be set on first create")
+	}
+}
+
+func TestCounterDocSetsCreatedAtOnFirstCreate(t *testing.T) {
+	doc := buildCounterDoc("default", 1, false, "2026-05-11T14:00:00Z")
+
+	if got := doc["created_at"]; got != "2026-05-11T14:00:00Z" {
+		t.Fatalf("created_at = %v, want timestamp on first create", got)
+	}
+	if got, want := doc["next_session_number"], int64(2); got != want {
+		t.Fatalf("next_session_number on first create = %v, want 2 (so the returned id is 1)", got)
+	}
+}
+
+func TestCounterDocIDIncludesNonDefaultScope(t *testing.T) {
+	doc := buildCounterDoc("slot-a", 5, true, "2026-05-11T14:00:00Z")
+
+	if got, want := doc["id"], "session-counter:slot-a"; got != want {
+		t.Fatalf("id = %q, want %q for non-default scope", got, want)
+	}
+	if got, want := doc["session_scope"], "slot-a"; got != want {
+		t.Fatalf("session_scope = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Restore the Python counter-doc shape in `NextSessionID` so the existing Cosmos row keeps advancing across the Go rewrite. The new code re-uses `id=session-counter[:scope]`, partition value `__tank_operator_system__`, and the `next_session_number` field.
- Stamp `email = __tank_operator_system__` on the doc body — the bug. The `profiles` container is partitioned on `/email`, so a doc with no `email` field fails 400 BadRequest on every write; the retry loop exhausts and `POST /api/sessions` returns 500.
- Propagate non-404 read errors and non-conflict write errors instead of silently restarting the counter from 1 on transient failures.
- Pin the doc shape with `write_test.go` so the partition-key field can't go missing again.

## Why this slipped through

The Go rewrite's `Upsert` got `email` right because the function takes an `Email` argument. `NextSessionID` had no email-shaped parameter, so the counter doc was implemented from scratch post-compaction without re-reading [the Python `next_session_id`](https://github.com/nelsong6/tank-operator/blob/08b40b3%5E/backend/src/tank_operator/profiles.py#L342-L388). Unit tests pass because they use stubs — only a live Cosmos write reveals the partition-key mismatch.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] New `TestCounterDocCarriesPartitionKeyEmail` fails on the pre-fix shape
- [ ] After deploy: `POST /api/sessions` returns 201 and a `session-N` pod appears in `tank-operator-sessions`
- [ ] After deploy: existing session ID counter advances from where Python left off (no collision with sessions 1..60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)