### PR TITLE
Login response includes profile fields (fixes spurious Connect GitHub wall)

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_auth.go
+++ b/backend-go/cmd/tank-operator/handlers_auth.go
@@ -40,9 +40,19 @@ func (s *appServer) handleMicrosoftLogin(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Create or update profile.
-	if _, err := s.profiles.GetOrCreate(r.Context(), email); err != nil {
-		slog.Warn("profile upsert failed", "email", email, "error", err)
+	// Read the profile so the response carries installation_id /
+	// github_login / run_prefs alongside the JWT. The SPA uses this
+	// `user` object directly on the fresh-login path (it does NOT then
+	// call /api/auth/me), so omitting these fields here makes the SPA
+	// believe installation_id is null even when the Cosmos doc has it
+	// — surfacing as a spurious "Connect GitHub" wall after any flow
+	// that forces a re-login (cookie expiry, localStorage reap, manual
+	// logout). Read-only here; don't write — there's nothing new to
+	// merge in. A bad Cosmos read shouldn't block sign-in, so we log
+	// and continue with a zero profile rather than 500.
+	profile, err := s.profiles.GetOrCreate(r.Context(), email)
+	if err != nil {
+		slog.Warn("profile read failed during login", "email", email, "error", err)
 	}
 
 	// Set httpOnly cookie.
@@ -59,9 +69,13 @@ func (s *appServer) handleMicrosoftLogin(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"token": token,
 		"user": map[string]any{
-			"sub":   sub,
-			"email": email,
-			"name":  name,
+			"sub":             sub,
+			"email":           email,
+			"name":            name,
+			"avatar_url":      auth.GravatarURL(email, 64),
+			"github_login":    profile.GitHubLogin,
+			"installation_id": profile.InstallationID,
+			"run_prefs":       profile.RunPrefs,
 		},
 	})
 }


### PR DESCRIPTION
## Summary

The SPA reads the `user` object from `/api/auth/microsoft/login` directly on the fresh-login path and does NOT then call `/api/auth/me`. So the login response was lacking `installation_id` / `github_login` / `run_prefs`, the SPA saw them as `undefined`, and `undefined == null` in JS — meaning the `OnboardingWall` ("Connect GitHub") rendered on every re-login even for users with the GitHub App already installed.

Latent bug: only surfaces when something forces a re-login (cookie expiry, manual logout, the localStorage reap shipped in #390). The normal "JWT survives reload" path goes through `bootstrapAuth` → `/api/auth/me`, which already returned the full profile shape — that's why the bug stayed hidden for so long.

The fix folds the profile fields into the login response — same shape as `/api/auth/me`, no extra round-trip. A Cosmos read failure is non-fatal: log and continue with a zero profile so a transient blip can't block sign-in.

## Test plan

- [ ] Sign out, sign back in: the SPA lands on the main shell, not the onboarding wall
- [ ] First-time user (no profile doc): login still succeeds, wall renders correctly because `installation_id` is genuinely null
- [ ] Existing user with `installation_id`: full app renders immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)