### PR TITLE
docs: define Tank conversation protocol

### DIFF
--- a/backend-go/internal/conversation/types.go
+++ b/backend-go/internal/conversation/types.go
@@ -1,0 +1,78 @@
+// Package conversation contains Tank's provider-neutral conversation event
+// envelope. Keep these types in sync with
+// schemas/tank-conversation-event.schema.json.
+package conversation
+
+type Actor string
+
+const (
+	ActorUser      Actor = "user"
+	ActorAssistant Actor = "assistant"
+	ActorSystem    Actor = "system"
+	ActorTool      Actor = "tool"
+	ActorRunner    Actor = "runner"
+)
+
+type Source string
+
+const (
+	SourceTank      Source = "tank"
+	SourceClaude    Source = "claude"
+	SourceCodex     Source = "codex"
+	SourceLegacyRun Source = "legacy-run"
+)
+
+type Visibility string
+
+const (
+	VisibilityDurable  Visibility = "durable"
+	VisibilityLiveOnly Visibility = "live-only"
+	VisibilityAudit    Visibility = "audit-only"
+)
+
+type EventType string
+
+const (
+	EventConversationStarted  EventType = "conversation.started"
+	EventConversationArchived EventType = "conversation.archived"
+	EventUserMessageCreated   EventType = "user_message.created"
+	EventTurnSubmitted        EventType = "turn.submitted"
+	EventTurnStarted          EventType = "turn.started"
+	EventTurnCompleted        EventType = "turn.completed"
+	EventTurnFailed           EventType = "turn.failed"
+	EventTurnInterrupted      EventType = "turn.interrupted"
+	EventItemStarted          EventType = "item.started"
+	EventItemDelta            EventType = "item.delta"
+	EventItemCompleted        EventType = "item.completed"
+	EventItemFailed           EventType = "item.failed"
+	EventApprovalRequested    EventType = "tool.approval_requested"
+	EventApprovalResolved     EventType = "tool.approval_resolved"
+	EventActivityUpdated      EventType = "session.activity_updated"
+	EventReadStateUpdated     EventType = "read_state.updated"
+)
+
+type ProducerMetadata struct {
+	Name            string `json:"name,omitempty"`
+	Version         string `json:"version,omitempty"`
+	Runtime         string `json:"runtime,omitempty"`
+	ProviderEventID string `json:"provider_event_id,omitempty"`
+}
+
+type Event struct {
+	EventID        string           `json:"event_id"`
+	OrderKey       string           `json:"order_key,omitempty"`
+	Sequence       *int64           `json:"sequence,omitempty"`
+	ConversationID string           `json:"conversation_id,omitempty"`
+	SessionID      string           `json:"session_id"`
+	TurnID         string           `json:"turn_id,omitempty"`
+	ItemID         string           `json:"item_id,omitempty"`
+	ParentID       string           `json:"parent_id,omitempty"`
+	ClientNonce    string           `json:"client_nonce,omitempty"`
+	Actor          Actor            `json:"actor"`
+	Source         Source           `json:"source"`
+	Type           EventType        `json:"type"`
+	CreatedAt      string           `json:"created_at"`
+	Producer       ProducerMetadata `json:"producer,omitempty"`
+	Visibility     Visibility       `json:"visibility"`
+	Payload        map[string]any   `json:"payload,omitempty"`
+}

--- a/docs/tank-conversation-protocol.md
+++ b/docs/tank-conversation-protocol.md
@@ -1,0 +1,270 @@
+# Tank Conversation Protocol
+
+Status: draft ADR for issue #402.
+
+Tank sessions should behave like durable conversations with live event
+delivery layered on top. Browser tabs are clients, pod-side runners are
+producers, Cosmos and the backend are the source of truth, and React renders a
+projection of Tank conversation events. Provider-specific events are inputs to
+adapters; they are not UI state.
+
+## Current Code Review
+
+The current implementation already has useful pieces, but they are implicit:
+
+- `agent-runner/src/runner.ts` and `codex-runner/src/runner.ts` both dispatch
+  Cosmos-first, then WebSocket, which is the right read-your-writes ordering.
+- `agent-runner/src/cosmos.ts` and `codex-runner/src/cosmos.ts` define
+  canonical-vs-live-only event allowlists, but the allowlists are provider
+  shaped rather than Tank shaped.
+- `backend-go/internal/store/session_events.go` reads `session-events` by
+  session and sorts by `tank_order_key`, then timestamps, then ids. Its public
+  API still paginates by `after` document id, so the requested cursor does not
+  yet match render order in every legacy case.
+- `frontend/src/App.tsx` has provider-specific projection helpers for Claude,
+  Codex, and legacy run events. It also owns status decisions such as stopped
+  vs error, active tool state, and reconnect behavior directly in the pane.
+- The legacy run path persists `active-runs` and `run-events`; the SDK path
+  persists `session-events`. A future provider would still need to touch
+  frontend sidebar and chat state logic unless the provider output is first
+  mapped into a stable Tank protocol.
+
+This ADR makes the missing contract explicit before the next implementation
+step rewires producers, backend APIs, and UI projection.
+
+## Borrowed Constraints
+
+Re-checked on 2026-05-12:
+
+- CloudCLI centers persistent cloud environments, cross-device continuity, and
+  agent choice. Tank should preserve agent-agnostic session pods and make
+  browser disconnects non-terminal for agent work.
+- Slack separates durable history from event delivery. Tank needs history APIs
+  that can reconstruct the transcript and sidebar state before a live socket is
+  attached.
+- Discord Gateway uses event envelopes, sequence numbers, heartbeat/ack, and
+  resume from the last sequence. Tank should make connection state separate
+  from agent state and resume from a cursor.
+- AI SDK UI exposes chat lifecycle states `submitted`, `streaming`, `ready`,
+  and `error`, and resumable streams require app-owned persistence of messages
+  and active streams. Tank should use that vocabulary, extending it only for
+  `stopped` and `needs_input`.
+- The OpenAI Codex App Server uses thread, turn, and item primitives. It also
+  translates low-level core events into stable UI-ready notifications and can
+  pause a turn for approval or other client input. Tank should follow the same
+  thread/turn/item split.
+
+References:
+
+- CloudCLI product and API docs: <https://cloudcli.ai/> and
+  <https://developer.cloudcli.ai/>
+- Slack Events API and history API:
+  <https://docs.slack.dev/apis/events-api/> and
+  <https://docs.slack.dev/reference/methods/conversations.history/>
+- Discord Gateway: <https://docs.discord.com/developers/events/gateway>
+- AI SDK UI: <https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat> and
+  <https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-resume-streams>
+- OpenAI Codex App Server:
+  <https://openai.com/index/unlocking-the-codex-harness/>
+
+## Event Envelope
+
+Every Tank event has a stable envelope. The shared JSON Schema lives at
+`schemas/tank-conversation-event.schema.json`; TypeScript and Go stubs live at
+`frontend/src/tankConversation.ts` and `backend-go/internal/conversation`.
+
+Required fields:
+
+- `event_id`: unique replay/dedupe id.
+- `order_key` or `sequence`: strict per-session render cursor. New events
+  should write both. Consumers sort by `order_key`, then `sequence`, then
+  `event_id`.
+- `session_id`: Tank session id.
+- `turn_id`: required for turn and item events.
+- `actor`: `user`, `assistant`, `system`, `tool`, or `runner`.
+- `source`: `tank`, `claude`, `codex`, or `legacy-run`.
+- `type`: stable Tank event type.
+- `created_at`: producer timestamp in RFC3339 format.
+- `visibility`: `durable`, `live-only`, or `audit-only`.
+
+Optional fields:
+
+- `conversation_id`: alias for future non-session conversations. Defaults to
+  `session_id` for current Tank sessions.
+- `item_id`: required when the event concerns a durable unit inside a turn.
+- `parent_id`: causal linkage, such as an item under a turn or approval under a
+  tool call.
+- `client_nonce`: idempotency key for user submissions.
+- `producer`: metadata such as adapter name, version, runtime, and raw provider
+  event id.
+- `payload`: type-specific data. Keep provider raw payloads under
+  `payload.provider` only when needed for a specialized renderer.
+
+## Event Families
+
+Conversation lifecycle:
+
+- `conversation.started`
+- `conversation.archived`
+
+User input:
+
+- `user_message.created`
+
+Turn lifecycle:
+
+- `turn.submitted`
+- `turn.started`
+- `turn.completed`
+- `turn.failed`
+- `turn.interrupted`
+
+Item lifecycle:
+
+- `item.started`
+- `item.delta`
+- `item.completed`
+- `item.failed`
+
+Tool and approval lifecycle:
+
+- `tool.approval_requested`
+- `tool.approval_resolved`
+
+Session/read activity:
+
+- `session.activity_updated`
+- `read_state.updated`
+
+## State Machine
+
+A conversation projection has these UI states:
+
+- `ready`: no active turn needs attention.
+- `submitted`: user input is durable and waiting for runner execution.
+- `streaming`: a runner is executing a turn or emitting items.
+- `needs_input`: the runner is paused for approval or other explicit client
+  input.
+- `stopped`: the active turn ended by user interrupt or runner shutdown, not by
+  provider failure.
+- `error`: a turn or item failed.
+
+Turn transitions:
+
+1. `user_message.created` records the user's input and `client_nonce`.
+2. `turn.submitted` moves the composer to `submitted`.
+3. `turn.started` moves the composer and sidebar to `streaming`.
+4. `tool.approval_requested` moves the projection to `needs_input` until
+   `tool.approval_resolved`.
+5. `turn.completed` returns to `ready`.
+6. `turn.interrupted` returns to `stopped`.
+7. `turn.failed` returns to `error`.
+
+`item.*` events update transcript units under a turn. `item.delta` is durable
+only when it is needed to replay the item. Pure typewriter deltas may remain
+`live-only` and must not be required to reconstruct final UI state.
+
+## Provider Mappings
+
+Claude SDK adapter:
+
+| Provider event | Tank event | Notes |
+| --- | --- | --- |
+| Browser submit frame | `user_message.created`, `turn.submitted` | Must persist before pushing to the SDK queue. `client_nonce` is required. |
+| First SDK output for a turn | `turn.started` | Current Claude SDK stream does not always expose a clean turn marker; adapter may synthesize this after the durable user message. |
+| `assistant` text block | `item.completed` | `actor=assistant`, item kind `message`; tool-use blocks become tool items. |
+| `assistant` tool_use block | `item.started` | `actor=tool`; include tool name/input in payload. |
+| `user` tool_result block | `item.completed` or `item.failed` | Completes the matching tool item by `item_id`. |
+| `result` success | `turn.completed` | Include usage when present. |
+| `result` error | `turn.failed` | Provider error, not user interrupt. |
+| SDK interrupt acknowledgement | `turn.interrupted` | Must not render as provider error. |
+| `stream_event`, status, hook/task progress | `item.delta` or live-only ignored | Durable only if needed for replay. |
+
+Codex SDK adapter:
+
+| Provider event | Tank event | Notes |
+| --- | --- | --- |
+| Browser submit frame | `user_message.created`, `turn.submitted` | `client_nonce` required; current `tank_turn_seq` becomes `turn_id` input. |
+| `turn.started` | `turn.started` | Preserve provider turn id when available. |
+| `item.started` | `item.started` | Tool-like items drive active item state. |
+| `item.updated` | `item.delta` | Durable only when final `item.completed` lacks enough state to replay. |
+| `item.completed` message/reasoning/tool | `item.completed` | Map command, file change, MCP, and web search to tool item payloads. |
+| `turn.completed` | `turn.completed` | Include usage. |
+| `turn.failed` or `error` | `turn.failed` | Unless adapter classifies it as abort/interrupt. |
+| Abort from user interrupt | `turn.interrupted` | Distinct from provider failure. |
+
+Legacy run adapter:
+
+| Legacy event | Tank event | Notes |
+| --- | --- | --- |
+| `run.message.created` user | `user_message.created` | Use run id as `turn_id` until the turn queue owns ids. |
+| `run.output.started` | `turn.started` | Synthetic start marker. |
+| `run.tool.started` | `item.started` | Tool item with `item_id=tool_use_id`. |
+| `run.tool.completed` | `item.completed` or `item.failed` | Failure when `is_error=true`. |
+| `run.message.created` assistant | `item.completed` | Assistant message item. |
+| `run.completed` | `turn.completed` | |
+| `run.failed` or `run.stale` | `turn.failed` | Stale is a distinct reason in payload. |
+
+## Backend API Sketch
+
+History read:
+
+`GET /api/sessions/{session_id}/timeline?after_order_key=<cursor>&limit=200`
+
+Returns:
+
+```json
+{
+  "session_id": "63",
+  "events": [],
+  "next_order_key": "001...",
+  "has_more": false,
+  "activity": {
+    "status": "streaming",
+    "last_order_key": "001...",
+    "unread_count": 3,
+    "needs_input": false,
+    "failed": false,
+    "active_turn_id": "turn_..."
+  },
+  "read_state": {
+    "last_read_order_key": "001..."
+  }
+}
+```
+
+Read state write:
+
+`PUT /api/sessions/{session_id}/read-state`
+
+Body:
+
+```json
+{ "last_read_order_key": "001..." }
+```
+
+Activity summary:
+
+`GET /api/sessions/activity`
+
+Returns per-session activity summaries for the sidebar so unopened sessions can
+show running, unread, failed, and needs-input states.
+
+Storage:
+
+- Keep `session-events` as the durable ledger, partitioned by `tank_session_id`.
+- Add or materialize per-user read state keyed by `email + session_id`.
+- Use `order_key` as the pagination cursor. Document id is only a dedupe key.
+- Compute unread and attention state server-side from durable events plus read
+  state.
+
+## Migration Guardrails
+
+- New provider events must map to Tank events, be marked `live-only`, or be
+  explicitly ignored with a test.
+- Replay and live delivery must produce the same reducer state for the same
+  canonical event sequence.
+- `client_nonce` is the idempotency boundary for user submission. The durable
+  store should reject or return the existing event for duplicate nonces.
+- Browser connection state is never agent state. Disconnect, reconnecting, and
+  resumed are transport states layered beside the conversation projection.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
+        "tsx": "^4.21.0",
         "typescript": "^5.6.3",
         "vite": "^5.4.10"
       }
@@ -1039,6 +1040,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1056,6 +1074,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1071,6 +1106,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -6407,6 +6459,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/ghostty-web": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/ghostty-web/-/ghostty-web-0.4.0.tgz",
@@ -9563,6 +9628,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -10389,6 +10464,459 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "tsx --test src/conversationReducer.test.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
@@ -33,6 +34,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "tsx": "^4.21.0",
     "typescript": "^5.6.3",
     "vite": "^5.4.10"
   }

--- a/frontend/src/conversationReducer.test.ts
+++ b/frontend/src/conversationReducer.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  initialConversationState,
+  reduceConversationEvents,
+} from "./conversationReducer.ts";
+import type { TankConversationEvent } from "./tankConversation.ts";
+
+function ev(
+  event_id: string,
+  type: TankConversationEvent["type"],
+  fields: Partial<TankConversationEvent> = {},
+): TankConversationEvent {
+  return {
+    event_id,
+    order_key: event_id.padStart(4, "0"),
+    session_id: "63",
+    turn_id: "turn-1",
+    actor: "runner",
+    source: "tank",
+    type,
+    created_at: "2026-05-12T00:00:00.000Z",
+    visibility: "durable",
+    ...fields,
+  };
+}
+
+test("Codex interrupt is stopped state, not provider error", () => {
+  const state = reduceConversationEvents([
+    ev("1", "user_message.created", {
+      actor: "user",
+      source: "tank",
+      client_nonce: "run-1",
+      payload: { text: "stop safely" },
+    }),
+    ev("2", "turn.submitted", { source: "codex" }),
+    ev("3", "turn.started", { source: "codex" }),
+    ev("4", "turn.interrupted", {
+      source: "codex",
+      payload: { reason: "client_interrupt" },
+    }),
+  ]);
+
+  assert.equal(state.runStatus, "stopped");
+  assert.equal(state.failed, false);
+  assert.equal(state.messages.length, 1);
+});
+
+test("Tool lifecycle replays to a completed tool item", () => {
+  const state = reduceConversationEvents([
+    ev("1", "turn.started"),
+    ev("2", "item.started", {
+      actor: "tool",
+      source: "claude",
+      item_id: "toolu-read",
+      payload: { kind: "tool", title: "Read", text: "{\"file_path\":\"README.md\"}" },
+    }),
+    ev("3", "item.completed", {
+      actor: "tool",
+      source: "claude",
+      item_id: "toolu-read",
+      payload: { kind: "tool", title: "Read", text: "README contents" },
+    }),
+    ev("4", "turn.completed"),
+  ]);
+
+  assert.equal(state.runStatus, "ready");
+  assert.equal(state.activeItemId, null);
+  assert.deepEqual(state.items.map((item) => [item.id, item.status, item.title]), [
+    ["toolu-read", "completed", "Read"],
+  ]);
+});
+
+test("Duplicate user submissions with the same client nonce do not duplicate bubbles", () => {
+  const state = reduceConversationEvents([
+    ev("1", "user_message.created", {
+      actor: "user",
+      client_nonce: "run-1",
+      payload: { text: "same prompt" },
+    }),
+    ev("2", "user_message.created", {
+      actor: "user",
+      client_nonce: "run-1",
+      payload: { text: "same prompt" },
+    }),
+  ]);
+
+  assert.equal(state.messages.length, 1);
+  assert.equal(state.messages[0]?.text, "same prompt");
+});
+
+test("Approval pause is explicit needs-input state and resumes streaming", () => {
+  const state = reduceConversationEvents([
+    ev("1", "turn.started", { turn_id: "turn-approval" }),
+    ev("2", "tool.approval_requested", {
+      turn_id: "turn-approval",
+      item_id: "approval-1",
+      actor: "tool",
+      payload: { kind: "approval", title: "Run tests" },
+    }),
+    ev("3", "tool.approval_resolved", {
+      turn_id: "turn-approval",
+      item_id: "approval-1",
+      actor: "tool",
+      payload: { decision: "allow" },
+    }),
+  ]);
+
+  assert.equal(state.needsInput, false);
+  assert.equal(state.runStatus, "streaming");
+  assert.equal(state.items[0]?.kind, "approval");
+});
+
+test("Replay and live delivery converge through event id dedupe", () => {
+  const events = [
+    ev("1", "user_message.created", {
+      actor: "user",
+      client_nonce: "run-1",
+      payload: { text: "hello" },
+    }),
+    ev("2", "turn.started"),
+    ev("3", "item.completed", {
+      actor: "assistant",
+      item_id: "msg-1",
+      payload: { kind: "message", text: "world" },
+    }),
+    ev("4", "turn.completed"),
+  ];
+  const replayOnly = reduceConversationEvents(events);
+  const replayThenLive = reduceConversationEvents(events, reduceConversationEvents(events));
+
+  assert.deepEqual(replayThenLive, replayOnly);
+  assert.notDeepEqual(replayOnly, initialConversationState);
+});

--- a/frontend/src/conversationReducer.ts
+++ b/frontend/src/conversationReducer.ts
@@ -1,0 +1,291 @@
+import type { TankConversationEvent } from "./tankConversation";
+
+export type ConversationRunStatus =
+  | "ready"
+  | "submitted"
+  | "streaming"
+  | "needs_input"
+  | "stopped"
+  | "error";
+
+export type ConversationItemStatus = "started" | "streaming" | "completed" | "failed";
+
+export interface ConversationMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  text: string;
+  turnId?: string;
+  clientNonce?: string;
+  orderKey?: string;
+}
+
+export interface ConversationItem {
+  id: string;
+  turnId?: string;
+  parentId?: string;
+  actor: "assistant" | "system" | "tool" | "runner";
+  kind: string;
+  status: ConversationItemStatus;
+  title?: string;
+  text?: string;
+  orderKey?: string;
+}
+
+export interface ConversationReducerState {
+  seenEventIds: string[];
+  seenClientNonces: string[];
+  messages: ConversationMessage[];
+  items: ConversationItem[];
+  runStatus: ConversationRunStatus;
+  activeTurnId: string | null;
+  activeItemId: string | null;
+  needsInput: boolean;
+  failed: boolean;
+  lastOrderKey: string | null;
+  lastReadOrderKey: string | null;
+  unreadCount: number;
+}
+
+export const initialConversationState: ConversationReducerState = {
+  seenEventIds: [],
+  seenClientNonces: [],
+  messages: [],
+  items: [],
+  runStatus: "ready",
+  activeTurnId: null,
+  activeItemId: null,
+  needsInput: false,
+  failed: false,
+  lastOrderKey: null,
+  lastReadOrderKey: null,
+  unreadCount: 0,
+};
+
+export function conversationReducer(
+  state: ConversationReducerState,
+  event: TankConversationEvent,
+): ConversationReducerState {
+  if (state.seenEventIds.includes(event.event_id)) return state;
+
+  let next: ConversationReducerState = {
+    ...state,
+    seenEventIds: [...state.seenEventIds, event.event_id],
+    lastOrderKey: event.order_key ?? state.lastOrderKey,
+  };
+
+  switch (event.type) {
+    case "conversation.started":
+      return next;
+    case "conversation.archived":
+      return { ...next, runStatus: "ready", activeTurnId: null, activeItemId: null };
+    case "user_message.created":
+      return applyUserMessage(next, event);
+    case "turn.submitted":
+      return {
+        ...next,
+        runStatus: "submitted",
+        activeTurnId: event.turn_id ?? next.activeTurnId,
+        failed: false,
+      };
+    case "turn.started":
+      return {
+        ...next,
+        runStatus: "streaming",
+        activeTurnId: event.turn_id ?? next.activeTurnId,
+        failed: false,
+      };
+    case "turn.completed":
+      return {
+        ...next,
+        runStatus: "ready",
+        activeTurnId: null,
+        activeItemId: null,
+        needsInput: false,
+        failed: false,
+      };
+    case "turn.failed":
+      return {
+        ...next,
+        runStatus: "error",
+        activeTurnId: null,
+        activeItemId: null,
+        needsInput: false,
+        failed: true,
+      };
+    case "turn.interrupted":
+      return {
+        ...next,
+        runStatus: "stopped",
+        activeTurnId: null,
+        activeItemId: null,
+        needsInput: false,
+        failed: false,
+      };
+    case "item.started":
+      return upsertItem(next, event, "started");
+    case "item.delta":
+      return upsertItem(next, event, "streaming", true);
+    case "item.completed":
+      return upsertItem(
+        { ...next, activeItemId: matchingActiveItem(next, event) ? null : next.activeItemId },
+        event,
+        "completed",
+      );
+    case "item.failed":
+      return upsertItem(
+        { ...next, runStatus: "error", failed: true },
+        event,
+        "failed",
+      );
+    case "tool.approval_requested":
+      return upsertItem(
+        {
+          ...next,
+          runStatus: "needs_input",
+          needsInput: true,
+          activeTurnId: event.turn_id ?? next.activeTurnId,
+        },
+        event,
+        "started",
+      );
+    case "tool.approval_resolved":
+      return {
+        ...next,
+        runStatus: next.activeTurnId ? "streaming" : "ready",
+        needsInput: false,
+      };
+    case "session.activity_updated":
+      return applyActivity(next, event);
+    case "read_state.updated":
+      return applyReadState(next, event);
+  }
+}
+
+export function reduceConversationEvents(
+  events: readonly TankConversationEvent[],
+  seed: ConversationReducerState = initialConversationState,
+): ConversationReducerState {
+  return events.reduce(conversationReducer, seed);
+}
+
+function applyUserMessage(
+  state: ConversationReducerState,
+  event: TankConversationEvent,
+): ConversationReducerState {
+  if (event.client_nonce && state.seenClientNonces.includes(event.client_nonce)) {
+    return state;
+  }
+  const text = stringPayload(event, "text") ?? stringPayload(event, "message") ?? "";
+  const message: ConversationMessage = {
+    id: event.item_id ?? event.event_id,
+    role: "user",
+    text,
+    turnId: event.turn_id,
+    clientNonce: event.client_nonce,
+    orderKey: event.order_key,
+  };
+  return {
+    ...state,
+    seenClientNonces: event.client_nonce
+      ? [...state.seenClientNonces, event.client_nonce]
+      : state.seenClientNonces,
+    messages: [...state.messages, message],
+  };
+}
+
+function upsertItem(
+  state: ConversationReducerState,
+  event: TankConversationEvent,
+  status: ConversationItemStatus,
+  appendDelta = false,
+): ConversationReducerState {
+  const id = event.item_id ?? event.event_id;
+  const existing = state.items.find((item) => item.id === id);
+  const text = stringPayload(event, appendDelta ? "delta" : "text");
+  const item: ConversationItem = {
+    id,
+    turnId: event.turn_id,
+    parentId: event.parent_id,
+    actor: event.actor === "user" ? "runner" : event.actor,
+    kind: stringPayload(event, "kind") ?? defaultItemKind(event),
+    status,
+    title: stringPayload(event, "title") ?? existing?.title,
+    text: appendDelta ? [existing?.text, text].filter(Boolean).join("") : (text ?? existing?.text),
+    orderKey: event.order_key ?? existing?.orderKey,
+  };
+  const items = existing
+    ? state.items.map((candidate) => (candidate.id === id ? item : candidate))
+    : [...state.items, item];
+  return {
+    ...state,
+    items,
+    activeItemId: status === "started" || status === "streaming" ? id : state.activeItemId,
+  };
+}
+
+function applyActivity(
+  state: ConversationReducerState,
+  event: TankConversationEvent,
+): ConversationReducerState {
+  const status = stringPayload(event, "status");
+  const unreadCount = numberPayload(event, "unread_count");
+  return {
+    ...state,
+    runStatus: isRunStatus(status) ? status : state.runStatus,
+    needsInput: booleanPayload(event, "needs_input") ?? state.needsInput,
+    failed: booleanPayload(event, "failed") ?? state.failed,
+    activeTurnId: stringPayload(event, "active_turn_id") ?? state.activeTurnId,
+    unreadCount: unreadCount ?? state.unreadCount,
+  };
+}
+
+function applyReadState(
+  state: ConversationReducerState,
+  event: TankConversationEvent,
+): ConversationReducerState {
+  return {
+    ...state,
+    lastReadOrderKey:
+      stringPayload(event, "last_read_order_key") ?? event.order_key ?? state.lastReadOrderKey,
+    unreadCount: 0,
+  };
+}
+
+function matchingActiveItem(
+  state: ConversationReducerState,
+  event: TankConversationEvent,
+): boolean {
+  return Boolean(event.item_id && state.activeItemId === event.item_id);
+}
+
+function defaultItemKind(event: TankConversationEvent): string {
+  if (event.type.startsWith("tool.")) return "approval";
+  if (event.actor === "assistant") return "message";
+  return event.actor;
+}
+
+function stringPayload(event: TankConversationEvent, key: string): string | undefined {
+  const value = event.payload?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberPayload(event: TankConversationEvent, key: string): number | undefined {
+  const value = event.payload?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanPayload(event: TankConversationEvent, key: string): boolean | undefined {
+  const value = event.payload?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function isRunStatus(value: string | undefined): value is ConversationRunStatus {
+  return (
+    value === "ready" ||
+    value === "submitted" ||
+    value === "streaming" ||
+    value === "needs_input" ||
+    value === "stopped" ||
+    value === "error"
+  );
+}

--- a/frontend/src/tankConversation.ts
+++ b/frontend/src/tankConversation.ts
@@ -1,0 +1,51 @@
+export type TankActor = "user" | "assistant" | "system" | "tool" | "runner";
+
+export type TankEventSource = "tank" | "claude" | "codex" | "legacy-run";
+
+export type TankVisibility = "durable" | "live-only" | "audit-only";
+
+export type TankEventType =
+  | "conversation.started"
+  | "conversation.archived"
+  | "user_message.created"
+  | "turn.submitted"
+  | "turn.started"
+  | "turn.completed"
+  | "turn.failed"
+  | "turn.interrupted"
+  | "item.started"
+  | "item.delta"
+  | "item.completed"
+  | "item.failed"
+  | "tool.approval_requested"
+  | "tool.approval_resolved"
+  | "session.activity_updated"
+  | "read_state.updated";
+
+export interface TankProducerMetadata {
+  name?: string;
+  version?: string;
+  runtime?: string;
+  provider_event_id?: string;
+}
+
+export interface TankConversationEvent<
+  TPayload extends Record<string, unknown> = Record<string, unknown>,
+> {
+  event_id: string;
+  order_key?: string;
+  sequence?: number;
+  conversation_id?: string;
+  session_id: string;
+  turn_id?: string;
+  item_id?: string;
+  parent_id?: string;
+  client_nonce?: string;
+  actor: TankActor;
+  source: TankEventSource;
+  type: TankEventType;
+  created_at: string;
+  producer?: TankProducerMetadata;
+  visibility: TankVisibility;
+  payload?: TPayload;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,5 +20,6 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/schemas/tank-conversation-event.schema.json
+++ b/schemas/tank-conversation-event.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tank.romaine.life/schemas/tank-conversation-event.schema.json",
+  "title": "Tank Conversation Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id",
+    "session_id",
+    "actor",
+    "source",
+    "type",
+    "created_at",
+    "visibility"
+  ],
+  "anyOf": [
+    { "required": ["order_key"] },
+    { "required": ["sequence"] }
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "order_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "conversation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "turn_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "parent_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "client_nonce": {
+      "type": "string",
+      "minLength": 1
+    },
+    "actor": {
+      "type": "string",
+      "enum": ["user", "assistant", "system", "tool", "runner"]
+    },
+    "source": {
+      "type": "string",
+      "enum": ["tank", "claude", "codex", "legacy-run"]
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "conversation.started",
+        "conversation.archived",
+        "user_message.created",
+        "turn.submitted",
+        "turn.started",
+        "turn.completed",
+        "turn.failed",
+        "turn.interrupted",
+        "item.started",
+        "item.delta",
+        "item.completed",
+        "item.failed",
+        "tool.approval_requested",
+        "tool.approval_resolved",
+        "session.activity_updated",
+        "read_state.updated"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "runtime": { "type": "string" },
+        "provider_event_id": { "type": "string" }
+      }
+    },
+    "visibility": {
+      "type": "string",
+      "enum": ["durable", "live-only", "audit-only"]
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add the Tank Conversation Protocol ADR/spec for issue #402, including event envelope, state machine, provider mappings, and backend API/read-state sketch.
- Add shared Tank event contract artifacts: JSON schema, Go type stubs, and TypeScript type stubs.
- Add a pure frontend conversation reducer with fixture tests for Codex interrupts, tool lifecycle replay, client nonce dedupe, approval pauses, and replay/live convergence.

## External Pattern Checkpoint
- CloudCLI: copied persistent, cross-device, agent-agnostic session framing.
- Slack: copied durable history plus event delivery, cursor pagination, and read/activity-state split.
- Discord: copied envelope/sequence/resume discipline as the transport target.
- AI SDK UI: copied submitted/streaming/ready/error vocabulary, with Tank extensions for stopped and needs_input.
- OpenAI Codex App Server: copied thread/turn/item lifecycle and explicit server-initiated approval/input pauses.

Refs #402

## Validation
- npm test (frontend)
- npm run build (frontend)
- go test ./... (backend-go)
- npm test (agent-runner)
- npm test (codex-runner)