### PR TITLE
Restore 'credential' JSON field on POST /api/auth/microsoft/login

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_auth.go
+++ b/backend-go/cmd/tank-operator/handlers_auth.go
@@ -14,11 +14,14 @@ import (
 
 // handleMicrosoftLogin exchanges an Entra ID token for a session JWT.
 func (s *appServer) handleMicrosoftLogin(w http.ResponseWriter, r *http.Request) {
+	// Frontend wire contract (inherited from Python): {"credential": "<token>"}.
+	// Kept `credential` rather than `id_token` to avoid a frontend change for
+	// what is a backend rewrite — see frontend/src/auth.ts.
 	var body struct {
-		IDToken string `json:"id_token"`
+		IDToken string `json:"credential"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.IDToken == "" {
-		writeError(w, http.StatusBadRequest, "missing id_token")
+		writeError(w, http.StatusBadRequest, "missing credential")
 		return
 	}
 


### PR DESCRIPTION
## Summary

The Python contract was `{"credential": "<id-token>"}`, matching the field name the SPA already sends ([frontend/src/auth.ts:106](frontend/src/auth.ts#L106)). The Go rewrite ([#373](https://github.com/nelsong6/tank-operator/pull/373)) renamed the request field to `id_token` without updating the frontend, so every login attempt 400s with `missing id_token`.

This was hidden until today because everyone had a valid HS256 cookie that survived the rewrite. The RS256 hard cutover in [#381](https://github.com/nelsong6/tank-operator/pull/381) invalidated those cookies, and the bug surfaced on the first re-login attempt — exactly what's blocking the user from logging back in.

Keeping the Go-side variable name `IDToken` for readability; only the JSON tag changes from `"id_token"` to `"credential"`.

## Test plan

- [x] `go build && go test ./...`
- [ ] After deploy: log out and back in via Microsoft; cookie is RS256-signed; `/api/auth/me` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)