### PR TITLE
Fix localStorage class of bug: allowlist reap + quota-aware auth

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -107,8 +107,41 @@ async function exchange(idToken: string): Promise<SessionUser> {
   });
   if (!res.ok) throw new Error(await loginErrorMessage(res, emailFromIdToken(idToken)));
   const body = await res.json();
-  localStorage.setItem(TOKEN_KEY, body.token);
+  storeToken(body.token);
   return body.user;
+}
+
+// Auth must win over cache. A bloated localStorage (transcript caches,
+// stale debris, other apps sharing the origin) shouldn't be able to
+// break sign-in — the failure mode is a dead-end auth error with no
+// in-app recovery. On a QuotaExceededError we drop every other key
+// and retry. Lost prefs are server-synced and recoverable; a broken
+// auth write is not.
+function storeToken(token: string): void {
+  try {
+    localStorage.setItem(TOKEN_KEY, token);
+    return;
+  } catch (err) {
+    if (!isQuotaExceeded(err)) throw err;
+  }
+  console.warn("localStorage quota exceeded on auth write; evicting and retrying");
+  for (const key of Object.keys(localStorage)) {
+    if (key === TOKEN_KEY) continue;
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // best-effort
+    }
+  }
+  // Single retry; if this still fails the surrounding caller surfaces it.
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+function isQuotaExceeded(err: unknown): boolean {
+  if (!(err instanceof DOMException)) return false;
+  // Browsers spell the error name differently — Safari's legacy name
+  // was QUOTA_EXCEEDED_ERR, modern browsers throw QuotaExceededError.
+  return err.name === "QuotaExceededError" || err.name === "QUOTA_EXCEEDED_ERR";
 }
 
 export function getStoredToken(): string | null {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,24 @@ if (typeof document !== "undefined") {
   document.documentElement.style.colorScheme = "dark";
 }
 
+// One-shot reap of pre-Phase-0 localStorage debris. The `tank-run-entries-*`
+// writer was removed in #384 (the transcript cache moved to the backend
+// replay paths) but the existing keys were left to rot — they accumulated
+// per-session, ate the 5MB quota, and broke JWT writes with a confusing
+// "exceeded the quota" auth error. Cheap to run on every boot; the
+// startsWith filter is a no-op once the keys are gone.
+if (typeof window !== "undefined") {
+  try {
+    for (const key of Object.keys(window.localStorage)) {
+      if (key.startsWith("tank-run-entries-")) {
+        window.localStorage.removeItem(key);
+      }
+    }
+  } catch {
+    // localStorage can be unavailable in hardened/private contexts.
+  }
+}
+
 // Tiny path-based routing — the only route we mount that isn't App is
 // the glimmung styleguide pilot's /_styleguide visual catalog. Avoids
 // pulling in react-router for this single split.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,16 +10,38 @@ if (typeof document !== "undefined") {
   document.documentElement.style.colorScheme = "dark";
 }
 
-// One-shot reap of pre-Phase-0 localStorage debris. The `tank-run-entries-*`
-// writer was removed in #384 (the transcript cache moved to the backend
-// replay paths) but the existing keys were left to rot — they accumulated
-// per-session, ate the 5MB quota, and broke JWT writes with a confusing
-// "exceeded the quota" auth error. Cheap to run on every boot; the
-// startsWith filter is a no-op once the keys are gone.
+// Allowlist-based reap of stale localStorage keys in our namespace.
+//
+// Generalized version of the original `tank-run-entries-*` reap: any
+// key whose name starts with `tank-` or `tank.` but isn't in the
+// known-good prefix list gets dropped on boot. This is how we close
+// the "stale key from a previous app version breaks the new version"
+// class of bug — when a writer is removed (#384 took out the transcript
+// cache writer, but #390 found 5MB of pre-removal keys still sitting
+// in users' localStorage), the keys reap themselves on next load.
+//
+// To add a new owned key/prefix: append to TANK_KEY_ALLOWLIST below.
+// Anything in our namespace not listed is treated as debris.
+// Non-tank keys are left alone — other libs/sites share this origin.
+const TANK_KEY_ALLOWLIST = [
+  "tank-operator-jwt",      // session JWT (auth.ts)
+  "tank-run-pref-",         // run-pane prefs (App.tsx)
+  "tank.defaultSessionMode",
+  "tank.defaultInteraction",
+  "tank.sessionInteraction:",
+  "tank.sessionOrder",      // matches tank.sessionOrder.<sub>
+];
+function isAllowedTankKey(key: string): boolean {
+  for (const allowed of TANK_KEY_ALLOWLIST) {
+    if (key === allowed || key.startsWith(allowed)) return true;
+  }
+  return false;
+}
 if (typeof window !== "undefined") {
   try {
     for (const key of Object.keys(window.localStorage)) {
-      if (key.startsWith("tank-run-entries-")) {
+      const isTankKey = key.startsWith("tank-") || key.startsWith("tank.");
+      if (isTankKey && !isAllowedTankKey(key)) {
         window.localStorage.removeItem(key);
       }
     }


### PR DESCRIPTION
## Summary

Two-part fix for the class of bug behind today's `Failed to execute 'setItem' on 'Storage': Setting the value of 'tank-operator-jwt' exceeded the quota` auth error:

**1. Allowlist-based stale-key reap on boot (`main.tsx`)**
The original trigger was Phase 0 (#384) removing the `tank-run-entries-*` writer but leaving the existing keys to rot in users' localStorage (~5MB accumulated, broke JWT writes). Replaces the targeted reap with an allowlist: any key in our namespace (`tank-` / `tank.` prefix) that isn't on `TANK_KEY_ALLOWLIST` gets dropped on boot. Adding a new owned key is a one-line allowlist edit; removing one is automatically cleaned up on next user load.

**2. Quota-aware auth writes (`auth.ts`)**
The actual UX failure was "auth dead-ended because a cache filled up." Auth should always win over cache. On `QuotaExceededError`, `storeToken()` drops every non-auth key and retries. Lost prefs are server-synced via `/api/auth/me` and recover on next load; a broken auth write is not recoverable from inside the app.

## Test plan

- [ ] Sign-in succeeds on a browser that previously hit the quota error (verified locally via the console snippet; deploy + refresh should now self-heal without intervention)
- [ ] No regression on a clean browser
- [ ] `tank-run-pref-*`, `tank.defaultSessionMode`, `tank.sessionInteraction:*`, `tank.sessionOrder.<sub>`, `tank-operator-jwt` all survive a reload
- [ ] An out-of-namespace key (e.g. some library's `react-something`) is *not* reaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)