### PR TITLE
Phase A: pod-side workload identity for Cosmos

### DIFF
--- a/backend-go/internal/compat/compat.go
+++ b/backend-go/internal/compat/compat.go
@@ -29,10 +29,11 @@ const (
 	DefaultSessionImage      = "romainecr.azurecr.io/claude-container:latest"
 	DefaultCodexSessionImage = "romainecr.azurecr.io/codex-container:latest"
 	DefaultPiSessionImage    = "romainecr.azurecr.io/pi-container:latest"
-	DefaultGitHubAppSecret   = "github-app-creds"
-	DefaultCodexCredsSecret  = "codex-credentials"
-	DefaultOAuthGatewayCA    = "claude-oauth-ca"
-	SessionConfigDirMount    = "/opt/tank/session-config"
+	DefaultGitHubAppSecret          = "github-app-creds"
+	DefaultCodexCredsSecret         = "codex-credentials"
+	DefaultOAuthGatewayCA           = "claude-oauth-ca"
+	DefaultSessionAzureConfigSecret = "tank-session-azure-config"
+	SessionConfigDirMount           = "/opt/tank/session-config"
 )
 
 var (
@@ -131,6 +132,11 @@ type ManifestOptions struct {
 	CodexCredsSecret string
 	// Secret name for GitHub App credentials (envFrom on claude container).
 	GitHubAppSecret string
+	// Secret name for pod-side Azure workload-identity config
+	// (AZURE_CLIENT_ID + AZURE_TENANT_ID). envFrom on the claude container
+	// so the Phase B agent-runner can talk to Cosmos via federated SA token.
+	// May be empty in Phase A test envs where the ExternalSecret isn't wired.
+	SessionAzureConfigSecret string
 	// GlimmungContext JSON-serialized dict (may be empty).
 	GlimmungContextJSON string
 }
@@ -315,10 +321,17 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		})
 	}
 
-	// GitHub App secret envFrom on claude container.
+	// envFrom on the claude container. GitHub App for git auth; session-azure
+	// config provides AZURE_CLIENT_ID + AZURE_TENANT_ID so DefaultAzureCredential
+	// can mint a federated Cosmos token from the projected SA token (the WI
+	// webhook injects AZURE_FEDERATED_TOKEN_FILE via the pod's
+	// azure.workload.identity/use=true label).
 	envFrom := []any{}
 	if opts.GitHubAppSecret != "" {
 		envFrom = append(envFrom, map[string]any{"secretRef": map[string]any{"name": opts.GitHubAppSecret}})
+	}
+	if opts.SessionAzureConfigSecret != "" {
+		envFrom = append(envFrom, map[string]any{"secretRef": map[string]any{"name": opts.SessionAzureConfigSecret}})
 	}
 
 	claudeContainer := map[string]any{
@@ -456,6 +469,9 @@ func withManifestDefaults(opts ManifestOptions) ManifestOptions {
 	}
 	if opts.GitHubAppSecret == "" {
 		opts.GitHubAppSecret = DefaultGitHubAppSecret
+	}
+	if opts.SessionAzureConfigSecret == "" {
+		opts.SessionAzureConfigSecret = DefaultSessionAzureConfigSecret
 	}
 	return opts
 }

--- a/infra/tank_session_identity.tf
+++ b/infra/tank_session_identity.tf
@@ -1,0 +1,58 @@
+# ============================================================================
+# Session-pod UAMI — pod-side workload identity for Cosmos
+# ============================================================================
+# Identity the session pods (claude-session SA) use to write run events to
+# Cosmos from the Phase B pod-side agent-runner. Decoupled from the
+# orchestrator's `claude-credentials-refresher-identity` and the api-proxy's
+# `claude-api-proxy-identity` on the same least-privilege grounds those two
+# are decoupled from each other: each identity has only the Azure surface
+# its workload actually needs.
+#
+# Pre-Phase B the UAMI exists but no pod consumes it (Phase A ships infra
+# inert; Phase B's Node runner is what reads the env). Pre-creating it
+# keeps the Tofu and chart sides independent — chart can land first and
+# wait for an apply, or vice versa.
+# ============================================================================
+
+resource "azurerm_user_assigned_identity" "tank_session" {
+  name                = "tank-session-identity"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+}
+
+# Federation against the session SA. Subject is fixed because the SA name
+# and namespace are stable across Helm releases (see
+# `tank-operator.sessionServiceAccount` and `tank-operator.sessionsNamespace`
+# helpers in k8s/templates/_helpers.tpl).
+resource "azurerm_federated_identity_credential" "tank_session" {
+  name                = "aks-tank-session"
+  resource_group_name = data.azurerm_resource_group.main.name
+  parent_id           = azurerm_user_assigned_identity.tank_session.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = local.aks_oidc_issuer_url
+  subject             = "system:serviceaccount:tank-operator-sessions:claude-session"
+}
+
+# Cosmos Built-in Data Contributor scoped to the tank-operator account.
+# Same role the orchestrator's UAMI has on this account — sessions write
+# run events (and read them on session-open for reconnect history),
+# nothing else. Account-scoped rather than per-container because Cosmos
+# SQL role assignments aren't currently per-container-scopable in the
+# Tofu provider and the blast radius is the same database either way.
+resource "azurerm_cosmosdb_sql_role_assignment" "tank_session_cosmos" {
+  resource_group_name = data.azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.tank_operator.name
+  role_definition_id  = "${azurerm_cosmosdb_account.tank_operator.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = azurerm_user_assigned_identity.tank_session.principal_id
+  scope               = azurerm_cosmosdb_account.tank_operator.id
+}
+
+# Publish the UAMI's client_id to KV so the sessions-namespace
+# ExternalSecret can sync it into AZURE_CLIENT_ID. Tenant ID is shared
+# with the rest of the cluster via the existing `mcp-tenant-id` KV
+# secret (infra/mcp.tf), so we don't republish it here.
+resource "azurerm_key_vault_secret" "tank_session_client_id" {
+  name         = "tank-session-mi-client-id"
+  value        = azurerm_user_assigned_identity.tank_session.client_id
+  key_vault_id = data.azurerm_key_vault.main.id
+}

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -79,6 +79,10 @@ claude-code-credentials
 {{- if .Values.testEnv.enabled -}}{{ printf "%s-credentials-refresher-config" .Release.Name }}{{- else -}}{{ .Values.credentialRefresher.configSecret }}{{- end -}}
 {{- end -}}
 
+{{- define "tank-operator.sessionAzureConfigSecret" -}}
+{{- if .Values.testEnv.enabled -}}{{ printf "%s-session-azure-config" .Release.Name }}{{- else -}}{{ .Values.externalSecret.sessionAzureConfig.secretName }}{{- end -}}
+{{- end -}}
+
 {{- define "tank-operator.apiProxyConfigSecret" -}}
 {{- if .Values.testEnv.enabled -}}{{ printf "%s-api-proxy-config" .Release.Name }}{{- else -}}{{ .Values.apiProxy.configSecret }}{{- end -}}
 {{- end -}}

--- a/k8s/templates/externalsecret-session-azure.yaml
+++ b/k8s/templates/externalsecret-session-azure.yaml
@@ -1,0 +1,40 @@
+# Mirrors the tank-session UAMI's client_id (and the shared cluster tenant
+# id) into a Secret in the SESSIONS namespace, where session pods envFrom
+# it to populate AZURE_CLIENT_ID + AZURE_TENANT_ID. Paired with the pod
+# label `azure.workload.identity/use=true` the WI webhook injects
+# AZURE_FEDERATED_TOKEN_FILE, completing the federated credential chain
+# DefaultAzureCredential expects. UAMI itself + role assignments live in
+# infra/tank_session_identity.tf.
+#
+# `creationPolicy: Owner` + verbose remoteRef defaults match the other
+# ExternalSecrets in this chart — without them ArgoCD's SSA diff treats
+# ESO defaults as drift and self-heals in a loop.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "tank-operator.sessionAzureConfigSecret" . }}
+  namespace: {{ include "tank-operator.sessionsNamespace" . }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.storeName }}
+    kind: {{ .Values.externalSecret.storeKind }}
+  target:
+    name: {{ include "tank-operator.sessionAzureConfigSecret" . }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: AZURE_CLIENT_ID
+      remoteRef:
+        key: {{ .Values.externalSecret.sessionAzureConfig.clientIdKvKey }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+    - secretKey: AZURE_TENANT_ID
+      remoteRef:
+        key: {{ .Values.externalSecret.sessionAzureConfig.tenantIdKvKey }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -247,6 +247,16 @@ externalSecret:
         kvKey: tank-operator-oauth-client-id
       - envVar: ALLOWED_EMAILS
         kvKey: romaine-life-admin-emails
+  # Pod-side workload-identity config for session pods. Mirrors the
+  # tank-session UAMI's client_id + the shared cluster tenant id into a
+  # Secret in the SESSIONS namespace; session pods envFrom it so
+  # DefaultAzureCredential can mint a federated Cosmos token via the
+  # pod's projected SA token. Phase A of the SDK migration.
+  # UAMI + role assignments: infra/tank_session_identity.tf
+  sessionAzureConfig:
+    secretName: tank-session-azure-config
+    clientIdKvKey: tank-session-mi-client-id
+    tenantIdKvKey: mcp-tenant-id
 
 # Session-JWT signing key in Key Vault. Private bytes never leave the vault;
 # orchestrator calls KV's Sign operation per mint and caches the public key


### PR DESCRIPTION
## Summary

First step of the redesigned SDK migration. Infra-only — provisions the federated UAMI + role assignments and wires env vars onto session pods, so the Phase B Node agent-runner can talk to Cosmos via DefaultAzureCredential. Nothing reads these env vars yet.

## What this adds

**Azure (tofu):**
- `tank-session-identity` UAMI federated to `system:serviceaccount:tank-operator-sessions:claude-session`
- Cosmos DB Built-in Data Contributor on the `tank-operator` account
- KV secret `tank-session-mi-client-id` with the UAMI's client_id

**Kubernetes (Helm):**
- ExternalSecret `tank-session-azure-config` in the sessions namespace, mirroring the new client_id + the existing shared `mcp-tenant-id` into `AZURE_CLIENT_ID` + `AZURE_TENANT_ID`
- Pod manifest in `compat.PodManifest` adds an `envFrom` for the new Secret on the claude container; the pod-level `azure.workload.identity/use=true` label was already in place

## Why now

This is the only piece of infra the new architecture depends on that doesn't touch user-facing code. Landing it first means:
- Phase B (Node agent-runner) can be built against real workload-identity creds in a session pod without infra blocking it
- The Tofu apply is a one-time grant, decoupled from any image rollout
- If anything goes wrong with the federation (rare but possible) it surfaces in isolation, not bundled with code changes

## Sequencing

Tofu applies on merge. Chart rolls via ArgoCD. Then a smoke test:

```
kubectl exec -n tank-operator-sessions session-<id> -c claude -- env | grep AZURE
# expect: AZURE_CLIENT_ID=<uuid>, AZURE_TENANT_ID=<uuid>, AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/...
```

Then a one-off pod-side `az login --identity --client-id $AZURE_CLIENT_ID` + `az cosmosdb sql container show ...` to confirm the role assignment actually works end-to-end.

## Architectural context

This is the new SDK migration path that replaced the Go agent-runner approach. The plan:
- Phase A (this PR) — pod-side Cosmos access via workload identity
- Phase B — Node agent-runner using `@anthropic-ai/claude-agent-sdk`, exposes WebSocket of typed events, writes canonical events to Cosmos `run_events`
- Phase C — orchestrator WebSocket reverse-proxy + per-session opt-in
- Phase D — SPA renderer rewrite to consume typed SDK events
- Phase E — run preferences moved from localStorage to Cosmos profile
- Phase F — flip default to SDK runtime + cleanup legacy paths
- Phase G — wire-shape conformance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)