### PR TITLE
Phase D-G: SPA SDK pane, profile prefs sync, conformance tests

### DIFF
--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -1,0 +1,96 @@
+// Pins the producer-contract invariants that the SPA depends on
+// (one serialization → two sinks, DB-first ordering, ws skipped on
+// cosmos failure). Drift in any of these silently breaks the
+// history-replay / live join in RunPaneSDK.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { dispatch } from "./runner.js";
+
+type Order = string[];
+function makeSink(order: Order, opts: { throws?: Error } = {}) {
+  return {
+    async upsert() {
+      if (opts.throws) throw opts.throws;
+      order.push("cosmos");
+    },
+  };
+}
+function makeWS(order: Order) {
+  return {
+    broadcastEvent() {
+      order.push("ws");
+    },
+  };
+}
+
+test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
+  const order: Order = [];
+  const ok = await dispatch(
+    makeSink(order),
+    makeWS(order),
+    { type: "assistant", uuid: "x" } as any,
+  );
+  assert.equal(ok, true);
+  assert.deepEqual(order, ["cosmos", "ws"]);
+});
+
+test("canonical: cosmos failure suppresses ws broadcast", async () => {
+  const order: Order = [];
+  const ok = await dispatch(
+    makeSink(order, { throws: new Error("boom") }),
+    makeWS(order),
+    { type: "assistant", uuid: "x" } as any,
+  );
+  // The SPA must never see a live event that wasn't persisted — otherwise
+  // history-replay on the next reload would diverge from what was rendered.
+  assert.equal(ok, false);
+  assert.deepEqual(order, []);
+});
+
+test("live-only: stream_event broadcast skips cosmos entirely", async () => {
+  const order: Order = [];
+  const ok = await dispatch(
+    makeSink(order),
+    makeWS(order),
+    { type: "stream_event" } as any,
+  );
+  assert.equal(ok, true);
+  // No "cosmos" entry — the live-only types (typewriter deltas, status
+  // pings, hook lifecycle) deliberately stay out of the durable log.
+  assert.deepEqual(order, ["ws"]);
+});
+
+test("live-only: cosmos is never even called for non-canonical", async () => {
+  let cosmosCalled = false;
+  const ws = { broadcastEvent() {} };
+  const sink = {
+    async upsert() {
+      cosmosCalled = true;
+    },
+  };
+  await dispatch(sink, ws, { type: "system", subtype: "status" } as any);
+  assert.equal(cosmosCalled, false);
+});
+
+test("system without subtype: not canonical (defensive default)", async () => {
+  let cosmosCalled = false;
+  let broadcasted = false;
+  const sink = {
+    async upsert() {
+      cosmosCalled = true;
+    },
+  };
+  const ws = {
+    broadcastEvent() {
+      broadcasted = true;
+    },
+  };
+  // Unknown system events with no subtype shouldn't be persisted — better
+  // to silently drop than to pollute the canonical stream with junk a
+  // future SDK release may have meant as transient.
+  await dispatch(sink, ws, { type: "system" } as any);
+  assert.equal(cosmosCalled, false);
+  assert.equal(broadcasted, true);
+});

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -26,6 +26,39 @@ import { CosmosSink, isCanonical } from "./cosmos.js";
 import { extractWakeup, type WakeupRequest } from "./wakeup.js";
 import { WSFanout, type ClientFrame } from "./ws.js";
 
+// Pull a single dispatch out as a free function so the producer
+// contract — cosmos-first ordering + cosmos-failure suppresses ws — is
+// testable without spinning up a Runner (the WSFanout binds to a port
+// in its constructor, which makes the full Runner painful to unit-test).
+//
+// Returns true on a successful end-to-end dispatch; false when the
+// canonical write failed and the broadcast was intentionally skipped.
+// Callers that don't care about the outcome can ignore it.
+interface DispatchSink {
+  upsert(message: SDKMessage): Promise<void>;
+}
+interface DispatchWS {
+  broadcastEvent(message: SDKMessage): void;
+}
+export async function dispatch(
+  sink: DispatchSink,
+  ws: DispatchWS,
+  message: SDKMessage,
+): Promise<boolean> {
+  if (isCanonical(message)) {
+    try {
+      await sink.upsert(message);
+    } catch (err) {
+      console.error("cosmos upsert failed:", err);
+      // Don't broadcast a live event we couldn't persist — the SPA's
+      // history-replay would then disagree with what it saw live.
+      return false;
+    }
+  }
+  ws.broadcastEvent(message);
+  return true;
+}
+
 // AsyncQueue is a one-writer-many-no-readers queue that yields each
 // pushed item exactly once. The SDK consumes this as the prompt source.
 class AsyncQueue<T> {
@@ -110,19 +143,11 @@ export class Runner {
   }
 
   private async handleEvent(message: SDKMessage): Promise<void> {
-    // 1. Cosmos first (durable, read-your-writes ordering)
-    if (isCanonical(message)) {
-      try {
-        await this.sink.upsert(message);
-      } catch (err) {
-        console.error("cosmos upsert failed:", err);
-        // Don't broadcast a live event we couldn't persist — the SPA's
-        // history-replay would then disagree with what it saw live.
-        return;
-      }
-    }
-    // 2. WebSocket broadcast (live tap)
-    this.ws.broadcastEvent(message);
+    // 1+2. Dual-sink dispatch (cosmos-first ordering). Extracted so the
+    // contract — canonical: cosmos before ws, ws skipped on cosmos
+    // failure; live-only: ws only — can be tested without spinning up a
+    // Runner.
+    await dispatch(this.sink, this.ws, message);
 
     // 3. ScheduleWakeup detection
     const wakeup = extractWakeup(message);

--- a/backend-go/cmd/tank-operator/handlers_auth.go
+++ b/backend-go/cmd/tank-operator/handlers_auth.go
@@ -99,6 +99,40 @@ func (s *appServer) handleMe(w http.ResponseWriter, r *http.Request) {
 		"avatar_url":      auth.GravatarURL(user.Email, 64),
 		"github_login":    profile.GitHubLogin,
 		"installation_id": profile.InstallationID,
+		"run_prefs":       profile.RunPrefs,
+	})
+}
+
+// handleUpdatePrefs persists the SPA's run-pane preferences (chat font
+// scale, sound volume, etc.) on the caller's Cosmos profile row. The
+// body shape is opaque to the orchestrator — the SPA owns the schema
+// (frontend/src/App.tsx → RunPrefs). The store does a merge-safe
+// upsert so unrelated profile fields (installation_id, github_login)
+// survive.
+func (s *appServer) handleUpdatePrefs(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	prefsStore, ok := s.profiles.(profilesPrefsStore)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "profile store does not support prefs writes")
+		return
+	}
+	var body struct {
+		RunPrefs map[string]any `json:"run_prefs"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	profile, err := prefsStore.UpdatePrefs(r.Context(), user.Email, body.RunPrefs)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"run_prefs": profile.RunPrefs,
 	})
 }
 

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -288,6 +288,14 @@ type profilesUpdateStore interface {
 	UpdateInstallation(ctx context.Context, email string, installationID int64, githubLogin *string) (profiles.Profile, error)
 }
 
+// profilesPrefsStore is an optional interface for the SPA's run-pref
+// sync (Phase E). Implemented by CosmosStore and StubStore. The handler
+// surfaces a 503 when the backing store doesn't satisfy it.
+type profilesPrefsStore interface {
+	profilesStore
+	UpdatePrefs(ctx context.Context, email string, prefs map[string]any) (profiles.Profile, error)
+}
+
 // cosmosSessionRegistryAdapter wraps CosmosStore to satisfy sessions.SessionRegistry.
 type cosmosSessionRegistryAdapter struct {
 	*sessionregistry.CosmosStore

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -73,7 +73,12 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/sessions/{session_id}/skills", s.handleListSkills)
 	mux.HandleFunc("GET /api/sessions/{session_id}/mcp-servers", s.handleListMCPServers)
 
-	// Run endpoints.
+	// Legacy run endpoints — claude_cli/codex_gui/pi pods still hit these
+	// (they have no agent-runner sidecar). Phase F2 deletes them once
+	// every claude_gui code path is on the SDK runtime AND codex_gui
+	// either gets its own SDK pane or is removed. Don't delete in the
+	// same diff as the runtime swap: running pre-Phase-B pods still need
+	// these to render until they reap.
 	mux.HandleFunc("GET /api/sessions/{session_id}/run/active", s.handleGetActiveRun)
 	mux.HandleFunc("GET /api/sessions/{session_id}/run/history", s.handleRunHistory)
 	mux.HandleFunc("GET /api/sessions/{session_id}/runs/latest/events", s.handleLatestRunEvents)
@@ -81,9 +86,10 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/sessions/{session_id}/runs/{run_id}/events", s.handleRunEvents)
 	mux.HandleFunc("GET /api/sessions/{session_id}/run", s.handleRunWebSocket)
 
-	// Phase C agent surface (new SDK runtime). Lives next to the legacy
-	// run endpoints during the rollout — Phase D switches the SPA over;
-	// Phase F deletes the legacy paths above.
+	// Phase C agent surface (SDK runtime). The SPA's RunPaneSDK opens
+	// agent-ws for live and hits /events for history; together they're
+	// the producer-contract reader (one canonical event stream from the
+	// pod-side runner, two consumers).
 	mux.HandleFunc("GET /api/sessions/{session_id}/agent-ws", s.handleAgentWebSocket)
 	mux.HandleFunc("GET /api/sessions/{session_id}/events", s.handleListSessionEvents)
 

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -40,6 +40,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/auth/microsoft/login", s.handleMicrosoftLogin)
 	mux.HandleFunc("POST /api/auth/logout", s.handleLogout)
 	mux.HandleFunc("GET /api/auth/me", s.handleMe)
+	mux.HandleFunc("PUT /api/auth/prefs", s.handleUpdatePrefs)
 	mux.HandleFunc("POST /api/internal/auth/k8s", s.handleK8sAuth)
 
 	// GitHub install.

--- a/backend-go/internal/profiles/profiles.go
+++ b/backend-go/internal/profiles/profiles.go
@@ -15,6 +15,11 @@ type Profile struct {
 	Email          string  `json:"email"`
 	GitHubLogin    *string `json:"github_login"`
 	InstallationID *int64  `json:"installation_id"`
+	// RunPrefs is opaque on the wire — the SPA owns the schema (chat font
+	// scale, sound volume, etc., see frontend/src/App.tsx → RunPrefs).
+	// Storing as a free-form map lets us evolve UI prefs without coupling
+	// to a Cosmos schema migration. Nil when the user has never set prefs.
+	RunPrefs map[string]any `json:"run_prefs,omitempty"`
 }
 
 type Store interface {
@@ -68,9 +73,10 @@ func (StubStore) GetOrCreate(_ context.Context, email string) (Profile, error) {
 
 func profileFromDoc(data []byte) (Profile, error) {
 	var doc struct {
-		Email          string  `json:"email"`
-		GitHubLogin    *string `json:"github_login"`
-		InstallationID *int64  `json:"installation_id"`
+		Email          string         `json:"email"`
+		GitHubLogin    *string        `json:"github_login"`
+		InstallationID *int64         `json:"installation_id"`
+		RunPrefs       map[string]any `json:"run_prefs"`
 	}
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return Profile{}, err
@@ -79,5 +85,6 @@ func profileFromDoc(data []byte) (Profile, error) {
 		Email:          doc.Email,
 		GitHubLogin:    doc.GitHubLogin,
 		InstallationID: doc.InstallationID,
+		RunPrefs:       doc.RunPrefs,
 	}, nil
 }

--- a/backend-go/internal/profiles/profiles_test.go
+++ b/backend-go/internal/profiles/profiles_test.go
@@ -23,3 +23,41 @@ func TestProfileFromDocAllowsNullProfileFields(t *testing.T) {
 		t.Fatalf("profile = %#v", profile)
 	}
 }
+
+func TestProfileFromDocParsesRunPrefs(t *testing.T) {
+	profile, err := profileFromDoc([]byte(`{"email":"u@x","run_prefs":{"chatFontScale":1.2,"showThinking":true}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.RunPrefs == nil {
+		t.Fatalf("expected run_prefs, got nil")
+	}
+	if v, ok := profile.RunPrefs["chatFontScale"].(float64); !ok || v != 1.2 {
+		t.Fatalf("chatFontScale = %#v", profile.RunPrefs["chatFontScale"])
+	}
+	if v, ok := profile.RunPrefs["showThinking"].(bool); !ok || !v {
+		t.Fatalf("showThinking = %#v", profile.RunPrefs["showThinking"])
+	}
+}
+
+func TestProfileFromMapPreservesRunPrefs(t *testing.T) {
+	doc := map[string]any{
+		"email":           "u@x",
+		"installation_id": float64(7),
+		"github_login":    "ghuser",
+		"run_prefs":       map[string]any{"showThinking": false},
+	}
+	p := profileFromMap(doc)
+	if p.Email != "u@x" {
+		t.Fatalf("email = %q", p.Email)
+	}
+	if p.InstallationID == nil || *p.InstallationID != 7 {
+		t.Fatalf("installation_id = %#v", p.InstallationID)
+	}
+	if p.GitHubLogin == nil || *p.GitHubLogin != "ghuser" {
+		t.Fatalf("github_login = %#v", p.GitHubLogin)
+	}
+	if p.RunPrefs == nil || p.RunPrefs["showThinking"] != false {
+		t.Fatalf("run_prefs = %#v", p.RunPrefs)
+	}
+}

--- a/backend-go/internal/profiles/update.go
+++ b/backend-go/internal/profiles/update.go
@@ -3,59 +3,130 @@ package profiles
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 )
 
+// readRawDoc fetches the existing profile doc as an untyped map so a
+// caller can splice fields into it without clobbering unrelated keys.
+// Returns an empty map when the doc doesn't exist yet — the caller is
+// responsible for seeding `id` and `email`.
+//
+// We have to go through a raw map because the Profile struct only types
+// the fields the orchestrator knows about today. The doc may carry
+// future fields (or fields a newer SPA wrote that this build doesn't
+// know about); a read-decode-write round-trip on the typed struct would
+// drop them. The merge pattern here is the same one Discord/Slack-style
+// settings APIs use: never overwrite the whole doc, splice the delta.
+func (s *CosmosStore) readRawDoc(ctx context.Context, email string) (map[string]any, error) {
+	pk := azcosmos.NewPartitionKeyString(email)
+	response, err := s.container.ReadItem(ctx, pk, email, nil)
+	if err != nil {
+		var responseErr *azcore.ResponseError
+		if errors.As(err, &responseErr) && responseErr.StatusCode == http.StatusNotFound {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(response.Value, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UpdateInstallation upserts the GitHub installation_id (and optionally github_login)
-// on the profile row for the given email.
+// on the profile row for the given email. Other fields on the doc (e.g. run_prefs)
+// are preserved via the readRawDoc merge.
 func (s *CosmosStore) UpdateInstallation(ctx context.Context, email string, installationID int64, githubLogin *string) (Profile, error) {
 	normalized := strings.ToLower(strings.TrimSpace(email))
 	if normalized == "" {
 		return Profile{}, nil
 	}
 
-	// Read existing (or start from blank).
-	existing, err := s.GetOrCreate(ctx, normalized)
+	doc, err := s.readRawDoc(ctx, normalized)
 	if err != nil {
 		return Profile{}, err
 	}
-
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	doc := map[string]any{
-		"id":              normalized,
-		"email":           normalized,
-		"installation_id": installationID,
-		"updated_at":      now,
-	}
+	doc["id"] = normalized
+	doc["email"] = normalized
+	doc["installation_id"] = installationID
+	doc["updated_at"] = time.Now().UTC().Format(time.RFC3339Nano)
 	if githubLogin != nil {
 		doc["github_login"] = *githubLogin
-	} else if existing.GitHubLogin != nil {
-		doc["github_login"] = *existing.GitHubLogin
 	}
 
+	if err := s.upsertDoc(ctx, normalized, doc); err != nil {
+		return Profile{}, err
+	}
+	return profileFromMap(doc), nil
+}
+
+// UpdatePrefs upserts the SPA's run-pane preferences. The body is opaque
+// on the orchestrator side — see RunPrefs in the SPA for the shape. Other
+// fields on the doc are preserved.
+func (s *CosmosStore) UpdatePrefs(ctx context.Context, email string, prefs map[string]any) (Profile, error) {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return Profile{}, nil
+	}
+	if prefs == nil {
+		prefs = map[string]any{}
+	}
+
+	doc, err := s.readRawDoc(ctx, normalized)
+	if err != nil {
+		return Profile{}, err
+	}
+	doc["id"] = normalized
+	doc["email"] = normalized
+	doc["run_prefs"] = prefs
+	doc["updated_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+
+	if err := s.upsertDoc(ctx, normalized, doc); err != nil {
+		return Profile{}, err
+	}
+	return profileFromMap(doc), nil
+}
+
+func (s *CosmosStore) upsertDoc(ctx context.Context, partitionEmail string, doc map[string]any) error {
 	raw, err := json.Marshal(doc)
 	if err != nil {
-		return Profile{}, err
+		return err
 	}
+	_, err = s.container.UpsertItem(ctx, azcosmos.NewPartitionKeyString(partitionEmail), raw, nil)
+	return err
+}
 
-	pk := azcosmos.NewPartitionKeyString(normalized)
-	_, err = s.container.UpsertItem(ctx, pk, raw, nil)
-	if err != nil {
-		return Profile{}, err
+func profileFromMap(doc map[string]any) Profile {
+	p := Profile{}
+	if v, ok := doc["email"].(string); ok {
+		p.Email = v
 	}
-
-	profile := Profile{
-		Email:          normalized,
-		GitHubLogin:    githubLogin,
-		InstallationID: &installationID,
+	if v, ok := doc["github_login"].(string); ok {
+		login := v
+		p.GitHubLogin = &login
 	}
-	if profile.GitHubLogin == nil {
-		profile.GitHubLogin = existing.GitHubLogin
+	switch v := doc["installation_id"].(type) {
+	case float64:
+		id := int64(v)
+		p.InstallationID = &id
+	case int64:
+		id := v
+		p.InstallationID = &id
+	case int:
+		id := int64(v)
+		p.InstallationID = &id
 	}
-	return profile, nil
+	if v, ok := doc["run_prefs"].(map[string]any); ok {
+		p.RunPrefs = v
+	}
+	return p
 }
 
 // UpdateInstallation is a no-op for StubStore.
@@ -64,5 +135,14 @@ func (StubStore) UpdateInstallation(_ context.Context, email string, installatio
 		Email:          strings.ToLower(strings.TrimSpace(email)),
 		GitHubLogin:    githubLogin,
 		InstallationID: &installationID,
+	}, nil
+}
+
+// UpdatePrefs is a no-op for StubStore — the SPA falls back to
+// localStorage when the orchestrator runs without Cosmos configured.
+func (StubStore) UpdatePrefs(_ context.Context, email string, prefs map[string]any) (Profile, error) {
+	return Profile{
+		Email:    strings.ToLower(strings.TrimSpace(email)),
+		RunPrefs: prefs,
 	}, nil
 }

--- a/backend-go/internal/sessions/sessions.go
+++ b/backend-go/internal/sessions/sessions.go
@@ -33,6 +33,13 @@ type Info struct {
 	Owner        string         `json:"owner"`
 	Status       string         `json:"status"`
 	Mode         string         `json:"mode"`
+	// Runtime is the dispatch shape for this session pod:
+	//   "sdk"    — Phase B+ pods with the agent-runner container. SPA
+	//              should open /agent-ws + /events for live + history.
+	//   "legacy" — pre-Phase B pods (no agent-runner container) or
+	//              non-claude modes. SPA falls back to /run + /run/history.
+	// Derived from the pod spec at read time; not stored anywhere.
+	Runtime      string         `json:"runtime"`
 	RequestedAt  *string        `json:"requested_at"`
 	CreatedAt    *string        `json:"created_at"`
 	ReadyAt      *string        `json:"ready_at"`
@@ -168,6 +175,7 @@ func infoFromPod(owner string, pod *corev1.Pod) Info {
 		Owner:        owner,
 		Status:       podStatus(pod),
 		Mode:         compat.NormalizeSessionMode(pod.Labels["tank-operator/mode"]),
+		Runtime:      runtimeFromPod(pod),
 		RequestedAt:  createdAt,
 		CreatedAt:    createdAt,
 		ReadyAt:      readyAt,
@@ -175,6 +183,20 @@ func infoFromPod(owner string, pod *corev1.Pod) Info {
 		TestState:    annotationObject(pod.Annotations, testStateAnnotation),
 		RolloutState: annotationObject(pod.Annotations, rolloutStateAnnotation),
 	}
+}
+
+// runtimeFromPod returns "sdk" if the pod has the Phase B agent-runner
+// container in its spec, "legacy" otherwise. The SPA branches on this
+// to pick the new typed-event consumer or the old stream-json one.
+// Old pods that pre-date the Phase B image roll won't have the
+// container; they stay on the legacy path until reaped.
+func runtimeFromPod(pod *corev1.Pod) string {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "agent-runner" {
+			return "sdk"
+		}
+	}
+	return "legacy"
 }
 
 func optionalString(value string) *string {

--- a/backend-go/internal/sessions/sessions_test.go
+++ b/backend-go/internal/sessions/sessions_test.go
@@ -143,6 +143,33 @@ func TestListMergesRegistryRecordsWithPods(t *testing.T) {
 	}
 }
 
+// runtimeFromPod drives the SPA's choice between RunPaneSDK (Phase B+
+// pods with the agent-runner container) and the legacy HeadlessRun
+// renderer. The contract is observable as a JSON field on /api/sessions
+// — keep it pinned so we don't silently start routing legacy pods to
+// the SDK pane (or vice versa) when refactoring container detection.
+func TestRuntimeFromPodDetectsAgentRunner(t *testing.T) {
+	withRunner := sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true)
+	withRunner.Spec.Containers = append(withRunner.Spec.Containers, corev1.Container{Name: "agent-runner"})
+	if got := runtimeFromPod(withRunner); got != "sdk" {
+		t.Fatalf("runtime with agent-runner = %q, want sdk", got)
+	}
+
+	withoutRunner := sessionPod("13", "nelson@romaine.life", corev1.PodRunning, true)
+	if got := runtimeFromPod(withoutRunner); got != "legacy" {
+		t.Fatalf("runtime without agent-runner = %q, want legacy", got)
+	}
+}
+
+func TestInfoFromPodSurfacesRuntime(t *testing.T) {
+	pod := sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true)
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "agent-runner"})
+	info := infoFromPod("nelson@romaine.life", pod)
+	if info.Runtime != "sdk" {
+		t.Fatalf("Info.Runtime = %q, want sdk", info.Runtime)
+	}
+}
+
 func TestPodStatusCompatibility(t *testing.T) {
 	pending := sessionPod("12", "nelson@romaine.life", corev1.PodPending, true)
 	if got := podStatus(pending); got != "Pending" {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,6 +82,7 @@ import {
 import { authedFetch, bootstrapAuth, getStoredToken, logout, startLogin } from "./auth";
 import { McpIcon } from "./McpIcon";
 import { ProviderIcon } from "./providerIcons";
+import { RunPaneSDK } from "./RunPaneSDK";
 import { ANSI_256_OVERRIDES, ANSI_STANDARD_OVERRIDES } from "./terminalTheme";
 
 type SessionMode =
@@ -119,6 +120,12 @@ interface Session {
   owner: string;
   status: string;
   mode: SessionMode;
+  // Dispatch shape for this session's pod. "sdk" → Phase B+ pod with the
+  // agent-runner container; SPA opens /agent-ws + /events. "legacy" →
+  // pre-Phase B pod (no runner); SPA falls back to /run + /run/history.
+  // Derived server-side from pod spec; absent on pods that pre-date the
+  // field (treat as "legacy").
+  runtime?: "sdk" | "legacy";
   requested_at: string | null;
   created_at: string | null;
   ready_at: string | null;
@@ -7341,16 +7348,24 @@ export function App() {
                     className="run-body"
                     hidden={active !== s.id}
                   >
-                    <HeadlessRun
-                      session={s}
-                      visible={active === s.id}
-                      onRename={renameSession}
-                      onSessionPatch={patchSession}
-                      runPrefs={runPrefs}
-                      setRunPref={setRunPref}
-                      user={user!}
-                      onActivityChange={updateSessionActivity}
-                    />
+                    {s.runtime === "sdk" ? (
+                      <RunPaneSDK
+                        sessionId={s.id}
+                        visible={active === s.id}
+                        onActivityChange={updateSessionActivity}
+                      />
+                    ) : (
+                      <HeadlessRun
+                        session={s}
+                        visible={active === s.id}
+                        onRename={renameSession}
+                        onSessionPatch={patchSession}
+                        runPrefs={runPrefs}
+                        setRunPref={setRunPref}
+                        user={user!}
+                        onActivityChange={updateSessionActivity}
+                      />
+                    )}
                   </div>
                 ) : (
                   <div

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -680,6 +680,9 @@ interface SessionUser {
   // wall — null means show the install CTA, non-null means full app.
   github_login: string | null;
   installation_id: number | null;
+  // Phase E: cross-device run-pane prefs. Null when the user has never
+  // saved prefs; SPA falls back to localStorage + defaults.
+  run_prefs: Record<string, unknown> | null;
 }
 
 type GlimmungLaunchContext = {
@@ -2635,6 +2638,26 @@ function loadRunPrefs(): RunPrefs {
 }
 
 type SetRunPref = <K extends keyof RunPrefs>(key: K, value: RunPrefs[K]) => void;
+
+// Phase E: type-narrow the opaque server-side run_prefs blob into the
+// SPA's RunPrefs shape. Unknown keys are dropped (a future SPA may have
+// written them); unknown values for known keys are ignored (defensive
+// against type drift).
+function mergeServerRunPrefs(prev: RunPrefs, server: Record<string, unknown>): RunPrefs {
+  const out: RunPrefs = { ...prev };
+  for (const key of Object.keys(prev) as (keyof RunPrefs)[]) {
+    const raw = server[key];
+    if (raw === undefined) continue;
+    if (key === "chatFontScale") {
+      if (typeof raw === "number") out[key] = clampChatFontScale(raw);
+    } else if (key === "turnCompleteSoundVolume") {
+      if (typeof raw === "number") out[key] = clampTurnCompleteSoundVolume(raw);
+    } else if (typeof raw === "boolean") {
+      (out as unknown as Record<string, unknown>)[key] = raw;
+    }
+  }
+  return out;
+}
 
 // transcriptComparable returns a stable JSON of the transcript's load-bearing
 // fields, used to short-circuit no-op replay updates. Backend replay paths
@@ -6446,9 +6469,34 @@ export function App() {
   const [active, setActive] = useState<string | null>(null);
   // Per-user run-pane prefs live at app scope so mounted GUI sessions stay in
   // sync immediately, while localStorage keeps them across reloads/windows.
+  // Phase E: also persisted to the Cosmos profile row so prefs ride across
+  // devices. The localStorage write stays as the offline fallback.
   const [runPrefs, setRunPrefs] = useState<RunPrefs>(() => loadRunPrefs());
+  const prefsWriteTimer = useRef<number | null>(null);
+  const persistRunPrefs = useCallback((prefs: RunPrefs) => {
+    // 500ms debounce — sliders fire setRunPref dozens of times per drag,
+    // and a single PUT at the end is enough for cross-device sync.
+    if (prefsWriteTimer.current) {
+      window.clearTimeout(prefsWriteTimer.current);
+    }
+    prefsWriteTimer.current = window.setTimeout(() => {
+      void authedFetch("/api/auth/prefs", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ run_prefs: prefs }),
+      }).catch(() => {
+        // Best-effort — localStorage is the source of truth on this
+        // device; failed sync just means other devices won't see the
+        // change until the next successful write.
+      });
+    }, 500);
+  }, []);
   function setRunPref<K extends keyof RunPrefs>(key: K, value: RunPrefs[K]) {
-    setRunPrefs((p) => ({ ...p, [key]: value }));
+    setRunPrefs((p) => {
+      const next = { ...p, [key]: value };
+      persistRunPrefs(next);
+      return next;
+    });
     try {
       localStorage.setItem(RUN_PREF_PREFIX + String(key), String(value));
     } catch {
@@ -6478,6 +6526,23 @@ export function App() {
     window.addEventListener("storage", syncRunPrefs);
     return () => window.removeEventListener("storage", syncRunPrefs);
   }, []);
+
+  // Phase E: merge server-canonical prefs in once the user resolves. If
+  // the server has prefs they win (this device may be stale); if it
+  // doesn't, push our local prefs up so cross-device sync stops at the
+  // first-write boundary instead of perpetually empty.
+  useEffect(() => {
+    if (!user) return;
+    const server = user.run_prefs;
+    if (server && Object.keys(server).length > 0) {
+      setRunPrefs((prev) => mergeServerRunPrefs(prev, server));
+    } else {
+      persistRunPrefs(runPrefs);
+    }
+    // We deliberately don't re-run when runPrefs changes — this is a
+    // one-shot reconciliation per user identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, persistRunPrefs]);
   const [closingIds, setClosingIds] = useState<Set<string>>(() => new Set());
   // Sessions stay mounted after first activation so chat state and websocket
   // runs survive switching. Unopened sessions do not initialize their panel.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7392,7 +7392,14 @@ export function App() {
                           <ProviderIcon provider={MODE_MENU_ICONS[s.mode]} className="home-session-icon" />
                           <span className="home-session-main">
                             <span className="home-session-title">{sessionDisplayName(s)}</span>
-                            <span className="home-session-sub">{MODE_LABELS[s.mode]}</span>
+                            <span className="home-session-sub">
+                              {MODE_LABELS[s.mode]}
+                              {HEADLESS_MODES.has(s.mode) && s.runtime && (
+                                <span className={`home-session-runtime is-${s.runtime}`}>
+                                  {s.runtime}
+                                </span>
+                              )}
+                            </span>
                           </span>
                         </button>
                       ))

--- a/frontend/src/RunPaneSDK.tsx
+++ b/frontend/src/RunPaneSDK.tsx
@@ -1,0 +1,541 @@
+// SDK-aware run pane (Phase D). Lives next to the legacy HeadlessRun
+// during the rollout; chosen at render time when session.runtime === "sdk".
+//
+// Contract:
+//   - GET /api/sessions/{id}/events?after=<uuid>  → history backfill
+//   - WS  /api/sessions/{id}/agent-ws             → live tap
+//   - Server emits canonical SDK events; we dedupe by `uuid` so the join
+//     between history-replay and live is idempotent.
+//   - Client → server frames are { type:"user", message:{...} } |
+//     { type:"interrupt" }. Slash commands are sent as regular user
+//     messages — the SDK / claude binary handles them.
+//
+// Renderer reuses the project's prose styles via className strings; it
+// does not import the legacy TranscriptEntry shape. SDK message types
+// are rendered directly so Phase F can delete HeadlessRun without
+// disturbing this file.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+import { authedFetch, getStoredToken } from "./auth";
+
+// Minimal local typing for SDK messages. We intentionally don't pull
+// `@anthropic-ai/claude-agent-sdk` into the frontend bundle — its
+// transitive deps assume a Node runtime. The wire format is JSON, so
+// `unknown`-ish typing with discriminator narrowing is fine here.
+type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; tool_use_id: string; content: unknown; is_error?: boolean }
+  | { type: "image"; source: { type: string; media_type?: string; data?: string; url?: string } }
+  | { type: string; [k: string]: unknown };
+
+interface AssistantMessage {
+  type: "assistant";
+  uuid: string;
+  message: { role: "assistant"; content: ContentBlock[]; model?: string };
+  parent_tool_use_id?: string | null;
+  session_id?: string;
+}
+
+interface UserMessage {
+  type: "user";
+  uuid: string;
+  message: { role: "user"; content: ContentBlock[] | string };
+  parent_tool_use_id?: string | null;
+  session_id?: string;
+}
+
+interface SystemMessage {
+  type: "system";
+  uuid: string;
+  subtype?: string;
+  // init carries cwd / model / tools / mcp_servers; other subtypes vary.
+  [k: string]: unknown;
+}
+
+interface ResultMessage {
+  type: "result";
+  uuid: string;
+  subtype?: string;
+  duration_ms?: number;
+  duration_api_ms?: number;
+  is_error?: boolean;
+  num_turns?: number;
+  total_cost_usd?: number;
+  usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number };
+}
+
+interface RateLimitMessage {
+  type: "rate_limit";
+  uuid: string;
+  message?: string;
+  retry_after_ms?: number;
+}
+
+interface GenericCanonical {
+  type: string;
+  uuid: string;
+  [k: string]: unknown;
+}
+
+type SDKEvent =
+  | AssistantMessage
+  | UserMessage
+  | SystemMessage
+  | ResultMessage
+  | RateLimitMessage
+  | GenericCanonical;
+
+// Live-only stream delta. Not durable; we use it for the typewriter
+// effect under the in-progress message. See agent-runner/src/cosmos.ts
+// for the canonical/live split.
+interface StreamEvent {
+  type: "stream_event";
+  uuid?: string;
+  // The SDK wraps the upstream Anthropic API event under `event`.
+  event?: {
+    type: string;
+    delta?: { type?: string; text?: string };
+    content_block?: { type?: string };
+  };
+}
+
+interface RunPaneSDKProps {
+  sessionId: string;
+  visible: boolean;
+  onActivityChange?: (id: string, activity: "waiting" | "working") => void;
+}
+
+export function RunPaneSDK({ sessionId, visible, onActivityChange }: RunPaneSDKProps) {
+  const [events, setEvents] = useState<SDKEvent[]>([]);
+  const [partialText, setPartialText] = useState("");
+  const [connected, setConnected] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [composer, setComposer] = useState("");
+  const [queued, setQueued] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // uuid → seen, so the history-replay + live join is idempotent. Lives
+  // outside React state so neither the history fetch nor the WS callback
+  // need to read the latest events[] to know what's already there.
+  const seenRef = useRef<Set<string>>(new Set());
+  const wsRef = useRef<WebSocket | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  const appendEvent = useCallback((ev: SDKEvent) => {
+    const id = ev.uuid;
+    if (!id) return;
+    if (seenRef.current.has(id)) return;
+    seenRef.current.add(id);
+    setEvents((prev) => [...prev, ev]);
+  }, []);
+
+  // History backfill. Runs once per session change. We pass after="" to
+  // get everything; the server returns events strictly after that
+  // watermark in ascending uuid order.
+  useEffect(() => {
+    let cancelled = false;
+    seenRef.current = new Set();
+    setEvents([]);
+    setPartialText("");
+    setError(null);
+    (async () => {
+      try {
+        const res = await authedFetch(`/api/sessions/${sessionId}/events?limit=1000`);
+        if (!res.ok) throw new Error(`history fetch ${res.status}`);
+        const body = (await res.json()) as { events: SDKEvent[] };
+        if (cancelled) return;
+        for (const ev of body.events ?? []) {
+          appendEvent(ev);
+        }
+      } catch (e) {
+        if (!cancelled) setError(`history: ${(e as Error).message}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, appendEvent]);
+
+  // Live WebSocket. Browsers can't set Authorization on WS upgrades, so
+  // the orchestrator accepts the JWT via cookie (set at login). The
+  // protocol is text JSON frames; no subprotocol negotiation.
+  useEffect(() => {
+    const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
+    // Token in query string is the desktop-app fallback when cookies
+    // don't ride along (electron). Web path uses the cookie.
+    const token = getStoredToken();
+    const tokenParam = token ? `?auth=${encodeURIComponent(token)}` : "";
+    const url = `${scheme}//${window.location.host}/api/sessions/${sessionId}/agent-ws${tokenParam}`;
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+    let openedAt = 0;
+
+    ws.onopen = () => {
+      openedAt = Date.now();
+      setConnected(true);
+      setError(null);
+    };
+    ws.onclose = (e) => {
+      setConnected(false);
+      wsRef.current = null;
+      // Only surface a closed-too-fast error if the open never settled or
+      // closed within a second — otherwise the close is the user navigating
+      // away and there's no point yelling about it.
+      if (Date.now() - openedAt < 1000) {
+        setError(`agent-ws closed (${e.code})`);
+      }
+    };
+    ws.onerror = () => {
+      // The browser fires error before close; close handler does the work.
+    };
+    ws.onmessage = (msg) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(typeof msg.data === "string" ? msg.data : "");
+      } catch {
+        return;
+      }
+      if (!parsed || typeof parsed !== "object") return;
+      const ev = parsed as SDKEvent | StreamEvent;
+      if (ev.type === "stream_event") {
+        const delta = (ev as StreamEvent).event?.delta;
+        if (delta?.type === "text_delta" && typeof delta.text === "string") {
+          setPartialText((prev) => prev + delta.text);
+        }
+        return;
+      }
+      // Any non-stream event tears down the partial buffer. If it's an
+      // assistant message, the durable text replaces what the partial
+      // was showing. If it's a result, the turn is over.
+      if (ev.type === "assistant") {
+        setPartialText("");
+      }
+      if (ev.type === "result") {
+        setPartialText("");
+        setRunning(false);
+        // Flush the next queued message, if any.
+        setQueued((prev) => {
+          if (prev.length === 0) return prev;
+          const [next, ...rest] = prev;
+          sendUserMessage(next);
+          return rest;
+        });
+      }
+      if (ev.type === "user") {
+        // A user event from the wire means a turn is about to run.
+        setRunning(true);
+      }
+      appendEvent(ev as SDKEvent);
+    };
+
+    return () => {
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      wsRef.current = null;
+    };
+    // Send helper is hoisted below; the dep on appendEvent is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, appendEvent]);
+
+  useEffect(() => {
+    onActivityChange?.(sessionId, running ? "working" : "waiting");
+  }, [onActivityChange, running, sessionId]);
+
+  // Auto-scroll on new events when the user is already at the bottom.
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const near = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    if (near) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [events.length, partialText]);
+
+  const sendUserMessage = useCallback((text: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      setError("agent-ws not connected");
+      return;
+    }
+    const frame = {
+      type: "user" as const,
+      message: { role: "user" as const, content: text },
+    };
+    ws.send(JSON.stringify(frame));
+    setRunning(true);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    const text = composer.trim();
+    if (!text) return;
+    setComposer("");
+    if (running) {
+      // Codex-style queueing. Enter on a busy session queues; the next
+      // result event flushes the head of the queue.
+      setQueued((prev) => [...prev, text]);
+      return;
+    }
+    sendUserMessage(text);
+  }, [composer, running, sendUserMessage]);
+
+  const handleInterrupt = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ type: "interrupt" }));
+  }, []);
+
+  const handleKey = useCallback(
+    (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const rendered = useMemo(() => events.map((ev) => renderEvent(ev)), [events]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="sdk-run-pane">
+      <div className="sdk-run-status">
+        <span className={`sdk-run-dot ${connected ? "ok" : "off"}`} />
+        <span>{connected ? "connected" : "connecting…"}</span>
+        {running && <span className="sdk-run-running">working…</span>}
+        {error && <span className="sdk-run-error">{error}</span>}
+      </div>
+      <div ref={scrollerRef} className="sdk-run-transcript">
+        {rendered}
+        {partialText && (
+          <div className="sdk-event sdk-event-assistant sdk-event-partial">
+            <pre>{partialText}</pre>
+          </div>
+        )}
+        {queued.length > 0 && (
+          <div className="sdk-run-queued">
+            {queued.length} message{queued.length === 1 ? "" : "s"} queued
+          </div>
+        )}
+      </div>
+      <div className="sdk-run-composer">
+        <textarea
+          value={composer}
+          onChange={(e) => setComposer(e.target.value)}
+          onKeyDown={handleKey}
+          placeholder={running ? "queue a follow-up… (Enter)" : "send a message… (Enter)"}
+          rows={3}
+        />
+        <div className="sdk-run-composer-bar">
+          {running ? (
+            <button type="button" onClick={handleInterrupt}>
+              interrupt
+            </button>
+          ) : (
+            <button type="button" onClick={handleSubmit} disabled={!composer.trim()}>
+              send
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderEvent(ev: SDKEvent) {
+  const key = ev.uuid;
+  switch (ev.type) {
+    case "system":
+      return renderSystem(ev as SystemMessage, key);
+    case "assistant":
+      return renderAssistant(ev as AssistantMessage, key);
+    case "user":
+      return renderUser(ev as UserMessage, key);
+    case "result":
+      return renderResult(ev as ResultMessage, key);
+    case "rate_limit":
+      return renderRateLimit(ev as RateLimitMessage, key);
+    default:
+      return (
+        <div key={key} className="sdk-event sdk-event-meta">
+          <span className="sdk-event-label">{ev.type}</span>
+        </div>
+      );
+  }
+}
+
+function renderSystem(ev: SystemMessage, key: string) {
+  const subtype = ev.subtype ?? "system";
+  if (subtype === "init") {
+    const model = (ev as any).model as string | undefined;
+    const cwd = (ev as any).cwd as string | undefined;
+    return (
+      <div key={key} className="sdk-event sdk-event-meta">
+        <span className="sdk-event-label">session started</span>
+        {model && <span className="sdk-event-tag">{model}</span>}
+        {cwd && <span className="sdk-event-tag">{cwd}</span>}
+      </div>
+    );
+  }
+  if (subtype === "compact_boundary") {
+    return (
+      <div key={key} className="sdk-event sdk-event-divider">
+        <span>context compacted</span>
+      </div>
+    );
+  }
+  return (
+    <div key={key} className="sdk-event sdk-event-meta">
+      <span className="sdk-event-label">{subtype}</span>
+    </div>
+  );
+}
+
+function renderAssistant(ev: AssistantMessage, key: string) {
+  const blocks = ev.message?.content ?? [];
+  return (
+    <div key={key} className="sdk-event sdk-event-assistant">
+      {blocks.map((b, i) => renderBlock(b, `${key}:${i}`, "assistant"))}
+    </div>
+  );
+}
+
+function renderUser(ev: UserMessage, key: string) {
+  const content = ev.message?.content;
+  // The pod-side runner sends user text as a string; the SDK normalizes
+  // to an array of blocks. Handle both.
+  if (typeof content === "string") {
+    return (
+      <div key={key} className="sdk-event sdk-event-user">
+        <pre>{content}</pre>
+      </div>
+    );
+  }
+  const blocks = content ?? [];
+  return (
+    <div key={key} className="sdk-event sdk-event-user">
+      {blocks.map((b, i) => renderBlock(b, `${key}:${i}`, "user"))}
+    </div>
+  );
+}
+
+function renderBlock(block: ContentBlock, key: string, _role: "assistant" | "user") {
+  if (block.type === "text") {
+    return (
+      <pre key={key} className="sdk-block sdk-block-text">
+        {(block as { text: string }).text}
+      </pre>
+    );
+  }
+  if (block.type === "thinking") {
+    return (
+      <details key={key} className="sdk-block sdk-block-thinking">
+        <summary>thinking</summary>
+        <pre>{(block as { thinking: string }).thinking}</pre>
+      </details>
+    );
+  }
+  if (block.type === "tool_use") {
+    const tu = block as { name: string; input: unknown };
+    return (
+      <div key={key} className="sdk-block sdk-block-tool-use">
+        <span className="sdk-block-label">{tu.name}</span>
+        <pre>{safeStringify(tu.input)}</pre>
+      </div>
+    );
+  }
+  if (block.type === "tool_result") {
+    const tr = block as { content: unknown; is_error?: boolean };
+    return (
+      <div
+        key={key}
+        className={`sdk-block sdk-block-tool-result ${tr.is_error ? "is-error" : ""}`}
+      >
+        <span className="sdk-block-label">{tr.is_error ? "tool error" : "tool result"}</span>
+        <pre>{renderToolResultContent(tr.content)}</pre>
+      </div>
+    );
+  }
+  if (block.type === "image") {
+    const img = block as { source: { type: string; media_type?: string; data?: string; url?: string } };
+    if (img.source.type === "base64" && img.source.data && img.source.media_type) {
+      return (
+        <img
+          key={key}
+          className="sdk-block sdk-block-image"
+          src={`data:${img.source.media_type};base64,${img.source.data}`}
+          alt=""
+        />
+      );
+    }
+    if (img.source.type === "url" && img.source.url) {
+      return <img key={key} className="sdk-block sdk-block-image" src={img.source.url} alt="" />;
+    }
+    return (
+      <div key={key} className="sdk-block sdk-block-meta">
+        image ({img.source.type})
+      </div>
+    );
+  }
+  return (
+    <div key={key} className="sdk-block sdk-block-meta">
+      {block.type}
+    </div>
+  );
+}
+
+function renderResult(ev: ResultMessage, key: string) {
+  const ms = ev.duration_ms;
+  const seconds = ms ? (ms / 1000).toFixed(1) : null;
+  const cost = ev.total_cost_usd;
+  return (
+    <div key={key} className="sdk-event sdk-event-result">
+      <span className="sdk-event-label">turn complete</span>
+      {seconds && <span className="sdk-event-tag">{seconds}s</span>}
+      {typeof cost === "number" && <span className="sdk-event-tag">${cost.toFixed(4)}</span>}
+      {ev.usage?.output_tokens && (
+        <span className="sdk-event-tag">{ev.usage.output_tokens} out</span>
+      )}
+    </div>
+  );
+}
+
+function renderRateLimit(ev: RateLimitMessage, key: string) {
+  return (
+    <div key={key} className="sdk-event sdk-event-rate-limit">
+      <span className="sdk-event-label">rate limit</span>
+      <span>{ev.message ?? "throttled"}</span>
+    </div>
+  );
+}
+
+function renderToolResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) => {
+        if (c && typeof c === "object" && (c as { type?: string }).type === "text") {
+          return (c as { text: string }).text;
+        }
+        return safeStringify(c);
+      })
+      .join("\n");
+  }
+  return safeStringify(content);
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -14,6 +14,11 @@ interface SessionUser {
   // completes the GitHub App install (#57 stage 2).
   github_login: string | null;
   installation_id: number | null;
+  // Phase E: SPA run-pane preferences, persisted on the Cosmos profile
+  // row so they ride across browsers. Null when the user has never
+  // saved prefs (e.g., first sign-in on a new account — the SPA falls
+  // back to localStorage, then to defaults).
+  run_prefs: Record<string, unknown> | null;
 }
 
 const SCOPES = ["User.Read", "openid", "profile", "email"];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5168,3 +5168,187 @@ textarea.run-files-viewer-editor:focus {
     @apply font-sans;
   }
 }
+
+/* RunPaneSDK — Phase D. Minimal first-cut styles so the SDK transcript
+   renders without inheriting the legacy HeadlessRun bubble CSS. Phase F
+   replaces these with the real design once the legacy pane is gone. */
+.sdk-run-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.sdk-run-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--muted-foreground, #888);
+  border-bottom: 1px solid var(--border, #2a2a2a);
+}
+.sdk-run-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #888;
+}
+.sdk-run-dot.ok {
+  background: #4ade80;
+}
+.sdk-run-dot.off {
+  background: #f59e0b;
+}
+.sdk-run-running {
+  color: #4ade80;
+}
+.sdk-run-error {
+  color: #f87171;
+  margin-left: auto;
+}
+.sdk-run-transcript {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sdk-run-queued {
+  align-self: center;
+  font-size: 12px;
+  color: var(--muted-foreground, #888);
+  padding: 4px 8px;
+  border: 1px dashed var(--border, #2a2a2a);
+  border-radius: 4px;
+}
+.sdk-run-composer {
+  border-top: 1px solid var(--border, #2a2a2a);
+  padding: 8px 12px;
+}
+.sdk-run-composer textarea {
+  width: 100%;
+  resize: vertical;
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 6px;
+  padding: 8px;
+  font-family: inherit;
+  font-size: 14px;
+}
+.sdk-run-composer-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+.sdk-run-composer-bar button {
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #2a2a2a);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.sdk-run-composer-bar button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.sdk-event {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+}
+.sdk-event-meta,
+.sdk-event-result,
+.sdk-event-rate-limit {
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted-foreground, #888);
+}
+.sdk-event-divider {
+  align-items: center;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted-foreground, #888);
+  border-top: 1px dashed var(--border, #2a2a2a);
+  padding-top: 8px;
+}
+.sdk-event-rate-limit {
+  color: #f59e0b;
+}
+.sdk-event-label {
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 3px;
+}
+.sdk-event-tag {
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--muted, #1f1f1f);
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+}
+.sdk-event-assistant {
+  background: var(--muted, #181818);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+.sdk-event-user {
+  background: var(--accent, #1f2933);
+  border-radius: 6px;
+  padding: 10px 12px;
+  align-self: flex-end;
+  max-width: 80%;
+}
+.sdk-event-partial {
+  opacity: 0.7;
+}
+.sdk-block {
+  margin: 0;
+}
+.sdk-block-text,
+.sdk-block-tool-use pre,
+.sdk-block-tool-result pre,
+.sdk-block-thinking pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: inherit;
+}
+.sdk-block-tool-use,
+.sdk-block-tool-result {
+  border-left: 2px solid var(--border, #2a2a2a);
+  padding-left: 8px;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+.sdk-block-tool-result.is-error {
+  border-left-color: #f87171;
+}
+.sdk-block-thinking summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--muted-foreground, #888);
+}
+.sdk-block-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground, #888);
+}
+.sdk-block-image {
+  max-width: 100%;
+  border-radius: 4px;
+}
+.sdk-block-meta {
+  font-size: 12px;
+  color: var(--muted-foreground, #888);
+  font-style: italic;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5169,6 +5169,30 @@ textarea.run-files-viewer-editor:focus {
   }
 }
 
+/* Sidebar runtime chip — Phase F observability. Small label next to the
+   mode that flags whether a claude_gui session opens the SDK pane or the
+   legacy one. The legacy chip is amber to nudge the user — those pods
+   pre-date the Phase B image roll and stay legacy until reaped. */
+.home-session-runtime {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+  font-family: ui-monospace, monospace;
+}
+.home-session-runtime.is-sdk {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+.home-session-runtime.is-legacy {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+}
+
 /* RunPaneSDK — Phase D. Minimal first-cut styles so the SDK transcript
    renders without inheriting the legacy HeadlessRun bubble CSS. Phase F
    replaces these with the real design once the legacy pane is gone. */


### PR DESCRIPTION
## Summary

Lands the remaining phases of the SDK migration on top of the merged Phase A/B/C base:

- **Phase D** — `RunPaneSDK` component (live WebSocket + history-replay with dedupe-by-uuid + Codex-style queueing), gated by a server-derived `runtime` field on session info. Legacy `HeadlessRun` untouched; `codex_gui` and any pre-Phase-B `claude_gui` pods keep rendering through the old path.
- **Phase E** — `run_prefs` (opaque map) on the Cosmos profile row. Backend gains `PUT /api/auth/prefs` and a merge-safe upsert (read the raw doc, splice the field, write back) so the new field — and any future field — doesn't clobber `installation_id` or `github_login`. SPA reconciles server-vs-local on user load and debounce-writes back.
- **Phase F1** — sdk/legacy chip in the sidebar; `server.go` documents why F2 (delete legacy `HeadlessRun` + legacy run endpoints) is deferred until (a) every claude_gui pod is on the SDK runtime and (b) codex_gui either gets its own SDK pane or is removed.
- **Phase G** — conformance tests for the producer contract (`dispatch()` extracted from Runner so cosmos-before-ws ordering, cosmos-failure-suppresses-broadcast, and live-only-bypasses-cosmos can be pinned without spinning up a port-binding WS server) and for `runtimeFromPod` (the field that drives the SPA's renderer choice).

## Test plan

- [ ] `claude_gui` session in the cluster shows the new pane (sdk chip in sidebar, live + history events, queueing while running, interrupt button)
- [ ] `codex_gui` session still renders through `HeadlessRun` (legacy chip in sidebar)
- [ ] Toggling a run pref on one browser shows up on a different browser after reload (Cosmos round-trip)
- [ ] Backend tests: `go test ./...`
- [ ] Agent-runner tests: `cd agent-runner && npm test`
- [ ] Frontend build: `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)