### PR TITLE
Fix codex /agent-ws upgrade: WS proxy recognizes codex-runner, not just agent-runner

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_agent_ws.go
+++ b/backend-go/cmd/tank-operator/handlers_agent_ws.go
@@ -57,8 +57,8 @@ func (s *appServer) handleAgentWebSocket(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusServiceUnavailable, "pod has no IP yet")
 		return
 	}
-	if !podHasAgentRunner(pod) {
-		writeError(w, http.StatusBadRequest, "session pod has no agent-runner container (legacy claude_cli/codex/pi modes don't use the SDK runner)")
+	if !podHasSDKRunner(pod) {
+		writeError(w, http.StatusBadRequest, "session pod has no SDK runner container (legacy claude_cli/codex_cli/pi modes don't use a runner)")
 		return
 	}
 
@@ -117,12 +117,17 @@ func (s *appServer) handleAgentWebSocket(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// podHasAgentRunner returns true if the pod spec includes the
-// agent-runner container (claude_gui mode only today; Phase B
-// added it conditionally in compat.PodManifest).
-func podHasAgentRunner(pod *corev1.Pod) bool {
+// podHasSDKRunner returns true if the pod spec includes either of the
+// SDK runner sidecars: agent-runner (claude_gui, @anthropic-ai/claude-
+// agent-sdk) or codex-runner (codex_gui, @openai/codex-sdk). Both
+// listen on the same agent-ws port and speak the same client-side
+// protocol, so the WS reverse-proxy doesn't care which one is on the
+// other end. Without this, codex_gui sessions were 400'd at WS upgrade
+// despite having a working codex-runner — visible to the user as a
+// codex session timing out the moment they tried to send a message.
+func podHasSDKRunner(pod *corev1.Pod) bool {
 	for _, c := range pod.Spec.Containers {
-		if c.Name == "agent-runner" {
+		if c.Name == "agent-runner" || c.Name == "codex-runner" {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

The orchestrator's `/agent-ws` reverse-proxy validates that the session pod has an SDK runner before upgrading. It was only checking for the `agent-runner` container (claude side); `codex_gui` pods carry `codex-runner` instead, so every codex `/agent-ws` upgrade got a `400 "session pod has no agent-runner container"`. From the user's seat: codex sessions appeared to time out the moment they sent a message, because the SPA's `ws.onopen` never fired.

The fix is two lines: `podHasAgentRunner` → `podHasSDKRunner`; accept either container name.

I had already wired `runtimeFromPod` (the SPA-facing field that drives the data-source branch) to recognize both runners in PR #395, but missed this parallel check in the WS proxy itself.

## Test plan

- [x] Direct WS test against the running codex-runner works end-to-end: `thread.started` → `turn.started` → `item.completed agent_message` → `turn.completed`. The runner is correct; only the proxy upgrade path was broken.
- [ ] After deploy: open a fresh `codex_gui` session in the SPA, send a message → response renders as an assistant bubble, no timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)