### PR TITLE
Require fingerprinted session image tags; drop :latest fallback

### DIFF
--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -69,9 +69,33 @@ func main() {
 
 	// 8. Init Manager.
 	namespace := envDefault("SESSIONS_NAMESPACE", compat.SessionsNamespace)
+
+	// Session image tags come from the chart's values.yaml session.*
+	// keys, bumped per-commit to fingerprinted tags by the
+	// claude-container-build workflow. Fail loudly at startup if any
+	// are missing — a silent `:latest` fallback hid this exact bug for
+	// 15 hours after the Go cutover (the Python orchestrator read these
+	// env vars; the Go port forgot, every new session pod fell back to
+	// an April-25 `:latest` that didn't have mcp-auth-proxy installed,
+	// every claude_gui session crashlooped).
+	sessionImage := os.Getenv("SESSION_IMAGE")
+	codexSessionImage := os.Getenv("CODEX_SESSION_IMAGE")
+	piSessionImage := os.Getenv("PI_SESSION_IMAGE")
+	if sessionImage == "" || codexSessionImage == "" || piSessionImage == "" {
+		slog.Error("session image env vars missing — chart must set SESSION_IMAGE / CODEX_SESSION_IMAGE / PI_SESSION_IMAGE to fingerprinted tags",
+			"SESSION_IMAGE", sessionImage,
+			"CODEX_SESSION_IMAGE", codexSessionImage,
+			"PI_SESSION_IMAGE", piSessionImage,
+		)
+		os.Exit(1)
+	}
+
 	mgr := sessions.NewManager(k8sClient, restCfg, namespace, sessionReg, eventBus, sessions.ManagerOptions{
 		ManifestOpts: compat.ManifestOptions{
 			ArgoCDTrackingApp: envDefault("ARGOCD_TRACKING_APP", "tank-operator-sessions"),
+			SessionImage:      sessionImage,
+			CodexSessionImage: codexSessionImage,
+			PiSessionImage:    piSessionImage,
 			// Pass the orchestrator's Cosmos config through to the pod's
 			// agent-runner via env vars — same endpoint, same database,
 			// the runner authenticates with its own UAMI (federated to

--- a/backend-go/internal/compat/compat.go
+++ b/backend-go/internal/compat/compat.go
@@ -27,9 +27,14 @@ const (
 	SessionConfigMap         = "tank-session-config"
 	SandboxAgentPort         = 2468
 	AgentRunnerWSPort        = 8090
-	DefaultSessionImage      = "romainecr.azurecr.io/claude-container:latest"
-	DefaultCodexSessionImage = "romainecr.azurecr.io/codex-container:latest"
-	DefaultPiSessionImage    = "romainecr.azurecr.io/pi-container:latest"
+	// No DefaultSessionImage constants. The Helm chart owns image tags
+	// (k8s/values.yaml's session.* keys are bumped per-commit to
+	// fingerprinted tags by .github/workflows/claude-container-build.yml),
+	// passes them in via SESSION_IMAGE / CODEX_SESSION_IMAGE /
+	// PI_SESSION_IMAGE env vars. A `:latest` fallback here would silently
+	// pin every session pod to whichever stale image happened to carry
+	// that tag — which is exactly what bricked claude_gui session creation
+	// for the 15h between the Go cutover and the env-var wiring.
 	DefaultGitHubAppSecret          = "github-app-creds"
 	DefaultCodexCredsSecret         = "codex-credentials"
 	DefaultOAuthGatewayCA           = "claude-oauth-ca"
@@ -537,15 +542,10 @@ func glimmungField(contextJSON, field string) string {
 }
 
 func withManifestDefaults(opts ManifestOptions) ManifestOptions {
-	if opts.SessionImage == "" {
-		opts.SessionImage = DefaultSessionImage
-	}
-	if opts.CodexSessionImage == "" {
-		opts.CodexSessionImage = DefaultCodexSessionImage
-	}
-	if opts.PiSessionImage == "" {
-		opts.PiSessionImage = DefaultPiSessionImage
-	}
+	// Session images are caller-required. The chart owns the
+	// fingerprinted tag; the orchestrator's job is to plumb it through,
+	// not to invent a fallback. See main.go for the startup-time check
+	// that fails the pod loudly when the env vars are missing.
 	if opts.SessionsNamespace == "" {
 		opts.SessionsNamespace = SessionsNamespace
 	}

--- a/backend-go/internal/compat/compat_test.go
+++ b/backend-go/internal/compat/compat_test.go
@@ -250,11 +250,21 @@ func TestPythonCompatFixture(t *testing.T) {
 
 	core := fixture["pod_manifest_core"].(map[string]any)
 	input := core["input"].(map[string]any)
+	// Inject the same image strings the fixture asserts on. The
+	// orchestrator's runtime path gets these from the chart's
+	// SESSION_IMAGE / CODEX_SESSION_IMAGE / PI_SESSION_IMAGE env vars
+	// (see cmd/tank-operator/main.go); the test stands in for that
+	// wiring with literals so the manifest contract is exercised
+	// without dragging Helm into the test.
 	manifest := PodManifest(
 		input["session_id"].(string),
 		input["owner"].(string),
 		input["mode"].(string),
-		ManifestOptions{},
+		ManifestOptions{
+			SessionImage:      "romainecr.azurecr.io/claude-container:latest",
+			CodexSessionImage: "romainecr.azurecr.io/codex-container:latest",
+			PiSessionImage:    "romainecr.azurecr.io/pi-container:latest",
+		},
 	)
 	spec := manifest["spec"].(map[string]any)
 	containers := spec["containers"].([]any)


### PR DESCRIPTION
## Summary

Two-part fix for the bug that broke every `claude_gui` session created after the Go cutover (#373).

### The bug

The Python orchestrator read `SESSION_IMAGE` / `CODEX_SESSION_IMAGE` / `PI_SESSION_IMAGE` env vars (the Helm chart sets these from `values.yaml`'s `session.*` keys, bumped per-commit to fingerprinted tags by `.github/workflows/claude-container-build.yml`). The Go port forgot the reads, and `compat.go` carried a `DefaultSessionImage = "claude-container:latest"` fallback. So every session pod created since 2026-05-11T07:22Z fell back to `:latest`, which happened to point to an April-25 image that doesn't have `/usr/bin/mcp-auth-proxy`. Every new `claude_gui` session crashlooped on `exec: "mcp-auth-proxy": executable file not found in $PATH`.

The bug hid for 15 hours because the only working session pods on the cluster (35/51/52/57) were Python-orchestrator-created.

### The fix

The `:latest` fallback was the load-bearing footgun — a silent fallback to a stale image. Removed entirely:

- `compat.go`'s `DefaultSessionImage` / `DefaultCodexSessionImage` / `DefaultPiSessionImage` constants are gone.
- `withManifestDefaults` no longer fills them in.
- `main.go` reads the three env vars at startup and `slog.Error + os.Exit(1)` if any are missing. Refusing to start beats silently pinning every session pod to a stale image.

The chart-side build pipeline (Dockerfile, `claude-container-build.yml`, `image-fingerprint.sh`, chart-bump workflow, ArgoCD reconcile) already does the right thing — no changes needed there.

### Test plan

- [x] `go test ./...` clean (fixture test updated to pass literal images via `ManifestOptions`)
- [ ] After deploy: new `claude_gui` session pod uses the fingerprinted tag from `values.yaml`'s `session.image`, all three containers (`mcp-auth-proxy`, `claude`, `agent-runner`) reach Ready
- [ ] If the env var is unset (misconfigured chart), the orchestrator pod fails to start with a clear log line — not a silent regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)