### PR TITLE
Add render-order timeline cursor

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_agent_ws.go
+++ b/backend-go/cmd/tank-operator/handlers_agent_ws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/websocket"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
 )
 
 const agentRunnerDialTimeout = 10 * time.Second
@@ -136,8 +137,9 @@ func podHasSDKRunner(pod *corev1.Pod) bool {
 
 // handleListSessionEvents reads canonical SDK events from the
 // `session-events` Cosmos container for the SPA's history-replay path.
-// Returns events strictly after the watermark `after` (a v7 UUID — sorts
-// by emit order), in ascending order, up to `limit` (max 1000).
+// Returns events strictly after `after_order_key`, the same cursor the SPA
+// renders by. The legacy `after` document-id cursor remains accepted for old
+// tabs.
 //
 // SPA contract: on session open, fetch with after="" to get the full
 // history; then open the WebSocket for live updates and dedupe by uuid.
@@ -157,7 +159,7 @@ func (s *appServer) handleListSessionEvents(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	after := r.URL.Query().Get("after")
+	cursor := sessionEventCursorFromRequest(r)
 	limit := 200
 	if l := r.URL.Query().Get("limit"); l != "" {
 		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 1000 {
@@ -165,16 +167,36 @@ func (s *appServer) handleListSessionEvents(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	events, err := s.sessionEvents.ListBySession(r.Context(), sessionID, after, limit)
+	page, err := s.sessionEvents.ListBySession(r.Context(), sessionID, cursor, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if events == nil {
-		events = []map[string]any{}
+	if page.Events == nil {
+		page.Events = []map[string]any{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"session_id": sessionID,
-		"events":     events,
+		"session_id":      sessionID,
+		"events":          page.Events,
+		"next_order_key":  page.NextOrderKey,
+		"has_more":        page.HasMore,
+		"cursor_semantic": "render_order",
 	})
+}
+
+func (s *appServer) handleSessionTimeline(w http.ResponseWriter, r *http.Request) {
+	s.handleListSessionEvents(w, r)
+}
+
+func sessionEventCursorFromRequest(r *http.Request) store.SessionEventCursor {
+	if afterOrderKey := r.URL.Query().Get("after_order_key"); afterOrderKey != "" {
+		return store.SessionEventCursor{AfterOrderKey: afterOrderKey}
+	}
+	if afterOrderKey := r.URL.Query().Get("after_sequence"); afterOrderKey != "" {
+		return store.SessionEventCursor{AfterOrderKey: afterOrderKey}
+	}
+	if afterID := r.URL.Query().Get("after"); afterID != "" {
+		return store.SessionEventCursor{AfterID: afterID}
+	}
+	return store.SessionEventCursor{}
 }

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -14,18 +14,18 @@ import (
 
 // appServer holds shared application state for all handlers.
 type appServer struct {
-	k8s        kubernetes.Interface
-	restCfg    *rest.Config
-	mgr        *sessions.Manager
-	profiles   profilesStore
+	k8s           kubernetes.Interface
+	restCfg       *rest.Config
+	mgr           *sessions.Manager
+	profiles      profilesStore
 	activeRuns    store.ActiveRunStore
 	runEvents     store.RunEventStore
 	turnQueue     store.TurnQueueStore
 	sessionEvents store.SessionEventStore
 	eventBus      *sessions.EventBus
-	verifier   *auth.Verifier
-	minter     *auth.Minter
-	namespace  string
+	verifier      *auth.Verifier
+	minter        *auth.Minter
+	namespace     string
 
 	// internalAllowedSubjects maps "namespace/serviceaccount" → email for internal SA auth.
 	internalAllowedSubjects map[string]string
@@ -90,10 +90,11 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/sessions/{session_id}/run", s.handleRunWebSocket)
 
 	// SDK runtime surface. The same chat pane consumes /agent-ws (live)
-	// and /events (history) when session.runtime is "sdk" — the data
+	// and /timeline (history) when session.runtime is "sdk" — the data
 	// source differs from the legacy path, but the renderer is the same.
 	mux.HandleFunc("GET /api/sessions/{session_id}/agent-ws", s.handleAgentWebSocket)
 	mux.HandleFunc("GET /api/sessions/{session_id}/events", s.handleListSessionEvents)
+	mux.HandleFunc("GET /api/sessions/{session_id}/timeline", s.handleSessionTimeline)
 
 	// CLI / sandbox agent.
 	mux.HandleFunc("POST /api/sessions/{session_id}/cli-process", s.handleCLIProcess)

--- a/backend-go/internal/sessions/sessions.go
+++ b/backend-go/internal/sessions/sessions.go
@@ -28,15 +28,15 @@ var (
 )
 
 type Info struct {
-	ID           string         `json:"id"`
-	PodName      *string        `json:"pod_name"`
-	Owner        string         `json:"owner"`
-	Status       string         `json:"status"`
-	Mode         string         `json:"mode"`
+	ID      string  `json:"id"`
+	PodName *string `json:"pod_name"`
+	Owner   string  `json:"owner"`
+	Status  string  `json:"status"`
+	Mode    string  `json:"mode"`
 	// Runtime tells the SPA's chat pane which data-ingestion path to use
 	// for this session:
 	//   "sdk"    — pod has the agent-runner sidecar. Chat pane opens
-	//              /agent-ws (live) + /events (history).
+	//              /agent-ws (live) + /timeline (history).
 	//   "legacy" — no agent-runner sidecar. Chat pane uses /run (live)
 	//              + /runs/latest/events.json + /run/history (history).
 	// The renderer is the same for both; only the data source differs.

--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
@@ -17,10 +19,21 @@ import (
 // WS subscriber = SPA live tap).
 //
 // Container partition key is /tank_session_id (the small-integer pod id,
-// not the SDK's UUID). Doc id is the SDK event uuid (v7, monotonic) so
-// the watermark works as a simple string comparison.
+// not the SDK's UUID). New clients page by the same render-order cursor the
+// SPA sorts on; the legacy document-id cursor remains accepted for old tabs.
 type SessionEventStore interface {
-	ListBySession(ctx context.Context, tankSessionID, afterUUID string, limit int) ([]map[string]any, error)
+	ListBySession(ctx context.Context, tankSessionID string, cursor SessionEventCursor, limit int) (SessionEventPage, error)
+}
+
+type SessionEventCursor struct {
+	AfterOrderKey string
+	AfterID       string
+}
+
+type SessionEventPage struct {
+	Events       []map[string]any
+	NextOrderKey string
+	HasMore      bool
 }
 
 type cosmosSessionEventStore struct {
@@ -40,30 +53,27 @@ func NewCosmosSessionEventStore(endpoint, database, container string, cred azcor
 }
 
 // ListBySession returns events for one session, strictly after the
-// given uuid watermark, in ascending uuid order. afterUUID="" returns
-// everything from the beginning. limit caps the page size.
+// given render-order cursor. An empty cursor returns from the beginning.
+// limit caps the page size.
 //
 // Single-partition read (tank_session_id is the partition key) so the
 // query is one RU per ~1KB doc — fast and cheap. The /message/* path
 // is excluded from indexing (see infra/cosmos.tf) so large assistant
-// content doesn't inflate index size; this query doesn't need it
-// indexed because we filter on id (the partition's clustering key).
-func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSessionID, afterUUID string, limit int) ([]map[string]any, error) {
-	if limit <= 0 || limit > 1000 {
-		limit = 200
-	}
-	query := "SELECT * FROM c WHERE c.tank_session_id = @sid AND c.id > @after ORDER BY c.id ASC OFFSET 0 LIMIT @limit"
+// content doesn't inflate index size. Page slicing happens after the Go sort
+// because legacy docs may not have tank_order_key; filtering by id first can
+// skip events when id order and render order diverge.
+func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSessionID string, cursor SessionEventCursor, limit int) (SessionEventPage, error) {
+	limit = normalizeSessionEventLimit(limit)
+	query := "SELECT * FROM c WHERE c.tank_session_id = @sid"
 	params := []azcosmos.QueryParameter{
 		{Name: "@sid", Value: tankSessionID},
-		{Name: "@after", Value: afterUUID},
-		{Name: "@limit", Value: limit},
 	}
 	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(tankSessionID), &azcosmos.QueryOptions{QueryParameters: params})
 	out := make([]map[string]any, 0, limit)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, err
+			return SessionEventPage{}, err
 		}
 		for _, raw := range page.Items {
 			var doc map[string]any
@@ -78,7 +88,7 @@ func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSession
 	// used UUIDv4, so fall back through write timestamps before id to avoid
 	// reshuffling existing sessions on every history refresh.
 	sortSessionEvents(out)
-	return out, nil
+	return paginateSessionEvents(out, cursor, limit), nil
 }
 
 func sortSessionEvents(out []map[string]any) {
@@ -99,15 +109,35 @@ func sortSessionEvents(out []map[string]any) {
 		if ti != tj {
 			return tj == ""
 		}
-		ai, _ := out[i]["id"].(string)
-		aj, _ := out[j]["id"].(string)
-		return ai < aj
+		return eventDocumentID(out[i]) < eventDocumentID(out[j])
 	})
 }
 
 func eventOrderKey(doc map[string]any) string {
-	if value, ok := doc["tank_order_key"].(string); ok && value != "" {
-		return value
+	for _, field := range []string{"order_key", "tank_order_key"} {
+		if value, ok := doc[field].(string); ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func eventSequence(doc map[string]any) string {
+	for _, field := range []string{"sequence", "tank_event_seq"} {
+		switch value := doc[field].(type) {
+		case int:
+			return strconv.FormatInt(int64(value), 10)
+		case int64:
+			return strconv.FormatInt(value, 10)
+		case float64:
+			if value == float64(int64(value)) {
+				return strconv.FormatInt(int64(value), 10)
+			}
+		case string:
+			if value != "" {
+				return value
+			}
+		}
 	}
 	return ""
 }
@@ -121,9 +151,77 @@ func eventOrderTime(doc map[string]any) string {
 	return ""
 }
 
+func paginateSessionEvents(events []map[string]any, cursor SessionEventCursor, limit int) SessionEventPage {
+	limit = normalizeSessionEventLimit(limit)
+	start := sessionEventStartIndex(events, cursor)
+	if start > len(events) {
+		start = len(events)
+	}
+	end := start + limit
+	if end > len(events) {
+		end = len(events)
+	}
+	pageEvents := append([]map[string]any(nil), events[start:end]...)
+	nextOrderKey := ""
+	if len(pageEvents) > 0 {
+		nextOrderKey = eventOrderCursor(pageEvents[len(pageEvents)-1])
+	}
+	return SessionEventPage{
+		Events:       pageEvents,
+		NextOrderKey: nextOrderKey,
+		HasMore:      end < len(events),
+	}
+}
+
+func sessionEventStartIndex(events []map[string]any, cursor SessionEventCursor) int {
+	if cursor.AfterOrderKey != "" {
+		for i, doc := range events {
+			if eventOrderCursor(doc) == cursor.AfterOrderKey {
+				return i + 1
+			}
+		}
+		return 0
+	}
+	if cursor.AfterID != "" {
+		for i, doc := range events {
+			if eventDocumentID(doc) == cursor.AfterID {
+				return i + 1
+			}
+		}
+		return 0
+	}
+	return 0
+}
+
+func eventOrderCursor(doc map[string]any) string {
+	parts := []string{
+		eventOrderKey(doc),
+		eventOrderTime(doc),
+		eventSequence(doc),
+		eventDocumentID(doc),
+	}
+	return strings.Join(parts, "\x1f")
+}
+
+func eventDocumentID(doc map[string]any) string {
+	for _, field := range []string{"id", "uuid", "event_id"} {
+		if value, ok := doc[field].(string); ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeSessionEventLimit(limit int) int {
+	if limit <= 0 || limit > 1000 {
+		return 200
+	}
+	return limit
+}
+
 // Stub for local dev where Cosmos isn't configured.
 type StubSessionEventStore struct{}
 
-func (StubSessionEventStore) ListBySession(_ context.Context, _, _ string, _ int) ([]map[string]any, error) {
-	return nil, nil
+func (StubSessionEventStore) ListBySession(_ context.Context, _ string, _ SessionEventCursor, _ int) (SessionEventPage, error) {
+	return SessionEventPage{Events: []map[string]any{}}, nil
 }

--- a/backend-go/internal/store/session_events_test.go
+++ b/backend-go/internal/store/session_events_test.go
@@ -46,6 +46,19 @@ func TestSortSessionEventsPrefersTankOrderKey(t *testing.T) {
 	}
 }
 
+func TestSortSessionEventsRecognizesCanonicalOrderKey(t *testing.T) {
+	events := []map[string]any{
+		{"id": "a", "order_key": "0002", "written_at": "2026-05-12T01:00:01Z", "type": "second"},
+		{"id": "b", "order_key": "0001", "written_at": "2026-05-12T01:00:03Z", "type": "first"},
+	}
+
+	sortSessionEvents(events)
+
+	if got := events[0]["type"]; got != "first" {
+		t.Fatalf("first event = %v, want first", got)
+	}
+}
+
 func TestSortSessionEventsFallsBackToID(t *testing.T) {
 	events := []map[string]any{
 		{"id": "b", "type": "second"},
@@ -57,4 +70,50 @@ func TestSortSessionEventsFallsBackToID(t *testing.T) {
 	if got := events[0]["type"]; got != "first" {
 		t.Fatalf("first event = %v, want first", got)
 	}
+}
+
+func TestPaginateSessionEventsUsesRenderOrderCursor(t *testing.T) {
+	events := []map[string]any{
+		{"id": "random-c", "tank_order_key": "0003", "type": "third"},
+		{"id": "random-a", "tank_order_key": "0001", "type": "first"},
+		{"id": "random-b", "tank_order_key": "0002", "type": "second"},
+	}
+	sortSessionEvents(events)
+
+	firstPage := paginateSessionEvents(events, SessionEventCursor{}, 2)
+	if !firstPage.HasMore {
+		t.Fatal("first page HasMore = false, want true")
+	}
+	if got := eventTypes(firstPage.Events); got[0] != "first" || got[1] != "second" {
+		t.Fatalf("first page types = %#v, want first, second", got)
+	}
+
+	secondPage := paginateSessionEvents(events, SessionEventCursor{AfterOrderKey: firstPage.NextOrderKey}, 2)
+	if secondPage.HasMore {
+		t.Fatal("second page HasMore = true, want false")
+	}
+	if got := eventTypes(secondPage.Events); len(got) != 1 || got[0] != "third" {
+		t.Fatalf("second page types = %#v, want third", got)
+	}
+}
+
+func TestPaginateSessionEventsAcceptsLegacyDocumentIDCursor(t *testing.T) {
+	events := []map[string]any{
+		{"id": "b", "written_at": "2026-05-12T01:00:01Z", "type": "first"},
+		{"id": "a", "written_at": "2026-05-12T01:00:02Z", "type": "second"},
+	}
+	sortSessionEvents(events)
+
+	page := paginateSessionEvents(events, SessionEventCursor{AfterID: "b"}, 10)
+	if got := eventTypes(page.Events); len(got) != 1 || got[0] != "second" {
+		t.Fatalf("page types = %#v, want second", got)
+	}
+}
+
+func eventTypes(events []map[string]any) []string {
+	types := make([]string, 0, len(events))
+	for _, event := range events {
+		types = append(types, event["type"].(string))
+	}
+	return types
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,7 +135,7 @@ interface Session {
   mode: SessionMode;
   // Which data-ingestion path the chat pane should use for this session.
   // "sdk" → pod has the agent-runner sidecar; chat pane opens /agent-ws
-  // + /events. "legacy" → no agent-runner; chat pane uses /run +
+  // + /timeline. "legacy" → no agent-runner; chat pane uses /run +
   // /runs/latest/events.json + /run/history. Renderer is the same for
   // both; only the event source differs. Absent on older pods — treated
   // as "legacy".
@@ -1799,6 +1799,9 @@ function eventID(event: JsonObject, fallbackPrefix: string): string {
   if (typeof event.uuid === "string" && event.uuid) return event.uuid;
   if (typeof event.id === "string" && event.id) return event.id;
   if (typeof event.event_id === "string" && event.event_id) return event.event_id;
+  if (typeof event.order_key === "string" && event.order_key) {
+    return event.order_key;
+  }
   if (typeof event.tank_order_key === "string" && event.tank_order_key) {
     return event.tank_order_key;
   }
@@ -1806,6 +1809,9 @@ function eventID(event: JsonObject, fallbackPrefix: string): string {
 }
 
 function eventOrderKey(event: JsonObject): string {
+  if (typeof event.order_key === "string" && event.order_key) {
+    return event.order_key;
+  }
   if (typeof event.tank_order_key === "string" && event.tank_order_key) {
     return event.tank_order_key;
   }
@@ -2271,12 +2277,6 @@ function sdkHistoryTerminalForRun(
     if (terminal) return terminal;
   }
   return undefined;
-}
-
-function sdkEventDocumentID(event: unknown): string {
-  if (!isJsonObject(event)) return "";
-  const id = event.id ?? event.uuid;
-  return typeof id === "string" ? id : "";
 }
 
 function isClaudeRunMode(mode: SessionMode): boolean {
@@ -4386,7 +4386,7 @@ function HeadlessRun({
 
   // SDK-runtime history replay. Hits the canonical event log written by the
   // pod-side agent-runner (Cosmos session-events container, exposed via
-  // /api/sessions/{id}/events). Each event is the same shape applyProviderEvent
+  // /api/sessions/{id}/timeline). Each event is the same shape applyProviderEvent
   // already consumes — the chat pane was built around Claude's stream-json,
   // which the SDK is a TypeScript wrapper over the same binary's stdout.
   function refreshSdkRunHistory(showHint: boolean, clearRealtime = false): Promise<boolean> {
@@ -4403,26 +4403,27 @@ function HeadlessRun({
     const refreshSessionId = session.id;
     const events: unknown[] = [];
     const load = async (): Promise<SdkHistoryRefreshResult> => {
-      let after = "";
+      let afterOrderKey = "";
       for (let page = 0; page < 50; page += 1) {
         const params = new URLSearchParams({ limit: "1000" });
-        if (after) params.set("after", after);
+        if (afterOrderKey) params.set("after_order_key", afterOrderKey);
         const res = await authedFetch(
-          `/api/sessions/${encodeURIComponent(refreshSessionId)}/events?${params.toString()}`,
+          `/api/sessions/${encodeURIComponent(refreshSessionId)}/timeline?${params.toString()}`,
         );
         if (!res.ok) return { replayed: false };
-        const body = (await res.json()) as { session_id?: string; events?: unknown[] };
+        const body = (await res.json()) as {
+          session_id?: string;
+          events?: unknown[];
+          next_order_key?: string;
+          has_more?: boolean;
+        };
         if (sessionIdRef.current !== refreshSessionId) return { replayed: false };
         if (!Array.isArray(body.events)) return { replayed: false };
         events.push(...body.events);
-        if (body.events.length < 1000) break;
-        const nextAfter = body.events
-          .map(sdkEventDocumentID)
-          .filter(Boolean)
-          .sort()
-          .at(-1);
-        if (!nextAfter || nextAfter === after) break;
-        after = nextAfter;
+        if (!body.has_more) break;
+        const nextAfter = typeof body.next_order_key === "string" ? body.next_order_key : "";
+        if (!nextAfter || nextAfter === afterOrderKey) break;
+        afterOrderKey = nextAfter;
       }
 
       let acc: TranscriptEntry[] = [];


### PR DESCRIPTION
## Summary
- add render-order cursor paging for SDK session event history
- expose `/api/sessions/{session_id}/timeline` with `next_order_key` and `has_more`, while keeping legacy `/events` compatible
- make the frontend SDK replay path advance by `after_order_key` instead of sorting Cosmos document ids locally
- cover canonical `order_key`, legacy `tank_order_key`, and legacy document-id cursor behavior in store tests

## Patterns re-checked for #402
- CloudCLI: copied the persistence/cross-device constraint; browser replay attaches to durable session history instead of treating a tab as the source of truth.
- Slack: copied the split between durable history and event delivery; this PR moves history pagination toward a backend-owned conversation timeline.
- Discord: copied opaque ordered resume cursor discipline; replay advances by the same render-order cursor the UI consumes.
- AI SDK UI: preserved resumable chat behavior by hydrating stored events before live attachment, without turning transport state into agent state.
- OpenAI Codex App Server: kept the thread/turn/item direction by recognizing canonical `order_key` fields in addition to current runner `tank_order_key` fields.

## Tests
- `go test ./...`
- `npm run build`

Refs #402