### PR TITLE
Remove legacy tank-operator-jwt-secret KV resource

### DIFF
--- a/infra/oauth_app.tf
+++ b/infra/oauth_app.tf
@@ -105,14 +105,6 @@ resource "azuread_service_principal" "oauth_test" {
   client_id = azuread_application.oauth_test.client_id
 }
 
-# Self-signed JWT secret used by the backend to mint per-session tokens after
-# verifying the Entra ID token. Single secret, rotate by tainting and applying;
-# tainting invalidates all live sessions, which is fine for a single-user tool.
-resource "random_password" "jwt_secret" {
-  length  = 64
-  special = false
-}
-
 resource "azurerm_key_vault_secret" "oauth_client_id" {
   name         = "tank-operator-oauth-client-id"
   value        = azuread_application.oauth.client_id
@@ -122,12 +114,6 @@ resource "azurerm_key_vault_secret" "oauth_client_id" {
 resource "azurerm_key_vault_secret" "oauth_test_client_id" {
   name         = "tank-operator-test-oauth-client-id"
   value        = azuread_application.oauth_test.client_id
-  key_vault_id = data.azurerm_key_vault.main.id
-}
-
-resource "azurerm_key_vault_secret" "jwt_secret" {
-  name         = "tank-operator-jwt-secret"
-  value        = random_password.jwt_secret.result
   key_vault_id = data.azurerm_key_vault.main.id
 }
 


### PR DESCRIPTION
## Summary

Removes the `random_password.jwt_secret` and the `azurerm_key_vault_secret.tank_operator_jwt_secret` resources. They were the home of the old HS256 shared signing secret, replaced by the Key Vault Key in [#379](https://github.com/nelsong6/tank-operator/pull/379), which the orchestrator now signs against per [#381](https://github.com/nelsong6/tank-operator/pull/381).

The new image has rolled and verified end-to-end — RS256 token minted via KV's `Sign` operation, orchestrator's `/api/auth/me` returned 200 and decoded the claims. No consumer references the HS256 secret anymore.

Tofu will destroy both. KV's soft-delete keeps the secret recoverable for the default 90-day retention window if anything missed the migration.

## Test plan

- [x] Plan shows exactly 2 destroys (random_password.jwt_secret, azurerm_key_vault_secret.jwt_secret) and 0 changes elsewhere.
- [ ] Apply succeeds; KV no longer lists `tank-operator-jwt-secret`.
- [ ] No new orchestrator pod restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)