### PR TITLE
Switch session JWT from HS256 to RS256 with KV Keys API

### DIFF
--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -70,11 +70,15 @@ func main() {
 		APIProxyHost:     os.Getenv("CLAUDE_API_PROXY_HOST"),
 	})
 
-	// 9. Init auth verifier and minter.
-	jwtSecret := os.Getenv("JWT_SECRET")
+	// 9. Init auth signer + verifier (RS256, signing key in KV).
+	jwtKey, err := buildJWTSigner(azCred)
+	if err != nil {
+		slog.Error("JWT signing key failed", "error", err)
+		os.Exit(1)
+	}
 	allowedEmails := os.Getenv("ALLOWED_EMAILS")
-	verifier := auth.NewVerifier(jwtSecret, allowedEmails)
-	minter := auth.NewMinter(jwtSecret, allowedEmails)
+	verifier := auth.NewVerifier(jwtKey, allowedEmails)
+	minter := auth.NewMinter(jwtKey, jwtKey, allowedEmails)
 
 	// 10. Start reaper.
 	ctx := context.Background()
@@ -128,6 +132,23 @@ func loadKubeConfig() (*rest.Config, error) {
 		}
 	}
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// buildJWTSigner constructs the Key Vault-backed JWT signer/verifier the
+// orchestrator uses for its session and install-state tokens. Required:
+// JWT_KV_VAULT (vault DNS URL) and JWT_KV_KEY_NAME (key name within the
+// vault). Returns an error if either is unset or KV is unreachable —
+// the orchestrator must not silently fall back to an unsigned/HS256 path.
+func buildJWTSigner(azCred *azidentity.DefaultAzureCredential) (*auth.KeyVaultJWT, error) {
+	vaultURL := strings.TrimSpace(os.Getenv("JWT_KV_VAULT"))
+	keyName := strings.TrimSpace(os.Getenv("JWT_KV_KEY_NAME"))
+	if vaultURL == "" || keyName == "" {
+		return nil, fmt.Errorf("JWT_KV_VAULT and JWT_KV_KEY_NAME must be set")
+	}
+	if azCred == nil {
+		return nil, fmt.Errorf("azure credential not available")
+	}
+	return auth.NewKeyVaultJWT(vaultURL, keyName, azCred)
 }
 
 func buildProfileStore(azCred *azidentity.DefaultAzureCredential) profilesStore {

--- a/backend-go/cmd/tank-operator/main_test.go
+++ b/backend-go/cmd/tank-operator/main_test.go
@@ -65,7 +65,7 @@ func TestConfig(t *testing.T) {
 
 func TestAuthenticatedListSessionsUsesTokenEmail(t *testing.T) {
 	reader := &fakeSessionReader{listOut: []sessions.Info{{ID: "1", Owner: "user@example.com"}}}
-	handler := authenticatedListSessions(auth.NewVerifier("secret", "user@example.com"), reader)
+	handler := authenticatedListSessions(auth.NewVerifier(testJWT(t), "user@example.com"), reader)
 	request := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
 	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
 	response := httptest.NewRecorder()
@@ -89,7 +89,7 @@ func TestAuthenticatedListSessionsUsesTokenEmail(t *testing.T) {
 
 func TestAuthenticatedGetSessionUsesTokenEmail(t *testing.T) {
 	reader := &fakeSessionReader{getOut: sessions.Info{ID: "2", Owner: "user@example.com"}}
-	handler := authenticatedGetSession(auth.NewVerifier("secret", "user@example.com"), reader)
+	handler := authenticatedGetSession(auth.NewVerifier(testJWT(t), "user@example.com"), reader)
 	request := httptest.NewRequest(http.MethodGet, "/api/sessions/2", nil)
 	request.SetPathValue("session_id", "2")
 	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
@@ -107,7 +107,7 @@ func TestAuthenticatedGetSessionUsesTokenEmail(t *testing.T) {
 
 func TestAuthenticatedGetSessionHidesNotOwned(t *testing.T) {
 	reader := &fakeSessionReader{getErr: sessions.ErrNotOwned}
-	handler := authenticatedGetSession(auth.NewVerifier("secret", "user@example.com"), reader)
+	handler := authenticatedGetSession(auth.NewVerifier(testJWT(t), "user@example.com"), reader)
 	request := httptest.NewRequest(http.MethodGet, "/api/sessions/2", nil)
 	request.SetPathValue("session_id", "2")
 	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
@@ -121,7 +121,7 @@ func TestAuthenticatedGetSessionHidesNotOwned(t *testing.T) {
 }
 
 func TestAuthenticatedListSessionsRejectsUnauthenticated(t *testing.T) {
-	handler := authenticatedListSessions(auth.NewVerifier("secret", "user@example.com"), &fakeSessionReader{})
+	handler := authenticatedListSessions(auth.NewVerifier(testJWT(t), "user@example.com"), &fakeSessionReader{})
 	response := httptest.NewRecorder()
 
 	handler(response, httptest.NewRequest(http.MethodGet, "/api/sessions", nil))
@@ -134,7 +134,7 @@ func TestAuthenticatedListSessionsRejectsUnauthenticated(t *testing.T) {
 func TestMe(t *testing.T) {
 	login := "octocat"
 	installationID := int64(123)
-	verifier := auth.NewVerifier("secret", "user@example.com")
+	verifier := auth.NewVerifier(testJWT(t), "user@example.com")
 	handler := me(verifier, fakeProfileStore{profile: profiles.Profile{
 		Email:          "user@example.com",
 		GitHubLogin:    &login,
@@ -163,7 +163,7 @@ func TestMe(t *testing.T) {
 
 func TestMeReturnsProfileError(t *testing.T) {
 	handler := me(
-		auth.NewVerifier("secret", "user@example.com"),
+		auth.NewVerifier(testJWT(t), "user@example.com"),
 		fakeProfileStore{err: errors.New("profile failed")},
 	)
 	request := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
@@ -178,7 +178,7 @@ func TestMeReturnsProfileError(t *testing.T) {
 }
 
 func TestMeRejectsUnauthenticated(t *testing.T) {
-	handler := me(auth.NewVerifier("secret", "user@example.com"), profiles.StubStore{})
+	handler := me(auth.NewVerifier(testJWT(t), "user@example.com"), profiles.StubStore{})
 	response := httptest.NewRecorder()
 
 	handler(response, httptest.NewRequest(http.MethodGet, "/api/auth/me", nil))
@@ -188,18 +188,35 @@ func TestMeRejectsUnauthenticated(t *testing.T) {
 	}
 }
 
-func signedMainToken(t *testing.T, secret, email string) string {
+// testJWT returns a process-singleton InMemoryJWT so verifier and signed-token
+// helpers in this file share the same key — necessary because each test now
+// constructs a verifier and a token separately and they must agree on the kid.
+var sharedTestJWT *auth.InMemoryJWT
+
+func testJWT(t *testing.T) *auth.InMemoryJWT {
 	t.Helper()
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+	if sharedTestJWT != nil {
+		return sharedTestJWT
+	}
+	j, err := auth.NewInMemoryJWT("main-test-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sharedTestJWT = j
+	return j
+}
+
+func signedMainToken(t *testing.T, _ /*legacy secret arg*/, email string) string {
+	t.Helper()
+	tok, err := testJWT(t).MintJWT(context.Background(), jwt.MapClaims{
 		"sub":   "sub-1",
 		"email": email,
 		"name":  "User",
 		"iat":   time.Now().Unix(),
 		"exp":   time.Now().Add(time.Hour).Unix(),
 	})
-	signed, err := token.SignedString([]byte(secret))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return signed
+	return tok
 }

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -10,6 +10,8 @@ github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0/go.mod h1:Y2b/1clN4zsAoUd/pgNAQHjLDnTis/6ROkUfyob6psM=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0/go.mod h1:gpl+q95AzZlKVI3xSoseF9QPrypk0hQqBiJYeB/cR/I=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=

--- a/backend-go/internal/auth/auth.go
+++ b/backend-go/internal/auth/auth.go
@@ -1,17 +1,24 @@
 package auth
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
 const CookieName = "auth_token"
+
+// keyResolveTimeout caps how long a verify call can spend fetching a missing
+// public key from KV. Verify is on the request path; a stalled KV call must
+// not block forever.
+const keyResolveTimeout = 5 * time.Second
 
 type User struct {
 	Sub   string
@@ -20,11 +27,11 @@ type User struct {
 }
 
 type Verifier struct {
-	secret        []byte
+	resolver      KeyResolver
 	allowedEmails map[string]struct{}
 }
 
-func NewVerifier(secret, allowedEmails string) *Verifier {
+func NewVerifier(resolver KeyResolver, allowedEmails string) *Verifier {
 	allowed := map[string]struct{}{}
 	for _, email := range strings.Split(allowedEmails, ",") {
 		normalized := strings.ToLower(strings.TrimSpace(email))
@@ -32,7 +39,7 @@ func NewVerifier(secret, allowedEmails string) *Verifier {
 			allowed[normalized] = struct{}{}
 		}
 	}
-	return &Verifier{secret: []byte(secret), allowedEmails: allowed}
+	return &Verifier{resolver: resolver, allowedEmails: allowed}
 }
 
 func (v *Verifier) CurrentUser(r *http.Request) (User, error) {
@@ -44,15 +51,21 @@ func (v *Verifier) CurrentUser(r *http.Request) (User, error) {
 }
 
 func (v *Verifier) Decode(tokenString string) (User, error) {
-	if len(v.secret) == 0 {
-		return User{}, errHTTP{status: http.StatusInternalServerError, message: "JWT_SECRET not configured"}
+	if v.resolver == nil {
+		return User{}, errHTTP{status: http.StatusInternalServerError, message: "JWT key resolver not configured"}
 	}
 	claims := jwt.MapClaims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (any, error) {
-		if token.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+		if token.Method.Alg() != jwt.SigningMethodRS256.Alg() {
 			return nil, fmt.Errorf("unexpected signing method: %s", token.Method.Alg())
 		}
-		return v.secret, nil
+		kid, _ := token.Header["kid"].(string)
+		if kid == "" {
+			return nil, errors.New("token missing kid")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), keyResolveTimeout)
+		defer cancel()
+		return v.resolver.PublicKey(ctx, kid)
 	})
 	if err != nil || !token.Valid {
 		if err == nil {

--- a/backend-go/internal/auth/auth_test.go
+++ b/backend-go/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,8 +12,9 @@ import (
 )
 
 func TestVerifierAcceptsBearerToken(t *testing.T) {
-	verifier := NewVerifier("secret", "USER@example.com")
-	token := signedToken(t, "secret", "user@example.com")
+	jwtKey := newTestJWT(t)
+	verifier := NewVerifier(jwtKey, "USER@example.com")
+	token := signedTestToken(t, jwtKey, "user@example.com", nil)
 	request := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
 	request.Header.Set("Authorization", "Bearer "+token)
 
@@ -26,9 +28,10 @@ func TestVerifierAcceptsBearerToken(t *testing.T) {
 }
 
 func TestVerifierAcceptsCookie(t *testing.T) {
-	verifier := NewVerifier("secret", "user@example.com")
+	jwtKey := newTestJWT(t)
+	verifier := NewVerifier(jwtKey, "user@example.com")
 	request := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
-	request.AddCookie(&http.Cookie{Name: CookieName, Value: signedToken(t, "secret", "user@example.com")})
+	request.AddCookie(&http.Cookie{Name: CookieName, Value: signedTestToken(t, jwtKey, "user@example.com", nil)})
 
 	if _, err := verifier.CurrentUser(request); err != nil {
 		t.Fatalf("CurrentUser returned error: %v", err)
@@ -36,7 +39,7 @@ func TestVerifierAcceptsCookie(t *testing.T) {
 }
 
 func TestVerifierRejectsMissingAuthentication(t *testing.T) {
-	verifier := NewVerifier("secret", "user@example.com")
+	verifier := NewVerifier(newTestJWT(t), "user@example.com")
 	_, err := verifier.CurrentUser(httptest.NewRequest(http.MethodGet, "/api/auth/me", nil))
 	if err == nil || ErrorStatus(err) != http.StatusUnauthorized || !strings.Contains(err.Error(), "missing authentication") {
 		t.Fatalf("err = %v, status = %d", err, ErrorStatus(err))
@@ -44,10 +47,73 @@ func TestVerifierRejectsMissingAuthentication(t *testing.T) {
 }
 
 func TestVerifierRejectsDisallowedEmail(t *testing.T) {
-	verifier := NewVerifier("secret", "allowed@example.com")
-	_, err := verifier.Decode(signedToken(t, "secret", "other@example.com"))
+	jwtKey := newTestJWT(t)
+	verifier := NewVerifier(jwtKey, "allowed@example.com")
+	_, err := verifier.Decode(signedTestToken(t, jwtKey, "other@example.com", nil))
 	if err == nil || ErrorStatus(err) != http.StatusForbidden {
 		t.Fatalf("err = %v, status = %d", err, ErrorStatus(err))
+	}
+}
+
+func TestVerifierRejectsHS256Tokens(t *testing.T) {
+	verifier := NewVerifier(newTestJWT(t), "user@example.com")
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":   "sub-1",
+		"email": "user@example.com",
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(time.Hour).Unix(),
+	})
+	hs256, err := tok.SignedString([]byte("legacy-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.Decode(hs256); err == nil || ErrorStatus(err) != http.StatusUnauthorized {
+		t.Fatalf("HS256 token accepted; want 401. err = %v", err)
+	}
+}
+
+func TestMinterIssuesVerifiableSession(t *testing.T) {
+	jwtKey := newTestJWT(t)
+	minter := NewMinter(jwtKey, jwtKey, "user@example.com")
+	tok, err := minter.MintSession("sub-1", "user@example.com", "User")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := NewVerifier(jwtKey, "user@example.com")
+	got, err := verifier.Decode(tok)
+	if err != nil {
+		t.Fatalf("minted token did not verify: %v", err)
+	}
+	if got.Email != "user@example.com" || got.Sub != "sub-1" {
+		t.Fatalf("user = %#v", got)
+	}
+}
+
+func TestInstallStateRoundtrips(t *testing.T) {
+	jwtKey := newTestJWT(t)
+	minter := NewMinter(jwtKey, jwtKey, "user@example.com")
+	tok, err := minter.MintInstallState("user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	email, err := minter.VerifyInstallState(tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != "user@example.com" {
+		t.Fatalf("email = %q, want %q", email, "user@example.com")
+	}
+}
+
+func TestInstallStateRejectsSessionTokenWithDifferentAudience(t *testing.T) {
+	jwtKey := newTestJWT(t)
+	minter := NewMinter(jwtKey, jwtKey, "user@example.com")
+	sessionTok, err := minter.MintSession("sub-1", "user@example.com", "User")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := minter.VerifyInstallState(sessionTok); err == nil {
+		t.Fatal("session token accepted as install-state token; audience check broken")
 	}
 }
 
@@ -59,18 +125,30 @@ func TestGravatarURLMatchesPython(t *testing.T) {
 	}
 }
 
-func signedToken(t *testing.T, secret, email string) string {
+func newTestJWT(t *testing.T) *InMemoryJWT {
 	t.Helper()
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+	j, err := NewInMemoryJWT("test-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return j
+}
+
+func signedTestToken(t *testing.T, jwtKey *InMemoryJWT, email string, extra jwt.MapClaims) string {
+	t.Helper()
+	claims := jwt.MapClaims{
 		"sub":   "sub-1",
 		"email": email,
 		"name":  "User",
 		"iat":   time.Now().Unix(),
 		"exp":   time.Now().Add(time.Hour).Unix(),
-	})
-	signed, err := token.SignedString([]byte(secret))
+	}
+	for k, v := range extra {
+		claims[k] = v
+	}
+	tok, err := jwtKey.MintJWT(context.Background(), claims)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return signed
+	return tok
 }

--- a/backend-go/internal/auth/inmemory_signer.go
+++ b/backend-go/internal/auth/inmemory_signer.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// InMemoryJWT is a test-only Signer + KeyResolver. Generates an ephemeral
+// RSA key, signs in-process, resolves its own kid. Lets unit tests exercise
+// the Verifier/Minter without standing up Key Vault.
+type InMemoryJWT struct {
+	priv *rsa.PrivateKey
+	pub  *rsa.PublicKey
+	kid  string
+}
+
+func NewInMemoryJWT(kid string) (*InMemoryJWT, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	if kid == "" {
+		kid = "test"
+	}
+	return &InMemoryJWT{priv: priv, pub: &priv.PublicKey, kid: kid}, nil
+}
+
+func (m *InMemoryJWT) MintJWT(_ context.Context, claims jwt.MapClaims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = m.kid
+	return token.SignedString(m.priv)
+}
+
+func (m *InMemoryJWT) PublicKey(_ context.Context, kid string) (*rsa.PublicKey, error) {
+	if kid != m.kid {
+		return nil, fmt.Errorf("unknown kid %q", kid)
+	}
+	return m.pub, nil
+}

--- a/backend-go/internal/auth/keyvault_signer.go
+++ b/backend-go/internal/auth/keyvault_signer.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// currentKIDTTL controls how stale the cached "what version is current"
+// answer can be. After rotation, mints lag by at most this duration before
+// switching to the new version. Verification is unaffected (verifier
+// resolves whichever kid the JWT carries, regardless of "current").
+const currentKIDTTL = 60 * time.Second
+
+// KeyVaultJWT signs and verifies session JWTs against an Azure Key Vault Key.
+// The private key never leaves KV — minting is a remote `Sign` call; verifying
+// fetches the public key (cached per kid) and validates in-process.
+type KeyVaultJWT struct {
+	client  *azkeys.Client
+	keyName string
+
+	currentMu     sync.Mutex
+	currentKID    string
+	currentExpiry time.Time
+
+	keysMu sync.RWMutex
+	keys   map[string]*rsa.PublicKey
+}
+
+// NewKeyVaultJWT constructs a JWT signer/resolver backed by `<keyName>` in the
+// vault at `vaultURL`. Both Signer and KeyResolver are satisfied by the
+// returned value; tests use the InMemoryJWT impl below.
+func NewKeyVaultJWT(vaultURL, keyName string, cred azcore.TokenCredential) (*KeyVaultJWT, error) {
+	client, err := azkeys.NewClient(vaultURL, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("azkeys client: %w", err)
+	}
+	return &KeyVaultJWT{
+		client:  client,
+		keyName: keyName,
+		keys:    map[string]*rsa.PublicKey{},
+	}, nil
+}
+
+// MintJWT builds an RS256 JWT from claims, signs it remotely in Key Vault.
+func (j *KeyVaultJWT) MintJWT(ctx context.Context, claims jwt.MapClaims) (string, error) {
+	kid, err := j.currentKIDCached(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve current kid: %w", err)
+	}
+
+	header := map[string]string{"alg": "RS256", "typ": "JWT", "kid": kid}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := b64URL(headerJSON) + "." + b64URL(payloadJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+
+	resp, err := j.client.Sign(ctx, j.keyName, kid, azkeys.SignParameters{
+		Algorithm: to.Ptr(azkeys.SignatureAlgorithmRS256),
+		Value:     digest[:],
+	}, nil)
+	if err != nil {
+		return "", fmt.Errorf("kv sign: %w", err)
+	}
+	if resp.Result == nil {
+		return "", fmt.Errorf("kv sign: empty signature")
+	}
+	return signingInput + "." + b64URL(resp.Result), nil
+}
+
+// PublicKey resolves a kid (= KV key version) to its RSA public key, caching
+// the result indefinitely. Versions are immutable in KV, so a hit on the
+// cache is always correct; misses fall through to a GetKey call.
+func (j *KeyVaultJWT) PublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	if kid == "" {
+		return nil, fmt.Errorf("missing kid")
+	}
+	j.keysMu.RLock()
+	if k, ok := j.keys[kid]; ok {
+		j.keysMu.RUnlock()
+		return k, nil
+	}
+	j.keysMu.RUnlock()
+
+	resp, err := j.client.GetKey(ctx, j.keyName, kid, nil)
+	if err != nil {
+		return nil, fmt.Errorf("kv get key: %w", err)
+	}
+	if resp.Key == nil {
+		return nil, fmt.Errorf("kv get key: empty key bundle")
+	}
+	pub, err := jwkToRSAPublic(resp.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	j.keysMu.Lock()
+	j.keys[kid] = pub
+	j.keysMu.Unlock()
+	return pub, nil
+}
+
+func (j *KeyVaultJWT) currentKIDCached(ctx context.Context) (string, error) {
+	j.currentMu.Lock()
+	defer j.currentMu.Unlock()
+	if j.currentKID != "" && time.Now().Before(j.currentExpiry) {
+		return j.currentKID, nil
+	}
+	resp, err := j.client.GetKey(ctx, j.keyName, "", nil)
+	if err != nil {
+		return "", fmt.Errorf("kv get current key: %w", err)
+	}
+	if resp.Key == nil || resp.Key.KID == nil {
+		return "", fmt.Errorf("kv get current key: missing KID")
+	}
+	// KID is a URL like https://vault.vault.azure.net/keys/<name>/<version>.
+	// The version is the last path segment and is what callers pass to
+	// Sign/GetKey to pin a specific key generation.
+	kid := path.Base(string(*resp.Key.KID))
+	if kid == "" {
+		return "", fmt.Errorf("kv get current key: kid has no version segment: %q", string(*resp.Key.KID))
+	}
+	j.currentKID = kid
+	j.currentExpiry = time.Now().Add(currentKIDTTL)
+	// Warm the verification cache too — saves the verifier from a roundtrip
+	// the first time it sees this kid.
+	if pub, err := jwkToRSAPublic(resp.Key); err == nil {
+		j.keysMu.Lock()
+		j.keys[kid] = pub
+		j.keysMu.Unlock()
+	}
+	return kid, nil
+}
+
+func jwkToRSAPublic(jwk *azkeys.JSONWebKey) (*rsa.PublicKey, error) {
+	if jwk == nil {
+		return nil, fmt.Errorf("nil JWK")
+	}
+	if jwk.Kty == nil || (*jwk.Kty != azkeys.KeyTypeRSA && *jwk.Kty != azkeys.KeyTypeRSAHSM) {
+		return nil, fmt.Errorf("unsupported key type %v", jwk.Kty)
+	}
+	if len(jwk.N) == 0 || len(jwk.E) == 0 {
+		return nil, fmt.Errorf("JWK missing modulus or exponent")
+	}
+	n := new(big.Int).SetBytes(jwk.N)
+	e := 0
+	for _, b := range jwk.E {
+		e = e<<8 | int(b)
+	}
+	if e == 0 {
+		return nil, fmt.Errorf("JWK exponent is zero")
+	}
+	return &rsa.PublicKey{N: n, E: e}, nil
+}
+
+func b64URL(b []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+}

--- a/backend-go/internal/auth/mint.go
+++ b/backend-go/internal/auth/mint.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -16,14 +17,19 @@ const (
 	SessionTTL      = 7 * 24 * time.Hour
 	installStateTTL = 10 * time.Minute
 	installAudience = "tank-operator/github-install"
+	mintTimeout     = 10 * time.Second
 )
 
+// Minter signs session and install-state JWTs via a remote Signer (Key Vault
+// in prod, in-memory in tests). Holds the verifier's KeyResolver too so it
+// can validate the install-state tokens it issued.
 type Minter struct {
-	secret        []byte
+	signer        Signer
+	resolver      KeyResolver
 	allowedEmails map[string]struct{}
 }
 
-func NewMinter(secret, allowedEmails string) *Minter {
+func NewMinter(signer Signer, resolver KeyResolver, allowedEmails string) *Minter {
 	allowed := map[string]struct{}{}
 	for _, e := range strings.Split(allowedEmails, ",") {
 		normalized := strings.ToLower(strings.TrimSpace(e))
@@ -31,7 +37,7 @@ func NewMinter(secret, allowedEmails string) *Minter {
 			allowed[normalized] = struct{}{}
 		}
 	}
-	return &Minter{secret: []byte(secret), allowedEmails: allowed}
+	return &Minter{signer: signer, resolver: resolver, allowedEmails: allowed}
 }
 
 func (m *Minter) IsAllowed(email string) bool {
@@ -40,8 +46,8 @@ func (m *Minter) IsAllowed(email string) bool {
 }
 
 func (m *Minter) MintSession(sub, email, name string) (string, error) {
-	if len(m.secret) == 0 {
-		return "", fmt.Errorf("JWT_SECRET not configured")
+	if m.signer == nil {
+		return "", fmt.Errorf("JWT signer not configured")
 	}
 	now := time.Now()
 	claims := jwt.MapClaims{
@@ -51,12 +57,14 @@ func (m *Minter) MintSession(sub, email, name string) (string, error) {
 		"iat":   now.Unix(),
 		"exp":   now.Add(SessionTTL).Unix(),
 	}
-	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(m.secret)
+	ctx, cancel := context.WithTimeout(context.Background(), mintTimeout)
+	defer cancel()
+	return m.signer.MintJWT(ctx, claims)
 }
 
 func (m *Minter) MintInstallState(email string) (string, error) {
-	if len(m.secret) == 0 {
-		return "", fmt.Errorf("JWT_SECRET not configured")
+	if m.signer == nil {
+		return "", fmt.Errorf("JWT signer not configured")
 	}
 	now := time.Now()
 	claims := jwt.MapClaims{
@@ -65,20 +73,28 @@ func (m *Minter) MintInstallState(email string) (string, error) {
 		"iat":   now.Unix(),
 		"exp":   now.Add(installStateTTL).Unix(),
 	}
-	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(m.secret)
+	ctx, cancel := context.WithTimeout(context.Background(), mintTimeout)
+	defer cancel()
+	return m.signer.MintJWT(ctx, claims)
 }
 
 func (m *Minter) VerifyInstallState(state string) (string, error) {
-	if len(m.secret) == 0 {
-		return "", errHTTP{status: http.StatusInternalServerError, message: "JWT_SECRET not configured"}
+	if m.resolver == nil {
+		return "", errHTTP{status: http.StatusInternalServerError, message: "JWT key resolver not configured"}
 	}
 	claims := jwt.MapClaims{}
 	token, err := jwt.ParseWithClaims(state, claims,
 		func(t *jwt.Token) (any, error) {
-			if t.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+			if t.Method.Alg() != jwt.SigningMethodRS256.Alg() {
 				return nil, fmt.Errorf("unexpected alg: %s", t.Method.Alg())
 			}
-			return m.secret, nil
+			kid, _ := t.Header["kid"].(string)
+			if kid == "" {
+				return nil, errors.New("token missing kid")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), keyResolveTimeout)
+			defer cancel()
+			return m.resolver.PublicKey(ctx, kid)
 		},
 		jwt.WithAudience(installAudience),
 	)

--- a/backend-go/internal/auth/signer.go
+++ b/backend-go/internal/auth/signer.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Signer mints a signed RS256 JWT from the given claims. Implementations stamp
+// `kid` in the header so verifiers know which public key to validate against
+// — production signs in Key Vault (private key never leaves the vault), tests
+// use an in-process ephemeral RSA key.
+type Signer interface {
+	MintJWT(ctx context.Context, claims jwt.MapClaims) (string, error)
+}
+
+// KeyResolver returns the RSA public key matching a JWT's kid header. KV's
+// versioned-key model maps cleanly onto JWT key rotation: each key version
+// produces a stable kid, the resolver caches the public bytes per kid so
+// hot-path verifies stay in-process.
+type KeyResolver interface {
+	PublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error)
+}

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -126,6 +126,13 @@ spec:
             # internal session API responses (mcp-tank-operator uses these).
             - name: TANK_UI_HOST
               value: {{ .Values.internalApi.tankUiHost | quote }}
+            # Session-JWT signing key in Key Vault. The orchestrator never
+            # holds the private bytes — it calls KV's Sign operation per mint
+            # via workload identity. See infra/jwt_signing_key.tf.
+            - name: JWT_KV_VAULT
+              value: {{ .Values.jwt.kvVault | quote }}
+            - name: JWT_KV_KEY_NAME
+              value: {{ .Values.jwt.kvKeyName | quote }}
           envFrom:
             - secretRef:
                 name: {{ include "tank-operator.authSecret" . }}

--- a/k8s/templates/externalsecret-auth.yaml
+++ b/k8s/templates/externalsecret-auth.yaml
@@ -24,13 +24,6 @@ spec:
         decodingStrategy: None
         metadataPolicy: None
         nullBytePolicy: Ignore
-    - secretKey: JWT_SECRET
-      remoteRef:
-        key: tank-operator-jwt-secret
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
-        nullBytePolicy: Ignore
     - secretKey: ALLOWED_EMAILS
       remoteRef:
         key: romaine-life-admin-emails

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -235,15 +235,22 @@ externalSecret:
     secretKey: auth.json
     kvKey: codex-credentials
   # Auth secrets for the orchestrator's MSAL → backend JWT flow. ENTRA_CLIENT_ID
-  # is the audience for verifying Entra ID tokens; JWT_SECRET signs the backend's
-  # own session tokens; ALLOWED_EMAILS (comma-separated) gates which signed-in
-  # users can use the app.
+  # is the audience for verifying Entra ID tokens; ALLOWED_EMAILS
+  # (comma-separated) gates which signed-in users can use the app. The session
+  # JWT signing key lives in Key Vault as a Key (see jwt.kvVault/kvKeyName below)
+  # — orchestrator pods sign via the KV API per mint, so there is no JWT_SECRET
+  # to mirror into env.
   auth:
     secretName: tank-operator-auth
     keys:
       - envVar: ENTRA_CLIENT_ID
         kvKey: tank-operator-oauth-client-id
-      - envVar: JWT_SECRET
-        kvKey: tank-operator-jwt-secret
       - envVar: ALLOWED_EMAILS
         kvKey: romaine-life-admin-emails
+
+# Session-JWT signing key in Key Vault. Private bytes never leave the vault;
+# orchestrator calls KV's Sign operation per mint and caches the public key
+# locally for in-process verification. See infra/jwt_signing_key.tf.
+jwt:
+  kvVault: https://romaine-kv.vault.azure.net/
+  kvKeyName: tank-operator-jwt-signing


### PR DESCRIPTION
## Summary

Replaces the orchestrator's shared-HS256-secret design with a Key Vault Key that signs in-vault. The orchestrator pod calls KV's `Sign` operation per mint (rare — login-only, ~once per user per week at 7-day TTL) and caches the public key locally for in-process verification. A compromised orchestrator pod can now **verify** session tokens but cannot **forge** them — the private bytes never leave KV.

The KV key + role were created in [#379](https://github.com/nelsong6/tank-operator/pull/379) (already applied). The legacy `tank-operator-jwt-secret` KV secret stays in place during this rollout; a follow-up PR removes it once the new image has fully rolled.

## What changed

- **`internal/auth/`**: add `Signer` / `KeyResolver` interfaces; `KeyVaultJWT` impl using `azkeys`; `InMemoryJWT` for tests. Verifier resolves `*rsa.PublicKey` by `kid` (= KV key version) with an indefinite cache (versions are immutable); current kid is cached for 60s so post-rotation mints lag by at most a minute.
- **`internal/auth/`**: `Verifier` and `Minter` switch HS256 → RS256. Install-state and session JWTs both go through the same signer; audience separation keeps them from being confused.
- **`cmd/tank-operator/`**: build `KeyVaultJWT` from `JWT_KV_VAULT` + `JWT_KV_KEY_NAME` envs. Fails fast if either is missing — no silent fallback to an unsigned path. `JWT_SECRET` plumbing removed.
- **Helm chart**: drop `JWT_SECRET` from the auth ExternalSecret; add `jwt.kvVault` + `jwt.kvKeyName` values and surface them on the Deployment as plain env.
- **Tests**: convert `auth_test` and `main_test` to `InMemoryJWT`-backed setup. New tests cover session↔install-state audience separation, and reject leftover HS256 tokens.

## Hard cutover

Per [the design discussion](https://github.com/nelsong6/tank-operator/pull/376), no dual-verify grace period: every existing HS256 cookie 401s on the next request and the SPA re-logs the user in. Five people on the allowlist, 7-day TTL meant most would have re-logged in this week anyway. Not worth the dual-verify complexity.

## Test plan

- [x] `go build ./... && go test ./... && go vet ./...`
- [x] In-memory signer + verifier roundtrip works (`TestMinterIssuesVerifiableSession`).
- [x] Session token cannot pass install-state verification (`TestInstallStateRejectsSessionTokenWithDifferentAudience`).
- [x] Leftover HS256 tokens get a 401 (`TestVerifierRejectsHS256Tokens`).
- [ ] After deploy: log in fresh, confirm cookie is RS256 (`alg=RS256`, `kid=<version-guid>` in header), `/api/auth/me` returns 200.
- [ ] After deploy: orchestrator logs show no `JWT key resolver not configured` errors; pod logs should be quiet on auth.

## Sequencing notes

Tofu CI applied #379 before this lands, so the KV key already exists. If this image somehow rolls before KV is reachable for any reason, the orchestrator pods will crashloop with `JWT_KV_VAULT and JWT_KV_KEY_NAME must be set` or `azkeys client:` errors — which is what we want; no silent fallback to forgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)