### PR TITLE
Fix codex turn refusal + claude stream_event JSON leak

### DIFF
--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -118,7 +118,16 @@ export class Runner {
   // message, runs one turn, drains its events. The thread persists
   // across iterations so codex sees the full conversation context.
   async run(signal: AbortSignal): Promise<void> {
-    this.thread = this.codex.startThread({ workingDirectory: this.cfg.workspace });
+    this.thread = this.codex.startThread({
+      workingDirectory: this.cfg.workspace,
+      // /workspace inside session pods isn't a git repo (and may never be —
+      // users mount projects ad hoc). Without this flag the CLI exits with
+      // "Not inside a trusted directory and --skip-git-repo-check was not
+      // specified." Same flag legacy headless-run.sh has always passed.
+      skipGitRepoCheck: true,
+      sandboxMode: "danger-full-access",
+      approvalPolicy: "never",
+    });
     while (!signal.aborted) {
       const next = await this.userQueue.next();
       if (next.done) break;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1979,10 +1979,15 @@ function applyClaudeToolResults(entries: TranscriptEntry[], event: JsonObject): 
 function applyClaudeEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
   const type = event.type;
   const time = eventTime(event);
-  // Skip internal claude-code events that appear in the JSONL file but are
-  // not streamed via WebSocket and have no chat-visible meaning.
+  // Skip events that have no chat-visible meaning. stream_event is the
+  // SDK's typewriter-partial channel (deltas inside an in-flight turn) —
+  // the final `assistant` event carries the full content, so we silently
+  // drop the partials. Before this filter they fell through to the
+  // fallback appendMeta and briefly rendered as raw JSON until the
+  // history-replay path clobbered them.
   if (
     type === "system" ||
+    type === "stream_event" ||
     type === "rate_limit_event" ||
     type === "ai-title" ||
     type === "last-prompt" ||


### PR DESCRIPTION
## Summary

Two post-deploy issues found in the Phase 2 smoke test:

### 1. Codex turns refuse to start

Sending a user frame to the codex-runner reproduces:
```
"type":"error","message":"Codex Exec exited with code 1: Reading prompt from stdin...
Not inside a trusted directory and --skip-git-repo-check was not specified."
```

`/workspace` inside session pods isn't a git repo. Legacy `headless-run.sh` always passed `--skip-git-repo-check`; the SDK exposes the same control as `ThreadOptions.skipGitRepoCheck`. Fix: pass it (plus explicit `sandboxMode` + `approvalPolicy` because SDK defaults override the `config.toml` approach).

### 2. Claude SDK sessions briefly showed raw JSON, then it vanished

The SDK emits `stream_event` events (typewriter-partial channel). The chat pane's `applyClaudeEvent` had a skip-list for non-renderable events but `stream_event` wasn't on it, so each partial fell through to the fallback `appendMeta` and rendered as raw JSON. Then history-replay (Cosmos doesn't store `stream_event` — non-canonical) wiped them. Add `stream_event` to the skip list; the final `assistant` event carries the full content already.

## Test plan

- [x] codex-runner: `npm run build` + `npm test` (14 cases) pass
- [x] frontend + backend: build clean
- [ ] After deploy: send a message in a codex session → it actually runs (no trusted-directory error), events render in your chat pane
- [ ] After deploy: send a message in a claude session → no transient JSON flash before the assistant bubble lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)