### PR TITLE
tofu: allow apply on workflow_dispatch

### DIFF
--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -79,7 +79,12 @@ jobs:
         run: tofu plan -out=tfplan
 
       - name: tofu apply
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # Apply on push to main (the normal path), and on manual
+        # workflow_dispatch so an out-of-band rerun (recovering from a
+        # failed apply, etc.) doesn't need an empty commit to retrigger.
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'workflow_dispatch'
         working-directory: infra
         env:
           TF_VAR_github_pat: ${{ steps.secrets.outputs.github_pat }}


### PR DESCRIPTION
## Summary

The apply step was gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`. That means re-running an apply out-of-band (e.g., to recover after a failed apply once permissions are granted) required pushing an empty/no-op commit to main and relying on the path filter to catch it. Allowing `workflow_dispatch` to apply means `gh workflow run tofu.yml --ref main` does the right thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)