### PR TITLE
Fix SDK transcript ordering and replay merge

### DIFF
--- a/agent-runner/src/cosmos.ts
+++ b/agent-runner/src/cosmos.ts
@@ -84,7 +84,10 @@ export class CosmosSink {
       id: (message as any).uuid as string,
       tank_session_id: this.cfg.sessionId,
       email: this.cfg.ownerEmail,
-      written_at: new Date().toISOString(),
+      written_at:
+        typeof (message as any).written_at === "string"
+          ? ((message as any).written_at as string)
+          : new Date().toISOString(),
     };
     await this.container.items.upsert(doc);
   }

--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -36,6 +36,28 @@ test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
   assert.deepEqual(order, ["cosmos", "ws"]);
 });
 
+test("dispatch stamps same tank ordering metadata to cosmos and ws", async () => {
+  let cosmosMessage: any;
+  let wsMessage: any;
+  const ok = await dispatch(
+    {
+      async upsert(message) {
+        cosmosMessage = message;
+      },
+    },
+    {
+      broadcastEvent(message) {
+        wsMessage = message;
+      },
+    },
+    { type: "assistant", uuid: "x" } as any,
+  );
+  assert.equal(ok, true);
+  assert.equal(cosmosMessage.tank_event_seq, wsMessage.tank_event_seq);
+  assert.equal(cosmosMessage.tank_order_key, wsMessage.tank_order_key);
+  assert.equal(cosmosMessage.written_at, wsMessage.written_at);
+});
+
 test("canonical: cosmos failure suppresses ws broadcast", async () => {
   const order: Order = [];
   const ok = await dispatch(

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -40,14 +40,35 @@ interface DispatchSink {
 interface DispatchWS {
   broadcastEvent(message: SDKMessage): void;
 }
+
+let tankEventSeq = 0;
+
+function stampTankEvent(message: SDKMessage): SDKMessage {
+  tankEventSeq += 1;
+  const now = Date.now();
+  const uuid = (message as any).uuid;
+  const stableId = typeof uuid === "string" && uuid ? uuid : String(tankEventSeq);
+  return {
+    ...(message as Record<string, unknown>),
+    tank_event_seq: tankEventSeq,
+    tank_order_key: [
+      String(now).padStart(13, "0"),
+      String(tankEventSeq).padStart(8, "0"),
+      stableId,
+    ].join("-"),
+    written_at: new Date(now).toISOString(),
+  } as unknown as SDKMessage;
+}
+
 export async function dispatch(
   sink: DispatchSink,
   ws: DispatchWS,
   message: SDKMessage,
 ): Promise<boolean> {
-  if (isCanonical(message)) {
+  const stamped = stampTankEvent(message);
+  if (isCanonical(stamped)) {
     try {
-      await sink.upsert(message);
+      await sink.upsert(stamped);
     } catch (err) {
       console.error("cosmos upsert failed:", err);
       // Don't broadcast a live event we couldn't persist — the SPA's
@@ -55,7 +76,7 @@ export async function dispatch(
       return false;
     }
   }
-  ws.broadcastEvent(message);
+  ws.broadcastEvent(stamped);
   return true;
 }
 

--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -73,16 +73,52 @@ func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSession
 			out = append(out, doc)
 		}
 	}
-	// Cosmos should already sort by the ORDER BY clause, but the pager
-	// concatenation across pages can return slightly out-of-order rows
-	// on the page boundary; an explicit sort is cheap and removes the
-	// edge case for the SPA's dedupe-by-uuid path.
+	// New runner events carry tank_order_key (producer write time + local
+	// sequence + event id). Older Claude docs use UUIDv7 and old Codex docs
+	// used UUIDv4, so fall back through write timestamps before id to avoid
+	// reshuffling existing sessions on every history refresh.
+	sortSessionEvents(out)
+	return out, nil
+}
+
+func sortSessionEvents(out []map[string]any) {
 	sort.SliceStable(out, func(i, j int) bool {
+		ki := eventOrderKey(out[i])
+		kj := eventOrderKey(out[j])
+		if ki != "" && kj != "" && ki != kj {
+			return ki < kj
+		}
+		if ki != kj {
+			return kj == ""
+		}
+		ti := eventOrderTime(out[i])
+		tj := eventOrderTime(out[j])
+		if ti != "" && tj != "" && ti != tj {
+			return ti < tj
+		}
+		if ti != tj {
+			return tj == ""
+		}
 		ai, _ := out[i]["id"].(string)
 		aj, _ := out[j]["id"].(string)
 		return ai < aj
 	})
-	return out, nil
+}
+
+func eventOrderKey(doc map[string]any) string {
+	if value, ok := doc["tank_order_key"].(string); ok && value != "" {
+		return value
+	}
+	return ""
+}
+
+func eventOrderTime(doc map[string]any) string {
+	for _, field := range []string{"written_at", "timestamp", "time", "created_at"} {
+		if value, ok := doc[field].(string); ok && value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // Stub for local dev where Cosmos isn't configured.

--- a/backend-go/internal/store/session_events_test.go
+++ b/backend-go/internal/store/session_events_test.go
@@ -1,0 +1,60 @@
+package store
+
+import "testing"
+
+func TestSortSessionEventsPrefersWrittenAt(t *testing.T) {
+	events := []map[string]any{
+		{"id": "0002-random-v4", "written_at": "2026-05-12T01:00:02Z", "type": "item.completed"},
+		{"id": "0001-random-v4", "written_at": "2026-05-12T01:00:03Z", "type": "turn.completed"},
+		{"id": "9999-random-v4", "written_at": "2026-05-12T01:00:01Z", "type": "tank.user_message"},
+	}
+
+	sortSessionEvents(events)
+
+	got := []string{
+		events[0]["type"].(string),
+		events[1]["type"].(string),
+		events[2]["type"].(string),
+	}
+	want := []string{"tank.user_message", "item.completed", "turn.completed"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sorted event %d = %q, want %q (all events: %#v)", i, got[i], want[i], events)
+		}
+	}
+}
+
+func TestSortSessionEventsPrefersTankOrderKey(t *testing.T) {
+	events := []map[string]any{
+		{"id": "a", "tank_order_key": "0003", "written_at": "2026-05-12T01:00:01Z", "type": "third"},
+		{"id": "b", "tank_order_key": "0001", "written_at": "2026-05-12T01:00:03Z", "type": "first"},
+		{"id": "c", "tank_order_key": "0002", "written_at": "2026-05-12T01:00:02Z", "type": "second"},
+	}
+
+	sortSessionEvents(events)
+
+	got := []string{
+		events[0]["type"].(string),
+		events[1]["type"].(string),
+		events[2]["type"].(string),
+	}
+	want := []string{"first", "second", "third"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sorted event %d = %q, want %q (all events: %#v)", i, got[i], want[i], events)
+		}
+	}
+}
+
+func TestSortSessionEventsFallsBackToID(t *testing.T) {
+	events := []map[string]any{
+		{"id": "b", "type": "second"},
+		{"id": "a", "type": "first"},
+	}
+
+	sortSessionEvents(events)
+
+	if got := events[0]["type"]; got != "first" {
+		t.Fatalf("first event = %v, want first", got)
+	}
+}

--- a/codex-runner/src/cosmos.test.ts
+++ b/codex-runner/src/cosmos.test.ts
@@ -44,14 +44,21 @@ test("NOT canonical: unknown event types", () => {
   assert.equal(isCanonical({ type: "" }), false);
 });
 
-test("stampEventID attaches a v4 uuid without mutating the input", () => {
+test("canonical: tank.user_message", () => {
+  assert.equal(isCanonical({ type: "tank.user_message", message: "hello" }), true);
+});
+
+test("stampEventID attaches a sortable uuid and order metadata without mutating the input", () => {
   const before = { type: "thread.started", thread_id: "t1" };
   const after = stampEventID(before);
   assert.equal(typeof after.uuid, "string");
   assert.match(
     after.uuid,
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    /^\d{13}-\d{6}-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
   );
+  assert.equal(typeof after.tank_event_seq, "number");
+  assert.equal(typeof after.tank_order_key, "string");
+  assert.equal(typeof after.written_at, "string");
   // Input untouched: pins purity at this boundary so retries don't
   // double-stamp.
   assert.equal((before as { uuid?: string }).uuid, undefined);

--- a/codex-runner/src/cosmos.ts
+++ b/codex-runner/src/cosmos.ts
@@ -7,12 +7,15 @@
 //
 // Difference from claude: the codex SDK's `ThreadEvent` union has no
 // per-event `uuid` field — only contained `ThreadItem`s carry ids, and
-// only some events have items. We stamp our own random v4 uuid as the
-// doc id at production time. The producer is the only writer, so the
-// id is unique by construction.
+// only some events have items. We stamp our own sortable id as the doc id
+// at production time. The producer is the only writer, so the id is unique
+// by construction. The id is lexicographically sortable and
+// every dispatched event also carries a Tank order key so history replay
+// and live delivery can be reconciled without depending on render timing.
 //
 // "Canonical" = events the SPA's history-replay path should see:
 //   thread.started     — session boot marker (analog of claude system/init)
+//   tank.user_message  — user's prompt as submitted through Tank's WS bridge
 //   turn.completed     — turn-end marker with usage
 //   turn.failed        — turn-level error
 //   item.completed     — main durable signal: agent_message, reasoning,
@@ -35,6 +38,7 @@ import type { Config } from "./config.js";
 
 const CANONICAL_TYPES = new Set<string>([
   "thread.started",
+  "tank.user_message",
   "turn.completed",
   "turn.failed",
   "item.completed",
@@ -50,11 +54,56 @@ export function isCanonical(event: CodexEvent): boolean {
   return CANONICAL_TYPES.has(event.type);
 }
 
-// Stamp a generated uuid on the event. The runner uses the same stamped
-// value when dispatching to both Cosmos and the WS, so consumers can
-// dedupe across the history+live join.
-export function stampEventID(event: CodexEvent): CodexEvent & { uuid: string } {
-  return { ...event, uuid: randomUUID() };
+let lastEventMs = 0;
+let eventSeq = 0;
+let tankEventSeq = 0;
+
+export function nextSortableEventID(now = Date.now()): string {
+  const ms = Math.max(now, lastEventMs);
+  if (ms === lastEventMs) {
+    eventSeq += 1;
+  } else {
+    lastEventMs = ms;
+    eventSeq = 0;
+  }
+  return [
+    String(ms).padStart(13, "0"),
+    String(eventSeq).padStart(6, "0"),
+    randomUUID(),
+  ].join("-");
+}
+
+function nextTankEventSeq(): number {
+  tankEventSeq += 1;
+  return tankEventSeq;
+}
+
+// Stamp a generated, lexicographically sortable id on the event. The runner
+// uses the same stamped value when dispatching to both Cosmos and the WS, so
+// consumers can dedupe across the history+live join. This is intentionally
+// not UUIDv4: replay sorts by id, so random ids reorder multi-turn history.
+export function stampEventID(
+  event: CodexEvent,
+): CodexEvent & {
+  uuid: string;
+  tank_event_seq: number;
+  tank_order_key: string;
+  written_at: string;
+} {
+  const now = Date.now();
+  const uuid = nextSortableEventID(now);
+  const seq = nextTankEventSeq();
+  return {
+    ...event,
+    uuid,
+    tank_event_seq: seq,
+    tank_order_key: [
+      String(now).padStart(13, "0"),
+      String(seq).padStart(8, "0"),
+      uuid,
+    ].join("-"),
+    written_at: new Date(now).toISOString(),
+  };
 }
 
 export class CosmosSink {
@@ -82,7 +131,10 @@ export class CosmosSink {
       tank_session_id: this.cfg.sessionId,
       email: this.cfg.ownerEmail,
       runtime: "codex",
-      written_at: new Date().toISOString(),
+      written_at:
+        typeof event.written_at === "string"
+          ? event.written_at
+          : new Date().toISOString(),
     };
     await this.container.items.upsert(doc);
   }

--- a/codex-runner/src/runner.test.ts
+++ b/codex-runner/src/runner.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { dispatch } from "./runner.js";
-import type { CodexEvent } from "./cosmos.js";
+import { isCanonical, nextSortableEventID, type CodexEvent } from "./cosmos.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -34,6 +34,29 @@ test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
   } as CodexEvent);
   assert.equal(ok, true);
   assert.deepEqual(order, ["cosmos", "ws"]);
+});
+
+test("dispatch stamps same tank ordering metadata to cosmos and ws", async () => {
+  let cosmosEvent: any;
+  let wsEvent: any;
+  const ok = await dispatch(
+    {
+      async upsert(event) {
+        cosmosEvent = event;
+      },
+    },
+    {
+      broadcastEvent(event) {
+        wsEvent = event;
+      },
+    },
+    { type: "item.completed", item: { id: "i1" } } as CodexEvent,
+  );
+  assert.equal(ok, true);
+  assert.equal(cosmosEvent.uuid, wsEvent.uuid);
+  assert.equal(cosmosEvent.tank_event_seq, wsEvent.tank_event_seq);
+  assert.equal(cosmosEvent.tank_order_key, wsEvent.tank_order_key);
+  assert.equal(cosmosEvent.written_at, wsEvent.written_at);
 });
 
 test("canonical: cosmos failure suppresses ws broadcast", async () => {
@@ -83,4 +106,18 @@ test("error events ARE canonical (durable error log)", async () => {
     { type: "error", message: "x" } as CodexEvent,
   );
   assert.deepEqual(order, ["cosmos", "ws"]);
+});
+
+test("tank.user_message is canonical so replay preserves user bubbles", () => {
+  assert.equal(
+    isCanonical({ type: "tank.user_message", message: "hello" }),
+    true,
+  );
+});
+
+test("generated event ids sort by production order", () => {
+  const first = nextSortableEventID(1000);
+  const second = nextSortableEventID(1000);
+  const third = nextSortableEventID(1001);
+  assert.deepEqual([third, first, second].sort(), [first, second, third]);
 });

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -102,6 +102,7 @@ export class Runner {
   private readonly codex: Codex;
   private thread: Thread | null = null;
   private currentAbort: AbortController | null = null;
+  private turnSeq = 0;
 
   constructor(private readonly cfg: Config) {
     this.sink = new CosmosSink(cfg);
@@ -132,6 +133,12 @@ export class Runner {
       const next = await this.userQueue.next();
       if (next.done) break;
       const input = next.value;
+      const turnSeq = ++this.turnSeq;
+      await dispatch(this.sink, this.ws, {
+        type: "tank.user_message",
+        message: input,
+        tank_turn_seq: turnSeq,
+      });
 
       this.currentAbort = new AbortController();
       // If the outer signal aborts mid-turn, also abort the in-flight
@@ -146,7 +153,10 @@ export class Runner {
         });
         for await (const event of streamed.events) {
           if (signal.aborted) break;
-          await dispatch(this.sink, this.ws, event as CodexEvent);
+          await dispatch(this.sink, this.ws, {
+            ...(event as CodexEvent),
+            tank_turn_seq: turnSeq,
+          });
         }
       } catch (err) {
         // Synthetic error event so the SPA sees something when the SDK
@@ -157,6 +167,7 @@ export class Runner {
         await dispatch(this.sink, this.ws, {
           type: "error",
           message: errMessage,
+          tank_turn_seq: turnSeq,
         });
         console.error("codex turn failed:", err);
       } finally {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -110,6 +110,11 @@ type TranscriptEntry = SandboxTranscriptEntry & {
   toolKind?: ToolKind;
   toolServer?: string;
   toolAction?: string;
+  transcriptSource?: "server" | "realtime";
+  sourceEventId?: string;
+  orderKey?: string;
+  localOnly?: boolean;
+  clientNonce?: string;
 };
 type SkillStateName = "test" | "rollout";
 
@@ -1564,11 +1569,21 @@ function normalizeIsoTimestamp(value: unknown): string | null {
 
 function eventTime(event: JsonObject): string {
   return (
+    normalizeIsoTimestamp(event.written_at) ??
     normalizeIsoTimestamp(event.timestamp) ??
     normalizeIsoTimestamp(event.time) ??
     normalizeIsoTimestamp(event.created_at) ??
     nowIso()
   );
+}
+
+function stableStringHash(value: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
 }
 
 function upsertEntry(entries: TranscriptEntry[], entry: TranscriptEntry): TranscriptEntry[] {
@@ -1676,16 +1691,13 @@ function appendAssistantMessage(
   time: string = nowIso(),
 ): TranscriptEntry[] {
   if (!text.trim()) return entries;
-  return [
-    ...entries,
-    {
-      id,
-      kind: "message",
-      role: "assistant",
-      text,
-      time,
-    },
-  ];
+  return upsertEntry(entries, {
+    id,
+    kind: "message",
+    role: "assistant",
+    text,
+    time,
+  });
 }
 
 function skillInvocationTitle(name: string): string {
@@ -1761,10 +1773,41 @@ function describeUsage(usage: unknown): string {
     .join(" · ");
 }
 
+function eventID(event: JsonObject, fallbackPrefix: string): string {
+  if (typeof event.uuid === "string" && event.uuid) return event.uuid;
+  if (typeof event.id === "string" && event.id) return event.id;
+  if (typeof event.event_id === "string" && event.event_id) return event.event_id;
+  if (typeof event.tank_order_key === "string" && event.tank_order_key) {
+    return event.tank_order_key;
+  }
+  return `${fallbackPrefix}-${eventTime(event)}-${stableStringHash(shortJson(event))}`;
+}
+
+function eventOrderKey(event: JsonObject): string {
+  if (typeof event.tank_order_key === "string" && event.tank_order_key) {
+    return event.tank_order_key;
+  }
+  const time = eventTime(event);
+  return [time, eventID(event, "event")].join("-");
+}
+
+function codexTurnScope(event: JsonObject): string {
+  const turnSeq = event.tank_turn_seq;
+  if (typeof turnSeq === "number" && Number.isFinite(turnSeq)) return String(turnSeq);
+  if (typeof turnSeq === "string" && turnSeq) return turnSeq;
+  return eventID(event, "codex-event");
+}
+
+function codexItemEntryId(event: JsonObject, item: JsonObject, fallbackPrefix: string): string {
+  const itemId = typeof item.id === "string" && item.id ? item.id : "";
+  if (itemId) return `${fallbackPrefix}-${codexTurnScope(event)}-${itemId}`;
+  return `${fallbackPrefix}-${eventID(event, fallbackPrefix)}`;
+}
+
 function codexToolEntry(event: JsonObject): TranscriptEntry | null {
   const item = event.item;
   if (!isJsonObject(item)) return null;
-  const id = typeof item.id === "string" ? item.id : `codex-tool-${Date.now()}`;
+  const id = codexItemEntryId(event, item, "codex-tool");
   const status = typeof item.status === "string" ? item.status : String(event.type ?? "");
   const itemType = item.type;
   const time = eventTime(event);
@@ -1832,35 +1875,30 @@ function applyCodexEvent(entries: TranscriptEntry[], event: JsonObject): Transcr
     const text = typeof event.message === "string" ? event.message.trim() : "";
     const skillName = skillNameFromTrigger(text);
     if (skillName && hasSkillInvocation(entries, skillName)) return entries;
-    if (!text || entries.some((entry) => entry.kind === "message" && entry.role === "user" && entry.text === text)) {
-      return entries;
-    }
-    return [
-      ...entries,
-      {
-        id: `codex-user-message-${Date.now()}`,
-        kind: "message",
-        role: "user",
-        text,
-        time,
-      },
-    ];
+    if (!text) return entries;
+    return upsertEntry(entries, {
+      id: `codex-user-message-${eventID(event, "codex-user-message")}`,
+      kind: "message",
+      role: "user",
+      text,
+      time,
+    });
   }
   if (type === "thread.started") {
     const threadId = typeof event.thread_id === "string" ? event.thread_id : "";
-    return appendMeta(entries, `codex-thread-${threadId || Date.now()}`, "Codex thread started", threadId, "info", time);
+    return appendMeta(entries, `codex-thread-${eventID(event, threadId || "codex-thread")}`, "Codex thread started", threadId, "info", time);
   }
   if (type === "turn.started") {
-    return appendMeta(entries, `codex-turn-started-${Date.now()}`, "Turn started", undefined, "info", time);
+    return appendMeta(entries, `codex-turn-started-${eventID(event, "codex-turn-started")}`, "Turn started", undefined, "info", time);
   }
   if (type === "turn.completed") {
-    return appendMeta(entries, `codex-turn-completed-${Date.now()}`, "Turn completed", describeUsage(event.usage), "info", time);
+    return appendMeta(entries, `codex-turn-completed-${eventID(event, "codex-turn-completed")}`, "Turn completed", describeUsage(event.usage), "info", time);
   }
   if (type === "turn.failed" || type === "error") {
     const error = isJsonObject(event.error) ? event.error.message : event.message;
     return appendMeta(
       entries,
-      `codex-error-${Date.now()}`,
+      `codex-error-${eventID(event, "codex-error")}`,
       type === "turn.failed" ? "Turn failed" : "Codex error",
       typeof error === "string" ? error : shortJson(event),
       "error",
@@ -1873,12 +1911,13 @@ function applyCodexEvent(entries: TranscriptEntry[], event: JsonObject): Transcr
     if (item.type === "agent_message") {
       return appendAssistantMessage(
         entries,
-        typeof item.id === "string" ? item.id : `codex-message-${Date.now()}`,
+        codexItemEntryId(event, item, "codex-message"),
         typeof item.text === "string" ? item.text : "",
+        time,
       );
     }
     if (item.type === "reasoning") {
-      const id = typeof item.id === "string" ? item.id : `codex-reasoning-${Date.now()}`;
+      const id = codexItemEntryId(event, item, "codex-reasoning");
       return upsertEntry(entries, {
         id,
         kind: "reasoning",
@@ -1889,7 +1928,7 @@ function applyCodexEvent(entries: TranscriptEntry[], event: JsonObject): Transcr
     const toolEntry = codexToolEntry(event);
     return toolEntry ? upsertEntry(entries, toolEntry) : entries;
   }
-  return appendMeta(entries, `codex-event-${Date.now()}`, String(type || "Codex event"), shortJson(event), "info", time);
+  return appendMeta(entries, `codex-event-${eventID(event, "codex-event")}`, String(type || "Codex event"), shortJson(event), "info", time);
 }
 
 function claudeTextFromContent(content: unknown, includeToolResults: boolean): string {
@@ -2042,21 +2081,17 @@ function applyClaudeEvent(entries: TranscriptEntry[], event: JsonObject): Transc
           }
         }
       }
-      for (const text of texts) {
+      const baseId = eventID(event, "claude-user-message");
+      for (const [index, text] of texts.entries()) {
         const skillName = skillNameFromTrigger(text);
         if (skillName && hasSkillInvocation(nextEntries, skillName)) continue;
-        if (!nextEntries.some((e) => e.kind === "message" && e.role === "user" && e.text === text)) {
-          nextEntries = [
-            ...nextEntries,
-            {
-              id: typeof event.uuid === "string" ? event.uuid : `user-msg-${Date.now()}`,
-              kind: "message" as const,
-              role: "user" as const,
-              text,
-              time,
-            },
-          ];
-        }
+        nextEntries = upsertEntry(nextEntries, {
+          id: `${baseId}-${index}`,
+          kind: "message",
+          role: "user",
+          text,
+          time,
+        });
       }
     }
     return nextEntries;
@@ -2064,26 +2099,27 @@ function applyClaudeEvent(entries: TranscriptEntry[], event: JsonObject): Transc
   if (type === "result") {
     const isError = event.is_error === true || event.subtype === "error";
     const result = typeof event.result === "string" ? event.result : "";
+    const id = eventID(event, "claude-result");
     if (!isError) {
       if (result && !entries.some((entry) => entry.kind === "message" && entry.text === result)) {
-        return appendAssistantMessage(entries, `claude-result-message-${Date.now()}`, result, time);
+        return appendAssistantMessage(entries, `claude-result-message-${id}`, result, time);
       }
       return entries;
     }
     let nextEntries = appendMeta(
       entries,
-      `claude-result-${Date.now()}`,
+      `claude-result-${id}`,
       "Claude run failed",
       result,
       "error",
       time,
     );
     if (result && !entries.some((entry) => entry.kind === "message" && entry.text === result)) {
-      nextEntries = appendAssistantMessage(nextEntries, `claude-result-message-${Date.now()}`, result, time);
+      nextEntries = appendAssistantMessage(nextEntries, `claude-result-message-${id}`, result, time);
     }
     return nextEntries;
   }
-  return appendMeta(entries, `claude-event-${Date.now()}`, String(type || "Claude event"), shortJson(event), "info", time);
+  return appendMeta(entries, `claude-event-${eventID(event, "claude-event")}`, String(type || "Claude event"), shortJson(event), "info", time);
 }
 
 function applyProviderEvent(
@@ -2674,8 +2710,10 @@ function transcriptComparable(entries: TranscriptEntry[]): string {
       if (entry.kind === "message") {
         return {
           kind: entry.kind,
+          id: entry.id,
           role: entry.role,
           text: entry.text,
+          durationMs: (entry as Record<string, unknown>).durationMs,
         };
       }
       if (entry.kind === "tool") {
@@ -2701,6 +2739,143 @@ function transcriptComparable(entries: TranscriptEntry[]): string {
       };
     }),
   );
+}
+
+function entryMessageFingerprint(entry: TranscriptEntry): string | null {
+  if (entry.kind !== "message" || !entry.role || !entry.text) return null;
+  const text = entry.text.trim();
+  return text ? `${entry.role}:${text}` : null;
+}
+
+function entryMetaFingerprint(entry: TranscriptEntry): string | null {
+  if (entry.kind !== "meta") return null;
+  return [
+    entry.meta?.title ?? "",
+    entry.meta?.detail ?? "",
+    entry.meta?.severity ?? "",
+  ].join("\u0000");
+}
+
+function annotateEntriesFromEvent(
+  before: TranscriptEntry[],
+  after: TranscriptEntry[],
+  source: "server" | "realtime",
+  event: JsonObject,
+): TranscriptEntry[] {
+  const known = new Set(before.map((entry) => entry.id));
+  const sourceEventId = eventID(event, `${source}-event`);
+  const orderKey = eventOrderKey(event);
+  return after.map((entry) =>
+    known.has(entry.id)
+      ? entry
+      : {
+          ...entry,
+          transcriptSource: source,
+          sourceEventId,
+          orderKey,
+        },
+  );
+}
+
+function applySdkProviderEvent(
+  entries: TranscriptEntry[],
+  mode: SessionMode,
+  event: JsonObject,
+  source: "server" | "realtime",
+): TranscriptEntry[] {
+  return annotateEntriesFromEvent(
+    entries,
+    applyProviderEvent(entries, mode, event),
+    source,
+    event,
+  );
+}
+
+function shouldDropRealtimeEntry(
+  entry: TranscriptEntry,
+  serverIds: Set<string>,
+  serverEventIds: Set<string>,
+  serverMetaFingerprints: Set<string>,
+): boolean {
+  if (serverIds.has(entry.id)) return true;
+  if (entry.sourceEventId && serverEventIds.has(entry.sourceEventId)) return true;
+  const metaFingerprint = entryMetaFingerprint(entry);
+  return Boolean(
+    metaFingerprint &&
+      entry.localOnly &&
+      serverMetaFingerprints.has(metaFingerprint),
+  );
+}
+
+function pruneRealtimeEntries(
+  server: TranscriptEntry[],
+  realtime: TranscriptEntry[],
+): TranscriptEntry[] {
+  if (server.length === 0) return realtime;
+  const serverIds = new Set(server.map((entry) => entry.id));
+  const serverEventIds = new Set(
+    server.map((entry) => entry.sourceEventId).filter((id): id is string => Boolean(id)),
+  );
+  const serverMetaFingerprints = new Set(
+    server
+      .map(entryMetaFingerprint)
+      .filter((fingerprint): fingerprint is string => fingerprint !== null),
+  );
+  return realtime.filter(
+    (entry) =>
+      !shouldDropRealtimeEntry(
+        entry,
+        serverIds,
+        serverEventIds,
+        serverMetaFingerprints,
+      ),
+  );
+}
+
+function pruneLocalRealtimeEchoes(realtime: TranscriptEntry[]): TranscriptEntry[] {
+  const nonLocalMessageFingerprints = new Set(
+    realtime
+      .filter((entry) => !entry.localOnly)
+      .map(entryMessageFingerprint)
+      .filter((fingerprint): fingerprint is string => fingerprint !== null),
+  );
+  if (nonLocalMessageFingerprints.size === 0) return realtime;
+  return realtime.filter((entry) => {
+    if (!entry.localOnly) return true;
+    const fingerprint = entryMessageFingerprint(entry);
+    return !fingerprint || !nonLocalMessageFingerprints.has(fingerprint);
+  });
+}
+
+function dedupeAdjacentAssistantEchoes(entries: TranscriptEntry[]): TranscriptEntry[] {
+  const out: TranscriptEntry[] = [];
+  for (const entry of entries) {
+    const prev = out[out.length - 1];
+    if (
+      prev?.kind === "message" &&
+      entry.kind === "message" &&
+      prev.role === "assistant" &&
+      entry.role === "assistant" &&
+      prev.text?.trim() &&
+      prev.text.trim() === entry.text?.trim()
+    ) {
+      out[out.length - 1] = entry.transcriptSource === "server" ? entry : prev;
+      continue;
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+function mergeSdkTranscript(
+  server: TranscriptEntry[],
+  realtime: TranscriptEntry[],
+): TranscriptEntry[] {
+  if (realtime.length === 0) return server;
+  const extra = pruneRealtimeEntries(server, realtime);
+  if (server.length === 0) return dedupeAdjacentAssistantEchoes(extra);
+  if (extra.length === 0) return server;
+  return dedupeAdjacentAssistantEchoes([...server, ...extra]);
 }
 
 function parseRunHistory(text: string, mode: SessionMode): TranscriptEntry[] {
@@ -3633,6 +3808,8 @@ function HeadlessRun({
   onActivityChange?: (id: string, activity: AgentSessionActivity) => void;
 }) {
   const [entries, setEntries] = useState<TranscriptEntry[]>([]);
+  const sdkServerEntriesRef = useRef<TranscriptEntry[]>([]);
+  const sdkRealtimeEntriesRef = useRef<TranscriptEntry[]>([]);
   const [running, setRunning] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [editingTitleValue, setEditingTitleValue] = useState("");
@@ -3767,6 +3944,78 @@ function HeadlessRun({
   function nextEntryId(prefix: string): string {
     entryIdSeqRef.current += 1;
     return `${prefix}-${session.id}-${entryIdSeqRef.current}`;
+  }
+  function localOrderKey(prefix: string): string {
+    return [
+      String(Date.now()).padStart(13, "0"),
+      String(entryIdSeqRef.current + 1).padStart(8, "0"),
+      prefix,
+    ].join("-");
+  }
+  function markLocalEntries(localEntries: TranscriptEntry[], nonce: string): TranscriptEntry[] {
+    return localEntries.map((entry, index) => ({
+      ...entry,
+      transcriptSource: "realtime",
+      localOnly: true,
+      clientNonce: nonce,
+      orderKey: entry.orderKey ?? `${localOrderKey(nonce)}-${index}`,
+    }));
+  }
+  function syncSdkRenderedEntries(): void {
+    const merged = mergeSdkTranscript(
+      sdkServerEntriesRef.current,
+      sdkRealtimeEntriesRef.current,
+    );
+    setEntries((prev) =>
+      transcriptComparable(prev) === transcriptComparable(merged) ? prev : merged,
+    );
+  }
+  function replaceSdkServerEntries(
+    serverEntries: TranscriptEntry[],
+    clearRealtime = false,
+  ): void {
+    sdkServerEntriesRef.current = serverEntries;
+    sdkRealtimeEntriesRef.current = clearRealtime
+      ? []
+      : pruneRealtimeEntries(serverEntries, sdkRealtimeEntriesRef.current);
+    syncSdkRenderedEntries();
+  }
+  function appendSdkRealtimeEntries(localEntries: TranscriptEntry[]): void {
+    sdkRealtimeEntriesRef.current = pruneRealtimeEntries(
+      sdkServerEntriesRef.current,
+      pruneLocalRealtimeEchoes(
+        [...sdkRealtimeEntriesRef.current, ...localEntries].slice(-500),
+      ),
+    );
+    syncSdkRenderedEntries();
+  }
+  function applySdkRealtimeEvent(event: JsonObject): void {
+    const nextRealtime = applySdkProviderEvent(
+      sdkRealtimeEntriesRef.current,
+      session.mode,
+      event,
+      "realtime",
+    );
+    sdkRealtimeEntriesRef.current = pruneRealtimeEntries(
+      sdkServerEntriesRef.current,
+      pruneLocalRealtimeEchoes(nextRealtime.slice(-500)),
+    );
+    syncSdkRenderedEntries();
+  }
+  function updateSdkLastAssistantDuration(durationMs: number): void {
+    const update = (list: TranscriptEntry[]) => {
+      for (let i = list.length - 1; i >= 0; i -= 1) {
+        if (list[i].kind === "message" && list[i].role === "assistant") {
+          const next = [...list];
+          next[i] = { ...next[i], durationMs } as TranscriptEntry;
+          return next;
+        }
+      }
+      return list;
+    };
+    sdkRealtimeEntriesRef.current = update(sdkRealtimeEntriesRef.current);
+    sdkServerEntriesRef.current = update(sdkServerEntriesRef.current);
+    syncSdkRenderedEntries();
   }
   const queuedMessageSeqRef = useRef(0);
   function nextQueuedMessageId(): string {
@@ -3993,7 +4242,7 @@ function HeadlessRun({
   // /api/sessions/{id}/events). Each event is the same shape applyProviderEvent
   // already consumes — the chat pane was built around Claude's stream-json,
   // which the SDK is a TypeScript wrapper over the same binary's stdout.
-  function refreshSdkRunHistory(showHint: boolean): Promise<boolean> {
+  function refreshSdkRunHistory(showHint: boolean, clearRealtime = false): Promise<boolean> {
     const refreshSessionId = session.id;
     return authedFetch(
       `/api/sessions/${encodeURIComponent(refreshSessionId)}/events?limit=1000`,
@@ -4006,17 +4255,11 @@ function HeadlessRun({
         let acc: TranscriptEntry[] = [];
         for (const ev of body.events) {
           if (isJsonObject(ev)) {
-            acc = applyProviderEvent(acc, session.mode, ev);
+            acc = applySdkProviderEvent(acc, session.mode, ev, "server");
           }
         }
         if (acc.length === 0) return false;
-        setEntries((prev) => {
-          if (transcriptComparable(prev) === transcriptComparable(acc)) return prev;
-          // For SDK history we trust the server's canonical log over any
-          // partial in-memory state. The dedupe-by-uuid in upsertEntry handles
-          // any overlap if a live event arrived before history finished.
-          return acc;
-        });
+        replaceSdkServerEntries(acc, clearRealtime);
         if (showHint) {
           setContinueHintVisible(true);
           window.setTimeout(() => setContinueHintVisible(false), 3000);
@@ -4433,6 +4676,8 @@ function HeadlessRun({
   // history sync to run again. The replay paths repopulate from backend.
   useEffect(() => {
     sessionIdRef.current = session.id;
+    sdkServerEntriesRef.current = [];
+    sdkRealtimeEntriesRef.current = [];
     setEntries([]);
     setQueuedMessages([]);
     historyRefreshRef.current = null;
@@ -5140,19 +5385,31 @@ function HeadlessRun({
     };
     currentRunRef.current = run;
     setActiveRunId(run.id);
+    const optimisticTime = nowIso();
     if (skillName) {
-      setEntries((prev) => appendSkillInvocation(prev, skillName, trimmed, nowIso()));
+      if (session.runtime === "sdk") {
+        appendSdkRealtimeEntries(
+          markLocalEntries(
+            appendSkillInvocation([], skillName, trimmed, optimisticTime),
+            run.id,
+          ),
+        );
+      } else {
+        setEntries((prev) => appendSkillInvocation(prev, skillName, trimmed, optimisticTime));
+      }
     } else {
-      setEntries((prev) => [
-        ...prev,
-        {
+      const userEntry = {
           id: nextEntryId("user"),
           kind: "message",
           role: "user",
           text: displayText,
-          time: nowIso(),
-        },
-      ]);
+          time: optimisticTime,
+        } as TranscriptEntry;
+      if (session.runtime === "sdk") {
+        appendSdkRealtimeEntries(markLocalEntries([userEntry], run.id));
+      } else {
+        setEntries((prev) => [...prev, userEntry]);
+      }
     }
     setRunStatus("running");
     setRunning(true);
@@ -5197,12 +5454,11 @@ function HeadlessRun({
       try {
         parsed = JSON.parse(String(event.data));
       } catch {
-        setEntries((prev) =>
-          appendMeta(
-            prev,
-            nextEntryId("agent-ws-message"),
-            "agent-ws message",
-            String(event.data),
+        const id = nextEntryId("agent-ws-message");
+        appendSdkRealtimeEntries(
+          markLocalEntries(
+            appendMeta([], id, "agent-ws message", String(event.data)),
+            id,
           ),
         );
         return;
@@ -5267,7 +5523,7 @@ function HeadlessRun({
         setActiveTool(null);
       }
 
-      setEntries((prev) => applyProviderEvent(prev, session.mode, parsed));
+      applySdkRealtimeEvent(parsed);
 
       // Terminal events. Each runtime closes the WS so a fresh open per
       // turn works. The runners themselves stay alive for the pod's
@@ -5279,16 +5535,7 @@ function HeadlessRun({
       if (isTerminal) {
         currentRunRef.current = null;
         const durationMs = Date.now() - run.turnStart;
-        setEntries((prev) => {
-          for (let i = prev.length - 1; i >= 0; i--) {
-            if (prev[i].kind === "message" && prev[i].role === "assistant") {
-              const updated = [...prev];
-              updated[i] = { ...updated[i], durationMs } as TranscriptEntry;
-              return updated;
-            }
-          }
-          return prev;
-        });
+        updateSdkLastAssistantDuration(durationMs);
         setLastStatusText(
           scheduledWakeupRef.current
             ? "Wakeup scheduled"
@@ -5303,6 +5550,7 @@ function HeadlessRun({
         setActiveRunId(null);
         playTurnCompleteSound();
         ws.close();
+        void refreshSdkRunHistory(false, true);
       }
     };
     ws.onerror = () => {
@@ -5325,18 +5573,23 @@ function HeadlessRun({
       scheduledWakeupRef.current = false;
       setActiveTool(null);
       setRunning(false);
-      setEntries((entries) =>
-        appendMeta(
-          entries,
-          nextEntryId("ws-close"),
-          "Connection lost",
+      const id = nextEntryId("ws-close");
+      appendSdkRealtimeEntries(
+        markLocalEntries(
+          appendMeta(
+            [],
+            id,
+            "Connection lost",
           `WebSocket closed with code ${event.code}${
             event.reason ? ` — ${event.reason}` : ""
-          }. Reload to resume.`,
+          }. Reconnecting from history.`,
           "error",
+          ),
+          id,
         ),
       );
       setRunStatus("error");
+      void refreshSdkRunHistory(false);
     };
   }
 


### PR DESCRIPTION
## Summary
- add durable Tank ordering metadata to Claude and Codex SDK runner events
- persist Codex user messages and scope Codex item ids by turn
- render SDK sessions from separate server replay and realtime/optimistic transcript ledgers
- sort backend session replay by Tank order key, then write time, then id

## Verification
- frontend: npm run build
- codex-runner: npm run build; npm test
- agent-runner: npm run build; npm test
- backend-go: go test ./...
- git diff --check