### PR TITLE
Resolve session pods by label, not by name guess

### DIFF
--- a/backend-go/internal/sessions/manager.go
+++ b/backend-go/internal/sessions/manager.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -360,10 +361,14 @@ func (m *Manager) Create(ctx context.Context, owner, mode string, glimmungContex
 
 // Delete deletes a session pod and marks it deleted in the registry.
 func (m *Manager) Delete(ctx context.Context, owner, sessionID string) error {
-	podName := "session-" + sessionID
-	err := m.client.CoreV1().Pods(m.namespace).Delete(ctx, podName, metav1.DeleteOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return fmt.Errorf("delete pod: %w", err)
+	pod, err := m.findPodBySessionID(ctx, owner, sessionID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	if pod != nil {
+		if delErr := m.client.CoreV1().Pods(m.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
+			return fmt.Errorf("delete pod: %w", delErr)
+		}
 	}
 
 	m.mu.Lock()
@@ -396,9 +401,14 @@ func (m *Manager) SetName(ctx context.Context, owner, sessionID string, name *st
 		},
 	}
 	raw, _ := json.Marshal(patch)
-	podName := "session-" + sessionID
-	if _, err := m.client.CoreV1().Pods(m.namespace).Patch(ctx, podName, types.MergePatchType, raw, metav1.PatchOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		return Info{}, fmt.Errorf("patch pod name: %w", err)
+	pod, err := m.findPodBySessionID(ctx, owner, sessionID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return Info{}, err
+	}
+	if pod != nil {
+		if _, patchErr := m.client.CoreV1().Pods(m.namespace).Patch(ctx, pod.Name, types.MergePatchType, raw, metav1.PatchOptions{}); patchErr != nil && !k8serrors.IsNotFound(patchErr) {
+			return Info{}, fmt.Errorf("patch pod name: %w", patchErr)
+		}
 	}
 
 	if m.registry != nil {
@@ -437,9 +447,12 @@ func (m *Manager) patchAnnotation(ctx context.Context, owner, sessionID, annotat
 		},
 	}
 	raw, _ := json.Marshal(patch)
-	podName := "session-" + sessionID
-	if _, err := m.client.CoreV1().Pods(m.namespace).Patch(ctx, podName, types.MergePatchType, raw, metav1.PatchOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		return Info{}, fmt.Errorf("patch annotation %s: %w", annotation, err)
+	pod, err := m.findPodBySessionID(ctx, owner, sessionID)
+	if err != nil {
+		return Info{}, err
+	}
+	if _, patchErr := m.client.CoreV1().Pods(m.namespace).Patch(ctx, pod.Name, types.MergePatchType, raw, metav1.PatchOptions{}); patchErr != nil && !k8serrors.IsNotFound(patchErr) {
+		return Info{}, fmt.Errorf("patch annotation %s: %w", annotation, patchErr)
 	}
 	if m.events != nil {
 		m.events.Publish(owner)
@@ -457,17 +470,18 @@ func (m *Manager) GetByOwner(ctx context.Context, owner, sessionID string) (Info
 func (m *Manager) GetPodName(ctx context.Context, owner, sessionID string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, podReadyTimeout)
 	defer cancel()
-	podName := "session-" + sessionID
 	for {
-		pod, err := m.client.CoreV1().Pods(m.namespace).Get(ctx, podName, metav1.GetOptions{})
+		pod, err := m.findPodBySessionID(ctx, owner, sessionID)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return "", ErrNotFound
+			if errors.Is(err, ErrNotFound) {
+				select {
+				case <-ctx.Done():
+					return "", ErrNotFound
+				case <-time.After(500 * time.Millisecond):
+					continue
+				}
 			}
 			return "", err
-		}
-		if pod.Labels["tank-operator/owner"] != compat.OwnerLabel(owner) {
-			return "", ErrNotOwned
 		}
 		if podReady(pod) {
 			return pod.Name, nil
@@ -484,17 +498,18 @@ func (m *Manager) GetPodName(ctx context.Context, owner, sessionID string) (stri
 func (m *Manager) GetTerminalEndpoint(ctx context.Context, owner, sessionID string) (string, int, error) {
 	ctx, cancel := context.WithTimeout(ctx, podReadyTimeout)
 	defer cancel()
-	podName := "session-" + sessionID
 	for {
-		pod, err := m.client.CoreV1().Pods(m.namespace).Get(ctx, podName, metav1.GetOptions{})
+		pod, err := m.findPodBySessionID(ctx, owner, sessionID)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return "", 0, ErrNotFound
+			if errors.Is(err, ErrNotFound) {
+				select {
+				case <-ctx.Done():
+					return "", 0, ErrNotFound
+				case <-time.After(500 * time.Millisecond):
+					continue
+				}
 			}
 			return "", 0, err
-		}
-		if pod.Labels["tank-operator/owner"] != compat.OwnerLabel(owner) {
-			return "", 0, ErrNotOwned
 		}
 		if podReady(pod) && pod.Status.PodIP != "" {
 			return pod.Status.PodIP, compat.SandboxAgentPort, nil
@@ -505,6 +520,39 @@ func (m *Manager) GetTerminalEndpoint(ctx context.Context, owner, sessionID stri
 		case <-time.After(500 * time.Millisecond):
 		}
 	}
+}
+
+// findPodBySessionID resolves the session pod by label (preferred — handles
+// both the current "session-<id>" naming and legacy hash-suffixed names like
+// "session-189268a4e4" from earlier orchestrator versions). Falls back to a
+// by-name Get for the brief race between pod Create and the label cache
+// catching up. Returns ErrNotOwned if the pod exists but belongs to someone
+// else, ErrNotFound if no pod for this session_id is in the namespace.
+func (m *Manager) findPodBySessionID(ctx context.Context, owner, sessionID string) (*corev1.Pod, error) {
+	pods, err := m.client.CoreV1().Pods(m.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "tank-operator/session-id=" + sessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) > 0 {
+		pod := &pods.Items[0]
+		if pod.Labels["tank-operator/owner"] != compat.OwnerLabel(owner) {
+			return nil, ErrNotOwned
+		}
+		return pod, nil
+	}
+	pod, err := m.client.CoreV1().Pods(m.namespace).Get(ctx, "session-"+sessionID, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if pod.Labels["tank-operator/owner"] != compat.OwnerLabel(owner) {
+		return nil, ErrNotOwned
+	}
+	return pod, nil
 }
 
 // FindPodByIP returns the owner email and pod name for a session pod with the given IP.

--- a/backend-go/internal/sessions/manager_test.go
+++ b/backend-go/internal/sessions/manager_test.go
@@ -1,0 +1,71 @@
+package sessions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
+)
+
+// Pre-rewrite Python created session pods named "session-<hash>" rather than
+// "session-<id>"; those rows are still in Cosmos and the pods are still
+// Running. The Manager must resolve them via the session-id label, not by
+// guessing the name, or every send/run/file-op on legacy sessions 404s.
+func TestManagerResolvesLegacyPodNameForSessionInteractions(t *testing.T) {
+	pod := sessionPod("8", "nelson@romaine.life", corev1.PodRunning, true)
+	pod.Name = "session-189268a4e4"
+	client := fake.NewSimpleClientset(pod)
+	mgr := &Manager{client: client, namespace: compat.SessionsNamespace}
+
+	t.Run("GetPodName returns the actual pod name, not the computed one", func(t *testing.T) {
+		got, err := mgr.GetPodName(context.Background(), "nelson@romaine.life", "8")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "session-189268a4e4" {
+			t.Fatalf("pod name = %q, want %q (must read the real name from the label-selector lookup, not assume session-<id>)", got, "session-189268a4e4")
+		}
+	})
+
+	t.Run("GetTerminalEndpoint returns endpoint for the legacy pod", func(t *testing.T) {
+		updated := pod.DeepCopy()
+		updated.Status.PodIP = "10.0.0.42"
+		if _, err := client.CoreV1().Pods(compat.SessionsNamespace).UpdateStatus(context.Background(), updated, metav1.UpdateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		ip, port, err := mgr.GetTerminalEndpoint(context.Background(), "nelson@romaine.life", "8")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ip != "10.0.0.42" || port != compat.SandboxAgentPort {
+			t.Fatalf("endpoint = %s:%d, want 10.0.0.42:%d", ip, port, compat.SandboxAgentPort)
+		}
+	})
+}
+
+func TestManagerFindPodRejectsWrongOwner(t *testing.T) {
+	pod := sessionPod("8", "someone-else@example.com", corev1.PodRunning, true)
+	pod.Name = "session-189268a4e4"
+	client := fake.NewSimpleClientset(pod)
+	mgr := &Manager{client: client, namespace: compat.SessionsNamespace}
+
+	_, err := mgr.findPodBySessionID(context.Background(), "nelson@romaine.life", "8")
+	if !errors.Is(err, ErrNotOwned) {
+		t.Fatalf("err = %v, want ErrNotOwned (label-selector path should reject when owner label doesn't match)", err)
+	}
+}
+
+func TestManagerFindPodReturnsNotFoundWhenAbsent(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	mgr := &Manager{client: client, namespace: compat.SessionsNamespace}
+
+	_, err := mgr.findPodBySessionID(context.Background(), "nelson@romaine.life", "999")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary

Several `Manager` methods — `Delete`, `SetName`, `patchAnnotation`, `GetPodName`, `GetTerminalEndpoint` — computed the target pod name as `"session-" + sessionID` and operated on it directly. The `Reader` already handled the older `session-<hash>` naming via a `tank-operator/session-id` label fallback, but the `Manager` write paths never picked that up — so any legacy session was readable but errored on every write (send message, run WebSocket, file ops, patch annotations, delete).

Adds `findPodBySessionID` to the manager: list by `tank-operator/session-id=<id>` label first, fall back to a by-name Get for the brief race between Create and the list-cache catching up. Validates the owner label in both branches. All five callers switched over and now address pods by the real `pod.Name` returned from the lookup.

Side benefit: `Delete` now performs the owner check it was missing before — the previous code happily ran `MarkDeleted` on the registry row whether or not the caller owned the pod (silently no-op'd the K8s delete when the computed name didn't exist).

## Test plan

- [x] `go build ./... && go test ./... && go vet ./...`
- [x] New `TestManagerResolvesLegacyPodNameForSessionInteractions` fails on the pre-fix code (it would 404 on `session-8`-the-guess instead of finding `session-189268a4e4`-the-real-pod).
- [x] `TestManagerFindPodRejectsWrongOwner` covers the new ownership check.
- [ ] After deploy: orphan session "wait for go fefactor - ui overlap" (pod `session-189268a4e4`) accepts a new message without 404.

## Context

This is the third regression in the Go rewrite of the orchestrator (#373). Previous: [#376](https://github.com/nelsong6/tank-operator/pull/376) for the create-session 500. Still outstanding: `MarkCompleted`-on-transport-error in the run-WS handler, to be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)