### PR TITLE
Fix messaging event state drift

### DIFF
--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -235,12 +235,24 @@ export class Runner {
 
   private scheduleWakeup(req: WakeupRequest): void {
     setTimeout(() => {
-      this.userQueue.push({
-        type: "user",
-        session_id: "",
-        message: { role: "user", content: req.prompt },
-        parent_tool_use_id: null,
-      } as unknown as SDKUserMessage);
+      void this.enqueueWakeup(req).catch((err) =>
+        console.error("schedule wakeup failed:", err),
+      );
     }, req.delayMs);
+  }
+
+  private async enqueueWakeup(req: WakeupRequest): Promise<void> {
+    const persisted = await dispatch(this.sink, this.ws, {
+      type: "tank.user_message",
+      message: req.prompt,
+      source: "schedule_wakeup",
+    });
+    if (!persisted) return;
+    this.userQueue.push({
+      type: "user",
+      session_id: "",
+      message: { role: "user", content: req.prompt },
+      parent_tool_use_id: null,
+    } as unknown as SDKUserMessage);
   }
 }

--- a/backend-go/cmd/tank-operator/handlers_run.go
+++ b/backend-go/cmd/tank-operator/handlers_run.go
@@ -386,6 +386,11 @@ func (s *appServer) streamRunEvents(w http.ResponseWriter, r *http.Request, sess
 	}
 
 	var lastEventID int64
+	if rawLastEventID := strings.TrimSpace(r.Header.Get("Last-Event-ID")); rawLastEventID != "" {
+		if parsed, err := strconv.ParseInt(rawLastEventID, 10, 64); err == nil && parsed > 0 {
+			lastEventID = parsed
+		}
+	}
 	pollTicker := time.NewTicker(2 * time.Second)
 	keepaliveTicker := time.NewTicker(15 * time.Second)
 	defer pollTicker.Stop()
@@ -575,13 +580,16 @@ func buildStdoutObserver(ctx context.Context, runEventStore store.RunEventStore,
 
 		lineBuf.WriteString(text)
 		buf := lineBuf.String()
-		scanner := bufio.NewScanner(strings.NewReader(buf))
-		remaining := buf
+		lastNewline := strings.LastIndexByte(buf, '\n')
+		if lastNewline < 0 {
+			return
+		}
+		complete := buf[:lastNewline+1]
+		remaining := buf[lastNewline+1:]
+		scanner := bufio.NewScanner(strings.NewReader(complete))
 
 		for scanner.Scan() {
 			line := scanner.Text()
-			remaining = strings.TrimPrefix(remaining, line+"\n")
-
 			line = strings.TrimSpace(line)
 			if line == "" || line[0] != '{' {
 				continue
@@ -593,27 +601,38 @@ func buildStdoutObserver(ctx context.Context, runEventStore store.RunEventStore,
 			msgType, _ := msg["type"].(string)
 			switch msgType {
 			case "assistant":
-				content, _ := msg["message"].(map[string]any)
-				if content == nil {
-					content, _ = msg["content"].(map[string]any)
+				for _, item := range messageContentBlocks(msg) {
+					itemMap, _ := item.(map[string]any)
+					if itemMap == nil {
+						continue
+					}
+					if itemMap["type"] == "tool_use" {
+						_, _ = runEventStore.Append(ctx, email, sessionID, runID, "run.tool.started", map[string]any{
+							"name":        itemMap["name"],
+							"tool_use_id": itemMap["id"],
+							"tool_name":   itemMap["name"],
+							"tool_id":     itemMap["id"],
+						})
+					}
 				}
-				if content != nil {
-					contentArr, _ := content["content"].([]any)
-					for _, item := range contentArr {
-						itemMap, _ := item.(map[string]any)
-						if itemMap == nil {
-							continue
-						}
-						if itemMap["type"] == "tool_use" {
-							_, _ = runEventStore.Append(ctx, email, sessionID, runID, "run.tool.started", map[string]any{
-								"tool_name": itemMap["name"],
-								"tool_id":   itemMap["id"],
-							})
-						}
+			case "user":
+				for _, item := range messageContentBlocks(msg) {
+					itemMap, _ := item.(map[string]any)
+					if itemMap == nil {
+						continue
+					}
+					if itemMap["type"] == "tool_result" {
+						_, _ = runEventStore.Append(ctx, email, sessionID, runID, "run.tool.completed", map[string]any{
+							"tool_use_id": itemMap["tool_use_id"],
+							"output":      toolResultText(itemMap["content"]),
+							"is_error":    itemMap["is_error"] == true,
+						})
 					}
 				}
 			case "result":
 				_, _ = runEventStore.Append(ctx, email, sessionID, runID, "run.message.created", map[string]any{
+					"role":    "assistant",
+					"text":    msg["result"],
 					"content": msg["result"],
 				})
 			}
@@ -623,6 +642,54 @@ func buildStdoutObserver(ctx context.Context, runEventStore store.RunEventStore,
 		lineBuf.Reset()
 		lineBuf.WriteString(remaining)
 	}
+}
+
+func messageContentBlocks(msg map[string]any) []any {
+	for _, key := range []string{"message", "content"} {
+		content, _ := msg[key].(map[string]any)
+		if content == nil {
+			continue
+		}
+		if contentArr, _ := content["content"].([]any); contentArr != nil {
+			return contentArr
+		}
+	}
+	if contentArr, _ := msg["content"].([]any); contentArr != nil {
+		return contentArr
+	}
+	return nil
+}
+
+func toolResultText(value any) string {
+	switch content := value.(type) {
+	case string:
+		return content
+	case []any:
+		var parts []string
+		for _, item := range content {
+			itemMap, _ := item.(map[string]any)
+			if itemMap == nil {
+				continue
+			}
+			if text, _ := itemMap["text"].(string); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return shortJSON(value)
+	}
+}
+
+func shortJSON(value any) string {
+	if value == nil {
+		return ""
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(b)
 }
 
 func mustJSON(v any) []byte {

--- a/backend-go/cmd/tank-operator/handlers_run_test.go
+++ b/backend-go/cmd/tank-operator/handlers_run_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+type recordingRunEventStore struct {
+	events []store.RunEventRecord
+}
+
+func (s *recordingRunEventStore) Append(_ context.Context, email, sessionID, runID, eventType string, payload map[string]any) (store.RunEventRecord, error) {
+	rec := store.RunEventRecord{
+		RunID:     runID,
+		SessionID: sessionID,
+		Email:     email,
+		EventID:   int64(len(s.events) + 1),
+		Type:      eventType,
+		Payload:   payload,
+		CreatedAt: "2026-05-12T00:00:00Z",
+	}
+	s.events = append(s.events, rec)
+	return rec, nil
+}
+
+func (s *recordingRunEventStore) ListAfter(_ context.Context, _, _ string, _ int64, _ int) ([]store.RunEventRecord, error) {
+	return nil, nil
+}
+
+func TestBuildStdoutObserverEmitsFrontendLifecyclePayloads(t *testing.T) {
+	recorder := &recordingRunEventStore{}
+	observe := buildStdoutObserver(context.Background(), recorder, "user@example.com", "session-1", "run-1", "claude")
+	if observe == nil {
+		t.Fatal("observer is nil")
+	}
+
+	observe(`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"go test ./..."}}]}}` + "\n")
+	observe(`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"text","text":"ok"}],"is_error":false}]}}` + "\n")
+	observe(`{"type":"result","result":"done"}` + "\n")
+
+	var toolStarted, toolCompleted, messageCreated *store.RunEventRecord
+	for i := range recorder.events {
+		switch recorder.events[i].Type {
+		case "run.tool.started":
+			toolStarted = &recorder.events[i]
+		case "run.tool.completed":
+			toolCompleted = &recorder.events[i]
+		case "run.message.created":
+			messageCreated = &recorder.events[i]
+		}
+	}
+	if toolStarted == nil {
+		t.Fatal("missing run.tool.started")
+	}
+	if got := toolStarted.Payload["name"]; got != "Bash" {
+		t.Fatalf("run.tool.started name = %v, want Bash", got)
+	}
+	if got := toolStarted.Payload["tool_use_id"]; got != "toolu_1" {
+		t.Fatalf("run.tool.started tool_use_id = %v, want toolu_1", got)
+	}
+	if toolCompleted == nil {
+		t.Fatal("missing run.tool.completed")
+	}
+	if got := toolCompleted.Payload["tool_use_id"]; got != "toolu_1" {
+		t.Fatalf("run.tool.completed tool_use_id = %v, want toolu_1", got)
+	}
+	if got := toolCompleted.Payload["output"]; got != "ok" {
+		t.Fatalf("run.tool.completed output = %v, want ok", got)
+	}
+	if messageCreated == nil {
+		t.Fatal("missing run.message.created")
+	}
+	if got := messageCreated.Payload["role"]; got != "assistant" {
+		t.Fatalf("run.message.created role = %v, want assistant", got)
+	}
+	if got := messageCreated.Payload["text"]; got != "done" {
+		t.Fatalf("run.message.created text = %v, want done", got)
+	}
+}
+
+func TestBuildStdoutObserverWaitsForNewlineBeforeParsing(t *testing.T) {
+	recorder := &recordingRunEventStore{}
+	observe := buildStdoutObserver(context.Background(), recorder, "user@example.com", "session-1", "run-1", "claude")
+	if observe == nil {
+		t.Fatal("observer is nil")
+	}
+
+	observe(`{"type":"result","result":"done"}`)
+	if countEvents(recorder.events, "run.message.created") != 0 {
+		t.Fatal("parsed JSON before line was complete")
+	}
+	observe("\n")
+	if got := countEvents(recorder.events, "run.message.created"); got != 1 {
+		t.Fatalf("run.message.created count = %d, want 1", got)
+	}
+}
+
+func countEvents(events []store.RunEventRecord, eventType string) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType {
+			count++
+		}
+	}
+	return count
+}

--- a/codex-runner/src/cosmos.test.ts
+++ b/codex-runner/src/cosmos.test.ts
@@ -16,6 +16,10 @@ test("canonical: turn.completed + turn.failed", () => {
   assert.equal(isCanonical({ type: "turn.failed", error: { message: "x" } } as never), true);
 });
 
+test("canonical: turn.interrupted", () => {
+  assert.equal(isCanonical({ type: "turn.interrupted", reason: "client_interrupt" }), true);
+});
+
 test("canonical: item.completed (the main durable signal)", () => {
   assert.equal(
     isCanonical({

--- a/codex-runner/src/cosmos.ts
+++ b/codex-runner/src/cosmos.ts
@@ -18,6 +18,7 @@
 //   tank.user_message  — user's prompt as submitted through Tank's WS bridge
 //   turn.completed     — turn-end marker with usage
 //   turn.failed        — turn-level error
+//   turn.interrupted   — Tank interrupt/cancel marker
 //   item.completed     — main durable signal: agent_message, reasoning,
 //                        command_execution, file_change, mcp_tool_call,
 //                        web_search, todo_list, error items
@@ -41,6 +42,7 @@ const CANONICAL_TYPES = new Set<string>([
   "tank.user_message",
   "turn.completed",
   "turn.failed",
+  "turn.interrupted",
   "item.completed",
   "error",
 ]);

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -95,6 +95,16 @@ export async function dispatch(
   return true;
 }
 
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: unknown }).code;
+  return (
+    err.name === "AbortError" ||
+    code === "ABORT_ERR" ||
+    /operation was aborted/i.test(err.message)
+  );
+}
+
 export class Runner {
   private readonly sink: CosmosSink;
   private readonly ws: WSFanout;
@@ -102,6 +112,7 @@ export class Runner {
   private readonly codex: Codex;
   private thread: Thread | null = null;
   private currentAbort: AbortController | null = null;
+  private interruptRequested = false;
   private turnSeq = 0;
 
   constructor(private readonly cfg: Config) {
@@ -134,12 +145,13 @@ export class Runner {
       if (next.done) break;
       const { text: input, clientNonce } = next.value;
       const turnSeq = ++this.turnSeq;
-      await dispatch(this.sink, this.ws, {
+      const persisted = await dispatch(this.sink, this.ws, {
         type: "tank.user_message",
         message: input,
         tank_turn_seq: turnSeq,
         ...(clientNonce ? { client_nonce: clientNonce } : {}),
       });
+      if (!persisted) continue;
 
       this.currentAbort = new AbortController();
       // If the outer signal aborts mid-turn, also abort the in-flight
@@ -160,6 +172,18 @@ export class Runner {
           });
         }
       } catch (err) {
+        const interrupted = this.currentAbort.signal.aborted && isAbortError(err);
+        if (interrupted) {
+          if (!signal.aborted || this.interruptRequested) {
+            await dispatch(this.sink, this.ws, {
+              type: "turn.interrupted",
+              reason: this.interruptRequested ? "client_interrupt" : "runner_shutdown",
+              tank_turn_seq: turnSeq,
+            });
+          }
+          console.info("codex turn interrupted");
+          continue;
+        }
         // Synthetic error event so the SPA sees something when the SDK
         // throws (e.g., process exit, network failure, quota error that
         // surfaced as an exception rather than a turn.failed).
@@ -174,6 +198,7 @@ export class Runner {
       } finally {
         signal.removeEventListener("abort", onOuterAbort);
         this.currentAbort = null;
+        this.interruptRequested = false;
       }
     }
     this.userQueue.close();
@@ -203,6 +228,7 @@ export class Runner {
         this.userQueue.push({ text, clientNonce: frame.client_nonce });
       }
     } else if (frame.type === "interrupt") {
+      this.interruptRequested = true;
       this.currentAbort?.abort();
     }
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,7 +116,7 @@ type TranscriptEntry = SandboxTranscriptEntry & {
   localOnly?: boolean;
   clientNonce?: string;
 };
-type SdkTerminalStatus = "done" | "error";
+type SdkTerminalStatus = "done" | "error" | "stopped";
 type SdkTerminalResult = {
   status: SdkTerminalStatus;
   detail?: string;
@@ -1830,7 +1830,7 @@ function codexToolEntry(event: JsonObject): TranscriptEntry | null {
   const item = event.item;
   if (!isJsonObject(item)) return null;
   const id = codexItemEntryId(event, item, "codex-tool");
-  const status = typeof item.status === "string" ? item.status : String(event.type ?? "");
+  const status = codexItemStatus(event, item);
   const itemType = item.type;
   const time = eventTime(event);
 
@@ -1890,6 +1890,29 @@ function codexToolEntry(event: JsonObject): TranscriptEntry | null {
   return null;
 }
 
+function codexItemStatus(event: JsonObject, item: JsonObject): string {
+  if (typeof item.status === "string" && item.status) return item.status;
+  if (event.type === "item.started") return "started";
+  if (event.type === "item.updated") return "running";
+  if (event.type === "item.completed") {
+    return item.error ? "failed" : "completed";
+  }
+  return String(event.type ?? "");
+}
+
+function isCodexAbortMessage(message: unknown): boolean {
+  return typeof message === "string" && /operation was aborted/i.test(message);
+}
+
+function isCodexToolishItemType(itemType: string): boolean {
+  return (
+    itemType === "command_execution" ||
+    itemType === "file_change" ||
+    itemType === "mcp_tool_call" ||
+    itemType === "web_search"
+  );
+}
+
 function tankUserMessageText(event: JsonObject): string {
   if (typeof event.message === "string") return event.message.trim();
   if (isJsonObject(event.message)) {
@@ -1937,8 +1960,28 @@ function applyCodexEvent(entries: TranscriptEntry[], event: JsonObject): Transcr
   if (type === "turn.completed") {
     return appendMeta(entries, `codex-turn-completed-${eventID(event, "codex-turn-completed")}`, "Turn completed", describeUsage(event.usage), "info", time);
   }
+  if (type === "turn.interrupted") {
+    return appendMeta(
+      entries,
+      `codex-turn-interrupted-${eventID(event, "codex-turn-interrupted")}`,
+      "Turn stopped",
+      typeof event.reason === "string" ? event.reason : undefined,
+      "info",
+      time,
+    );
+  }
   if (type === "turn.failed" || type === "error") {
     const error = isJsonObject(event.error) ? event.error.message : event.message;
+    if (isCodexAbortMessage(error)) {
+      return appendMeta(
+        entries,
+        `codex-turn-stopped-${eventID(event, "codex-turn-stopped")}`,
+        "Turn stopped",
+        "The turn was interrupted before completion.",
+        "info",
+        time,
+      );
+    }
     return appendMeta(
       entries,
       `codex-error-${eventID(event, "codex-error")}`,
@@ -2197,8 +2240,12 @@ function sdkTerminalResult(event: JsonObject): SdkTerminalResult | null {
   if (type === "turn.completed") {
     return { status: "done" };
   }
+  if (type === "turn.interrupted") {
+    return { status: "stopped" };
+  }
   if (type === "turn.failed" || type === "error") {
     const error = isJsonObject(event.error) ? event.error.message : event.message;
+    if (isCodexAbortMessage(error)) return { status: "stopped" };
     return {
       status: "error",
       detail: typeof error === "string" ? error : shortJson(event),
@@ -2335,7 +2382,9 @@ function normalizeToolState(status: string | undefined): string {
     normalized === "running" ||
     normalized === "pending" ||
     normalized === "in_progress" ||
-    normalized === "in-progress"
+    normalized === "in-progress" ||
+    normalized === "item.started" ||
+    normalized === "item.updated"
   ) {
     return "running";
   }
@@ -3940,8 +3989,11 @@ function HeadlessRun({
   const [slashIndex, setSlashIndex] = useState(0);
 
   useEffect(() => {
-    onActivityChange?.(session.id, running ? "working" : "waiting");
-  }, [onActivityChange, running, session.id]);
+    onActivityChange?.(
+      session.id,
+      running || activeToolName !== null ? "working" : "waiting",
+    );
+  }, [activeToolName, onActivityChange, running, session.id]);
   const [slashCommands, setSlashCommands] = useState<SlashCommand[]>(SLASH_COMMANDS);
   const [mcpOpen, setMcpOpen] = useState(false);
   // @filename mention palette state. paths is lazily loaded from
@@ -4842,7 +4894,7 @@ function HeadlessRun({
   // Skips when the slash palette is open — Esc closes the palette in that
   // case (handled below).
   useEffect(() => {
-    if (!running) return;
+    if (!visible || !running) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape" && !slashOpen) {
         e.preventDefault();
@@ -4851,7 +4903,7 @@ function HeadlessRun({
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [running, slashOpen]);
+  }, [running, slashOpen, visible]);
 
   // Slash- + mention-palette typing detection + composer-text mirror.
   // Listens at the composer wrap; reads the textarea's value + cursor on
@@ -5580,6 +5632,9 @@ function HeadlessRun({
       );
       setRunStatus("done");
       playTurnCompleteSound();
+    } else if (terminal.status === "stopped") {
+      setLastStatusText("Stopped");
+      setRunStatus("done");
     } else {
       setLastStatusText(activeToolNameRef.current ? `Used ${formatToolLabel(activeToolNameRef.current)}` : "Error");
       setRunStatus("error");
@@ -5737,14 +5792,16 @@ function HeadlessRun({
         const item = parsed.item;
         if (isJsonObject(item)) {
           const itemType = typeof item.type === "string" ? item.type : "";
-          const toolish = new Set([
-            "command_execution",
-            "file_change",
-            "mcp_tool_call",
-            "web_search",
-          ]);
-          if (toolish.has(itemType)) {
+          if (isCodexToolishItemType(itemType)) {
             setActiveTool(itemType, typeof item.id === "string" ? item.id : null);
+          }
+        }
+      } else if (t === "item.completed") {
+        const item = parsed.item;
+        if (isJsonObject(item)) {
+          const itemType = typeof item.type === "string" ? item.type : "";
+          if (isCodexToolishItemType(itemType)) {
+            completeActiveTool(typeof item.id === "string" ? item.id : null);
           }
         }
       } else if (t === "turn.completed") {


### PR DESCRIPTION
## Summary
- normalize Codex tool/interruption lifecycle events so active session state and transcript replay agree
- persist runner-owned user prompts before SDK turns, including scheduled wakeups
- repair legacy Claude run-event payloads and SSE resume behavior, with backend regression coverage

## Verification
- npm run build (frontend)
- npm run build && npm test (codex-runner)
- npm run build && npm test (agent-runner)
- go test ./... (backend-go)