### PR TITLE
Phase 1: Cosmos turn_queue + orchestrator producer

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_internal.go
+++ b/backend-go/cmd/tank-operator/handlers_internal.go
@@ -289,6 +289,7 @@ func (s *appServer) doInternalSendMessage(w http.ResponseWriter, r *http.Request
 			PermissionMode: permMode,
 			SkillName:      skillName,
 			ActiveRuns:     s.activeRuns,
+			TurnQueue:      s.turnQueue,
 			Events:         s.eventBus,
 		}); err != nil {
 			slog.Warn("internal send message dispatch failed", "session", sessionID, "err", err)
@@ -345,6 +346,7 @@ func (s *appServer) doInternalRunSession(w http.ResponseWriter, r *http.Request)
 			PermissionMode: permMode,
 			SkillName:      skillName,
 			ActiveRuns:     s.activeRuns,
+			TurnQueue:      s.turnQueue,
 			Events:         s.eventBus,
 		}); err != nil {
 			slog.Warn("internal run session dispatch failed", "session", info.ID, "err", err)

--- a/backend-go/cmd/tank-operator/handlers_run.go
+++ b/backend-go/cmd/tank-operator/handlers_run.go
@@ -109,6 +109,26 @@ func (s *appServer) handleRunWebSocket(w http.ResponseWriter, r *http.Request) {
 	pidPath := compat.RunPIDPath(runID)
 
 	if !params.Resume {
+		// Phase 1: enqueue a turn descriptor for every claude WS dispatch.
+		// Producer-only; the Phase 2 pod-side runner is the consumer. Codex
+		// path skipped — it stays per-turn with no long-lived runner.
+		if provider == "claude" && s.turnQueue != nil {
+			if enqErr := s.turnQueue.Enqueue(ctx, store.TurnRecord{
+				RunID:          runID,
+				SessionID:      sessionID,
+				Email:          user.Email,
+				Provider:       provider,
+				Prompt:         params.Prompt,
+				Model:          model,
+				PermissionMode: permMode,
+				SkillName:      skillName,
+				FollowUp:       params.FollowUp,
+			}); enqErr != nil {
+				slog.Warn("turn queue enqueue failed",
+					"session", sessionID, "run_id", runID, "err", enqErr)
+			}
+		}
+
 		// Write prompt file and launch live run script.
 		promptPath := "/tmp/tank-prompt-" + auth.RandomHex(8)
 		if writeErr := kubeexec.WriteFile(ctx, s.k8s, s.restCfg, s.namespace, podName, promptPath, []byte(params.Prompt)); writeErr != nil {

--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -86,6 +86,7 @@ func (s *appServer) handleCreateAndRunSession(w http.ResponseWriter, r *http.Req
 			PermissionMode: permMode,
 			SkillName:      skillName,
 			ActiveRuns:     s.activeRuns,
+			TurnQueue:      s.turnQueue,
 			Events:         s.eventBus,
 		})
 		if err != nil {
@@ -388,6 +389,7 @@ func (s *appServer) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			PermissionMode: permMode,
 			SkillName:      skillName,
 			ActiveRuns:     s.activeRuns,
+			TurnQueue:      s.turnQueue,
 			Events:         s.eventBus,
 		})
 		if err != nil {

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -57,6 +57,9 @@ func main() {
 	// 6. Init run events store.
 	runEventsStore := buildRunEventStore(azCred)
 
+	// 6b. Init turn queue store (Phase 1 of SDK migration).
+	turnQueueStore := buildTurnQueueStore(azCred)
+
 	// 7. Init event bus.
 	eventBus := sessions.NewEventBus()
 
@@ -99,6 +102,7 @@ func main() {
 		profiles:                profileStore,
 		activeRuns:              activeRunsStore,
 		runEvents:               runEventsStore,
+		turnQueue:               turnQueueStore,
 		eventBus:                eventBus,
 		verifier:                verifier,
 		minter:                  minter,
@@ -203,6 +207,24 @@ func buildActiveRunStore(azCred *azidentity.DefaultAzureCredential) store.Active
 	if err != nil {
 		slog.Warn("active run store disabled", "error", err)
 		return store.StubActiveRunStore{}
+	}
+	return s
+}
+
+func buildTurnQueueStore(azCred *azidentity.DefaultAzureCredential) store.TurnQueueStore {
+	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
+	if endpoint == "" || azCred == nil {
+		return store.StubTurnQueueStore{}
+	}
+	s, err := store.NewCosmosTurnQueueStore(
+		endpoint,
+		envDefault("COSMOS_DATABASE", "tank-operator"),
+		envDefault("COSMOS_TURN_QUEUE_CONTAINER", "turn-queue"),
+		azCred,
+	)
+	if err != nil {
+		slog.Warn("turn queue store disabled", "error", err)
+		return store.StubTurnQueueStore{}
 	}
 	return s
 }

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -20,6 +20,7 @@ type appServer struct {
 	profiles   profilesStore
 	activeRuns store.ActiveRunStore
 	runEvents  store.RunEventStore
+	turnQueue  store.TurnQueueStore
 	eventBus   *sessions.EventBus
 	verifier   *auth.Verifier
 	minter     *auth.Minter

--- a/backend-go/internal/sessions/dispatch.go
+++ b/backend-go/internal/sessions/dispatch.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
@@ -22,6 +23,7 @@ type DispatchParams struct {
 	PermissionMode string // already validated against [A-Za-z0-9._-]{1,64}
 	SkillName      string // already validated against [A-Za-z0-9_-]{1,64}
 	ActiveRuns     store.ActiveRunStore // may be nil
+	TurnQueue      store.TurnQueueStore // may be nil; only the claude path consumes this in Phase 2
 	Events         *EventBus
 }
 
@@ -56,6 +58,31 @@ func (m *Manager) DispatchHeadless(ctx context.Context, p DispatchParams) error 
 	promptPath := "/tmp/tank-prompt-" + auth.RandomHex(8)
 	streamPath := compat.RunStreamPath(runID)
 	pidPath := compat.RunPIDPath(runID)
+
+	// Phase 1 of the SDK migration: enqueue a turn descriptor for every
+	// claude dispatch. The pod-side runner (Phase 2) will consume these
+	// rows; for now this is a write-only record that the headless-run.sh
+	// path continues to do the actual work. Codex skipped — its dispatch
+	// shape stays per-turn, no long-lived runner.
+	if provider == "claude" && p.TurnQueue != nil {
+		if enqErr := p.TurnQueue.Enqueue(ctx, store.TurnRecord{
+			RunID:          runID,
+			SessionID:      p.SessionID,
+			Email:          p.Email,
+			Provider:       provider,
+			Prompt:         p.Prompt,
+			Model:          p.Model,
+			PermissionMode: p.PermissionMode,
+			SkillName:      p.SkillName,
+			FollowUp:       p.FollowUp,
+		}); enqErr != nil {
+			// Non-fatal in Phase 1: the headless-run.sh path is still the
+			// load-bearing dispatch. Surfaces as a slog.Warn so a real
+			// Cosmos outage shows up in logs without breaking sessions.
+			slog.Warn("turn queue enqueue failed",
+				"session", p.SessionID, "run_id", runID, "err", enqErr)
+		}
+	}
 
 	// Write prompt to pod.
 	if err := kubeexec.WriteFile(ctx, m.client, m.restCfg, namespace, podName, promptPath, []byte(p.Prompt)); err != nil {

--- a/backend-go/internal/store/turn_queue.go
+++ b/backend-go/internal/store/turn_queue.go
@@ -1,0 +1,279 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// TurnQueueStatus is the lifecycle status of a queued turn.
+type TurnQueueStatus string
+
+const (
+	TurnPending   TurnQueueStatus = "pending"
+	TurnClaimed   TurnQueueStatus = "claimed"
+	TurnCompleted TurnQueueStatus = "completed"
+	TurnFailed    TurnQueueStatus = "failed"
+)
+
+// TurnRecord is a single queued turn descriptor. The orchestrator enqueues
+// one per dispatch; the pod-side runner (Phase 2) claims pending rows in
+// created_at order, drives the agent, then marks completed. Pod or
+// orchestrator restart mid-turn leaves the row as "claimed" — the runner
+// recovers on relaunch by either resuming or marking failed.
+type TurnRecord struct {
+	RunID          string          `json:"run_id"`
+	SessionID      string          `json:"session_id"`
+	Email          string          `json:"email"`
+	Provider       string          `json:"provider"`
+	Prompt         string          `json:"prompt"`
+	Model          string          `json:"model,omitempty"`
+	PermissionMode string          `json:"permission_mode,omitempty"`
+	SkillName      string          `json:"skill_name,omitempty"`
+	FollowUp       bool            `json:"follow_up"`
+	Status         TurnQueueStatus `json:"status"`
+	CreatedAt      string          `json:"created_at"`
+	ClaimedAt      *string         `json:"claimed_at"`
+	CompletedAt    *string         `json:"completed_at"`
+}
+
+// TurnQueueStore persists per-session turn descriptors. The orchestrator
+// is the only producer today; the pod-side runner (Phase 2) is the
+// consumer. Containers partition on session_id so a session's turn
+// history is one-partition reads.
+type TurnQueueStore interface {
+	Enqueue(ctx context.Context, rec TurnRecord) error
+	NextPending(ctx context.Context, sessionID string) (*TurnRecord, error)
+	MarkClaimed(ctx context.Context, sessionID, runID string) error
+	MarkCompleted(ctx context.Context, sessionID, runID string) error
+	MarkFailed(ctx context.Context, sessionID, runID string) error
+}
+
+type cosmosTurnQueueStore struct {
+	container *azcosmos.ContainerClient
+}
+
+func NewCosmosTurnQueueStore(endpoint, database, container string, cred azcore.TokenCredential) (TurnQueueStore, error) {
+	client, err := azcosmos.NewClient(endpoint, cred, nil)
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.NewContainer(database, container)
+	if err != nil {
+		return nil, err
+	}
+	return &cosmosTurnQueueStore{container: c}, nil
+}
+
+func (s *cosmosTurnQueueStore) Enqueue(ctx context.Context, rec TurnRecord) error {
+	if rec.RunID == "" || rec.SessionID == "" {
+		return fmt.Errorf("turn queue: run_id and session_id are required")
+	}
+	if rec.Status == "" {
+		rec.Status = TurnPending
+	}
+	if rec.CreatedAt == "" {
+		rec.CreatedAt = nowISO()
+	}
+	rec.Email = strings.ToLower(strings.TrimSpace(rec.Email))
+	doc := turnDoc(rec)
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	pk := azcosmos.NewPartitionKeyString(rec.SessionID)
+	// CreateItem so a re-dispatch with the same run_id surfaces (409) rather
+	// than silently overwriting an in-flight turn. Re-dispatches should not
+	// happen in normal operation — each user message generates a fresh
+	// run_id — but if the orchestrator double-fires, a conflict is the
+	// right signal.
+	_, err = s.container.CreateItem(ctx, pk, raw, nil)
+	if err != nil {
+		var re *azcore.ResponseError
+		if errors.As(err, &re) && re.StatusCode == http.StatusConflict {
+			// Already enqueued. Producer is at-most-once from here.
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *cosmosTurnQueueStore) NextPending(ctx context.Context, sessionID string) (*TurnRecord, error) {
+	query := "SELECT TOP 1 * FROM c WHERE c.session_id = @session_id AND c.status = @status ORDER BY c.created_at ASC"
+	params := []azcosmos.QueryParameter{
+		{Name: "@session_id", Value: sessionID},
+		{Name: "@status", Value: string(TurnPending)},
+	}
+	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(sessionID), &azcosmos.QueryOptions{QueryParameters: params})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range page.Items {
+			rec, err := turnFromDoc(item)
+			if err != nil {
+				continue
+			}
+			return &rec, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *cosmosTurnQueueStore) MarkClaimed(ctx context.Context, sessionID, runID string) error {
+	now := nowISO()
+	return s.patchStatus(ctx, sessionID, runID, TurnClaimed, &now, nil)
+}
+
+func (s *cosmosTurnQueueStore) MarkCompleted(ctx context.Context, sessionID, runID string) error {
+	now := nowISO()
+	return s.patchStatus(ctx, sessionID, runID, TurnCompleted, nil, &now)
+}
+
+func (s *cosmosTurnQueueStore) MarkFailed(ctx context.Context, sessionID, runID string) error {
+	now := nowISO()
+	return s.patchStatus(ctx, sessionID, runID, TurnFailed, nil, &now)
+}
+
+func (s *cosmosTurnQueueStore) patchStatus(ctx context.Context, sessionID, runID string, status TurnQueueStatus, claimedAt, completedAt *string) error {
+	pk := azcosmos.NewPartitionKeyString(sessionID)
+	resp, err := s.container.ReadItem(ctx, pk, "turn:"+runID, nil)
+	if err != nil {
+		var re *azcore.ResponseError
+		if errors.As(err, &re) && re.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return err
+	}
+	rec, err := turnFromDoc(resp.Value)
+	if err != nil {
+		return err
+	}
+	rec.Status = status
+	if claimedAt != nil {
+		rec.ClaimedAt = claimedAt
+	}
+	if completedAt != nil {
+		rec.CompletedAt = completedAt
+	}
+	raw, err := json.Marshal(turnDoc(rec))
+	if err != nil {
+		return err
+	}
+	_, err = s.container.ReplaceItem(ctx, pk, "turn:"+runID, raw, nil)
+	return err
+}
+
+// turnDoc shapes the wire JSON. Doc id is `turn:<run_id>` so the partition
+// (session_id) can hold sibling kinds of docs later without collision.
+func turnDoc(r TurnRecord) map[string]any {
+	doc := map[string]any{
+		"id":              "turn:" + r.RunID,
+		"type":            "turn",
+		"run_id":          r.RunID,
+		"session_id":      r.SessionID,
+		"email":           r.Email,
+		"provider":        r.Provider,
+		"prompt":          r.Prompt,
+		"follow_up":       r.FollowUp,
+		"status":          string(r.Status),
+		"created_at":      r.CreatedAt,
+		"claimed_at":      r.ClaimedAt,
+		"completed_at":    r.CompletedAt,
+		"model":           r.Model,
+		"permission_mode": r.PermissionMode,
+		"skill_name":      r.SkillName,
+	}
+	return doc
+}
+
+func turnFromDoc(data []byte) (TurnRecord, error) {
+	var d struct {
+		RunID          string  `json:"run_id"`
+		SessionID      string  `json:"session_id"`
+		Email          string  `json:"email"`
+		Provider       string  `json:"provider"`
+		Prompt         string  `json:"prompt"`
+		Model          string  `json:"model"`
+		PermissionMode string  `json:"permission_mode"`
+		SkillName      string  `json:"skill_name"`
+		FollowUp       bool    `json:"follow_up"`
+		Status         string  `json:"status"`
+		CreatedAt      string  `json:"created_at"`
+		ClaimedAt      *string `json:"claimed_at"`
+		CompletedAt    *string `json:"completed_at"`
+	}
+	if err := json.Unmarshal(data, &d); err != nil {
+		return TurnRecord{}, err
+	}
+	return TurnRecord{
+		RunID:          d.RunID,
+		SessionID:      d.SessionID,
+		Email:          d.Email,
+		Provider:       d.Provider,
+		Prompt:         d.Prompt,
+		Model:          d.Model,
+		PermissionMode: d.PermissionMode,
+		SkillName:      d.SkillName,
+		FollowUp:       d.FollowUp,
+		Status:         TurnQueueStatus(d.Status),
+		CreatedAt:      d.CreatedAt,
+		ClaimedAt:      d.ClaimedAt,
+		CompletedAt:    d.CompletedAt,
+	}, nil
+}
+
+// Listing helper for tests / future admin surfaces.
+func (s *cosmosTurnQueueStore) ListBySession(ctx context.Context, sessionID string, limit int) ([]TurnRecord, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	query := "SELECT * FROM c WHERE c.session_id = @session_id ORDER BY c.created_at ASC OFFSET 0 LIMIT @limit"
+	params := []azcosmos.QueryParameter{
+		{Name: "@session_id", Value: sessionID},
+		{Name: "@limit", Value: limit},
+	}
+	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(sessionID), &azcosmos.QueryOptions{QueryParameters: params})
+	var out []TurnRecord
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range page.Items {
+			rec, err := turnFromDoc(item)
+			if err != nil {
+				continue
+			}
+			out = append(out, rec)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].CreatedAt < out[j].CreatedAt })
+	return out, nil
+}
+
+// StubTurnQueueStore satisfies the interface when Cosmos is unavailable
+// (first-install ordering, local dev without endpoint). Writes are no-ops;
+// reads return nothing, never error.
+type StubTurnQueueStore struct{}
+
+func (StubTurnQueueStore) Enqueue(_ context.Context, _ TurnRecord) error            { return nil }
+func (StubTurnQueueStore) NextPending(_ context.Context, _ string) (*TurnRecord, error) {
+	return nil, nil
+}
+func (StubTurnQueueStore) MarkClaimed(_ context.Context, _, _ string) error   { return nil }
+func (StubTurnQueueStore) MarkCompleted(_ context.Context, _, _ string) error { return nil }
+func (StubTurnQueueStore) MarkFailed(_ context.Context, _, _ string) error    { return nil }
+
+// Ensure the time import is referenced even when only used by the helpers above.
+var _ = time.Time{}

--- a/backend-go/internal/store/turn_queue_test.go
+++ b/backend-go/internal/store/turn_queue_test.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTurnDocShape pins the wire JSON the orchestrator writes to Cosmos.
+// The Phase 2 pod-side runner reads these exact fields; any drift here is
+// a wire-shape regression that the runner will silently misparse.
+func TestTurnDocShape(t *testing.T) {
+	claimed := "2026-05-11T17:00:00Z"
+	rec := TurnRecord{
+		RunID:          "abc123",
+		SessionID:      "61",
+		Email:          "nelson@romaine.life",
+		Provider:       "claude",
+		Prompt:         "hello",
+		Model:          "claude-sonnet-4-6",
+		PermissionMode: "bypassPermissions",
+		SkillName:      "init",
+		FollowUp:       false,
+		Status:         TurnPending,
+		CreatedAt:      "2026-05-11T16:59:59Z",
+		ClaimedAt:      &claimed,
+	}
+	doc := turnDoc(rec)
+
+	if got, want := doc["id"], "turn:abc123"; got != want {
+		t.Fatalf("id = %q, want %q (Phase 2 runner reads by 'turn:<run_id>')", got, want)
+	}
+	if got, want := doc["session_id"], "61"; got != want {
+		t.Fatalf("session_id = %q (must match container partition key /session_id)", got)
+	}
+	if got, want := doc["status"], "pending"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if got, want := doc["prompt"], "hello"; got != want {
+		t.Fatalf("prompt = %q, want %q", got, want)
+	}
+	if got, want := doc["model"], "claude-sonnet-4-6"; got != want {
+		t.Fatalf("model = %q, want %q", got, want)
+	}
+	if got, want := doc["follow_up"], false; got != want {
+		t.Fatalf("follow_up = %v, want %v", got, want)
+	}
+	if got, want := doc["claimed_at"], &claimed; got != want {
+		t.Fatalf("claimed_at = %v, want pointer", got)
+	}
+	if doc["completed_at"] != (*string)(nil) {
+		t.Fatalf("completed_at = %v, want nil", doc["completed_at"])
+	}
+}
+
+// TestTurnDocRoundtrip ensures the Phase 2 runner can decode what the
+// producer wrote without information loss on any field.
+func TestTurnDocRoundtrip(t *testing.T) {
+	orig := TurnRecord{
+		RunID:          "abc",
+		SessionID:      "61",
+		Email:          "nelson@romaine.life",
+		Provider:       "claude",
+		Prompt:         "say hi",
+		Model:          "claude-sonnet-4-6",
+		PermissionMode: "bypassPermissions",
+		SkillName:      "",
+		FollowUp:       true,
+		Status:         TurnClaimed,
+		CreatedAt:      "2026-05-11T16:00:00Z",
+		ClaimedAt:      strptr("2026-05-11T16:00:01Z"),
+		CompletedAt:    nil,
+	}
+	raw, err := json.Marshal(turnDoc(orig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := turnFromDoc(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RunID != orig.RunID || got.SessionID != orig.SessionID ||
+		got.Provider != orig.Provider || got.Prompt != orig.Prompt ||
+		got.Model != orig.Model || got.FollowUp != orig.FollowUp {
+		t.Fatalf("roundtrip mismatch:\ngot  = %#v\nwant = %#v", got, orig)
+	}
+	if got.Status != TurnClaimed {
+		t.Fatalf("status = %q, want %q", got.Status, TurnClaimed)
+	}
+	if got.ClaimedAt == nil || *got.ClaimedAt != "2026-05-11T16:00:01Z" {
+		t.Fatalf("claimed_at = %v, want pointer to set value", got.ClaimedAt)
+	}
+	if got.CompletedAt != nil {
+		t.Fatalf("completed_at = %v, want nil", got.CompletedAt)
+	}
+}
+
+func strptr(s string) *string { return &s }

--- a/infra/cosmos.tf
+++ b/infra/cosmos.tf
@@ -94,6 +94,26 @@ resource "azurerm_cosmosdb_sql_container" "active_runs" {
   }
 }
 
+resource "azurerm_cosmosdb_sql_container" "turn_queue" {
+  name                = "turn-queue"
+  resource_group_name = data.azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.tank_operator.name
+  database_name       = azurerm_cosmosdb_sql_database.tank_operator.name
+  partition_key_paths = ["/session_id"]
+  # 7d — turn rows have a lifecycle of seconds to minutes; the TTL is a
+  # safety net for any row a runner failed to mark completed (orchestrator
+  # restart mid-write, runner crash before the status flip, etc.). The
+  # active-runs row is the live "is this run done" pointer; turn-queue
+  # rows past the runner's claim time are just history.
+  default_ttl = 604800
+
+  indexing_policy {
+    indexing_mode = "consistent"
+    included_path { path = "/*" }
+    excluded_path { path = "/prompt/*" }
+  }
+}
+
 resource "azurerm_cosmosdb_sql_container" "run_events" {
   name                = "run-events"
   resource_group_name = data.azurerm_resource_group.main.name


### PR DESCRIPTION
## Summary

First half of the SDK migration. Durable queue of pending claude turns, with the orchestrator as the sole producer for now. The Phase 2 pod-side runner will consume these rows; until that lands, `headless-run.sh` keeps doing the actual dispatch and the queue accumulates a durable history the runner picks up from on first deploy.

### Cosmos
- New `turn-queue` container, partition key `/session_id`, 7-day TTL.
- Indexing excludes `/prompt/*` (cheap writes for arbitrarily long prompt bodies).
- Lives alongside the existing `active-runs` (PK `/session_id`) and `run-events` (PK `/run_id`) containers — pattern matches the rest of the schema.

### Go
- `internal/store/turn_queue.go`: `TurnRecord` + `TurnQueueStore` interface with `Cosmos*` and `Stub*` implementations.
- Doc id is `"turn:<run_id>"` so the partition (`session_id`) can host sibling kinds of docs later without collision.
- `CreateItem` (not Upsert) so a double-dispatch surfaces a 409 rather than silently overwriting; `Enqueue` swallows that one specific 409 to make the producer at-most-once.
- Enqueue is called from all four claude-dispatch paths: `/api/sessions/run` (live WS), `POST /api/sessions/{id}/messages`, internal `/api/internal/sessions/{id}/messages`, internal `/api/internal/sessions/{id}/run`.
- Codex skipped — codex_gui keeps per-turn dispatch, no long-lived runner planned.

### Tests
- Doc-shape pinning. The kind of wire drift that produced today's four Go-rewrite regressions (#376, #377, #378, #383) would now fail this test before merge.
- Roundtrip decoder test to confirm the Phase 2 consumer can read what the producer writes.

## Sequencing notes

Tofu applies on merge; the new container exists before the new image rolls. Enqueue failures are `slog.Warn`'d but non-fatal in Phase 1 — `headless-run.sh` is still load-bearing. Phase 2 flips that: the runner consumes the queue and `headless-run.sh`'s claude path goes away.

## Test plan

- [x] `go build ./... && go test ./... && go vet ./...`
- [x] `tofu plan` shows just the new `turn-queue` container.
- [ ] After deploy: send a message in a claude_gui session; observe a row appears in `turn-queue` (`session_id` matches the session, `status=pending`, `prompt` matches the message).
- [ ] After deploy: send a message in a codex_gui session; observe NO row in `turn-queue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)