### PR TITLE
Don't mark run completed on transport drops while agent is alive

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_run.go
+++ b/backend-go/cmd/tank-operator/handlers_run.go
@@ -157,13 +157,44 @@ func (s *appServer) handleRunWebSocket(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("run stream ended", "session", sessionID, "run_id", runID, "err", streamErr)
 	}
 
-	// Mark run completed.
+	// Only mark the run completed if the detached agent process is actually
+	// gone. The stream WebSocket can return on transport-level events that
+	// leave the agent inside the pod running — the AKS apiserver kills exec
+	// connections every few hours, and a tab close drops the WebSocket on
+	// purpose without cancelling the pod. In both cases, marking the run
+	// completed would hide it from /run/active so the next reconnect would
+	// see no run and lose the live stream. Use a fresh context: r.Context()
+	// is typically cancelled by the time we get here.
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cleanupCancel()
+	if !s.agentRunDone(cleanupCtx, podName, pidPath) {
+		slog.Info("run stream ended with agent still running; leaving active row",
+			"session", sessionID, "run_id", runID)
+		return
+	}
 	if s.activeRuns != nil {
-		_ = s.activeRuns.MarkCompleted(ctx, sessionID, runID)
+		_ = s.activeRuns.MarkCompleted(cleanupCtx, sessionID, runID)
 	}
 	if s.runEvents != nil {
-		_, _ = s.runEvents.Append(ctx, email, sessionID, runID, "run.completed", map[string]any{})
+		_, _ = s.runEvents.Append(cleanupCtx, email, sessionID, runID, "run.completed", map[string]any{})
 	}
+}
+
+// agentRunDone reports whether the detached agent process for a run has
+// exited inside the pod. Used to decide whether MarkCompleted is safe: a
+// premature MarkCompleted hides the run from /run/active and breaks any
+// future reconnect. False on exec errors — conservative bias is to leave
+// the row alone; handleGetActiveRun's own liveness probe will reconcile.
+func (s *appServer) agentRunDone(ctx context.Context, podName, pidPath string) bool {
+	script := fmt.Sprintf(
+		`pid=$(cat %s 2>/dev/null); if [ -z "$pid" ]; then echo D; exit 0; fi; if kill -0 "$pid" 2>/dev/null; then echo A; else echo D; fi; exit 0`,
+		shellQ(pidPath),
+	)
+	out, err := kubeexec.Capture(ctx, s.k8s, s.restCfg, s.namespace, podName, []string{"bash", "-lc", script})
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "D"
 }
 
 // handleGetActiveRun returns the currently active run for a session.


### PR DESCRIPTION
## Summary

`handleRunWebSocket` unconditionally called `activeRuns.MarkCompleted` after `StreamToWebSocket` returned, regardless of why the stream ended. The K8s exec stream returns errors for transport-layer events that have nothing to do with run completion — most commonly the AKS apiserver killing exec connections every few hours, or a browser tab close (which is the intended protocol; the pod is supposed to keep running).

In both cases the detached agent inside the pod kept running, but the active-run row got `status=completed`, which `GetActive` filters out. The next reconnect saw no active run, the frontend couldn't attach to the live stream, and the user had to send a fresh message to recover. (Confirmed live earlier today on session 60: PID 24143 still alive and writing to its stream file long after the orchestrator gave up at the timeout.)

Gate `MarkCompleted` (and the `run.completed` event append) on a pid-file liveness probe inside the pod: if `cat $pid && kill -0` reports the agent still alive, leave the row alone. Mirrors the shape `handleGetActiveRun` already uses for run-liveness checks. Run cleanup under a fresh context because `r.Context()` is typically cancelled by the time we reach this point.

Conservative on probe errors: treat "couldn't determine" as "still alive" and skip `MarkCompleted`. `handleGetActiveRun`'s own poll will reconcile via the same kind of check if the agent really did die.

## Test plan

- [x] `go build ./... && go test ./... && go vet ./...`
- [ ] After deploy: open a long-running session, wait for an AKS exec timeout (or close the tab and reopen), confirm `/run/active` still returns the run and the stream reconnects.

## Why no unit test

The decision lives in a Capture roundtrip that the existing tests don't have infrastructure to mock. The bash script logic mirrors the already-deployed `handleGetActiveRun` probe so the risk surface is small. Happy to add an interface seam + mock if reviewers want one.

## Context

Third regression from the Go rewrite (#373) cleanup; prior: [#376](https://github.com/nelsong6/tank-operator/pull/376) (create-session 500), [#377](https://github.com/nelsong6/tank-operator/pull/377) (orphaned legacy session pods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)