### PR TITLE
Phase C: orchestrator WS reverse-proxy + session-events read endpoint

### DIFF
--- a/.github/workflows/claude-container-build.yml
+++ b/.github/workflows/claude-container-build.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'claude-container/**'
+      - 'agent-runner/**'
       - 'scripts/image-fingerprint.sh'
       - '.github/workflows/claude-container-build.yml'
   workflow_dispatch:
@@ -94,7 +95,7 @@ jobs:
             --image ${{ matrix.agent }} \
             --dockerfile claude-container/Dockerfile \
             --context . \
-            --paths 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy' \
+            --paths 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner' \
             | awk -F= '$1 == "fingerprint" { print $2 }')"
           echo "ALIAS_TAG=${{ matrix.agent }}-${fingerprint}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/docker-build-check.yaml
+++ b/.github/workflows/docker-build-check.yaml
@@ -56,7 +56,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/claude-container-build-cache:claude
             image-repo: claude-container
             fingerprint-image: claude
-            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy
+            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner
           - name: session-agent-codex
             file: claude-container/Dockerfile
             context: .
@@ -64,7 +64,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/codex-container-build-cache:codex
             image-repo: codex-container
             fingerprint-image: codex
-            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy
+            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner
           - name: session-agent-pi
             file: claude-container/Dockerfile
             context: .
@@ -72,7 +72,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/pi-container-build-cache:pi
             image-repo: pi-container
             fingerprint-image: pi
-            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy
+            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/agent-runner/.gitignore
+++ b/agent-runner/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.log

--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -1,0 +1,2025 @@
+{
+  "name": "tank-agent-runner",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tank-agent-runner",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.0",
+        "@azure/cosmos": "^4.5.1",
+        "@azure/identity": "^4.7.0",
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.13",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.139.tgz",
+      "integrity": "sha512-9zmitYoxCQiQZsTUbm9IGC6VyZt70J3NLtkRQPQvFVfz7bKDrhlZZKzXmyl2XmqedXEIeQy2ACmwdjwzPIVIAw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.139"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.139.tgz",
+      "integrity": "sha512-dnuO2E0x6o9GAk9iZZKlEd10h+0PQFdTfr5aQU4I0W+0ReKsFEoE9LAqfomS2EvLUQ9L62X0+n0iyZQmAVi1kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.139.tgz",
+      "integrity": "sha512-SXyldBIwpMHDXppPGObXZ1wjSSWf/YPgD6vK4nssIXarC/DtMRnAQ419Hb3q5MaBB29vSjOPKmG0MOkMltFR/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.139.tgz",
+      "integrity": "sha512-qfnQ4SjEcq//iGAJkk25J6j4Tq+dvQe9wHks0dcaSdGOs2D96Teqrb358YJe+nke2DBKVUa9Y4ComW3aUBM29w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.139.tgz",
+      "integrity": "sha512-gzMfit9t7Fiy5taZ+miAaP8ZmOMc+hv8Ov3UOXGwJunK6H+0F88ctBSnolDPMPQaS6s2WoMD0o8fhUbBudtMVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.139.tgz",
+      "integrity": "sha512-2Gqy5hV/MyObbwSyNhj5ha2cY5EZnUfDLvpEwR1eeOaU1yqnxzsdNzXWgHIyWQGKGNE2ICwgLYtt6AtOJGWpPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.139.tgz",
+      "integrity": "sha512-Fg/aQs1vdyqLrNXqGa1i7/ODpGxP6ud/K/2AgVarLteg2Z3ZnrHPvPQ6iQmTGI8+BhxAZ141t4Dg0CWz3CoqCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.139.tgz",
+      "integrity": "sha512-HusAU/gSQ0G0AHU+Hj/ps0Tl5JaUF2nxkp+G42tU6hpnwLMOQMdLx/yqvSQnz4WSxggxiDFmYvMDLYAmuE9Qdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.139.tgz",
+      "integrity": "sha512-eJjbtLvEBJcTrl4WJhmhP7FYdTVvx/XtioifH7OEnCoxQozMHhOmA0X90csplIRpttX+jX2PqnE5j2FwU20eCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/cosmos": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.9.3.tgz",
+      "integrity": "sha512-AWRj+yhw1lybutNcsHJ8syxWXnTLvc3CPwwdCwG1I0I71f25ZcBkxneTeoaB3X57+xl1nO+zJKUqfm0RhpGUFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-keys": "^4.9.0",
+        "@azure/logger": "^1.1.4",
+        "fast-json-stable-stringify": "^2.1.0",
+        "priorityqueuejs": "^2.0.0",
+        "semaphore": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.0.tgz",
+      "integrity": "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.0.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.0.tgz",
+      "integrity": "sha512-2Y4TlG5mCfxviHutfW50i8Xd8xhGKTgieL02vMYOE5ZbZrVM+drKSGD//tweRAmlmqqp+F9vrKoHWri/buzxWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.0.tgz",
+      "integrity": "sha512-FemGljX0csPlBMUE5GUan7BfRn1emeMRUhHSARhqzLN6LA9nt+MgzmAQ1xVqdLm+6plVoxsq9mS5eoyKtpPSgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.0.tgz",
+      "integrity": "sha512-b/ak8XAqpnGk1N1nsyTVV0Remp48BP3QrGQZ1uCMcvg2S8X1eSXzhHQZEae2oX276Q4KFAqCUswanDtcvIKLrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/priorityqueuejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-2.0.0.tgz",
+      "integrity": "sha512-19BMarhgpq3x4ccvVi8k2QpJZcymo/iFUcrhPd4V96kYGovOdTsWwy7fxChYi4QY+m2EnGBWSX9Buakz+tWNQQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tank-agent-runner",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Long-lived pod-side runner that drives @anthropic-ai/claude-agent-sdk, exposes typed events to the SPA via WebSocket and persists canonical events to Cosmos.",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "node --test dist/**/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.0",
+    "@azure/cosmos": "^4.5.1",
+    "@azure/identity": "^4.7.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.13",
+    "typescript": "^5.6.0"
+  }
+}

--- a/agent-runner/src/config.ts
+++ b/agent-runner/src/config.ts
@@ -1,0 +1,44 @@
+// Runtime config sourced from env vars. SESSION_ID + POD_OWNER_EMAIL come
+// from the downward API on the pod spec (label tank-operator/session-id,
+// annotation tank-operator/owner-email). COSMOS_* mirror the orchestrator's
+// env. Azure workload-identity envs (AZURE_CLIENT_ID + AZURE_TENANT_ID +
+// AZURE_FEDERATED_TOKEN_FILE) are injected by the WI webhook because the
+// pod carries azure.workload.identity/use=true and the SA's federated
+// credential covers system:serviceaccount:tank-operator-sessions:claude-session
+// (see infra/tank_session_identity.tf). We don't read those directly —
+// DefaultAzureCredential picks them up.
+
+export interface Config {
+  sessionId: string;
+  ownerEmail: string;
+  cosmosEndpoint: string;
+  cosmosDatabase: string;
+  sessionEventsContainer: string;
+  workspace: string;
+  mcpConfig: string;
+  wsPort: number;
+}
+
+export function loadConfig(): Config {
+  const sessionId = (process.env.SESSION_ID ?? "").trim();
+  if (!sessionId) {
+    throw new Error(
+      "SESSION_ID is required (set from downward API: metadata.labels['tank-operator/session-id'])",
+    );
+  }
+  const cosmosEndpoint = (process.env.COSMOS_ENDPOINT ?? "").trim();
+  if (!cosmosEndpoint) {
+    throw new Error("COSMOS_ENDPOINT is required");
+  }
+  return {
+    sessionId,
+    ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
+    cosmosEndpoint,
+    cosmosDatabase: process.env.COSMOS_DATABASE?.trim() || "tank-operator",
+    sessionEventsContainer:
+      process.env.COSMOS_SESSION_EVENTS_CONTAINER?.trim() || "session-events",
+    workspace: process.env.WORKSPACE?.trim() || "/workspace",
+    mcpConfig: process.env.MCP_CONFIG?.trim() || "/workspace/.mcp.json",
+    wsPort: parseInt(process.env.AGENT_RUNNER_WS_PORT?.trim() || "8090", 10),
+  };
+}

--- a/agent-runner/src/cosmos.test.ts
+++ b/agent-runner/src/cosmos.test.ts
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isCanonical } from "./cosmos.js";
+
+// Pins which SDK event types make it into the durable Cosmos log vs which
+// stay live-only (the typewriter deltas, status pings, etc). Drift here
+// affects the SPA's history-replay correctness.
+
+test("canonical: user, assistant, result messages", () => {
+  assert.equal(isCanonical({ type: "user" } as any), true);
+  assert.equal(isCanonical({ type: "assistant" } as any), true);
+  assert.equal(isCanonical({ type: "result", subtype: "success" } as any), true);
+});
+
+test("canonical: system init + compact_boundary + tool_use_summary", () => {
+  assert.equal(isCanonical({ type: "system", subtype: "init" } as any), true);
+  assert.equal(
+    isCanonical({ type: "system", subtype: "compact_boundary" } as any),
+    true,
+  );
+  assert.equal(
+    isCanonical({ type: "system", subtype: "tool_use_summary" } as any),
+    true,
+  );
+});
+
+test("canonical: permission_denied + plugin_install + rate_limit", () => {
+  assert.equal(
+    isCanonical({ type: "system", subtype: "permission_denied" } as any),
+    true,
+  );
+  assert.equal(
+    isCanonical({ type: "system", subtype: "plugin_install" } as any),
+    true,
+  );
+  assert.equal(isCanonical({ type: "rate_limit" } as any), true);
+});
+
+test("NOT canonical: stream_event (typewriter deltas — live-only)", () => {
+  assert.equal(isCanonical({ type: "stream_event" } as any), false);
+});
+
+test("NOT canonical: tool_progress, status, hook_*, task_*", () => {
+  // Per the SDK docs these are ephemeral system events emitted during
+  // tool execution — they exist to drive live UX but have no replay value.
+  assert.equal(
+    isCanonical({ type: "system", subtype: "tool_progress" } as any),
+    false,
+  );
+  assert.equal(isCanonical({ type: "system", subtype: "status" } as any), false);
+  assert.equal(
+    isCanonical({ type: "system", subtype: "hook_started" } as any),
+    false,
+  );
+  assert.equal(
+    isCanonical({ type: "system", subtype: "task_started" } as any),
+    false,
+  );
+});
+
+test("NOT canonical: unknown types", () => {
+  assert.equal(isCanonical({ type: "weird_new_thing" } as any), false);
+  assert.equal(isCanonical({} as any), false);
+});

--- a/agent-runner/src/cosmos.ts
+++ b/agent-runner/src/cosmos.ts
@@ -1,0 +1,91 @@
+// Cosmos sink for canonical SDK events. Producer contract per the
+// design discussion:
+//   - One serialization at the producer (the runner)
+//   - Same bytes go to Cosmos and to the WS broadcast
+//   - DB write happens BEFORE the WS push (read-your-writes ordering)
+//   - Idempotent receivers — dedupe by event uuid
+//
+// "Canonical" = events the SPA's history-replay path should see:
+//   system (init / compact_boundary), user, assistant, tool_use_summary,
+//   result, permission_denied, rate_limit, plugin_install
+//
+// "Live-only" = transient deltas that drive the typewriter effect but
+// have no durable value (Discord's "typing..." analog):
+//   stream_event, tool_progress, hook_*, task_*, status, prompt_suggestion
+//
+// SDK type ref: https://code.claude.com/docs/en/agent-sdk/typescript
+
+import { CosmosClient } from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
+import type { Config } from "./config.js";
+
+const CANONICAL_TYPES = new Set<string>([
+  "system",
+  "user",
+  "assistant",
+  "result",
+]);
+
+const CANONICAL_SYSTEM_SUBTYPES = new Set<string>([
+  "init",
+  "compact_boundary",
+  "tool_use_summary",
+  "permission_denied",
+  "plugin_install",
+]);
+
+// Some SDK message types arrive top-level as their own discriminator
+// rather than `system/<subtype>`. Treat them as canonical regardless.
+const CANONICAL_TOP_LEVEL_TYPES = new Set<string>([
+  "rate_limit",
+]);
+
+export function isCanonical(message: SDKMessage): boolean {
+  const t = (message as any).type as string | undefined;
+  if (!t) return false;
+  if (CANONICAL_TOP_LEVEL_TYPES.has(t)) return true;
+  if (CANONICAL_TYPES.has(t)) {
+    if (t === "system") {
+      const subtype = (message as any).subtype as string | undefined;
+      // Some system events (status, hook progress) are ephemeral — only
+      // the documented turn-level subtypes are durable.
+      return subtype ? CANONICAL_SYSTEM_SUBTYPES.has(subtype) : false;
+    }
+    return true;
+  }
+  return false;
+}
+
+export class CosmosSink {
+  private readonly client: CosmosClient;
+  private readonly container;
+
+  constructor(private readonly cfg: Config) {
+    this.client = new CosmosClient({
+      endpoint: cfg.cosmosEndpoint,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+    this.container = this.client
+      .database(cfg.cosmosDatabase)
+      .container(cfg.sessionEventsContainer);
+  }
+
+  // Write a canonical event to Cosmos. Doc id is the SDK's uuid (v7,
+  // monotonic — naturally sorts by emit order). Partition is the
+  // orchestrator's session_id (the integer "63") not the SDK's internal
+  // session_id — the SPA queries on the integer (it knows the pod-level
+  // id), and pod restart may yield a new SDK session within the same
+  // tank-operator session. The SDK's session_id rides along as a field.
+  async upsert(message: SDKMessage): Promise<void> {
+    const doc: Record<string, unknown> = {
+      ...(message as Record<string, unknown>),
+      id: (message as any).uuid as string,
+      tank_session_id: this.cfg.sessionId,
+      email: this.cfg.ownerEmail,
+      written_at: new Date().toISOString(),
+    };
+    await this.container.items.upsert(doc);
+  }
+}

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1,0 +1,40 @@
+// tank-agent-runner — pod-side process that drives @anthropic-ai/
+// claude-agent-sdk for one session pod's lifetime. Fans events out to
+// (a) Cosmos `session-events` container for durable history, and
+// (b) a local WebSocket for the SPA's live view (proxied through the
+// orchestrator). See ../README.md, agent-runner/src/runner.ts.
+
+import { loadConfig } from "./config.js";
+import { Runner } from "./runner.js";
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  console.log(
+    JSON.stringify({
+      msg: "agent-runner starting",
+      session_id: cfg.sessionId,
+      owner_email: cfg.ownerEmail,
+      cosmos_endpoint: cfg.cosmosEndpoint,
+      cosmos_db: cfg.cosmosDatabase,
+      cosmos_container: cfg.sessionEventsContainer,
+      workspace: cfg.workspace,
+      ws_port: cfg.wsPort,
+    }),
+  );
+
+  const ctrl = new AbortController();
+  const shutdown = (sig: NodeJS.Signals) => {
+    console.log(JSON.stringify({ msg: "shutdown", signal: sig }));
+    ctrl.abort();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  const runner = new Runner(cfg);
+  await runner.run(ctrl.signal);
+}
+
+main().catch((err) => {
+  console.error("agent-runner exited with error:", err);
+  process.exit(1);
+});

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -1,0 +1,159 @@
+// Long-lived runner — drives one claude agent process via the SDK for
+// the pod's lifetime. The SDK's `query()` takes an async iterable of
+// user messages, so we push to a queue as WS clients submit, and the
+// SDK iterates events back out. Multi-turn coordination is implicit:
+// the SDK serializes turns internally, we just keep feeding it.
+//
+// Output fan-out per the producer contract:
+//   1. For every event, write to Cosmos FIRST (if canonical)
+//   2. Then broadcast to WS clients
+//   3. If the event contains a ScheduleWakeup, queue a wakeup turn
+//
+// On error: log and keep running. Single-turn failures shouldn't kill
+// the runner; persistent failures will show up via Cosmos write errors
+// and the SPA's user can refresh.
+
+import {
+  query,
+  type Query,
+  type SDKMessage,
+  type SDKUserMessage,
+  type Options,
+} from "@anthropic-ai/claude-agent-sdk";
+
+import type { Config } from "./config.js";
+import { CosmosSink, isCanonical } from "./cosmos.js";
+import { extractWakeup, type WakeupRequest } from "./wakeup.js";
+import { WSFanout, type ClientFrame } from "./ws.js";
+
+// AsyncQueue is a one-writer-many-no-readers queue that yields each
+// pushed item exactly once. The SDK consumes this as the prompt source.
+class AsyncQueue<T> {
+  private readonly items: T[] = [];
+  private waiters: ((v: IteratorResult<T>) => void)[] = [];
+  private closed = false;
+
+  push(v: T): void {
+    const w = this.waiters.shift();
+    if (w) w({ value: v, done: false });
+    else this.items.push(v);
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const w of this.waiters) w({ value: undefined as any, done: true });
+    this.waiters = [];
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    const self = this;
+    return {
+      next(): Promise<IteratorResult<T>> {
+        if (self.items.length > 0) {
+          return Promise.resolve({ value: self.items.shift()!, done: false });
+        }
+        if (self.closed) {
+          return Promise.resolve({ value: undefined as any, done: true });
+        }
+        return new Promise((resolve) => self.waiters.push(resolve));
+      },
+    };
+  }
+}
+
+export class Runner {
+  private readonly sink: CosmosSink;
+  private readonly ws: WSFanout;
+  private readonly userQueue = new AsyncQueue<SDKUserMessage>();
+  private sdkQuery: Query | null = null;
+
+  constructor(private readonly cfg: Config) {
+    this.sink = new CosmosSink(cfg);
+    this.ws = new WSFanout(cfg.wsPort);
+    this.ws.onMessage((frame) => this.handleClientFrame(frame));
+  }
+
+  // Run forever (or until externally aborted). Drives the SDK against
+  // the user queue and fans events out to both sinks.
+  async run(signal: AbortSignal): Promise<void> {
+    const options: Options = {
+      cwd: this.cfg.workspace,
+      // The api-proxy injects OAuth from KV when the placeholder bearer
+      // is seen — both the SDK and the raw CLI go through this path.
+      // Permission bypass matches what k8s/session-config/headless-run.sh
+      // used to set via --dangerously-skip-permissions.
+      permissionMode: "bypassPermissions",
+      // Resume an on-disk JSONL if one exists from a prior process
+      // life (e.g., agent-runner restart within the same pod).
+      // First boot with no JSONL: no-op.
+      continue: true,
+      // include_partial_messages keeps the typewriter effect — the SPA
+      // renders stream_event deltas live and snapshots to the canonical
+      // assistant message when it arrives.
+      includePartialMessages: true,
+      mcpServers: undefined, // file-mounted via --mcp-config below
+      // Bare mode would skip CLAUDE.md / skills / hooks; we want those.
+    };
+
+    this.sdkQuery = query({ prompt: this.userQueue, options });
+    try {
+      for await (const message of this.sdkQuery) {
+        if (signal.aborted) break;
+        await this.handleEvent(message);
+      }
+    } catch (err) {
+      console.error("SDK query exited with error:", err);
+    } finally {
+      this.userQueue.close();
+      this.ws.close();
+    }
+  }
+
+  private async handleEvent(message: SDKMessage): Promise<void> {
+    // 1. Cosmos first (durable, read-your-writes ordering)
+    if (isCanonical(message)) {
+      try {
+        await this.sink.upsert(message);
+      } catch (err) {
+        console.error("cosmos upsert failed:", err);
+        // Don't broadcast a live event we couldn't persist — the SPA's
+        // history-replay would then disagree with what it saw live.
+        return;
+      }
+    }
+    // 2. WebSocket broadcast (live tap)
+    this.ws.broadcastEvent(message);
+
+    // 3. ScheduleWakeup detection
+    const wakeup = extractWakeup(message);
+    if (wakeup) {
+      this.scheduleWakeup(wakeup);
+    }
+  }
+
+  private handleClientFrame(frame: ClientFrame): void {
+    if (frame.type === "user") {
+      // Hand straight to the SDK iterator. The SDK enforces "wait for
+      // result before next message" internally; we don't need to gate.
+      this.userQueue.push({
+        type: "user",
+        session_id: "",
+        message: frame.message,
+        parent_tool_use_id: null,
+      } as unknown as SDKUserMessage);
+    } else if (frame.type === "interrupt") {
+      this.sdkQuery?.interrupt();
+    }
+  }
+
+  private scheduleWakeup(req: WakeupRequest): void {
+    setTimeout(() => {
+      this.userQueue.push({
+        type: "user",
+        session_id: "",
+        message: { role: "user", content: req.prompt },
+        parent_tool_use_id: null,
+      } as unknown as SDKUserMessage);
+    }, req.delayMs);
+  }
+}

--- a/agent-runner/src/wakeup.test.ts
+++ b/agent-runner/src/wakeup.test.ts
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractWakeup } from "./wakeup.js";
+
+test("extracts ScheduleWakeup tool_use from assistant content", () => {
+  const got = extractWakeup({
+    type: "assistant",
+    uuid: "abc",
+    session_id: "s1",
+    parent_tool_use_id: null,
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "I'll check back later." },
+        {
+          type: "tool_use",
+          id: "toolu_x",
+          name: "ScheduleWakeup",
+          input: { delaySeconds: 300, prompt: "check the deploy" },
+        },
+      ],
+    },
+  } as any);
+  assert.ok(got);
+  assert.equal(got!.delayMs, 300_000);
+  assert.equal(got!.prompt, "check the deploy");
+});
+
+test("returns null for assistant without tool_use", () => {
+  const got = extractWakeup({
+    type: "assistant",
+    uuid: "abc",
+    session_id: "s1",
+    parent_tool_use_id: null,
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+    },
+  } as any);
+  assert.equal(got, null);
+});
+
+test("ignores other tool_use blocks", () => {
+  const got = extractWakeup({
+    type: "assistant",
+    uuid: "abc",
+    session_id: "s1",
+    parent_tool_use_id: null,
+    message: {
+      role: "assistant",
+      content: [
+        { type: "tool_use", id: "x", name: "Bash", input: { command: "ls" } },
+      ],
+    },
+  } as any);
+  assert.equal(got, null);
+});
+
+test("rejects ScheduleWakeup with missing prompt", () => {
+  // Scheduling an empty prompt would loop the agent on itself.
+  const got = extractWakeup({
+    type: "assistant",
+    uuid: "abc",
+    session_id: "s1",
+    parent_tool_use_id: null,
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "x",
+          name: "ScheduleWakeup",
+          input: { delaySeconds: 60 },
+        },
+      ],
+    },
+  } as any);
+  assert.equal(got, null);
+});
+
+test("case-insensitive tool name match", () => {
+  const got = extractWakeup({
+    type: "assistant",
+    uuid: "abc",
+    session_id: "s1",
+    parent_tool_use_id: null,
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "x",
+          name: "schedulewakeup",
+          input: { delaySeconds: 1, prompt: "hi" },
+        },
+      ],
+    },
+  } as any);
+  assert.ok(got);
+  assert.equal(got!.delayMs, 1000);
+});
+
+test("returns null for non-assistant message types", () => {
+  for (const t of ["user", "system", "result", "stream_event"]) {
+    assert.equal(extractWakeup({ type: t } as any), null);
+  }
+});

--- a/agent-runner/src/wakeup.ts
+++ b/agent-runner/src/wakeup.ts
@@ -1,0 +1,43 @@
+// ScheduleWakeup detection in SDK events. The pod-side runner detects
+// the agent's tool_use call, waits delaySeconds in-process (the whole
+// reason for the persistent-process model), then re-enqueues the wakeup
+// prompt as the next user turn. Preserves in-memory state across the
+// wakeup boundary — no JSONL replay, no orchestrator polling.
+
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
+export interface WakeupRequest {
+  delayMs: number;
+  prompt: string;
+}
+
+// Scan an assistant SDK event's content blocks for a ScheduleWakeup
+// tool_use. The agent emits content as an array of typed blocks;
+// tool_use blocks carry { type, id, name, input }. Multiple wakeups
+// in one turn aren't a documented protocol — the last one wins.
+export function extractWakeup(message: SDKMessage): WakeupRequest | null {
+  if ((message as any).type !== "assistant") return null;
+  const inner = (message as any).message;
+  if (!inner || typeof inner !== "object") return null;
+  const content = inner.content;
+  if (!Array.isArray(content)) return null;
+
+  let found: WakeupRequest | null = null;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type !== "tool_use") continue;
+    const name = String(block.name ?? "").toLowerCase();
+    if (name !== "schedulewakeup") continue;
+    const input = block.input;
+    if (!input || typeof input !== "object") continue;
+    const delaySeconds = Number((input as any).delaySeconds);
+    const prompt = String((input as any).prompt ?? "");
+    if (!Number.isFinite(delaySeconds) || delaySeconds < 0) continue;
+    if (!prompt) continue;
+    found = {
+      delayMs: Math.floor(delaySeconds * 1000),
+      prompt,
+    };
+  }
+  return found;
+}

--- a/agent-runner/src/ws.ts
+++ b/agent-runner/src/ws.ts
@@ -1,0 +1,75 @@
+// Per-pod WebSocket fan-out. The orchestrator reverse-proxies the SPA's
+// WebSocket onto this server (Phase C wiring). One pod has one runner has
+// one WS server — multiple SPA clients (e.g., user has two tabs open)
+// connect to the same instance and each gets the full event stream.
+//
+// Frame shapes:
+//   server → client: every SDK event, serialized as JSON.
+//   client → server: { type: "user", message: { role: "user", content: ... } }
+//                  | { type: "interrupt" }                         (cancel turn)
+//                  | { type: "ping" }                              (heartbeat)
+//
+// Authentication is the orchestrator's job (it terminates the user's TLS
+// + JWT before proxying). This server trusts whatever connects.
+
+import { WebSocketServer, type WebSocket } from "ws";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
+export type ClientFrame =
+  | { type: "user"; message: { role: "user"; content: unknown } }
+  | { type: "interrupt" }
+  | { type: "ping" };
+
+export class WSFanout {
+  private readonly server: WebSocketServer;
+  private readonly clients = new Set<WebSocket>();
+  private onUserMessage: ((c: ClientFrame) => void) | null = null;
+
+  constructor(port: number) {
+    this.server = new WebSocketServer({ port, host: "0.0.0.0" });
+    this.server.on("connection", (ws) => {
+      this.clients.add(ws);
+      ws.on("message", (raw) => {
+        let frame: ClientFrame;
+        try {
+          frame = JSON.parse(raw.toString());
+        } catch {
+          return;
+        }
+        if (frame.type === "ping") {
+          ws.send(JSON.stringify({ type: "pong" }));
+          return;
+        }
+        this.onUserMessage?.(frame);
+      });
+      ws.on("close", () => this.clients.delete(ws));
+    });
+  }
+
+  onMessage(handler: (c: ClientFrame) => void) {
+    this.onUserMessage = handler;
+  }
+
+  // Broadcast a fully-serialized JSON line to all connected clients. The
+  // serialization happens once at the producer; both Cosmos and this fan-out
+  // see byte-identical payloads (the producer contract).
+  broadcast(serialized: string): void {
+    for (const ws of this.clients) {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(serialized);
+      }
+    }
+  }
+
+  // Broadcast a typed SDKMessage by serializing once.
+  broadcastEvent(message: SDKMessage): void {
+    this.broadcast(JSON.stringify(message));
+  }
+
+  close(): void {
+    for (const ws of this.clients) {
+      ws.close();
+    }
+    this.server.close();
+  }
+}

--- a/agent-runner/tsconfig.json
+++ b/agent-runner/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/backend-go/cmd/tank-operator/handlers_agent_ws.go
+++ b/backend-go/cmd/tank-operator/handlers_agent_ws.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/coder/websocket"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
+)
+
+const agentRunnerDialTimeout = 10 * time.Second
+
+// handleAgentWebSocket reverse-proxies the SPA's WebSocket onto the
+// pod's agent-runner (Phase B Node service listening on
+// localhost:AgentRunnerWSPort). Auth happens here (JWT via cookie or
+// query param); inside the cluster the orchestrator-to-pod hop trusts
+// network policy and the pod's owner label check.
+//
+// Bytes are piped raw — no message inspection, no serialization touch.
+// The runner produces the wire format; this handler is a pure pipe so
+// SDK protocol changes don't require orchestrator changes.
+func (s *appServer) handleAgentWebSocket(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireWSAuth(w, r)
+	if !ok {
+		return
+	}
+	sessionID := r.PathValue("session_id")
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing session_id")
+		return
+	}
+
+	// Ownership check + pod-name resolution via the existing helper.
+	info, podName, herr := s.resolveSessionPod(r.Context(), user.Email, sessionID)
+	if herr != nil {
+		writeError(w, herr.status, herr.msg)
+		return
+	}
+	_ = info
+
+	// Need the pod IP to dial directly. Pod IPs are routable within the
+	// cluster from the orchestrator namespace per the AKS default CNI.
+	pod, err := s.k8s.CoreV1().Pods(s.namespace).Get(r.Context(), podName, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "pod fetch failed: "+err.Error())
+		return
+	}
+	if pod.Status.PodIP == "" {
+		writeError(w, http.StatusServiceUnavailable, "pod has no IP yet")
+		return
+	}
+	if !podHasAgentRunner(pod) {
+		writeError(w, http.StatusBadRequest, "session pod has no agent-runner container (legacy claude_cli/codex/pi modes don't use the SDK runner)")
+		return
+	}
+
+	// Upgrade the browser-side WebSocket.
+	browserConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	if err != nil {
+		return
+	}
+	defer browserConn.Close(websocket.StatusNormalClosure, "")
+
+	// Dial the pod's agent-runner. The runner listens on 0.0.0.0:WSPort
+	// inside the pod; from the orchestrator we reach it by pod IP.
+	podURL := fmt.Sprintf("ws://%s:%d/", pod.Status.PodIP, compat.AgentRunnerWSPort)
+	dialCtx, dialCancel := context.WithTimeout(r.Context(), agentRunnerDialTimeout)
+	defer dialCancel()
+	podConn, _, err := websocket.Dial(dialCtx, podURL, nil)
+	if err != nil {
+		_ = browserConn.Write(r.Context(), websocket.MessageText,
+			mustJSON(map[string]any{"error": "agent-runner not reachable: " + err.Error()}))
+		return
+	}
+	defer podConn.Close(websocket.StatusNormalClosure, "")
+
+	// Bidirectional pipe — independent goroutines per direction so neither
+	// blocks the other. First error in either direction (close, network
+	// hiccup, browser disconnect, pod crash) tears down both sides.
+	errCh := make(chan error, 2)
+	go func() {
+		for {
+			mt, data, err := browserConn.Read(r.Context())
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if err := podConn.Write(r.Context(), mt, data); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		for {
+			mt, data, err := podConn.Read(r.Context())
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if err := browserConn.Write(r.Context(), mt, data); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	if firstErr := <-errCh; firstErr != nil {
+		slog.Debug("agent-ws pipe ended", "session", sessionID, "err", firstErr)
+	}
+}
+
+// podHasAgentRunner returns true if the pod spec includes the
+// agent-runner container (claude_gui mode only today; Phase B
+// added it conditionally in compat.PodManifest).
+func podHasAgentRunner(pod *corev1.Pod) bool {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "agent-runner" {
+			return true
+		}
+	}
+	return false
+}
+
+// handleListSessionEvents reads canonical SDK events from the
+// `session-events` Cosmos container for the SPA's history-replay path.
+// Returns events strictly after the watermark `after` (a v7 UUID — sorts
+// by emit order), in ascending order, up to `limit` (max 1000).
+//
+// SPA contract: on session open, fetch with after="" to get the full
+// history; then open the WebSocket for live updates and dedupe by uuid.
+func (s *appServer) handleListSessionEvents(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	sessionID := r.PathValue("session_id")
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing session_id")
+		return
+	}
+	// Ownership check via the existing reader path.
+	if _, err := s.mgr.GetByOwner(r.Context(), user.Email, sessionID); err != nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	after := r.URL.Query().Get("after")
+	limit := 200
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 1000 {
+			limit = n
+		}
+	}
+
+	events, err := s.sessionEvents.ListBySession(r.Context(), sessionID, after, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if events == nil {
+		events = []map[string]any{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"session_id": sessionID,
+		"events":     events,
+	})
+}

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -60,6 +60,10 @@ func main() {
 	// 6b. Init turn queue store (Phase 1 of SDK migration).
 	turnQueueStore := buildTurnQueueStore(azCred)
 
+	// 6c. Init session events store (Phase C — reader side of the
+	// agent-runner's canonical event stream).
+	sessionEventsStore := buildSessionEventStore(azCred)
+
 	// 7. Init event bus.
 	eventBus := sessions.NewEventBus()
 
@@ -110,6 +114,7 @@ func main() {
 		activeRuns:              activeRunsStore,
 		runEvents:               runEventsStore,
 		turnQueue:               turnQueueStore,
+		sessionEvents:           sessionEventsStore,
 		eventBus:                eventBus,
 		verifier:                verifier,
 		minter:                  minter,
@@ -214,6 +219,24 @@ func buildActiveRunStore(azCred *azidentity.DefaultAzureCredential) store.Active
 	if err != nil {
 		slog.Warn("active run store disabled", "error", err)
 		return store.StubActiveRunStore{}
+	}
+	return s
+}
+
+func buildSessionEventStore(azCred *azidentity.DefaultAzureCredential) store.SessionEventStore {
+	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
+	if endpoint == "" || azCred == nil {
+		return store.StubSessionEventStore{}
+	}
+	s, err := store.NewCosmosSessionEventStore(
+		endpoint,
+		envDefault("COSMOS_DATABASE", "tank-operator"),
+		envDefault("COSMOS_SESSION_EVENTS_CONTAINER", "session-events"),
+		azCred,
+	)
+	if err != nil {
+		slog.Warn("session events store disabled", "error", err)
+		return store.StubSessionEventStore{}
 	}
 	return s
 }

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -68,6 +68,13 @@ func main() {
 	mgr := sessions.NewManager(k8sClient, restCfg, namespace, sessionReg, eventBus, sessions.ManagerOptions{
 		ManifestOpts: compat.ManifestOptions{
 			ArgoCDTrackingApp: envDefault("ARGOCD_TRACKING_APP", "tank-operator-sessions"),
+			// Pass the orchestrator's Cosmos config through to the pod's
+			// agent-runner via env vars — same endpoint, same database,
+			// the runner authenticates with its own UAMI (federated to
+			// claude-session SA, see infra/tank_session_identity.tf).
+			CosmosEndpoint:               envDefault("COSMOS_ENDPOINT", ""),
+			CosmosDatabase:               envDefault("COSMOS_DATABASE", "tank-operator"),
+			CosmosSessionEventsContainer: envDefault("COSMOS_SESSION_EVENTS_CONTAINER", "session-events"),
 		},
 		OAuthGatewayHost: os.Getenv("CLAUDE_OAUTH_GATEWAY_HOST"),
 		APIProxyHost:     os.Getenv("CLAUDE_API_PROXY_HOST"),

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -18,10 +18,11 @@ type appServer struct {
 	restCfg    *rest.Config
 	mgr        *sessions.Manager
 	profiles   profilesStore
-	activeRuns store.ActiveRunStore
-	runEvents  store.RunEventStore
-	turnQueue  store.TurnQueueStore
-	eventBus   *sessions.EventBus
+	activeRuns    store.ActiveRunStore
+	runEvents     store.RunEventStore
+	turnQueue     store.TurnQueueStore
+	sessionEvents store.SessionEventStore
+	eventBus      *sessions.EventBus
 	verifier   *auth.Verifier
 	minter     *auth.Minter
 	namespace  string
@@ -78,6 +79,12 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/sessions/{session_id}/runs/latest/events.json", s.handleLatestRunEventsJSON)
 	mux.HandleFunc("GET /api/sessions/{session_id}/runs/{run_id}/events", s.handleRunEvents)
 	mux.HandleFunc("GET /api/sessions/{session_id}/run", s.handleRunWebSocket)
+
+	// Phase C agent surface (new SDK runtime). Lives next to the legacy
+	// run endpoints during the rollout — Phase D switches the SPA over;
+	// Phase F deletes the legacy paths above.
+	mux.HandleFunc("GET /api/sessions/{session_id}/agent-ws", s.handleAgentWebSocket)
+	mux.HandleFunc("GET /api/sessions/{session_id}/events", s.handleListSessionEvents)
 
 	// CLI / sandbox agent.
 	mux.HandleFunc("POST /api/sessions/{session_id}/cli-process", s.handleCLIProcess)

--- a/backend-go/internal/compat/compat.go
+++ b/backend-go/internal/compat/compat.go
@@ -26,6 +26,7 @@ const (
 	SessionServiceAccount    = "claude-session"
 	SessionConfigMap         = "tank-session-config"
 	SandboxAgentPort         = 2468
+	AgentRunnerWSPort        = 8090
 	DefaultSessionImage      = "romainecr.azurecr.io/claude-container:latest"
 	DefaultCodexSessionImage = "romainecr.azurecr.io/codex-container:latest"
 	DefaultPiSessionImage    = "romainecr.azurecr.io/pi-container:latest"
@@ -93,6 +94,7 @@ var sessionConfigMounts = []struct{ key, mountPath string }{
 	{"write-glimmung-context.sh", "/opt/tank/write-glimmung-context.sh"},
 	{"tank-bootstrap.sh", "/opt/tank/bootstrap.sh"},
 	{"headless-run.sh", "/opt/tank/headless-run.sh"},
+	{"agent-runner-launch.sh", "/opt/tank/agent-runner-launch.sh"},
 }
 
 // noClaudeHijackModes are modes that should not receive the OAuth gateway / api proxy host aliases.
@@ -137,6 +139,14 @@ type ManifestOptions struct {
 	// so the Phase B agent-runner can talk to Cosmos via federated SA token.
 	// May be empty in Phase A test envs where the ExternalSecret isn't wired.
 	SessionAzureConfigSecret string
+	// Phase B agent-runner — Cosmos endpoint and session-events container,
+	// passed through the pod env so the runner can connect. AgentRunnerWSPort
+	// is the localhost port the runner's WebSocket listens on (orchestrator
+	// reverse-proxies onto it in Phase C).
+	CosmosEndpoint               string
+	CosmosDatabase               string
+	CosmosSessionEventsContainer string
+	AgentRunnerWSPort            int
 	// GlimmungContext JSON-serialized dict (may be empty).
 	GlimmungContextJSON string
 }
@@ -279,6 +289,26 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		map[string]any{"name": "session-config", "configMap": map[string]any{"name": opts.SessionConfigMap}},
 	}
 
+	// Phase B: shared /workspace across the claude container (sandbox-agent +
+	// the in-browser terminal pane) and the agent-runner container (drives
+	// the SDK). Without this, the agent's writes wouldn't be visible in the
+	// terminal pane and vice versa. emptyDir lives for the pod's lifetime,
+	// matching today's "pod restart loses workspace state" semantics.
+	// claude_gui is the only mode where the agent-runner exists today; the
+	// volume is harmless for the others but we keep it gated to avoid pod
+	// spec churn on legacy modes.
+	wantAgentRunner := mode == ClaudeGUIMode
+	if wantAgentRunner {
+		volumes = append(volumes, map[string]any{
+			"name":     "workspace",
+			"emptyDir": map[string]any{},
+		})
+		claudeVolumeMounts = append(claudeVolumeMounts, map[string]any{
+			"name":      "workspace",
+			"mountPath": "/workspace",
+		})
+	}
+
 	// OAuth gateway + API proxy host aliases and CA cert.
 	var hostAliases []any
 	if !noClaudeHijackModes[mode] && (opts.OAuthGatewayIP != "" || opts.APIProxyIP != "") {
@@ -350,6 +380,85 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		claudeContainer["envFrom"] = envFrom
 	}
 
+	containers := []any{
+		map[string]any{
+			"name":            "mcp-auth-proxy",
+			"image":           sessionImage,
+			"imagePullPolicy": "Always",
+			"command":         []any{"mcp-auth-proxy"},
+			"volumeMounts":    configMounts,
+		},
+		claudeContainer,
+	}
+
+	// Phase B agent-runner sidecar — claude_gui only. Shares /workspace
+	// with the claude container via the emptyDir above so the agent's
+	// edits show up in the terminal pane. Same image (binary baked in
+	// via the Dockerfile multi-stage build); different command + env.
+	// Ships INERT in Phase B — Phase C wires the orchestrator's
+	// reverse-proxy that actually drives the WebSocket port.
+	if wantAgentRunner {
+		runnerVolumeMounts := append([]any{}, configMounts...)
+		runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+			"name":      "workspace",
+			"mountPath": "/workspace",
+		})
+		runnerEnv := []any{
+			map[string]any{
+				"name": "SESSION_ID",
+				"valueFrom": map[string]any{
+					"fieldRef": map[string]any{
+						"fieldPath": "metadata.labels['tank-operator/session-id']",
+					},
+				},
+			},
+			map[string]any{
+				"name": "POD_OWNER_EMAIL",
+				"valueFrom": map[string]any{
+					"fieldRef": map[string]any{
+						"fieldPath": "metadata.annotations['tank-operator/owner-email']",
+					},
+				},
+			},
+			map[string]any{"name": "COSMOS_ENDPOINT", "value": opts.CosmosEndpoint},
+			map[string]any{"name": "COSMOS_DATABASE", "value": opts.CosmosDatabase},
+			map[string]any{"name": "COSMOS_SESSION_EVENTS_CONTAINER", "value": opts.CosmosSessionEventsContainer},
+			map[string]any{"name": "WORKSPACE", "value": "/workspace"},
+			map[string]any{"name": "MCP_CONFIG", "value": "/workspace/.mcp.json"},
+			map[string]any{"name": "AGENT_RUNNER_WS_PORT", "value": itoa(opts.AgentRunnerWSPort)},
+		}
+		// NODE_EXTRA_CA_CERTS — same gateway-CA injection the claude
+		// container gets, so the SDK's spawned claude binary trusts the
+		// OAuth gateway's self-signed cert.
+		if !noClaudeHijackModes[mode] && opts.OAuthGatewayCAConfigMap != "" {
+			runnerEnv = append(runnerEnv,
+				map[string]any{"name": "NODE_EXTRA_CA_CERTS", "value": "/etc/oauth-gateway-ca/ca.crt"},
+			)
+			runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+				"name":      "oauth-gateway-ca",
+				"mountPath": "/etc/oauth-gateway-ca",
+				"readOnly":  true,
+			})
+		}
+
+		runnerContainer := map[string]any{
+			"name":            "agent-runner",
+			"image":           sessionImage,
+			"imagePullPolicy": "Always",
+			"command":         []any{"bash", "/opt/tank/agent-runner-launch.sh"},
+			"ports": []any{map[string]any{
+				"name":          "agent-ws",
+				"containerPort": opts.AgentRunnerWSPort,
+			}},
+			"env":          runnerEnv,
+			"volumeMounts": runnerVolumeMounts,
+		}
+		if len(envFrom) > 0 {
+			runnerContainer["envFrom"] = envFrom
+		}
+		containers = append(containers, runnerContainer)
+	}
+
 	spec := map[string]any{
 		"serviceAccountName": opts.SessionServiceAccount,
 		"securityContext": map[string]any{
@@ -358,17 +467,8 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			"runAsGroup":   1000,
 			"fsGroup":      1000,
 		},
-		"containers": []any{
-			map[string]any{
-				"name":            "mcp-auth-proxy",
-				"image":           sessionImage,
-				"imagePullPolicy": "Always",
-				"command":         []any{"mcp-auth-proxy"},
-				"volumeMounts":    configMounts,
-			},
-			claudeContainer,
-		},
-		"volumes": volumes,
+		"containers": containers,
+		"volumes":    volumes,
 	}
 	if len(hostAliases) > 0 {
 		spec["hostAliases"] = hostAliases
@@ -472,6 +572,15 @@ func withManifestDefaults(opts ManifestOptions) ManifestOptions {
 	}
 	if opts.SessionAzureConfigSecret == "" {
 		opts.SessionAzureConfigSecret = DefaultSessionAzureConfigSecret
+	}
+	if opts.CosmosDatabase == "" {
+		opts.CosmosDatabase = "tank-operator"
+	}
+	if opts.CosmosSessionEventsContainer == "" {
+		opts.CosmosSessionEventsContainer = "session-events"
+	}
+	if opts.AgentRunnerWSPort == 0 {
+		opts.AgentRunnerWSPort = AgentRunnerWSPort
 	}
 	return opts
 }

--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -1,0 +1,93 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// SessionEventStore reads the canonical SDK events the pod-side
+// agent-runner writes to the `session-events` Cosmos container. The
+// orchestrator is a reader only here — the runner owns the write side
+// (see agent-runner/src/cosmos.ts). This split is the producer contract:
+// one producer, two consumers (DB reader = SPA history-replay,
+// WS subscriber = SPA live tap).
+//
+// Container partition key is /tank_session_id (the small-integer pod id,
+// not the SDK's UUID). Doc id is the SDK event uuid (v7, monotonic) so
+// the watermark works as a simple string comparison.
+type SessionEventStore interface {
+	ListBySession(ctx context.Context, tankSessionID, afterUUID string, limit int) ([]map[string]any, error)
+}
+
+type cosmosSessionEventStore struct {
+	container *azcosmos.ContainerClient
+}
+
+func NewCosmosSessionEventStore(endpoint, database, container string, cred azcore.TokenCredential) (SessionEventStore, error) {
+	client, err := azcosmos.NewClient(endpoint, cred, nil)
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.NewContainer(database, container)
+	if err != nil {
+		return nil, err
+	}
+	return &cosmosSessionEventStore{container: c}, nil
+}
+
+// ListBySession returns events for one session, strictly after the
+// given uuid watermark, in ascending uuid order. afterUUID="" returns
+// everything from the beginning. limit caps the page size.
+//
+// Single-partition read (tank_session_id is the partition key) so the
+// query is one RU per ~1KB doc — fast and cheap. The /message/* path
+// is excluded from indexing (see infra/cosmos.tf) so large assistant
+// content doesn't inflate index size; this query doesn't need it
+// indexed because we filter on id (the partition's clustering key).
+func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSessionID, afterUUID string, limit int) ([]map[string]any, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	query := "SELECT * FROM c WHERE c.tank_session_id = @sid AND c.id > @after ORDER BY c.id ASC OFFSET 0 LIMIT @limit"
+	params := []azcosmos.QueryParameter{
+		{Name: "@sid", Value: tankSessionID},
+		{Name: "@after", Value: afterUUID},
+		{Name: "@limit", Value: limit},
+	}
+	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(tankSessionID), &azcosmos.QueryOptions{QueryParameters: params})
+	out := make([]map[string]any, 0, limit)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range page.Items {
+			var doc map[string]any
+			if err := json.Unmarshal(raw, &doc); err != nil {
+				continue
+			}
+			out = append(out, doc)
+		}
+	}
+	// Cosmos should already sort by the ORDER BY clause, but the pager
+	// concatenation across pages can return slightly out-of-order rows
+	// on the page boundary; an explicit sort is cheap and removes the
+	// edge case for the SPA's dedupe-by-uuid path.
+	sort.SliceStable(out, func(i, j int) bool {
+		ai, _ := out[i]["id"].(string)
+		aj, _ := out[j]["id"].(string)
+		return ai < aj
+	})
+	return out, nil
+}
+
+// Stub for local dev where Cosmos isn't configured.
+type StubSessionEventStore struct{}
+
+func (StubSessionEventStore) ListBySession(_ context.Context, _, _ string, _ int) ([]map[string]any, error) {
+	return nil, nil
+}

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -1,9 +1,21 @@
-# azure-mcp + github-mcp + k8s-mcp run as in-cluster HTTP MCP servers.
-# The container
-# reaches them via the mcp-auth-proxy sidecar on 127.0.0.1, which reads
-# the projected SA token fresh per request and forwards as a Bearer
-# token. No co-located MCP binaries needed in this image — keep it
-# minimal.
+# Stage 1: build the pod-side Phase B agent-runner from agent-runner/.
+# TypeScript compiled to JS; production node_modules baked into the
+# runtime image. Source at /repo/agent-runner/, build context is repo
+# root (set by .github/workflows/claude-container-build.yml).
+FROM node:20-alpine AS agent-runner-build
+WORKDIR /src/agent-runner
+COPY agent-runner/package.json agent-runner/package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+COPY agent-runner/tsconfig.json ./
+COPY agent-runner/src ./src
+RUN npx tsc
+# Prune dev deps for a smaller runtime payload.
+RUN npm prune --omit=dev
+
+# Stage 2: runtime image. azure-mcp + github-mcp + k8s-mcp run as in-cluster
+# HTTP MCP servers. The container reaches them via the mcp-auth-proxy sidecar
+# on 127.0.0.1, which reads the projected SA token fresh per request and
+# forwards as a Bearer token. No co-located MCP binaries — keep it minimal.
 FROM node:20-alpine
 
 ARG TARGETARCH=amd64
@@ -106,6 +118,16 @@ RUN pip install --no-cache-dir --break-system-packages \
 # bearer in env vars.
 COPY claude-container/mcp-auth-proxy /opt/mcp-auth-proxy
 RUN pip install --no-cache-dir --break-system-packages /opt/mcp-auth-proxy
+
+# Phase B agent-runner: long-lived pod-side process that drives
+# @anthropic-ai/claude-agent-sdk, fans events to Cosmos (durable) + a
+# local WebSocket (live tap). Shipped inert in Phase B — no container
+# in the pod spec invokes it yet; Phase C wires the orchestrator's
+# WebSocket reverse-proxy and the per-session opt-in label that turns
+# it on. Entrypoint: `node /opt/agent-runner/dist/index.js`.
+COPY --from=agent-runner-build /src/agent-runner/dist /opt/agent-runner/dist
+COPY --from=agent-runner-build /src/agent-runner/node_modules /opt/agent-runner/node_modules
+COPY --from=agent-runner-build /src/agent-runner/package.json /opt/agent-runner/package.json
 
 # Session-facing MCP wiring, AGENTS/CLAUDE primers, bundled skill docs, and the
 # bootstrap script are mounted from the chart-managed tank-session-config

--- a/infra/cosmos.tf
+++ b/infra/cosmos.tf
@@ -94,6 +94,33 @@ resource "azurerm_cosmosdb_sql_container" "active_runs" {
   }
 }
 
+resource "azurerm_cosmosdb_sql_container" "session_events" {
+  name                = "session-events"
+  resource_group_name = data.azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.tank_operator.name
+  database_name       = azurerm_cosmosdb_sql_database.tank_operator.name
+  # Partitioned on the orchestrator's session_id (the small integer that
+  # identifies a tank-operator pod). The pod-side agent-runner stamps
+  # tank_session_id on every event so the SPA's "give me all events for
+  # this session" query becomes a single-partition read. The SDK's own
+  # session_id field rides along on each doc but isn't the partition key:
+  # multiple SDK sessions may exist within one tank-operator session
+  # (e.g., after a pod restart and resume).
+  partition_key_paths = ["/tank_session_id"]
+  default_ttl         = 2592000
+
+  indexing_policy {
+    indexing_mode = "consistent"
+    included_path { path = "/*" }
+    # Assistant message bodies and tool inputs/outputs can be large.
+    # Excluding them from indexing keeps writes cheap; the SPA never
+    # queries by content, only by tank_session_id + event uuid (the
+    # monotonic watermark).
+    excluded_path { path = "/message/*" }
+    excluded_path { path = "/result/*" }
+  }
+}
+
 resource "azurerm_cosmosdb_sql_container" "turn_queue" {
   name                = "turn-queue"
   resource_group_name = data.azurerm_resource_group.main.name

--- a/k8s/session-config/agent-runner-launch.sh
+++ b/k8s/session-config/agent-runner-launch.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Pod-side launch shim for the Phase B agent-runner Node service.
+# Mirrors the credential-setup logic from headless-run.sh (which runs
+# per-turn in the legacy dispatch path); here we do it ONCE per pod
+# lifetime, then exec the long-lived runner that drives the SDK.
+#
+# Why bash + exec node, not a Node entrypoint that does cred setup
+# itself: the credential blob shape and configure_claude logic are
+# small but very platform-specific (file modes, claude-code's
+# expected JSON shape), and keeping them in shell matches the
+# existing per-turn pattern so future changes can be made in one
+# place if both paths still exist.
+
+set -eu
+
+configure_claude() {
+  mkdir -p "$HOME/.claude"
+  cat > "$HOME/.claude/settings.json" <<'EOF'
+{"theme":"dark","permissions":{"defaultMode":"bypassPermissions"},"skipDangerousModePermissionPrompt":true}
+EOF
+
+  mcp_enabled='[]'
+  if [ -f /workspace/.mcp.json ]; then
+    mcp_enabled="$(jq -c '.mcpServers | keys' /workspace/.mcp.json)"
+  fi
+
+  # Placeholder OAuth bearer. The in-cluster api-proxy hostAlias-rewrites
+  # api.anthropic.com to the proxy's ClusterIP, sees this placeholder, and
+  # swaps in the real OAuth token from KV. The agent-runner / SDK never
+  # holds the real token directly. See api-proxy/src/tank_api_proxy/server.py.
+  cat > "$HOME/.claude/.credentials.json" <<'EOF'
+{
+  "claudeAiOauth": {
+    "accessToken": "managed-by-tank-operator",
+    "refreshToken": "managed-by-tank-operator",
+    "expiresAt": 9999999999000,
+    "scopes": ["user:inference", "user:profile"],
+    "subscriptionType": "max",
+    "rateLimitTier": "max"
+  }
+}
+EOF
+  chmod 600 "$HOME/.claude/.credentials.json"
+  unset ANTHROPIC_API_KEY
+
+  cat > "$HOME/.claude.json" <<EOF
+{
+  "hasCompletedOnboarding": true,
+  "remoteDialogSeen": true,
+  "officialMarketplaceAutoInstallAttempted": true,
+  "officialMarketplaceAutoInstalled": true,
+  "projects": {
+    "/workspace": {
+      "allowedTools": [],
+      "mcpContextUris": [],
+      "mcpServers": {},
+      "enabledMcpjsonServers": ${mcp_enabled},
+      "disabledMcpjsonServers": [],
+      "hasTrustDialogAccepted": true,
+      "projectOnboardingSeenCount": 1,
+      "hasClaudeMdExternalIncludesApproved": false,
+      "hasClaudeMdExternalIncludesWarningShown": false,
+      "lastGracefulShutdown": false
+    }
+  }
+}
+EOF
+}
+
+# Git identity for any commits the agent makes from /workspace.
+git config --global user.name "tank-operator-claude[bot]"
+git config --global user.email "tank-operator-claude@romaine.life"
+
+configure_claude
+
+# Optional: install tank-flavored skills into the agent's home dir.
+# Same script the per-turn path uses; idempotent.
+if [ -f /opt/tank/session-config/install-tank-skills.sh ]; then
+  sh /opt/tank/session-config/install-tank-skills.sh || true
+fi
+
+# Hand off to the runner. Node is PID 1 from this point — SIGTERM goes
+# straight to it, which handles graceful shutdown of the SDK subprocess.
+exec node /opt/agent-runner/dist/index.js

--- a/k8s/templates/session-configmap.yaml
+++ b/k8s/templates/session-configmap.yaml
@@ -18,6 +18,8 @@ data:
 {{ .Files.Get "session-config/tank-bootstrap.sh" | indent 4 }}
   headless-run.sh: |
 {{ .Files.Get "session-config/headless-run.sh" | indent 4 }}
+  agent-runner-launch.sh: |
+{{ .Files.Get "session-config/agent-runner-launch.sh" | indent 4 }}
 {{- range $scope := list "common" "claude" "codex" }}
 {{- range $path, $_ := $.Files.Glob (printf "session-config/skills/%s/**" $scope) }}
   skills__{{ trimPrefix "session-config/skills/" $path | replace "/" "__" }}: |


### PR DESCRIPTION
## Summary

Two new endpoints that let the SPA (Phase D) talk to the Phase B agent-runner:

- **`GET /api/sessions/{id}/agent-ws`** — WebSocket reverse-proxy. Auth-checks JWT, ownership-checks the pod, dials the pod IP at port 8090, pipes bytes both ways. Pure pipe — no message inspection, so SDK protocol changes don't require orchestrator changes.
- **`GET /api/sessions/{id}/events?after=<uuid>&limit=<n>`** — reads canonical SDK events from the `session-events` Cosmos container (where the Phase B agent-runner writes them). Single-partition read on `/tank_session_id`; ordered by SDK uuid (v7, time-sortable).

SPA contract: history from `/events`, live from `/agent-ws`, dedupe by uuid (the watermark).

## What's not in this PR

- The SPA doesn't open these endpoints yet — that's Phase D.
- No change to the legacy `/run/*` paths — they keep working for non-claude_gui sessions and for any pod created before Phase B's image rolled.
- No "opt-in" label needed on the pod for Phase C: every claude_gui pod created post-Phase B already has the agent-runner container available, and the new endpoints fail gracefully when the container is absent.

## Test plan

- [x] `go build ./... && go test ./... && go vet ./...`
- [ ] After deploy: hit `/api/sessions/{id}/events?after=` against a claude_gui session pod — expect `[]` (runner hasn't written anything yet because no SPA is talking to it)
- [ ] After deploy: `wscat` (or equivalent) into `/api/sessions/{id}/agent-ws` with a Bearer token — expect a clean upgrade, then write a `{"type":"ping"}` frame, expect `{"type":"pong"}` back from the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)