### PR TITLE
Add KV signing key for session-JWT RS256 migration

### DIFF
--- a/infra/jwt_signing_key.tf
+++ b/infra/jwt_signing_key.tf
@@ -1,0 +1,50 @@
+# ============================================================================
+# Tank-operator session-JWT signing key — Key Vault Keys API
+# ============================================================================
+# RSA key used to sign the orchestrator's session and install-state JWTs.
+# Lives in Key Vault as a Key (not a Secret) so the private bytes never leave
+# the vault — the orchestrator pod calls KV's sign operation per token mint
+# (a few times per user per week), and verifies in-process using the cached
+# public key. Trades a one-time ~50ms KV roundtrip on login for the property
+# that a compromised orchestrator pod can verify but cannot forge tokens.
+#
+# Replaces the prior HS256 shared-secret design (random_password →
+# azurerm_key_vault_secret.jwt_secret) where the secret bytes lived in the
+# pod's env and any process that could exec into tank-operator could mint a
+# JWT for any allowlisted email.
+#
+# Rotation: bump curve_or_size or run `az keyvault key rotate`; KV creates a
+# new version while old versions still verify. The minter stamps `kid` (= key
+# version) in the JWT header so the verifier can resolve the right public key
+# per token during rollover.
+#
+# Hard cutover from HS256: the existing tank-operator-jwt-secret KV secret
+# remains in place during the deploy of the verifier-switch PR so any
+# orchestrator pods still on the prior image keep working until they roll;
+# a follow-up will remove that resource once the rollout is settled.
+# ============================================================================
+
+resource "azurerm_key_vault_key" "tank_operator_jwt" {
+  name         = "tank-operator-jwt-signing"
+  key_vault_id = data.azurerm_key_vault.main.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  # The minimum set the orchestrator needs: sign with the private key in KV,
+  # publish the public key for in-process verification. No encrypt/wrap/etc.
+  key_opts = [
+    "sign",
+    "verify",
+  ]
+}
+
+# `Key Vault Crypto User` is the narrowest built-in role that grants both
+# `Microsoft.KeyVault/vaults/keys/read` (needed to fetch the public key for
+# verification) and the data-plane `sign`/`verify` operations. The next role
+# up (`Crypto Officer`) would also allow key creation and deletion — that
+# belongs to the infra deployment identity, not the orchestrator pod.
+resource "azurerm_role_assignment" "orchestrator_jwt_crypto_user" {
+  scope                = azurerm_key_vault_key.tank_operator_jwt.resource_versionless_id
+  role_definition_name = "Key Vault Crypto User"
+  principal_id         = azurerm_user_assigned_identity.credential_refresher.principal_id
+}


### PR DESCRIPTION
## Summary

Adds the Key Vault Key (RSA 2048, sign/verify) the orchestrator will use to sign session JWTs once the verifier-switch lands in the follow-up. Storing it as a KV **Key** rather than a KV **Secret** keeps the private bytes non-exportable — the orchestrator pod calls KV's `sign` operation per mint (rare, login-only) and verifies in-process using the cached public key.

Grants the orchestrator UAMI `Key Vault Crypto User` on this single key. That's the narrowest built-in role that covers both reading the public key for verification and the data-plane `sign`/`verify` operations. Scope is the key (not the vault) so the orchestrator can sign with this one key and nothing else.

This PR is **infra-only**. The existing `tank-operator-jwt-secret` KV secret stays in place so running orchestrator pods on the prior image keep working. The follow-up PR swaps the verifier code to RS256, points the Helm chart at the new key, and a third PR removes the legacy secret once the new image has fully rolled.

## Test plan

- [x] `tofu plan` from CI shows just the two new resources (key + role assignment), no churn elsewhere.
- [ ] After merge: `tofu apply` succeeds; `az keyvault key show --vault-name <kv> --name tank-operator-jwt-signing` returns the key.
- [ ] Role check: `az role assignment list --assignee <uami-principal-id> --scope <key-id>` shows `Key Vault Crypto User`.

## Why this comes first, alone

Tofu auto-applies on push to main, and the follow-up Helm change will reference the key. Landing infra first means the key exists before the next image build. If they shipped together there's a brief window where the new pod could boot before tofu finishes — both ought to win the race in practice (tofu is faster than the Docker build) but separating it makes the order explicit.

## Context

Background on why we're moving off the shared HS256 secret: [discussed in the parent thread](https://github.com/nelsong6/tank-operator/pull/376) — the JWT_SECRET env var on the orchestrator pod means any process that can `kubectl exec` into the namespace can mint a token for any allowlisted email, which is the wrong trust model for the multi-tenant LLM-as-a-service direction in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)