### PR TITLE
Pin login/me user-response shape with regression tests

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_auth.go
+++ b/backend-go/cmd/tank-operator/handlers_auth.go
@@ -10,7 +10,30 @@ import (
 	"time"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/profiles"
 )
+
+// userResponseBody is the canonical JSON shape returned for the SPA's
+// `user` object — used by /api/auth/microsoft/login (fresh sign-in)
+// and /api/auth/me (existing-JWT bootstrap). Both paths must agree:
+// the SPA reads whichever returns from the call it makes (login on
+// fresh, me on reload), and a missing field (e.g. installation_id)
+// reads as undefined → undefined == null in JS → the OnboardingWall
+// renders even for users with the GitHub App installed.
+//
+// Keep this the single source of truth so the shape can't drift
+// between the two paths again.
+func userResponseBody(sub, email, name string, profile profiles.Profile) map[string]any {
+	return map[string]any{
+		"sub":             sub,
+		"email":           email,
+		"name":            name,
+		"avatar_url":      auth.GravatarURL(email, 64),
+		"github_login":    profile.GitHubLogin,
+		"installation_id": profile.InstallationID,
+		"run_prefs":       profile.RunPrefs,
+	}
+}
 
 // handleMicrosoftLogin exchanges an Entra ID token for a session JWT.
 func (s *appServer) handleMicrosoftLogin(w http.ResponseWriter, r *http.Request) {
@@ -68,15 +91,7 @@ func (s *appServer) handleMicrosoftLogin(w http.ResponseWriter, r *http.Request)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"token": token,
-		"user": map[string]any{
-			"sub":             sub,
-			"email":           email,
-			"name":            name,
-			"avatar_url":      auth.GravatarURL(email, 64),
-			"github_login":    profile.GitHubLogin,
-			"installation_id": profile.InstallationID,
-			"run_prefs":       profile.RunPrefs,
-		},
+		"user":  userResponseBody(sub, email, name, profile),
 	})
 }
 
@@ -106,15 +121,7 @@ func (s *appServer) handleMe(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"sub":             user.Sub,
-		"email":           user.Email,
-		"name":            user.Name,
-		"avatar_url":      auth.GravatarURL(user.Email, 64),
-		"github_login":    profile.GitHubLogin,
-		"installation_id": profile.InstallationID,
-		"run_prefs":       profile.RunPrefs,
-	})
+	writeJSON(w, http.StatusOK, userResponseBody(user.Sub, user.Email, user.Name, profile))
 }
 
 // handleUpdatePrefs persists the SPA's run-pane preferences (chat font

--- a/backend-go/cmd/tank-operator/main_test.go
+++ b/backend-go/cmd/tank-operator/main_test.go
@@ -188,6 +188,71 @@ func TestMeRejectsUnauthenticated(t *testing.T) {
 	}
 }
 
+// Pins the canonical user-response shape that both /api/auth/microsoft/login
+// (fresh sign-in) and /api/auth/me (existing-JWT bootstrap) build via
+// userResponseBody. A missing field reads as undefined in the SPA and —
+// because `undefined == null` in JS — flips installation_id-driven UI like
+// the OnboardingWall into the "not installed" branch even for users who
+// are installed. That was the bug in #391; this test prevents it
+// reappearing if the helper is refactored.
+func TestUserResponseBodyCarriesProfileFields(t *testing.T) {
+	login := "octocat"
+	installationID := int64(42)
+	prefs := map[string]any{"chatFontScale": 1.25}
+
+	body := userResponseBody("sub-1", "user@example.com", "User Name", profiles.Profile{
+		Email:          "user@example.com",
+		GitHubLogin:    &login,
+		InstallationID: &installationID,
+		RunPrefs:       prefs,
+	})
+
+	// Cast InstallationID for comparison — go's map[string]any doesn't
+	// equate *int64 with int64 directly, so we dereference via the helper.
+	if got, ok := body["installation_id"].(*int64); !ok || got == nil || *got != installationID {
+		t.Fatalf("installation_id = %#v, want pointer to %d", body["installation_id"], installationID)
+	}
+	if got, ok := body["github_login"].(*string); !ok || got == nil || *got != login {
+		t.Fatalf("github_login = %#v, want pointer to %q", body["github_login"], login)
+	}
+	if got, _ := body["run_prefs"].(map[string]any); got == nil || got["chatFontScale"] != 1.25 {
+		t.Fatalf("run_prefs = %#v", body["run_prefs"])
+	}
+	if body["email"] != "user@example.com" || body["sub"] != "sub-1" || body["name"] != "User Name" {
+		t.Fatalf("body = %#v", body)
+	}
+	if got, _ := body["avatar_url"].(string); got == "" {
+		t.Fatalf("avatar_url empty: %#v", body["avatar_url"])
+	}
+}
+
+// Verifies the response shape also tolerates an empty profile (e.g. a
+// first-time login where the Cosmos doc doesn't exist yet). All profile-
+// derived fields should serialize as JSON null — not be missing — so the
+// SPA reads them as `null` and renders the install-CTA branch correctly
+// instead of dead-ending on an undefined field access. Asserting on the
+// marshaled JSON (not the map) because Go's typed-nil-in-interface
+// semantics make (*int64)(nil) != nil for `==` purposes, but both
+// marshal to JSON null. The SPA only sees the JSON.
+func TestUserResponseBodyEmptyProfileNullsOutFields(t *testing.T) {
+	body := userResponseBody("sub-1", "user@example.com", "User Name", profiles.Profile{})
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"installation_id", "github_login", "run_prefs"} {
+		if v, ok := parsed[key]; !ok {
+			t.Fatalf("missing key %q (must be present even if null)", key)
+		} else if v != nil {
+			t.Fatalf("expected JSON null for %q, got %#v", key, v)
+		}
+	}
+}
+
 // testJWT returns a process-singleton InMemoryJWT so verifier and signed-token
 // helpers in this file share the same key — necessary because each test now
 // constructs a verifier and a token separately and they must agree on the kid.


### PR DESCRIPTION
## Summary

Follow-up to #391. Extracts the canonical `user` JSON shape into a single `userResponseBody` helper used by both `/api/auth/microsoft/login` and `/api/auth/me`, so the two paths can't drift apart again. Adds two unit tests that pin the contract:

1. Populated profile → `installation_id`, `github_login`, `run_prefs`, `avatar_url`, `email`, `name`, `sub` all surface with the right values.
2. Empty profile (first-time login, doc absent) → all profile-derived fields serialize as **JSON null**, not missing. Without this, SPA `== null` checks (e.g. the `OnboardingWall` gate) land on the wrong branch.

The empty-profile test marshals to JSON before asserting because Go's typed-nil-in-interface semantics make `(*int64)(nil) != nil` for `==`, even though both round-trip to JSON null — and JSON is all the SPA sees.

## Test plan

- [x] `go test ./cmd/tank-operator/...` passes
- [x] Existing `TestMe`, `TestMeReturnsProfileError`, `TestMeRejectsUnauthenticated` still pass (helper extraction is behavior-preserving)
- [ ] No deploy-time verification needed — pure refactor + tests, same wire shape as #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)