### PR TITLE
Persist Tank-owned user messages for SDK sessions

### DIFF
--- a/agent-runner/src/cosmos.test.ts
+++ b/agent-runner/src/cosmos.test.ts
@@ -8,6 +8,7 @@ import { isCanonical } from "./cosmos.js";
 // affects the SPA's history-replay correctness.
 
 test("canonical: user, assistant, result messages", () => {
+  assert.equal(isCanonical({ type: "tank.user_message", message: "hello" }), true);
   assert.equal(isCanonical({ type: "user" } as any), true);
   assert.equal(isCanonical({ type: "assistant" } as any), true);
   assert.equal(isCanonical({ type: "result", subtype: "success" } as any), true);

--- a/agent-runner/src/cosmos.ts
+++ b/agent-runner/src/cosmos.ts
@@ -7,7 +7,7 @@
 //
 // "Canonical" = events the SPA's history-replay path should see:
 //   system (init / compact_boundary), user, assistant, tool_use_summary,
-//   result, permission_denied, rate_limit, plugin_install
+//   result, permission_denied, rate_limit, plugin_install, tank.user_message
 //
 // "Live-only" = transient deltas that drive the typewriter effect but
 // have no durable value (Discord's "typing..." analog):
@@ -21,8 +21,16 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import type { Config } from "./config.js";
 
+export interface RunnerEvent {
+  type: string;
+  uuid?: string;
+  subtype?: string;
+  [k: string]: unknown;
+}
+
 const CANONICAL_TYPES = new Set<string>([
   "system",
+  "tank.user_message",
   "user",
   "assistant",
   "result",
@@ -42,13 +50,13 @@ const CANONICAL_TOP_LEVEL_TYPES = new Set<string>([
   "rate_limit",
 ]);
 
-export function isCanonical(message: SDKMessage): boolean {
-  const t = (message as any).type as string | undefined;
+export function isCanonical(message: RunnerEvent | SDKMessage): boolean {
+  const t = (message as RunnerEvent).type;
   if (!t) return false;
   if (CANONICAL_TOP_LEVEL_TYPES.has(t)) return true;
   if (CANONICAL_TYPES.has(t)) {
     if (t === "system") {
-      const subtype = (message as any).subtype as string | undefined;
+      const subtype = (message as RunnerEvent).subtype;
       // Some system events (status, hook progress) are ephemeral — only
       // the documented turn-level subtypes are durable.
       return subtype ? CANONICAL_SYSTEM_SUBTYPES.has(subtype) : false;
@@ -78,15 +86,16 @@ export class CosmosSink {
   // session_id — the SPA queries on the integer (it knows the pod-level
   // id), and pod restart may yield a new SDK session within the same
   // tank-operator session. The SDK's session_id rides along as a field.
-  async upsert(message: SDKMessage): Promise<void> {
+  async upsert(message: RunnerEvent & { uuid: string }): Promise<void> {
     const doc: Record<string, unknown> = {
-      ...(message as Record<string, unknown>),
-      id: (message as any).uuid as string,
+      ...message,
+      id: message.uuid,
       tank_session_id: this.cfg.sessionId,
       email: this.cfg.ownerEmail,
+      runtime: "claude",
       written_at:
-        typeof (message as any).written_at === "string"
-          ? ((message as any).written_at as string)
+        typeof message.written_at === "string"
+          ? message.written_at
           : new Date().toISOString(),
     };
     await this.container.items.upsert(doc);

--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { dispatch } from "./runner.js";
+import { isCanonical } from "./cosmos.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -56,6 +57,35 @@ test("dispatch stamps same tank ordering metadata to cosmos and ws", async () =>
   assert.equal(cosmosMessage.tank_event_seq, wsMessage.tank_event_seq);
   assert.equal(cosmosMessage.tank_order_key, wsMessage.tank_order_key);
   assert.equal(cosmosMessage.written_at, wsMessage.written_at);
+});
+
+test("tank.user_message is canonical so Claude replay preserves user bubbles", () => {
+  assert.equal(
+    isCanonical({ type: "tank.user_message", message: "hello" }),
+    true,
+  );
+});
+
+test("dispatch assigns a shared uuid to Tank-owned user messages", async () => {
+  let cosmosMessage: any;
+  let wsMessage: any;
+  const ok = await dispatch(
+    {
+      async upsert(message) {
+        cosmosMessage = message;
+      },
+    },
+    {
+      broadcastEvent(message) {
+        wsMessage = message;
+      },
+    },
+    { type: "tank.user_message", message: "hello" },
+  );
+  assert.equal(ok, true);
+  assert.equal(typeof cosmosMessage.uuid, "string");
+  assert.equal(cosmosMessage.uuid, wsMessage.uuid);
+  assert.equal(cosmosMessage.tank_order_key, wsMessage.tank_order_key);
 });
 
 test("canonical: cosmos failure suppresses ws broadcast", async () => {

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -20,9 +20,10 @@ import {
   type SDKUserMessage,
   type Options,
 } from "@anthropic-ai/claude-agent-sdk";
+import { randomUUID } from "node:crypto";
 
 import type { Config } from "./config.js";
-import { CosmosSink, isCanonical } from "./cosmos.js";
+import { CosmosSink, isCanonical, type RunnerEvent } from "./cosmos.js";
 import { extractWakeup, type WakeupRequest } from "./wakeup.js";
 import { WSFanout, type ClientFrame } from "./ws.js";
 
@@ -35,35 +36,35 @@ import { WSFanout, type ClientFrame } from "./ws.js";
 // canonical write failed and the broadcast was intentionally skipped.
 // Callers that don't care about the outcome can ignore it.
 interface DispatchSink {
-  upsert(message: SDKMessage): Promise<void>;
+  upsert(message: RunnerEvent & { uuid: string }): Promise<void>;
 }
 interface DispatchWS {
-  broadcastEvent(message: SDKMessage): void;
+  broadcastEvent(message: RunnerEvent): void;
 }
 
 let tankEventSeq = 0;
 
-function stampTankEvent(message: SDKMessage): SDKMessage {
+function stampTankEvent(message: RunnerEvent): RunnerEvent & { uuid: string } {
   tankEventSeq += 1;
   const now = Date.now();
-  const uuid = (message as any).uuid;
-  const stableId = typeof uuid === "string" && uuid ? uuid : String(tankEventSeq);
+  const uuid = typeof message.uuid === "string" && message.uuid ? message.uuid : randomUUID();
   return {
-    ...(message as Record<string, unknown>),
+    ...message,
+    uuid,
     tank_event_seq: tankEventSeq,
     tank_order_key: [
       String(now).padStart(13, "0"),
       String(tankEventSeq).padStart(8, "0"),
-      stableId,
+      uuid,
     ].join("-"),
     written_at: new Date(now).toISOString(),
-  } as unknown as SDKMessage;
+  };
 }
 
 export async function dispatch(
   sink: DispatchSink,
   ws: DispatchWS,
-  message: SDKMessage,
+  message: RunnerEvent,
 ): Promise<boolean> {
   const stamped = stampTankEvent(message);
   if (isCanonical(stamped)) {
@@ -78,6 +79,28 @@ export async function dispatch(
   }
   ws.broadcastEvent(stamped);
   return true;
+}
+
+function userMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (
+          part &&
+          typeof part === "object" &&
+          "type" in part &&
+          (part as { type?: unknown }).type === "text" &&
+          "text" in part
+        ) {
+          return String((part as { text?: unknown }).text ?? "");
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return String(content ?? "");
 }
 
 // AsyncQueue is a one-writer-many-no-readers queue that yields each
@@ -120,11 +143,20 @@ export class Runner {
   private readonly ws: WSFanout;
   private readonly userQueue = new AsyncQueue<SDKUserMessage>();
   private sdkQuery: Query | null = null;
+  private userFrameChain: Promise<void> = Promise.resolve();
 
   constructor(private readonly cfg: Config) {
     this.sink = new CosmosSink(cfg);
     this.ws = new WSFanout(cfg.wsPort);
-    this.ws.onMessage((frame) => this.handleClientFrame(frame));
+    this.ws.onMessage((frame) => {
+      if (frame.type === "user") {
+        this.userFrameChain = this.userFrameChain
+          .then(() => this.handleClientFrame(frame))
+          .catch((err) => console.error("user frame handling failed:", err));
+        return;
+      }
+      void this.handleClientFrame(frame);
+    });
   }
 
   // Run forever (or until externally aborted). Drives the SDK against
@@ -177,10 +209,19 @@ export class Runner {
     }
   }
 
-  private handleClientFrame(frame: ClientFrame): void {
+  private async handleClientFrame(frame: ClientFrame): Promise<void> {
     if (frame.type === "user") {
-      // Hand straight to the SDK iterator. The SDK enforces "wait for
-      // result before next message" internally; we don't need to gate.
+      const text = userMessageText(frame.message?.content);
+      const persisted = await dispatch(this.sink, this.ws, {
+        type: "tank.user_message",
+        message: text,
+        ...(frame.client_nonce ? { client_nonce: frame.client_nonce } : {}),
+      });
+      if (!persisted) return;
+
+      // Hand to the SDK iterator only after Tank owns the durable user
+      // message. The SDK enforces "wait for result before next message"
+      // internally; we don't need to gate.
       this.userQueue.push({
         type: "user",
         session_id: "",

--- a/agent-runner/src/ws.ts
+++ b/agent-runner/src/ws.ts
@@ -13,10 +13,9 @@
 // + JWT before proxying). This server trusts whatever connects.
 
 import { WebSocketServer, type WebSocket } from "ws";
-import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 export type ClientFrame =
-  | { type: "user"; message: { role: "user"; content: unknown } }
+  | { type: "user"; message: { role: "user"; content: unknown }; client_nonce?: string }
   | { type: "interrupt" }
   | { type: "ping" };
 
@@ -61,8 +60,8 @@ export class WSFanout {
     }
   }
 
-  // Broadcast a typed SDKMessage by serializing once.
-  broadcastEvent(message: SDKMessage): void {
+  // Broadcast a typed event by serializing once.
+  broadcastEvent(message: unknown): void {
     this.broadcast(JSON.stringify(message));
   }
 

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -98,7 +98,7 @@ export async function dispatch(
 export class Runner {
   private readonly sink: CosmosSink;
   private readonly ws: WSFanout;
-  private readonly userQueue = new AsyncQueue<string>();
+  private readonly userQueue = new AsyncQueue<{ text: string; clientNonce?: string }>();
   private readonly codex: Codex;
   private thread: Thread | null = null;
   private currentAbort: AbortController | null = null;
@@ -132,12 +132,13 @@ export class Runner {
     while (!signal.aborted) {
       const next = await this.userQueue.next();
       if (next.done) break;
-      const input = next.value;
+      const { text: input, clientNonce } = next.value;
       const turnSeq = ++this.turnSeq;
       await dispatch(this.sink, this.ws, {
         type: "tank.user_message",
         message: input,
         tank_turn_seq: turnSeq,
+        ...(clientNonce ? { client_nonce: clientNonce } : {}),
       });
 
       this.currentAbort = new AbortController();
@@ -199,7 +200,7 @@ export class Runner {
                 .join("\n")
             : String(content ?? "");
       if (text.trim()) {
-        this.userQueue.push(text);
+        this.userQueue.push({ text, clientNonce: frame.client_nonce });
       }
     } else if (frame.type === "interrupt") {
       this.currentAbort?.abort();

--- a/codex-runner/src/ws.ts
+++ b/codex-runner/src/ws.ts
@@ -15,7 +15,7 @@
 import { WebSocketServer, type WebSocket } from "ws";
 
 export type ClientFrame =
-  | { type: "user"; message: { role: "user"; content: unknown } }
+  | { type: "user"; message: { role: "user"; content: unknown }; client_nonce?: string }
   | { type: "interrupt" }
   | { type: "ping" };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1728,6 +1728,19 @@ function hasSkillInvocation(entries: TranscriptEntry[], name: string): boolean {
   );
 }
 
+function hasUserMessageText(entries: TranscriptEntry[], text: string): boolean {
+  const normalized = text.trim();
+  return Boolean(
+    normalized &&
+      entries.some(
+        (entry) =>
+          entry.kind === "message" &&
+          entry.role === "user" &&
+          entry.text?.trim() === normalized,
+      ),
+  );
+}
+
 
 function appendSkillInvocation(
   entries: TranscriptEntry[],
@@ -1868,22 +1881,43 @@ function codexToolEntry(event: JsonObject): TranscriptEntry | null {
   return null;
 }
 
+function tankUserMessageText(event: JsonObject): string {
+  if (typeof event.message === "string") return event.message.trim();
+  if (isJsonObject(event.message)) {
+    const content = event.message.content;
+    if (typeof content === "string") return content.trim();
+    if (Array.isArray(content)) {
+      return content
+        .map((block) =>
+          isJsonObject(block) && block.type === "text" && typeof block.text === "string"
+            ? block.text
+            : "",
+        )
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+    }
+  }
+  return "";
+}
+
+function applyTankUserMessageEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
+  const text = tankUserMessageText(event);
+  if (!text || hasUserMessageText(entries, text)) return entries;
+  const skillName = skillNameFromTrigger(text);
+  if (skillName && hasSkillInvocation(entries, skillName)) return entries;
+  return upsertEntry(entries, {
+    id: `tank-user-message-${eventID(event, "tank-user-message")}`,
+    kind: "message",
+    role: "user",
+    text,
+    time: eventTime(event),
+  });
+}
+
 function applyCodexEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
   const type = event.type;
   const time = eventTime(event);
-  if (type === "tank.user_message") {
-    const text = typeof event.message === "string" ? event.message.trim() : "";
-    const skillName = skillNameFromTrigger(text);
-    if (skillName && hasSkillInvocation(entries, skillName)) return entries;
-    if (!text) return entries;
-    return upsertEntry(entries, {
-      id: `codex-user-message-${eventID(event, "codex-user-message")}`,
-      kind: "message",
-      role: "user",
-      text,
-      time,
-    });
-  }
   if (type === "thread.started") {
     const threadId = typeof event.thread_id === "string" ? event.thread_id : "";
     return appendMeta(entries, `codex-thread-${eventID(event, threadId || "codex-thread")}`, "Codex thread started", threadId, "info", time);
@@ -2085,6 +2119,7 @@ function applyClaudeEvent(entries: TranscriptEntry[], event: JsonObject): Transc
       for (const [index, text] of texts.entries()) {
         const skillName = skillNameFromTrigger(text);
         if (skillName && hasSkillInvocation(nextEntries, skillName)) continue;
+        if (hasUserMessageText(nextEntries, text)) continue;
         nextEntries = upsertEntry(nextEntries, {
           id: `${baseId}-${index}`,
           kind: "message",
@@ -2127,6 +2162,9 @@ function applyProviderEvent(
   mode: SessionMode,
   event: JsonObject,
 ): TranscriptEntry[] {
+  if (event.type === "tank.user_message") {
+    return applyTankUserMessageEvent(entries, event);
+  }
   if (event.type === "tank.skill_invocation") {
     const name = typeof event.name === "string" ? event.name.trim() : "";
     const trigger = typeof event.trigger === "string" ? event.trigger : "";
@@ -5446,6 +5484,7 @@ function HeadlessRun({
         JSON.stringify({
           type: "user",
           message: { role: "user", content: run.prompt },
+          client_nonce: run.id,
         }),
       );
     };


### PR DESCRIPTION
## Summary
- persist Claude SDK websocket user frames as canonical `tank.user_message` events before queueing them to Claude
- render `tank.user_message` through a provider-neutral frontend replay path, with duplicate protection if a provider also echoes user text
- pass client nonce through Claude/Codex SDK websocket frames for future exact reconciliation

## Verification
- `npm run build; npm test` in `agent-runner`
- `npm run build; npm test` in `codex-runner`
- `npm run build` in `frontend`