### PR TITLE
Codex parity: persistent codex-runner using @openai/codex-sdk

### DIFF
--- a/.github/workflows/claude-container-build.yml
+++ b/.github/workflows/claude-container-build.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'claude-container/**'
       - 'agent-runner/**'
+      - 'codex-runner/**'
       - 'scripts/image-fingerprint.sh'
       - '.github/workflows/claude-container-build.yml'
   workflow_dispatch:
@@ -95,7 +96,7 @@ jobs:
             --image ${{ matrix.agent }} \
             --dockerfile claude-container/Dockerfile \
             --context . \
-            --paths 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner' \
+            --paths 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner' \
             | awk -F= '$1 == "fingerprint" { print $2 }')"
           echo "ALIAS_TAG=${{ matrix.agent }}-${fingerprint}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/docker-build-check.yaml
+++ b/.github/workflows/docker-build-check.yaml
@@ -56,7 +56,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/claude-container-build-cache:claude
             image-repo: claude-container
             fingerprint-image: claude
-            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner
+            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner
           - name: session-agent-codex
             file: claude-container/Dockerfile
             context: .
@@ -64,7 +64,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/codex-container-build-cache:codex
             image-repo: codex-container
             fingerprint-image: codex
-            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner
+            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner
           - name: session-agent-pi
             file: claude-container/Dockerfile
             context: .
@@ -72,7 +72,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/pi-container-build-cache:pi
             image-repo: pi-container
             fingerprint-image: pi
-            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner
+            fingerprint-paths: claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/backend-go/internal/compat/compat.go
+++ b/backend-go/internal/compat/compat.go
@@ -100,6 +100,7 @@ var sessionConfigMounts = []struct{ key, mountPath string }{
 	{"tank-bootstrap.sh", "/opt/tank/bootstrap.sh"},
 	{"headless-run.sh", "/opt/tank/headless-run.sh"},
 	{"agent-runner-launch.sh", "/opt/tank/agent-runner-launch.sh"},
+	{"codex-runner-launch.sh", "/opt/tank/codex-runner-launch.sh"},
 }
 
 // noClaudeHijackModes are modes that should not receive the OAuth gateway / api proxy host aliases.
@@ -294,16 +295,16 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		map[string]any{"name": "session-config", "configMap": map[string]any{"name": opts.SessionConfigMap}},
 	}
 
-	// Phase B: shared /workspace across the claude container (sandbox-agent +
-	// the in-browser terminal pane) and the agent-runner container (drives
-	// the SDK). Without this, the agent's writes wouldn't be visible in the
-	// terminal pane and vice versa. emptyDir lives for the pod's lifetime,
-	// matching today's "pod restart loses workspace state" semantics.
-	// claude_gui is the only mode where the agent-runner exists today; the
-	// volume is harmless for the others but we keep it gated to avoid pod
-	// spec churn on legacy modes.
+	// Shared /workspace across the user-facing container and the
+	// SDK runner sidecar. Without this, the agent's writes wouldn't be
+	// visible in the in-browser terminal and vice versa. emptyDir lives
+	// for the pod's lifetime, matching today's "pod restart loses
+	// workspace state" semantics. claude_gui uses agent-runner,
+	// codex_gui uses codex-runner; both need the shared mount.
 	wantAgentRunner := mode == ClaudeGUIMode
-	if wantAgentRunner {
+	wantCodexRunner := mode == CodexGUIMode
+	wantSDKRunner := wantAgentRunner || wantCodexRunner
+	if wantSDKRunner {
 		volumes = append(volumes, map[string]any{
 			"name":     "workspace",
 			"emptyDir": map[string]any{},
@@ -462,6 +463,65 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			runnerContainer["envFrom"] = envFrom
 		}
 		containers = append(containers, runnerContainer)
+	}
+
+	// Codex-runner sidecar — codex_gui only. Sibling of agent-runner:
+	// same workspace mount, same Cosmos endpoint, same WS port (only
+	// one runner per pod, never both). Different SDK underneath, plus
+	// the codex-credentials secret mount so the SDK-spawned codex CLI
+	// can read auth.json.
+	if wantCodexRunner {
+		runnerVolumeMounts := append([]any{}, configMounts...)
+		runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+			"name":      "workspace",
+			"mountPath": "/workspace",
+		})
+		if opts.CodexCredsSecret != "" {
+			runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+				"name":      "codex-creds",
+				"mountPath": "/etc/codex-creds",
+				"readOnly":  true,
+			})
+		}
+		codexRunnerEnv := []any{
+			map[string]any{
+				"name": "SESSION_ID",
+				"valueFrom": map[string]any{
+					"fieldRef": map[string]any{
+						"fieldPath": "metadata.labels['tank-operator/session-id']",
+					},
+				},
+			},
+			map[string]any{
+				"name": "POD_OWNER_EMAIL",
+				"valueFrom": map[string]any{
+					"fieldRef": map[string]any{
+						"fieldPath": "metadata.annotations['tank-operator/owner-email']",
+					},
+				},
+			},
+			map[string]any{"name": "COSMOS_ENDPOINT", "value": opts.CosmosEndpoint},
+			map[string]any{"name": "COSMOS_DATABASE", "value": opts.CosmosDatabase},
+			map[string]any{"name": "COSMOS_SESSION_EVENTS_CONTAINER", "value": opts.CosmosSessionEventsContainer},
+			map[string]any{"name": "WORKSPACE", "value": "/workspace"},
+			map[string]any{"name": "AGENT_RUNNER_WS_PORT", "value": itoa(opts.AgentRunnerWSPort)},
+		}
+		codexRunnerContainer := map[string]any{
+			"name":            "codex-runner",
+			"image":           sessionImage,
+			"imagePullPolicy": "Always",
+			"command":         []any{"bash", "/opt/tank/codex-runner-launch.sh"},
+			"ports": []any{map[string]any{
+				"name":          "agent-ws",
+				"containerPort": opts.AgentRunnerWSPort,
+			}},
+			"env":          codexRunnerEnv,
+			"volumeMounts": runnerVolumeMounts,
+		}
+		if len(envFrom) > 0 {
+			codexRunnerContainer["envFrom"] = envFrom
+		}
+		containers = append(containers, codexRunnerContainer)
 	}
 
 	spec := map[string]any{

--- a/backend-go/internal/compat/compat_test.go
+++ b/backend-go/internal/compat/compat_test.go
@@ -144,7 +144,9 @@ func TestPodManifestCompatibilityCore(t *testing.T) {
 
 	spec := manifest["spec"].(map[string]any)
 	containers := spec["containers"].([]any)
-	if got, want := len(containers), 2; got != want {
+	// codex_gui now adds a third container, codex-runner (the @openai/
+	// codex-sdk runner), so the pod has 3 containers, not 2.
+	if got, want := len(containers), 3; got != want {
 		t.Fatalf("container count = %d, want %d", got, want)
 	}
 	if got, want := containers[0].(map[string]any)["name"], "mcp-auth-proxy"; got != want {
@@ -161,9 +163,17 @@ func TestPodManifestCompatibilityCore(t *testing.T) {
 	if got, want := ports[0].(map[string]any)["name"], "sandbox-agent"; got != want {
 		t.Fatalf("main container port name = %v, want %q", got, want)
 	}
+	codexRunner := containers[2].(map[string]any)
+	if got, want := codexRunner["name"], "codex-runner"; got != want {
+		t.Fatalf("codex-runner container name = %v, want %q", got, want)
+	}
+	if got, want := codexRunner["image"], "codex-image"; got != want {
+		t.Fatalf("codex-runner image = %v, want %q (same image as the user container; the runner is a multi-stage build into the same image)", got, want)
+	}
 	volumes := spec["volumes"].([]any)
-	// codex_gui mode adds session-config + codex-creds volumes.
-	if got, want := len(volumes), 2; got != want {
+	// codex_gui adds session-config + codex-creds + workspace emptyDir
+	// (shared between the claude container and the codex-runner sidecar).
+	if got, want := len(volumes), 3; got != want {
 		t.Fatalf("volume count = %d, want %d", got, want)
 	}
 }

--- a/backend-go/internal/compat/testdata/python_compat.json
+++ b/backend-go/internal/compat/testdata/python_compat.json
@@ -53,11 +53,13 @@
     },
     "container_images": {
       "claude": "romainecr.azurecr.io/codex-container:latest",
+      "codex-runner": "romainecr.azurecr.io/codex-container:latest",
       "mcp-auth-proxy": "romainecr.azurecr.io/codex-container:latest"
     },
     "container_names": [
       "mcp-auth-proxy",
-      "claude"
+      "claude",
+      "codex-runner"
     ],
     "input": {
       "mode": "codex_headless",

--- a/backend-go/internal/sessions/sessions.go
+++ b/backend-go/internal/sessions/sessions.go
@@ -187,14 +187,15 @@ func infoFromPod(owner string, pod *corev1.Pod) Info {
 	}
 }
 
-// runtimeFromPod returns "sdk" if the pod has the Phase B agent-runner
-// container in its spec, "legacy" otherwise. The SPA branches on this
-// to pick the new typed-event consumer or the old stream-json one.
-// Old pods that pre-date the Phase B image roll won't have the
-// container; they stay on the legacy path until reaped.
+// runtimeFromPod returns "sdk" if the pod has either of the SDK runner
+// sidecars in its spec (agent-runner for claude_gui, codex-runner for
+// codex_gui), "legacy" otherwise. The SPA's chat pane branches on this
+// to pick the canonical-event data source vs the old stream-json one.
+// Pods that pre-date the runner roll stay on the legacy path until
+// reaped.
 func runtimeFromPod(pod *corev1.Pod) string {
 	for _, c := range pod.Spec.Containers {
-		if c.Name == "agent-runner" {
+		if c.Name == "agent-runner" || c.Name == "codex-runner" {
 			return "sdk"
 		}
 	}

--- a/backend-go/internal/sessions/sessions_test.go
+++ b/backend-go/internal/sessions/sessions_test.go
@@ -161,6 +161,20 @@ func TestRuntimeFromPodDetectsAgentRunner(t *testing.T) {
 	}
 }
 
+func TestRuntimeFromPodDetectsCodexRunner(t *testing.T) {
+	// codex_gui pods get codex-runner instead of agent-runner. The SPA
+	// treats either as "sdk" runtime — same data source, different
+	// SDK underneath. A regression here would route the wrong path.
+	withCodexRunner := sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true)
+	withCodexRunner.Spec.Containers = append(
+		withCodexRunner.Spec.Containers,
+		corev1.Container{Name: "codex-runner"},
+	)
+	if got := runtimeFromPod(withCodexRunner); got != "sdk" {
+		t.Fatalf("runtime with codex-runner = %q, want sdk", got)
+	}
+}
+
 func TestInfoFromPodSurfacesRuntime(t *testing.T) {
 	pod := sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true)
 	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "agent-runner"})

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -12,6 +12,19 @@ RUN npx tsc
 # Prune dev deps for a smaller runtime payload.
 RUN npm prune --omit=dev
 
+# Stage 1b: build the codex-runner from codex-runner/. Sibling of
+# agent-runner — drives @openai/codex-sdk for codex_gui sessions instead
+# of @anthropic-ai/claude-agent-sdk. Baked into all three session images
+# (claude/codex/pi) for build symmetry; only the codex pod spec runs it.
+FROM node:20-alpine AS codex-runner-build
+WORKDIR /src/codex-runner
+COPY codex-runner/package.json codex-runner/package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+COPY codex-runner/tsconfig.json ./
+COPY codex-runner/src ./src
+RUN npx tsc
+RUN npm prune --omit=dev
+
 # Stage 2: runtime image. azure-mcp + github-mcp + k8s-mcp run as in-cluster
 # HTTP MCP servers. The container reaches them via the mcp-auth-proxy sidecar
 # on 127.0.0.1, which reads the projected SA token fresh per request and
@@ -121,13 +134,19 @@ RUN pip install --no-cache-dir --break-system-packages /opt/mcp-auth-proxy
 
 # Phase B agent-runner: long-lived pod-side process that drives
 # @anthropic-ai/claude-agent-sdk, fans events to Cosmos (durable) + a
-# local WebSocket (live tap). Shipped inert in Phase B — no container
-# in the pod spec invokes it yet; Phase C wires the orchestrator's
-# WebSocket reverse-proxy and the per-session opt-in label that turns
-# it on. Entrypoint: `node /opt/agent-runner/dist/index.js`.
+# local WebSocket (live tap). Entrypoint: `node /opt/agent-runner/dist/index.js`.
 COPY --from=agent-runner-build /src/agent-runner/dist /opt/agent-runner/dist
 COPY --from=agent-runner-build /src/agent-runner/node_modules /opt/agent-runner/node_modules
 COPY --from=agent-runner-build /src/agent-runner/package.json /opt/agent-runner/package.json
+
+# Codex-runner sibling: same pattern, @openai/codex-sdk underneath.
+# Baked into all three session images so the build is symmetric; only
+# the codex pod spec invokes it as a sidecar. The same WS port + Cosmos
+# container shape lets the orchestrator's reverse-proxy and the SPA's
+# chat pane consume both runtimes uniformly.
+COPY --from=codex-runner-build /src/codex-runner/dist /opt/codex-runner/dist
+COPY --from=codex-runner-build /src/codex-runner/node_modules /opt/codex-runner/node_modules
+COPY --from=codex-runner-build /src/codex-runner/package.json /opt/codex-runner/package.json
 
 # Session-facing MCP wiring, AGENTS/CLAUDE primers, bundled skill docs, and the
 # bootstrap script are mounted from the chart-managed tank-session-config

--- a/codex-runner/package-lock.json
+++ b/codex-runner/package-lock.json
@@ -1,0 +1,881 @@
+{
+  "name": "tank-codex-runner",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tank-codex-runner",
+      "version": "0.1.0",
+      "dependencies": {
+        "@azure/cosmos": "^4.5.1",
+        "@azure/identity": "^4.7.0",
+        "@openai/codex-sdk": "^0.130.0",
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.13",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/cosmos": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.9.3.tgz",
+      "integrity": "sha512-AWRj+yhw1lybutNcsHJ8syxWXnTLvc3CPwwdCwG1I0I71f25ZcBkxneTeoaB3X57+xl1nO+zJKUqfm0RhpGUFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-keys": "^4.9.0",
+        "@azure/logger": "^1.1.4",
+        "fast-json-stable-stringify": "^2.1.0",
+        "priorityqueuejs": "^2.0.0",
+        "semaphore": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.0.tgz",
+      "integrity": "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.0.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.1.tgz",
+      "integrity": "sha512-hTbvOi9Ko2Jvn+G/fSmjzHf9WbNcf/o3epMtbeGx/pMwMrVAbi6OgCJVeCfsAb8IybSRpaCSc4EDRlYAhgngUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.1.tgz",
+      "integrity": "sha512-VxKdEtUwDuLD0F1hOQP7kye0YadZxFJfv37Em440geEf/w9uggKnHpRrqwZJOdxmPUOdhZ9kyRtKuAJW8wUcRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.1.tgz",
+      "integrity": "sha512-tmQiQ2HvtzaeLqYGy3BemiPOSGPY4wCy1IW5zDWITKSs/s35WEd7Zij/hCxvUdAOzj6U3qnyaGbYXY91ortFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.1",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
+      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
+      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
+      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
+      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
+      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.130.0.tgz",
+      "integrity": "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.130.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
+      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
+      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/priorityqueuejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-2.0.0.tgz",
+      "integrity": "sha512-19BMarhgpq3x4ccvVi8k2QpJZcymo/iFUcrhPd4V96kYGovOdTsWwy7fxChYi4QY+m2EnGBWSX9Buakz+tWNQQ==",
+      "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/codex-runner/package.json
+++ b/codex-runner/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tank-codex-runner",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Long-lived pod-side runner that drives @openai/codex-sdk, exposes typed events to the SPA via WebSocket and persists canonical events to Cosmos. Sibling of agent-runner — same shape, codex SDK underneath.",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "node --test dist/**/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@openai/codex-sdk": "^0.130.0",
+    "@azure/cosmos": "^4.5.1",
+    "@azure/identity": "^4.7.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.13",
+    "typescript": "^5.6.0"
+  }
+}

--- a/codex-runner/src/config.ts
+++ b/codex-runner/src/config.ts
@@ -1,0 +1,42 @@
+// Runtime config sourced from env vars. Mirrors agent-runner/src/config.ts —
+// same downward-API + Cosmos plumbing, different SDK underneath.
+//
+// Auth path: codex-sdk wraps the codex CLI subprocess, which reads
+// ~/.codex/auth.json. The chart mounts that file from the codex-credentials
+// Secret. The SDK inherits process.env and the CLI reads auth.json as
+// normal — no CODEX_API_KEY env var required (subscription auth path).
+
+export interface Config {
+  sessionId: string;
+  ownerEmail: string;
+  cosmosEndpoint: string;
+  cosmosDatabase: string;
+  sessionEventsContainer: string;
+  workspace: string;
+  wsPort: number;
+}
+
+export function loadConfig(): Config {
+  const sessionId = (process.env.SESSION_ID ?? "").trim();
+  if (!sessionId) {
+    throw new Error(
+      "SESSION_ID is required (set from downward API: metadata.labels['tank-operator/session-id'])",
+    );
+  }
+  const cosmosEndpoint = (process.env.COSMOS_ENDPOINT ?? "").trim();
+  if (!cosmosEndpoint) {
+    throw new Error("COSMOS_ENDPOINT is required");
+  }
+  return {
+    sessionId,
+    ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
+    cosmosEndpoint,
+    cosmosDatabase: process.env.COSMOS_DATABASE?.trim() || "tank-operator",
+    sessionEventsContainer:
+      process.env.COSMOS_SESSION_EVENTS_CONTAINER?.trim() || "session-events",
+    workspace: process.env.WORKSPACE?.trim() || "/workspace",
+    // The orchestrator reverse-proxies the SPA's /agent-ws onto this port.
+    // Same port as agent-runner — only one runner per pod, no collision risk.
+    wsPort: parseInt(process.env.AGENT_RUNNER_WS_PORT?.trim() || "8090", 10),
+  };
+}

--- a/codex-runner/src/cosmos.test.ts
+++ b/codex-runner/src/cosmos.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isCanonical, stampEventID } from "./cosmos.js";
+
+// Pins which codex SDK event types make it into the durable Cosmos log
+// vs which stay live-only. Drift here affects the SPA's history-replay
+// correctness.
+
+test("canonical: thread.started", () => {
+  assert.equal(isCanonical({ type: "thread.started", thread_id: "t1" }), true);
+});
+
+test("canonical: turn.completed + turn.failed", () => {
+  assert.equal(isCanonical({ type: "turn.completed", usage: {} } as never), true);
+  assert.equal(isCanonical({ type: "turn.failed", error: { message: "x" } } as never), true);
+});
+
+test("canonical: item.completed (the main durable signal)", () => {
+  assert.equal(
+    isCanonical({
+      type: "item.completed",
+      item: { id: "i1", type: "agent_message" },
+    } as never),
+    true,
+  );
+});
+
+test("canonical: error (thread-level)", () => {
+  assert.equal(isCanonical({ type: "error", message: "boom" } as never), true);
+});
+
+test("NOT canonical: turn.started (structural marker, not user-visible)", () => {
+  assert.equal(isCanonical({ type: "turn.started" } as never), false);
+});
+
+test("NOT canonical: item.started / item.updated (partial / streaming)", () => {
+  assert.equal(isCanonical({ type: "item.started", item: {} } as never), false);
+  assert.equal(isCanonical({ type: "item.updated", item: {} } as never), false);
+});
+
+test("NOT canonical: unknown event types", () => {
+  assert.equal(isCanonical({ type: "weird_thing" }), false);
+  assert.equal(isCanonical({ type: "" }), false);
+});
+
+test("stampEventID attaches a v4 uuid without mutating the input", () => {
+  const before = { type: "thread.started", thread_id: "t1" };
+  const after = stampEventID(before);
+  assert.equal(typeof after.uuid, "string");
+  assert.match(
+    after.uuid,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+  );
+  // Input untouched: pins purity at this boundary so retries don't
+  // double-stamp.
+  assert.equal((before as { uuid?: string }).uuid, undefined);
+});
+
+test("stampEventID produces a fresh uuid each call (no accidental aliasing)", () => {
+  const a = stampEventID({ type: "thread.started" });
+  const b = stampEventID({ type: "thread.started" });
+  assert.notEqual(a.uuid, b.uuid);
+});

--- a/codex-runner/src/cosmos.ts
+++ b/codex-runner/src/cosmos.ts
@@ -1,0 +1,89 @@
+// Cosmos sink for canonical codex SDK events. Same producer contract as
+// agent-runner/src/cosmos.ts:
+//   - One serialization at the producer (the runner)
+//   - Same bytes go to Cosmos and to the WS broadcast
+//   - DB write happens BEFORE the WS push (read-your-writes ordering)
+//   - Idempotent receivers — dedupe by event id (stamped here)
+//
+// Difference from claude: the codex SDK's `ThreadEvent` union has no
+// per-event `uuid` field — only contained `ThreadItem`s carry ids, and
+// only some events have items. We stamp our own random v4 uuid as the
+// doc id at production time. The producer is the only writer, so the
+// id is unique by construction.
+//
+// "Canonical" = events the SPA's history-replay path should see:
+//   thread.started     — session boot marker (analog of claude system/init)
+//   turn.completed     — turn-end marker with usage
+//   turn.failed        — turn-level error
+//   item.completed     — main durable signal: agent_message, reasoning,
+//                        command_execution, file_change, mcp_tool_call,
+//                        web_search, todo_list, error items
+//   error              — thread-level error (e.g. unrecoverable SDK error)
+//
+// "Live-only" = transient deltas the SPA may use for typewriter UX but
+// have no durable value:
+//   turn.started, item.started, item.updated
+//
+// SDK type ref:
+//   https://github.com/openai/codex/blob/main/sdk/typescript/src/events.ts
+
+import { CosmosClient } from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+import { randomUUID } from "node:crypto";
+
+import type { Config } from "./config.js";
+
+const CANONICAL_TYPES = new Set<string>([
+  "thread.started",
+  "turn.completed",
+  "turn.failed",
+  "item.completed",
+  "error",
+]);
+
+export interface CodexEvent {
+  type: string;
+  [k: string]: unknown;
+}
+
+export function isCanonical(event: CodexEvent): boolean {
+  return CANONICAL_TYPES.has(event.type);
+}
+
+// Stamp a generated uuid on the event. The runner uses the same stamped
+// value when dispatching to both Cosmos and the WS, so consumers can
+// dedupe across the history+live join.
+export function stampEventID(event: CodexEvent): CodexEvent & { uuid: string } {
+  return { ...event, uuid: randomUUID() };
+}
+
+export class CosmosSink {
+  private readonly client: CosmosClient;
+  private readonly container;
+
+  constructor(private readonly cfg: Config) {
+    this.client = new CosmosClient({
+      endpoint: cfg.cosmosEndpoint,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+    this.container = this.client
+      .database(cfg.cosmosDatabase)
+      .container(cfg.sessionEventsContainer);
+  }
+
+  // Write a canonical event. Doc id is the runner-stamped uuid; partition
+  // is the orchestrator's session_id. Matches the shape agent-runner uses,
+  // so the orchestrator's read endpoint and the SPA's chat pane consume
+  // both claude- and codex-runner events out of the same container.
+  async upsert(event: CodexEvent & { uuid: string }): Promise<void> {
+    const doc: Record<string, unknown> = {
+      ...event,
+      id: event.uuid,
+      tank_session_id: this.cfg.sessionId,
+      email: this.cfg.ownerEmail,
+      runtime: "codex",
+      written_at: new Date().toISOString(),
+    };
+    await this.container.items.upsert(doc);
+  }
+}

--- a/codex-runner/src/index.ts
+++ b/codex-runner/src/index.ts
@@ -1,0 +1,42 @@
+// tank-codex-runner — pod-side process that drives @openai/codex-sdk
+// for one session pod's lifetime. Fans events to (a) Cosmos
+// `session-events` for durable history, and (b) a local WebSocket for
+// the SPA's live view (proxied through the orchestrator).
+//
+// Mirrors agent-runner/src/index.ts. Same entrypoint shape; different
+// SDK underneath. See ./runner.ts.
+
+import { loadConfig } from "./config.js";
+import { Runner } from "./runner.js";
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  console.log(
+    JSON.stringify({
+      msg: "codex-runner starting",
+      session_id: cfg.sessionId,
+      owner_email: cfg.ownerEmail,
+      cosmos_endpoint: cfg.cosmosEndpoint,
+      cosmos_db: cfg.cosmosDatabase,
+      cosmos_container: cfg.sessionEventsContainer,
+      workspace: cfg.workspace,
+      ws_port: cfg.wsPort,
+    }),
+  );
+
+  const ctrl = new AbortController();
+  const shutdown = (sig: NodeJS.Signals) => {
+    console.log(JSON.stringify({ msg: "shutdown", signal: sig }));
+    ctrl.abort();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  const runner = new Runner(cfg);
+  await runner.run(ctrl.signal);
+}
+
+main().catch((err) => {
+  console.error("codex-runner exited with error:", err);
+  process.exit(1);
+});

--- a/codex-runner/src/runner.test.ts
+++ b/codex-runner/src/runner.test.ts
@@ -1,0 +1,86 @@
+// Pins the producer-contract invariants the SPA depends on: one
+// serialization → two sinks, DB-first ordering, WS skipped on Cosmos
+// failure. Same shape as agent-runner/src/runner.test.ts — different
+// event types underneath.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { dispatch } from "./runner.js";
+import type { CodexEvent } from "./cosmos.js";
+
+type Order = string[];
+function makeSink(order: Order, opts: { throws?: Error } = {}) {
+  return {
+    async upsert() {
+      if (opts.throws) throw opts.throws;
+      order.push("cosmos");
+    },
+  };
+}
+function makeWS(order: Order) {
+  return {
+    broadcastEvent() {
+      order.push("ws");
+    },
+  };
+}
+
+test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
+  const order: Order = [];
+  const ok = await dispatch(makeSink(order), makeWS(order), {
+    type: "item.completed",
+    item: { id: "i1", type: "agent_message" },
+  } as CodexEvent);
+  assert.equal(ok, true);
+  assert.deepEqual(order, ["cosmos", "ws"]);
+});
+
+test("canonical: cosmos failure suppresses ws broadcast", async () => {
+  const order: Order = [];
+  const ok = await dispatch(
+    makeSink(order, { throws: new Error("boom") }),
+    makeWS(order),
+    { type: "item.completed", item: { id: "i1" } } as CodexEvent,
+  );
+  // SPA must never see a live event that wasn't persisted, or history
+  // replay diverges from what was rendered.
+  assert.equal(ok, false);
+  assert.deepEqual(order, []);
+});
+
+test("live-only: turn.started broadcasts without a cosmos write", async () => {
+  const order: Order = [];
+  const ok = await dispatch(
+    makeSink(order),
+    makeWS(order),
+    { type: "turn.started" } as CodexEvent,
+  );
+  assert.equal(ok, true);
+  // No "cosmos" entry — structural markers stay out of the durable log.
+  assert.deepEqual(order, ["ws"]);
+});
+
+test("live-only: item.started + item.updated bypass cosmos entirely", async () => {
+  for (const type of ["item.started", "item.updated"]) {
+    let cosmosCalled = false;
+    const ws = { broadcastEvent() {} };
+    const sink = {
+      async upsert() {
+        cosmosCalled = true;
+      },
+    };
+    await dispatch(sink, ws, { type, item: {} } as CodexEvent);
+    assert.equal(cosmosCalled, false, `${type} should not write to cosmos`);
+  }
+});
+
+test("error events ARE canonical (durable error log)", async () => {
+  const order: Order = [];
+  await dispatch(
+    makeSink(order),
+    makeWS(order),
+    { type: "error", message: "x" } as CodexEvent,
+  );
+  assert.deepEqual(order, ["cosmos", "ws"]);
+});

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -1,0 +1,188 @@
+// Long-lived codex runner — drives one codex thread for the pod's
+// lifetime via @openai/codex-sdk. Sibling of agent-runner/src/runner.ts
+// with a different inner loop shape:
+//
+//   claude SDK: query() iterates an AsyncIterable of user messages,
+//               yielding events forever. We push to a queue; one
+//               long-running iteration handles everything.
+//   codex SDK:  thread.runStreamed(input) processes ONE turn and
+//               returns. We pull a user message off the queue, await
+//               runStreamed to completion, then loop.
+//
+// Multi-turn coordination is explicit: only one runStreamed in flight
+// at a time. The Thread object keeps the conversation context across
+// turns (codex SDK persists threads to ~/.codex/sessions, so even pod
+// restart can resume via resumeThread()).
+//
+// Output fan-out per the producer contract:
+//   1. For every event, stamp a uuid + write to Cosmos FIRST (if canonical)
+//   2. Then broadcast the same bytes to WS clients
+// On error: log and keep accepting new user messages. Single-turn
+// failures shouldn't kill the runner.
+
+import { Codex, type Thread } from "@openai/codex-sdk";
+
+import type { Config } from "./config.js";
+import {
+  CosmosSink,
+  isCanonical,
+  stampEventID,
+  type CodexEvent,
+} from "./cosmos.js";
+import { WSFanout, type ClientFrame } from "./ws.js";
+
+// AsyncQueue — one writer, one consumer. WS frames push; the run loop
+// awaits the next value. Same shape as agent-runner's queue.
+class AsyncQueue<T> {
+  private readonly items: T[] = [];
+  private waiters: ((v: IteratorResult<T>) => void)[] = [];
+  private closed = false;
+
+  push(v: T): void {
+    const w = this.waiters.shift();
+    if (w) w({ value: v, done: false });
+    else this.items.push(v);
+  }
+
+  async next(): Promise<IteratorResult<T>> {
+    if (this.items.length > 0) {
+      return { value: this.items.shift()!, done: false };
+    }
+    if (this.closed) {
+      return { value: undefined as unknown as T, done: true };
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const w of this.waiters) {
+      w({ value: undefined as unknown as T, done: true });
+    }
+    this.waiters = [];
+  }
+}
+
+// Pull the per-event dual-sink dispatch out as a free function so the
+// ordering invariant (cosmos before ws) is testable without spinning up
+// a Runner. Mirrors agent-runner/src/runner.ts dispatch().
+//
+// Returns true on a successful end-to-end dispatch; false when the
+// canonical write failed and the broadcast was intentionally skipped.
+interface DispatchSink {
+  upsert(event: CodexEvent & { uuid: string }): Promise<void>;
+}
+interface DispatchWS {
+  broadcastEvent(event: unknown): void;
+}
+export async function dispatch(
+  sink: DispatchSink,
+  ws: DispatchWS,
+  event: CodexEvent,
+): Promise<boolean> {
+  const stamped = stampEventID(event);
+  if (isCanonical(stamped)) {
+    try {
+      await sink.upsert(stamped);
+    } catch (err) {
+      console.error("cosmos upsert failed:", err);
+      // Don't broadcast a live event we couldn't persist — the SPA's
+      // history-replay would then disagree with what it saw live.
+      return false;
+    }
+  }
+  ws.broadcastEvent(stamped);
+  return true;
+}
+
+export class Runner {
+  private readonly sink: CosmosSink;
+  private readonly ws: WSFanout;
+  private readonly userQueue = new AsyncQueue<string>();
+  private readonly codex: Codex;
+  private thread: Thread | null = null;
+  private currentAbort: AbortController | null = null;
+
+  constructor(private readonly cfg: Config) {
+    this.sink = new CosmosSink(cfg);
+    this.ws = new WSFanout(cfg.wsPort);
+    this.ws.onMessage((frame) => this.handleClientFrame(frame));
+
+    // Codex SDK spawns the codex CLI subprocess; the CLI reads
+    // ~/.codex/auth.json (mounted from the codex-credentials secret).
+    // No CODEX_API_KEY needed — subscription auth path.
+    this.codex = new Codex();
+  }
+
+  // Run until externally aborted. Each iteration awaits one user
+  // message, runs one turn, drains its events. The thread persists
+  // across iterations so codex sees the full conversation context.
+  async run(signal: AbortSignal): Promise<void> {
+    this.thread = this.codex.startThread({ workingDirectory: this.cfg.workspace });
+    while (!signal.aborted) {
+      const next = await this.userQueue.next();
+      if (next.done) break;
+      const input = next.value;
+
+      this.currentAbort = new AbortController();
+      // If the outer signal aborts mid-turn, also abort the in-flight
+      // codex subprocess. AbortSignal.any-style propagation done manually
+      // since Node 20's AbortSignal.any is stage 3.
+      const onOuterAbort = () => this.currentAbort?.abort();
+      signal.addEventListener("abort", onOuterAbort, { once: true });
+
+      try {
+        const streamed = await this.thread.runStreamed(input, {
+          signal: this.currentAbort.signal,
+        });
+        for await (const event of streamed.events) {
+          if (signal.aborted) break;
+          await dispatch(this.sink, this.ws, event as CodexEvent);
+        }
+      } catch (err) {
+        // Synthetic error event so the SPA sees something when the SDK
+        // throws (e.g., process exit, network failure, quota error that
+        // surfaced as an exception rather than a turn.failed).
+        const errMessage =
+          err instanceof Error ? err.message : String(err);
+        await dispatch(this.sink, this.ws, {
+          type: "error",
+          message: errMessage,
+        });
+        console.error("codex turn failed:", err);
+      } finally {
+        signal.removeEventListener("abort", onOuterAbort);
+        this.currentAbort = null;
+      }
+    }
+    this.userQueue.close();
+    this.ws.close();
+  }
+
+  private handleClientFrame(frame: ClientFrame): void {
+    if (frame.type === "user") {
+      // Codex SDK takes the user input as a plain string for v1. The
+      // chat pane sends `{message: {role: "user", content: string}}` for
+      // wire-compat with the claude path; we unwrap. Future: support
+      // structured content (images, etc.) when codex SDK does.
+      const content = frame.message?.content;
+      const text =
+        typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? content
+                .map((c: unknown) =>
+                  typeof c === "object" && c !== null && "text" in c
+                    ? String((c as { text?: unknown }).text ?? "")
+                    : "",
+                )
+                .join("\n")
+            : String(content ?? "");
+      if (text.trim()) {
+        this.userQueue.push(text);
+      }
+    } else if (frame.type === "interrupt") {
+      this.currentAbort?.abort();
+    }
+  }
+}

--- a/codex-runner/src/ws.ts
+++ b/codex-runner/src/ws.ts
@@ -1,0 +1,78 @@
+// Per-pod WebSocket fan-out for the codex SDK runtime. Sibling of
+// agent-runner/src/ws.ts. Identical client-protocol surface so the
+// orchestrator's /agent-ws proxy and the SPA's chat pane talk to either
+// runner with the same frames.
+//
+// Frame shapes:
+//   server → client: every SDK event, serialized as JSON.
+//   client → server: { type: "user", message: { role: "user", content: ... } }
+//                  | { type: "interrupt" }                         (abort turn)
+//                  | { type: "ping" }                              (heartbeat)
+//
+// Auth happens upstream at the orchestrator's TLS+JWT termination; this
+// server trusts whatever connects.
+
+import { WebSocketServer, type WebSocket } from "ws";
+
+export type ClientFrame =
+  | { type: "user"; message: { role: "user"; content: unknown } }
+  | { type: "interrupt" }
+  | { type: "ping" };
+
+export class WSFanout {
+  private readonly server: WebSocketServer;
+  private readonly clients = new Set<WebSocket>();
+  private onUserMessage: ((c: ClientFrame) => void) | null = null;
+
+  constructor(port: number) {
+    this.server = new WebSocketServer({ port, host: "0.0.0.0" });
+    this.server.on("connection", (ws) => {
+      this.clients.add(ws);
+      ws.on("message", (raw) => {
+        let frame: ClientFrame;
+        try {
+          frame = JSON.parse(raw.toString());
+        } catch {
+          return;
+        }
+        if (frame.type === "ping") {
+          ws.send(JSON.stringify({ type: "pong" }));
+          return;
+        }
+        this.onUserMessage?.(frame);
+      });
+      ws.on("close", () => this.clients.delete(ws));
+    });
+  }
+
+  onMessage(handler: (c: ClientFrame) => void): void {
+    this.onUserMessage = handler;
+  }
+
+  // Broadcast a fully-serialized JSON line to all connected clients. Both
+  // Cosmos and this fan-out see byte-identical payloads — the same producer
+  // contract agent-runner follows.
+  broadcast(serialized: string): void {
+    for (const ws of this.clients) {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(serialized);
+      }
+    }
+  }
+
+  // Broadcast a typed codex SDK event by serializing once. The event is
+  // typed as `unknown` here because @openai/codex-sdk's ThreadEvent union
+  // covers types we'll forward verbatim (the SPA renderer is the typed
+  // consumer); keeping it opaque at this boundary keeps the dependency
+  // surface small.
+  broadcastEvent(event: unknown): void {
+    this.broadcast(JSON.stringify(event));
+  }
+
+  close(): void {
+    for (const ws of this.clients) {
+      ws.close();
+    }
+    this.server.close();
+  }
+}

--- a/codex-runner/tsconfig.json
+++ b/codex-runner/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5204,8 +5204,13 @@ function HeadlessRun({
       }
       if (!isJsonObject(parsed)) return;
 
-      // Mirror the bookkeeping applyStdoutLine does for usage/active-tool so
-      // the context-window pie and the streaming pill stay accurate.
+      // Bookkeeping for usage/active-tool. Two flavors of SDK events come
+      // through this WS: claude's `{type:"assistant"|"user"|"result"}` and
+      // codex's `{type:"item.started"|"item.completed"|"turn.completed"}`.
+      // The chat pane renders both shapes via applyProviderEvent → the
+      // right applyXxxEvent for session.mode; the bookkeeping here also
+      // forks on the shape so the streaming pill + context pie work
+      // regardless of which runtime is streaming.
       const t = parsed.type;
       if (t === "assistant") {
         const msg = parsed.message;
@@ -5231,14 +5236,42 @@ function HeadlessRun({
         const total = totalContextTokens(u);
         if (total > 0) setTokensUsed(total);
         setActiveTool(null);
+      } else if (t === "item.started" || t === "item.updated") {
+        // Codex flag: a tool-like item (command_execution / file_change /
+        // mcp_tool_call / web_search) is in flight. Show its kind on the
+        // streaming pill the same way Claude's tool_use blocks do.
+        const item = parsed.item;
+        if (isJsonObject(item)) {
+          const itemType = typeof item.type === "string" ? item.type : "";
+          const toolish = new Set([
+            "command_execution",
+            "file_change",
+            "mcp_tool_call",
+            "web_search",
+          ]);
+          if (toolish.has(itemType)) {
+            setActiveTool(itemType, typeof item.id === "string" ? item.id : null);
+          }
+        }
+      } else if (t === "turn.completed") {
+        // Codex's per-turn closing event. Usage rides on the event itself
+        // (not nested under `message` like claude does).
+        const u = parsed.usage as ClaudeUsage | undefined;
+        const total = totalContextTokens(u);
+        if (total > 0) setTokensUsed(total);
+        setActiveTool(null);
       }
 
       setEntries((prev) => applyProviderEvent(prev, session.mode, parsed));
 
-      // Terminal events. A `result` marks the turn done; the SPA closes the
-      // WS — the next user submit opens a fresh one. The runner stays alive
-      // for the pod's lifetime; the WS is per-turn for the SPA's convenience.
-      if (t === "result") {
+      // Terminal events. Each runtime closes the WS so a fresh open per
+      // turn works. The runners themselves stay alive for the pod's
+      // lifetime; only the SPA's WS lifecycle is per-turn.
+      //   claude: `result` (analog of codex's turn.completed)
+      //   codex:  `turn.completed` (success) / `turn.failed` (error)
+      const isTerminal =
+        t === "result" || t === "turn.completed" || t === "turn.failed";
+      if (isTerminal) {
         currentRunRef.current = null;
         const durationMs = Date.now() - run.turnStart;
         setEntries((prev) => {

--- a/k8s/session-config/codex-runner-launch.sh
+++ b/k8s/session-config/codex-runner-launch.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Pod-side launch shim for the codex-runner Node service. Sibling of
+# agent-runner-launch.sh — same shape, codex-specific credential setup
+# instead of claude-specific.
+#
+# Codex auth path: the chart mounts ~/.codex/auth.json from the
+# codex-credentials Secret (subscription OAuth tokens obtained from a
+# one-time interactive `codex login` on the user's machine). The
+# codex CLI subprocess that @openai/codex-sdk spawns reads that file
+# directly; we don't touch the tokens here. Token refresh happens
+# inside the CLI subprocess at use time.
+#
+# Why bash + exec node: same reason as agent-runner-launch.sh — the
+# credential blob shape is small but platform-specific, and keeping it
+# in shell matches the existing per-turn pattern (headless-run.sh)
+# pieces of which still run for non-codex_gui codex modes.
+
+set -eu
+
+configure_codex() {
+  mkdir -p "$HOME/.codex"
+
+  # The codex CLI reads ~/.codex/auth.json. The chart mounts the
+  # codex-credentials Secret at /etc/codex-creds (same volume the
+  # legacy headless-run.sh uses). Copy + chmod 600 — not symlink,
+  # because the CLI rewrites this file on token refresh and the
+  # secret mount is read-only tmpfs. The rewritten file is lost on
+  # pod restart; that's fine, the cached refresh_token in the secret
+  # is still valid for the next pod.
+  if [ ! -f /etc/codex-creds/auth.json ]; then
+    echo "no codex credentials found in /etc/codex-creds/auth.json" >&2
+    echo "spawn a 'Codex config' session and save credentials first." >&2
+    exit 78
+  fi
+  cp /etc/codex-creds/auth.json "$HOME/.codex/auth.json"
+  chmod 600 "$HOME/.codex/auth.json"
+
+  # config.toml — codex CLI reads this for non-credential settings
+  # (model, sandbox mode, mcp servers). Keep it minimal; the SPA's
+  # per-turn TurnOptions can override most things via SDK turn config.
+  mcp_block=""
+  if [ -f /workspace/.mcp.json ]; then
+    # codex's mcp config lives in config.toml under [mcp_servers.<name>]
+    # blocks. Generate them from the same .mcp.json the claude path uses
+    # so both runtimes see the same MCP surface.
+    mcp_block="$(jq -r '
+      .mcpServers | to_entries[] |
+      "[mcp_servers." + .key + "]\nurl = \"" + (.value.url // "") + "\""
+    ' /workspace/.mcp.json 2>/dev/null || true)"
+  fi
+
+  cat > "$HOME/.codex/config.toml" <<EOF
+# Generated at pod start by codex-runner-launch.sh. Do not hand-edit;
+# changes will be overwritten on the next pod boot.
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+${mcp_block}
+EOF
+
+  unset OPENAI_API_KEY
+  unset CODEX_API_KEY
+}
+
+# Git identity for any commits the agent makes from /workspace.
+git config --global user.name "tank-operator-codex[bot]"
+git config --global user.email "tank-operator-codex@romaine.life"
+
+configure_codex
+
+# Optional: install tank-flavored skills into the agent's home dir.
+# Same script the per-turn path uses; idempotent.
+if [ -f /opt/tank/session-config/install-tank-skills.sh ]; then
+  sh /opt/tank/session-config/install-tank-skills.sh || true
+fi
+
+# Hand off to the runner. Node is PID 1 from this point — SIGTERM goes
+# straight to it, which propagates AbortSignal to any in-flight codex
+# turn via TurnOptions.signal.
+exec node /opt/codex-runner/dist/index.js

--- a/k8s/templates/session-configmap.yaml
+++ b/k8s/templates/session-configmap.yaml
@@ -20,6 +20,8 @@ data:
 {{ .Files.Get "session-config/headless-run.sh" | indent 4 }}
   agent-runner-launch.sh: |
 {{ .Files.Get "session-config/agent-runner-launch.sh" | indent 4 }}
+  codex-runner-launch.sh: |
+{{ .Files.Get "session-config/codex-runner-launch.sh" | indent 4 }}
 {{- range $scope := list "common" "claude" "codex" }}
 {{- range $path, $_ := $.Files.Glob (printf "session-config/skills/%s/**" $scope) }}
   skills__{{ trimPrefix "session-config/skills/" $path | replace "/" "__" }}: |


### PR DESCRIPTION
## Summary

Brings `codex_gui` sessions onto the same architectural baseline as `claude_gui` — persistent pod-side runner driving a typed-event SDK, canonical events durably written to Cosmos `session-events`, live-tap WebSocket fanned out to the SPA via the existing `/agent-ws` proxy. The chat pane consumes both runtimes through one renderer.

**What was wrong before this PR:** codex sessions ran on the per-turn dispatch path — each user message spawned a fresh `codex exec` via kubeexec from `headless-run.sh`, output went to `/tmp/tank-run-<id>.stream`, the orchestrator tailed the file over WebSocket. No persistent runtime; no durable event log; stderr errors got dropped, surfaced as downstream kubeexec timeouts. Same problem class the claude side had pre-Phase-B.

## What's in this PR

- `codex-runner/` — new Node TypeScript service mirroring `agent-runner/`. Imports `@openai/codex-sdk`, holds the persistent `Thread`, fans events to `CosmosSink` + `WSFanout`. Dispatch ordering invariant (cosmos-before-ws; ws-skipped-on-cosmos-failure) and `isCanonical` filter are tested (14 cases). User-input `AsyncQueue` + `AbortController` for interrupt mirror agent-runner. Per-event uuid stamped at production time (codex SDK events have no native uuid; the SPA's dedupe story still works).
- `claude-container/Dockerfile` — new `codex-runner-build` multi-stage block. Baked into all three session images for build symmetry; only the codex pod spec actually runs it.
- `k8s/session-config/codex-runner-launch.sh` — pod-side launch shim mirroring `agent-runner-launch.sh`. Copies `/etc/codex-creds/auth.json` into `~/.codex/auth.json` (same pattern as `headless-run.sh`), writes a minimal `config.toml` with MCP server URLs derived from the shared `.mcp.json`, execs the runner.
- `backend-go/internal/compat/compat.go` — adds `codex-runner` sidecar to `codex_gui` pod manifests. Same workspace `emptyDir`, same Cosmos env, same WS port as `agent-runner` (only one runner per pod). Codex-runner gets the `codex-credentials` secret mount.
- `backend-go/internal/sessions/sessions.go` — `runtimeFromPod` recognizes either runner sidecar.
- `frontend/src/App.tsx` — `openSdkRunSocket` extended to recognize codex shapes (`turn.completed` as terminal event, `item.started` for tool-like items drives the streaming pill). The chat pane's `applyCodexEvent` already understood the SDK event shape (because the legacy codex CLI with `--experimental-json` emits the same shape the SDK exposes).
- Workflows — `codex-runner/` added to fingerprint paths.

## Test plan

- [x] `codex-runner`: `npm test` (14 cases) all pass
- [x] `backend-go`: `go test ./...` all pass (compat fixture + Python-shape test updated for the new 3-container `codex_gui` pod spec)
- [x] `frontend`: `npm run build` clean
- [ ] After deploy: a fresh `codex_gui` session pod spawns with `codex-runner` sidecar, `runtime=sdk`, `/agent-ws` connects, a turn runs end-to-end, errors render as meta entries instead of silent kubeexec timeouts, interrupt aborts cleanly

## Known caveats (accepted per planning convo)

- `--experimental-json` flag on codex CLI is experimental; SDK version pinned to `^0.130.0`. Future SDK upgrades may surface event-shape changes.
- ChatGPT-plan headless auth is not officially supported. The chart-managed `codex-credentials` Secret (one-time interactive login on user's machine, dumped into the secret) keeps working as long as the cached refresh token is valid. If it expires, all codex sessions break until re-login.
- Runner's in-memory `AsyncQueue` is not durable — pod restart drops queued user messages. Same limitation `agent-runner` has today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)