### PR TITLE
Phase 2: emit canonical runner producer events

### DIFF
--- a/agent-runner/src/conversation.ts
+++ b/agent-runner/src/conversation.ts
@@ -1,0 +1,234 @@
+import { createHash } from "node:crypto";
+
+export type TankActor = "user" | "assistant" | "system" | "tool" | "runner";
+export type TankEventSource = "tank" | "claude" | "codex" | "legacy-run";
+export type TankVisibility = "durable" | "live-only" | "audit-only";
+
+export type TankEventType =
+  | "conversation.started"
+  | "conversation.archived"
+  | "user_message.created"
+  | "turn.submitted"
+  | "turn.started"
+  | "turn.completed"
+  | "turn.failed"
+  | "turn.interrupted"
+  | "item.started"
+  | "item.delta"
+  | "item.completed"
+  | "item.failed"
+  | "tool.approval_requested"
+  | "tool.approval_resolved"
+  | "session.activity_updated"
+  | "read_state.updated";
+
+export interface TankConversationEvent {
+  event_id: string;
+  order_key?: string;
+  sequence?: number;
+  conversation_id?: string;
+  session_id: string;
+  turn_id?: string;
+  item_id?: string;
+  parent_id?: string;
+  client_nonce?: string;
+  actor: TankActor;
+  source: TankEventSource;
+  type: TankEventType;
+  created_at: string;
+  producer?: {
+    name?: string;
+    version?: string;
+    runtime?: string;
+    provider_event_id?: string;
+  };
+  visibility: TankVisibility;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+const TANK_EVENT_TYPES = new Set<string>([
+  "conversation.started",
+  "conversation.archived",
+  "user_message.created",
+  "turn.submitted",
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.interrupted",
+  "item.started",
+  "item.delta",
+  "item.completed",
+  "item.failed",
+  "tool.approval_requested",
+  "tool.approval_resolved",
+  "session.activity_updated",
+  "read_state.updated",
+]);
+
+export function isTankConversationEvent(event: { [key: string]: unknown }): event is TankConversationEvent {
+  return (
+    typeof event.event_id === "string" &&
+    typeof event.session_id === "string" &&
+    typeof event.type === "string" &&
+    TANK_EVENT_TYPES.has(event.type) &&
+    typeof event.actor === "string" &&
+    typeof event.source === "string" &&
+    typeof event.created_at === "string" &&
+    typeof event.visibility === "string"
+  );
+}
+
+export function isDurableTankConversationEvent(event: { [key: string]: unknown }): boolean {
+  return isTankConversationEvent(event) && event.visibility !== "live-only";
+}
+
+export function normalizeClientNonce(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function turnIDForClientNonce(clientNonce: string): string {
+  return `turn_${stableIDPart(clientNonce)}`;
+}
+
+export function userItemID(turnID: string): string {
+  return `${turnID}:user`;
+}
+
+export function userSubmissionEvents(args: {
+  sessionID: string;
+  clientNonce: string;
+  text: string;
+  message: unknown;
+  runtime: "claude" | "codex";
+  now?: string;
+}): { turnID: string; userMessage: TankConversationEvent; turnSubmitted: TankConversationEvent } {
+  const createdAt = args.now ?? new Date().toISOString();
+  const turnID = turnIDForClientNonce(args.clientNonce);
+  const producer = { name: `${args.runtime}-runner`, runtime: args.runtime };
+  return {
+    turnID,
+    userMessage: {
+      event_id: `${turnID}:user_message.created`,
+      conversation_id: args.sessionID,
+      session_id: args.sessionID,
+      turn_id: turnID,
+      item_id: userItemID(turnID),
+      client_nonce: args.clientNonce,
+      actor: "user",
+      source: "tank",
+      type: "user_message.created",
+      created_at: createdAt,
+      producer,
+      visibility: "durable",
+      payload: {
+        text: args.text,
+        message: args.message,
+      },
+    },
+    turnSubmitted: {
+      event_id: `${turnID}:turn.submitted`,
+      conversation_id: args.sessionID,
+      session_id: args.sessionID,
+      turn_id: turnID,
+      client_nonce: args.clientNonce,
+      actor: "runner",
+      source: "tank",
+      type: "turn.submitted",
+      created_at: createdAt,
+      producer,
+      visibility: "durable",
+      payload: {
+        status: "submitted",
+      },
+    },
+  };
+}
+
+export function turnEvent(args: {
+  sessionID: string;
+  turnID: string;
+  clientNonce?: string;
+  source: "claude" | "codex";
+  type: "turn.started" | "turn.completed" | "turn.failed" | "turn.interrupted";
+  reason?: string;
+  usage?: unknown;
+  error?: unknown;
+  providerEventID?: string;
+}): TankConversationEvent {
+  const payload: Record<string, unknown> = {};
+  if (args.reason) payload.reason = args.reason;
+  if (args.usage !== undefined) payload.usage = args.usage;
+  if (args.error !== undefined) payload.error = args.error;
+  return {
+    event_id: `${args.turnID}:${args.type}:${args.reason ?? args.providerEventID ?? "runner"}`,
+    conversation_id: args.sessionID,
+    session_id: args.sessionID,
+    turn_id: args.turnID,
+    ...(args.clientNonce ? { client_nonce: args.clientNonce } : {}),
+    actor: "runner",
+    source: args.source,
+    type: args.type,
+    created_at: new Date().toISOString(),
+    producer: {
+      name: `${args.source}-runner`,
+      runtime: args.source,
+      ...(args.providerEventID ? { provider_event_id: args.providerEventID } : {}),
+    },
+    visibility: "durable",
+    ...(Object.keys(payload).length > 0 ? { payload } : {}),
+  };
+}
+
+export function itemEvent(args: {
+  sessionID: string;
+  turnID: string;
+  source: "claude" | "codex";
+  type:
+    | "item.started"
+    | "item.delta"
+    | "item.completed"
+    | "item.failed"
+    | "tool.approval_requested"
+    | "tool.approval_resolved";
+  itemID: string;
+  parentID?: string;
+  actor: TankActor;
+  visibility?: TankVisibility;
+  providerEventID?: string;
+  payload?: Record<string, unknown>;
+}): TankConversationEvent {
+  return {
+    event_id: `${args.turnID}:${args.type}:${stableIDPart(args.itemID)}:${args.providerEventID ?? "runner"}`,
+    conversation_id: args.sessionID,
+    session_id: args.sessionID,
+    turn_id: args.turnID,
+    item_id: args.itemID,
+    parent_id: args.parentID ?? args.turnID,
+    actor: args.actor,
+    source: args.source,
+    type: args.type,
+    created_at: new Date().toISOString(),
+    producer: {
+      name: `${args.source}-runner`,
+      runtime: args.source,
+      ...(args.providerEventID ? { provider_event_id: args.providerEventID } : {}),
+    },
+    visibility: args.visibility ?? "durable",
+    ...(args.payload ? { payload: args.payload } : {}),
+  };
+}
+
+function stableIDPart(value: string): string {
+  const safe = value
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const hash = createHash("sha256").update(value).digest("hex").slice(0, 12);
+  if (safe.length >= 6 && safe.length <= 80) return safe;
+  if (safe.length > 80) return `${safe.slice(0, 64)}-${hash}`;
+  return hash;
+}

--- a/agent-runner/src/cosmos.test.ts
+++ b/agent-runner/src/cosmos.test.ts
@@ -14,6 +14,40 @@ test("canonical: user, assistant, result messages", () => {
   assert.equal(isCanonical({ type: "result", subtype: "success" } as any), true);
 });
 
+test("canonical: durable Tank conversation envelope", () => {
+  assert.equal(
+    isCanonical({
+      event_id: "turn_1:item.started:toolu_1",
+      session_id: "63",
+      turn_id: "turn_1",
+      item_id: "toolu_1",
+      actor: "tool",
+      source: "claude",
+      type: "item.started",
+      created_at: "2026-05-12T00:00:00Z",
+      visibility: "durable",
+    } as any),
+    true,
+  );
+});
+
+test("NOT canonical: live-only Tank conversation envelope", () => {
+  assert.equal(
+    isCanonical({
+      event_id: "turn_1:item.delta:toolu_1",
+      session_id: "63",
+      turn_id: "turn_1",
+      item_id: "toolu_1",
+      actor: "tool",
+      source: "claude",
+      type: "item.delta",
+      created_at: "2026-05-12T00:00:00Z",
+      visibility: "live-only",
+    } as any),
+    false,
+  );
+});
+
 test("canonical: system init + compact_boundary + tool_use_summary", () => {
   assert.equal(isCanonical({ type: "system", subtype: "init" } as any), true);
   assert.equal(

--- a/agent-runner/src/cosmos.ts
+++ b/agent-runner/src/cosmos.ts
@@ -20,10 +20,12 @@ import { DefaultAzureCredential } from "@azure/identity";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import type { Config } from "./config.js";
+import { isDurableTankConversationEvent } from "./conversation.js";
 
 export interface RunnerEvent {
   type: string;
   uuid?: string;
+  event_id?: string;
   subtype?: string;
   [k: string]: unknown;
 }
@@ -51,6 +53,7 @@ const CANONICAL_TOP_LEVEL_TYPES = new Set<string>([
 ]);
 
 export function isCanonical(message: RunnerEvent | SDKMessage): boolean {
+  if (isDurableTankConversationEvent(message as RunnerEvent)) return true;
   const t = (message as RunnerEvent).type;
   if (!t) return false;
   if (CANONICAL_TOP_LEVEL_TYPES.has(t)) return true;
@@ -87,7 +90,23 @@ export class CosmosSink {
   // id), and pod restart may yield a new SDK session within the same
   // tank-operator session. The SDK's session_id rides along as a field.
   async upsert(message: RunnerEvent & { uuid: string }): Promise<void> {
-    const doc: Record<string, unknown> = {
+    const doc = this.docFromMessage(message);
+    await this.container.items.upsert(doc);
+  }
+
+  async create(message: RunnerEvent & { uuid: string }): Promise<"created" | "exists"> {
+    const doc = this.docFromMessage(message);
+    try {
+      await this.container.items.create(doc);
+      return "created";
+    } catch (err) {
+      if (isConflict(err)) return "exists";
+      throw err;
+    }
+  }
+
+  private docFromMessage(message: RunnerEvent & { uuid: string }): Record<string, unknown> {
+    return {
       ...message,
       id: message.uuid,
       tank_session_id: this.cfg.sessionId,
@@ -98,6 +117,12 @@ export class CosmosSink {
           ? message.written_at
           : new Date().toISOString(),
     };
-    await this.container.items.upsert(doc);
   }
+}
+
+function isConflict(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const statusCode = (err as { statusCode?: unknown; code?: unknown }).statusCode;
+  const code = (err as { statusCode?: unknown; code?: unknown }).code;
+  return statusCode === 409 || code === 409 || code === "Conflict";
 }

--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -6,8 +6,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { dispatch } from "./runner.js";
+import { dispatch, dispatchCreate } from "./runner.js";
 import { isCanonical } from "./cosmos.js";
+import { userSubmissionEvents } from "./conversation.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -24,6 +25,17 @@ function makeWS(order: Order) {
       order.push("ws");
     },
   };
+}
+
+function userMessageEvent() {
+  return userSubmissionEvents({
+    sessionID: "63",
+    clientNonce: "run-123",
+    text: "hello",
+    message: { role: "user", content: "hello" },
+    runtime: "claude",
+    now: "2026-05-12T00:00:00.000Z",
+  }).userMessage;
 }
 
 test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
@@ -86,6 +98,56 @@ test("dispatch assigns a shared uuid to Tank-owned user messages", async () => {
   assert.equal(typeof cosmosMessage.uuid, "string");
   assert.equal(cosmosMessage.uuid, wsMessage.uuid);
   assert.equal(cosmosMessage.tank_order_key, wsMessage.tank_order_key);
+});
+
+test("dispatchCreate uses event_id as the durable id for canonical Tank events", async () => {
+  let cosmosMessage: any;
+  let wsMessage: any;
+  const ok = await dispatchCreate(
+    {
+      async upsert() {
+        throw new Error("upsert should not be used for create path");
+      },
+      async create(message) {
+        cosmosMessage = message;
+        return "created";
+      },
+    },
+    {
+      broadcastEvent(message) {
+        wsMessage = message;
+      },
+    },
+    userMessageEvent(),
+  );
+  assert.equal(ok, "created");
+  assert.equal(cosmosMessage.uuid, "turn_run-123:user_message.created");
+  assert.equal(cosmosMessage.event_id, cosmosMessage.uuid);
+  assert.equal(cosmosMessage.order_key, cosmosMessage.tank_order_key);
+  assert.equal(cosmosMessage.sequence, cosmosMessage.tank_event_seq);
+  assert.equal(wsMessage.uuid, cosmosMessage.uuid);
+});
+
+test("dispatchCreate suppresses duplicate client_nonce submissions", async () => {
+  let broadcasted = false;
+  const ok = await dispatchCreate(
+    {
+      async upsert() {
+        throw new Error("upsert should not be used for create path");
+      },
+      async create() {
+        return "exists";
+      },
+    },
+    {
+      broadcastEvent() {
+        broadcasted = true;
+      },
+    },
+    userMessageEvent(),
+  );
+  assert.equal(ok, "exists");
+  assert.equal(broadcasted, false);
 });
 
 test("canonical: cosmos failure suppresses ws broadcast", async () => {

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -24,6 +24,13 @@ import { randomUUID } from "node:crypto";
 
 import type { Config } from "./config.js";
 import { CosmosSink, isCanonical, type RunnerEvent } from "./cosmos.js";
+import {
+  itemEvent,
+  normalizeClientNonce,
+  turnEvent,
+  userSubmissionEvents,
+  type TankConversationEvent,
+} from "./conversation.js";
 import { extractWakeup, type WakeupRequest } from "./wakeup.js";
 import { WSFanout, type ClientFrame } from "./ws.js";
 
@@ -37,6 +44,7 @@ import { WSFanout, type ClientFrame } from "./ws.js";
 // Callers that don't care about the outcome can ignore it.
 interface DispatchSink {
   upsert(message: RunnerEvent & { uuid: string }): Promise<void>;
+  create?(message: RunnerEvent & { uuid: string }): Promise<"created" | "exists">;
 }
 interface DispatchWS {
   broadcastEvent(message: RunnerEvent): void;
@@ -47,17 +55,30 @@ let tankEventSeq = 0;
 function stampTankEvent(message: RunnerEvent): RunnerEvent & { uuid: string } {
   tankEventSeq += 1;
   const now = Date.now();
-  const uuid = typeof message.uuid === "string" && message.uuid ? message.uuid : randomUUID();
+  const eventID = typeof message.event_id === "string" && message.event_id ? message.event_id : "";
+  const uuid = typeof message.uuid === "string" && message.uuid ? message.uuid : eventID || randomUUID();
+  const writtenAt = new Date(now).toISOString();
+  const tankOrderKey = [
+    String(now).padStart(13, "0"),
+    String(tankEventSeq).padStart(8, "0"),
+    uuid,
+  ].join("-");
   return {
     ...message,
     uuid,
+    ...(eventID ? { event_id: eventID } : {}),
     tank_event_seq: tankEventSeq,
-    tank_order_key: [
-      String(now).padStart(13, "0"),
-      String(tankEventSeq).padStart(8, "0"),
-      uuid,
-    ].join("-"),
-    written_at: new Date(now).toISOString(),
+    tank_order_key: tankOrderKey,
+    written_at: writtenAt,
+    ...(isTankEvent(message)
+      ? {
+          order_key:
+            typeof message.order_key === "string" && message.order_key ? message.order_key : tankOrderKey,
+          sequence: typeof message.sequence === "number" ? message.sequence : tankEventSeq,
+          created_at:
+            typeof message.created_at === "string" && message.created_at ? message.created_at : writtenAt,
+        }
+      : {}),
   };
 }
 
@@ -81,6 +102,31 @@ export async function dispatch(
   return true;
 }
 
+export async function dispatchCreate(
+  sink: DispatchSink,
+  ws: DispatchWS,
+  message: RunnerEvent,
+): Promise<"created" | "exists" | "failed"> {
+  const stamped = stampTankEvent(message);
+  if (!isCanonical(stamped)) {
+    ws.broadcastEvent(stamped);
+    return "created";
+  }
+  try {
+    const result = sink.create ? await sink.create(stamped) : (await sink.upsert(stamped), "created");
+    if (result === "exists") return "exists";
+  } catch (err) {
+    console.error("cosmos create failed:", err);
+    return "failed";
+  }
+  ws.broadcastEvent(stamped);
+  return "created";
+}
+
+function isTankEvent(message: RunnerEvent): message is TankConversationEvent {
+  return typeof message.event_id === "string" && typeof message.visibility === "string";
+}
+
 function userMessageText(content: unknown): string {
   if (typeof content === "string") return content;
   if (Array.isArray(content)) {
@@ -101,6 +147,170 @@ function userMessageText(content: unknown): string {
       .join("\n");
   }
   return String(content ?? "");
+}
+
+interface PendingTurn {
+  turnID: string;
+  clientNonce: string;
+  text: string;
+  started: boolean;
+  interrupted: boolean;
+  terminalEmitted: boolean;
+}
+
+function providerEventID(message: RunnerEvent): string | undefined {
+  for (const key of ["uuid", "id", "message_id", "session_id"]) {
+    const value = message[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+function claudeMessageContent(message: RunnerEvent): unknown[] {
+  const body = message.message;
+  if (body && typeof body === "object" && "content" in body) {
+    const content = (body as { content?: unknown }).content;
+    return Array.isArray(content) ? content : [];
+  }
+  return [];
+}
+
+function canonicalEventsForClaudeMessage(
+  cfg: Config,
+  turn: PendingTurn | null,
+  message: RunnerEvent,
+  needsInputItemIDs: Set<string>,
+): TankConversationEvent[] {
+  if (!turn) return [];
+  const providerID = providerEventID(message);
+  if (message.type === "assistant") {
+    const events: TankConversationEvent[] = [];
+    for (const [index, block] of claudeMessageContent(message).entries()) {
+      if (!block || typeof block !== "object") continue;
+      const item = block as Record<string, unknown>;
+      if (item.type === "text") {
+        const text = typeof item.text === "string" ? item.text : "";
+        if (!text) continue;
+        events.push(
+          itemEvent({
+            sessionID: cfg.sessionId,
+            turnID: turn.turnID,
+            source: "claude",
+            type: "item.completed",
+            itemID: `${turn.turnID}:assistant:${providerID ?? index}`,
+            actor: "assistant",
+            providerEventID: providerID,
+            payload: { kind: "message", text },
+          }),
+        );
+      } else if (item.type === "tool_use") {
+        const itemID =
+          typeof item.id === "string" && item.id ? item.id : `${turn.turnID}:tool:${index}`;
+        const name = typeof item.name === "string" ? item.name : "tool";
+        events.push(
+          itemEvent({
+            sessionID: cfg.sessionId,
+            turnID: turn.turnID,
+            source: "claude",
+            type: "item.started",
+            itemID,
+            actor: "tool",
+            providerEventID: providerID,
+            payload: {
+              kind: "tool",
+              title: name,
+              name,
+              input: item.input,
+            },
+          }),
+        );
+        if (name === "AskUserQuestion") {
+          needsInputItemIDs.add(itemID);
+          events.push(
+            itemEvent({
+              sessionID: cfg.sessionId,
+              turnID: turn.turnID,
+              source: "claude",
+              type: "tool.approval_requested",
+              itemID,
+              actor: "tool",
+              providerEventID: providerID,
+              payload: {
+                kind: "needs_input",
+                title: "Ask user question",
+                name,
+                input: item.input,
+              },
+            }),
+          );
+        }
+      }
+    }
+    return events;
+  }
+  if (message.type === "user") {
+    return claudeMessageContent(message).flatMap((block, index): TankConversationEvent[] => {
+      if (!block || typeof block !== "object") return [];
+      const item = block as Record<string, unknown>;
+      if (item.type !== "tool_result") return [];
+      const itemID =
+        typeof item.tool_use_id === "string" && item.tool_use_id
+          ? item.tool_use_id
+          : `${turn.turnID}:tool_result:${index}`;
+      const failed = item.is_error === true;
+      const completed = itemEvent({
+        sessionID: cfg.sessionId,
+        turnID: turn.turnID,
+        source: "claude",
+        type: failed ? "item.failed" : "item.completed",
+        itemID,
+        actor: "tool",
+        providerEventID: providerID,
+        payload: {
+          kind: "tool_result",
+          output: item.content,
+          is_error: failed,
+        },
+      });
+      if (!needsInputItemIDs.has(itemID)) return [completed];
+      needsInputItemIDs.delete(itemID);
+      return [
+        completed,
+        itemEvent({
+          sessionID: cfg.sessionId,
+          turnID: turn.turnID,
+          source: "claude",
+          type: "tool.approval_resolved",
+          itemID,
+          actor: "tool",
+          providerEventID: providerID,
+          payload: {
+            kind: "needs_input",
+            resolved: true,
+            is_error: failed,
+          },
+        }),
+      ];
+    });
+  }
+  if (message.type === "result") {
+    if (turn.interrupted && turn.terminalEmitted) return [];
+    const failed = message.is_error === true || message.subtype === "error";
+    return [
+      turnEvent({
+        sessionID: cfg.sessionId,
+        turnID: turn.turnID,
+        clientNonce: turn.clientNonce,
+        source: "claude",
+        type: turn.interrupted ? "turn.interrupted" : failed ? "turn.failed" : "turn.completed",
+        reason: turn.interrupted ? "client_interrupt" : failed ? "provider_failure" : undefined,
+        usage: message.usage,
+        error: failed ? message.result ?? message.error : undefined,
+        providerEventID: providerID,
+      }),
+    ];
+  }
+  return [];
 }
 
 // AsyncQueue is a one-writer-many-no-readers queue that yields each
@@ -142,6 +352,9 @@ export class Runner {
   private readonly sink: CosmosSink;
   private readonly ws: WSFanout;
   private readonly userQueue = new AsyncQueue<SDKUserMessage>();
+  private readonly pendingTurns: PendingTurn[] = [];
+  private readonly needsInputItemIDs = new Set<string>();
+  private activeTurn: PendingTurn | null = null;
   private sdkQuery: Query | null = null;
   private userFrameChain: Promise<void> = Promise.resolve();
 
@@ -190,17 +403,38 @@ export class Runner {
     } catch (err) {
       console.error("SDK query exited with error:", err);
     } finally {
+      if (signal.aborted) {
+        await this.interruptActiveTurn("runner_shutdown");
+      }
       this.userQueue.close();
       this.ws.close();
     }
   }
 
   private async handleEvent(message: SDKMessage): Promise<void> {
+    const runnerEvent = message as RunnerEvent;
+    const activeTurn = await this.ensureActiveTurn(runnerEvent);
+
     // 1+2. Dual-sink dispatch (cosmos-first ordering). Extracted so the
     // contract — canonical: cosmos before ws, ws skipped on cosmos
     // failure; live-only: ws only — can be tested without spinning up a
     // Runner.
-    await dispatch(this.sink, this.ws, message);
+    await dispatch(this.sink, this.ws, runnerEvent);
+
+    for (const event of canonicalEventsForClaudeMessage(
+      this.cfg,
+      activeTurn,
+      runnerEvent,
+      this.needsInputItemIDs,
+    )) {
+      await dispatch(this.sink, this.ws, event);
+      if (event.type === "turn.completed" || event.type === "turn.failed" || event.type === "turn.interrupted") {
+        if (activeTurn) activeTurn.terminalEmitted = true;
+      }
+    }
+    if (runnerEvent.type === "result" && this.activeTurn === activeTurn) {
+      this.activeTurn = null;
+    }
 
     // 3. ScheduleWakeup detection
     const wakeup = extractWakeup(message);
@@ -212,12 +446,9 @@ export class Runner {
   private async handleClientFrame(frame: ClientFrame): Promise<void> {
     if (frame.type === "user") {
       const text = userMessageText(frame.message?.content);
-      const persisted = await dispatch(this.sink, this.ws, {
-        type: "tank.user_message",
-        message: text,
-        ...(frame.client_nonce ? { client_nonce: frame.client_nonce } : {}),
-      });
-      if (!persisted) return;
+      const pendingTurn = await this.recordUserSubmission(text, frame.message, frame.client_nonce);
+      if (!pendingTurn) return;
+      this.pendingTurns.push(pendingTurn);
 
       // Hand to the SDK iterator only after Tank owns the durable user
       // message. The SDK enforces "wait for result before next message"
@@ -229,8 +460,83 @@ export class Runner {
         parent_tool_use_id: null,
       } as unknown as SDKUserMessage);
     } else if (frame.type === "interrupt") {
+      await this.interruptActiveTurn("client_interrupt");
       this.sdkQuery?.interrupt();
     }
+  }
+
+  private async recordUserSubmission(
+    text: string,
+    message: unknown,
+    rawClientNonce: unknown,
+  ): Promise<PendingTurn | null> {
+    const clientNonce = normalizeClientNonce(rawClientNonce);
+    if (!clientNonce) {
+      await dispatch(this.sink, this.ws, {
+        type: "error",
+        message: "client_nonce is required for user submissions",
+      });
+      return null;
+    }
+    const { turnID, userMessage, turnSubmitted } = userSubmissionEvents({
+      sessionID: this.cfg.sessionId,
+      clientNonce,
+      text,
+      message,
+      runtime: "claude",
+    });
+    const userResult = await dispatchCreate(this.sink, this.ws, userMessage);
+    if (userResult === "failed") return null;
+    const submittedResult = await dispatchCreate(this.sink, this.ws, turnSubmitted);
+    if (submittedResult !== "created") return null;
+    return {
+      turnID,
+      clientNonce,
+      text,
+      started: false,
+      interrupted: false,
+      terminalEmitted: false,
+    };
+  }
+
+  private async ensureActiveTurn(event: RunnerEvent): Promise<PendingTurn | null> {
+    if (!this.activeTurn && this.pendingTurns.length > 0 && startsProviderTurn(event)) {
+      this.activeTurn = this.pendingTurns.shift() ?? null;
+      if (this.activeTurn && !this.activeTurn.started) {
+        this.activeTurn.started = true;
+        await dispatch(
+          this.sink,
+          this.ws,
+          turnEvent({
+            sessionID: this.cfg.sessionId,
+            turnID: this.activeTurn.turnID,
+            clientNonce: this.activeTurn.clientNonce,
+            source: "claude",
+            type: "turn.started",
+          }),
+        );
+      }
+    }
+    return this.activeTurn;
+  }
+
+  private async interruptActiveTurn(reason: "client_interrupt" | "runner_shutdown"): Promise<void> {
+    const turn = this.activeTurn ?? this.pendingTurns[0] ?? null;
+    if (!turn || turn.terminalEmitted) return;
+    turn.interrupted = true;
+    turn.terminalEmitted = true;
+    await dispatch(
+      this.sink,
+      this.ws,
+      turnEvent({
+        sessionID: this.cfg.sessionId,
+        turnID: turn.turnID,
+        clientNonce: turn.clientNonce,
+        source: "claude",
+        type: "turn.interrupted",
+        reason,
+      }),
+    );
   }
 
   private scheduleWakeup(req: WakeupRequest): void {
@@ -242,12 +548,13 @@ export class Runner {
   }
 
   private async enqueueWakeup(req: WakeupRequest): Promise<void> {
-    const persisted = await dispatch(this.sink, this.ws, {
-      type: "tank.user_message",
-      message: req.prompt,
-      source: "schedule_wakeup",
-    });
-    if (!persisted) return;
+    const pendingTurn = await this.recordUserSubmission(
+      req.prompt,
+      { role: "user", content: req.prompt },
+      `schedule_wakeup:${randomUUID()}`,
+    );
+    if (!pendingTurn) return;
+    this.pendingTurns.push(pendingTurn);
     this.userQueue.push({
       type: "user",
       session_id: "",
@@ -255,4 +562,8 @@ export class Runner {
       parent_tool_use_id: null,
     } as unknown as SDKUserMessage);
   }
+}
+
+function startsProviderTurn(event: RunnerEvent): boolean {
+  return event.type === "assistant" || event.type === "user" || event.type === "result";
 }

--- a/codex-runner/src/conversation.ts
+++ b/codex-runner/src/conversation.ts
@@ -1,0 +1,234 @@
+import { createHash } from "node:crypto";
+
+export type TankActor = "user" | "assistant" | "system" | "tool" | "runner";
+export type TankEventSource = "tank" | "claude" | "codex" | "legacy-run";
+export type TankVisibility = "durable" | "live-only" | "audit-only";
+
+export type TankEventType =
+  | "conversation.started"
+  | "conversation.archived"
+  | "user_message.created"
+  | "turn.submitted"
+  | "turn.started"
+  | "turn.completed"
+  | "turn.failed"
+  | "turn.interrupted"
+  | "item.started"
+  | "item.delta"
+  | "item.completed"
+  | "item.failed"
+  | "tool.approval_requested"
+  | "tool.approval_resolved"
+  | "session.activity_updated"
+  | "read_state.updated";
+
+export interface TankConversationEvent {
+  event_id: string;
+  order_key?: string;
+  sequence?: number;
+  conversation_id?: string;
+  session_id: string;
+  turn_id?: string;
+  item_id?: string;
+  parent_id?: string;
+  client_nonce?: string;
+  actor: TankActor;
+  source: TankEventSource;
+  type: TankEventType;
+  created_at: string;
+  producer?: {
+    name?: string;
+    version?: string;
+    runtime?: string;
+    provider_event_id?: string;
+  };
+  visibility: TankVisibility;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+const TANK_EVENT_TYPES = new Set<string>([
+  "conversation.started",
+  "conversation.archived",
+  "user_message.created",
+  "turn.submitted",
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.interrupted",
+  "item.started",
+  "item.delta",
+  "item.completed",
+  "item.failed",
+  "tool.approval_requested",
+  "tool.approval_resolved",
+  "session.activity_updated",
+  "read_state.updated",
+]);
+
+export function isTankConversationEvent(event: { [key: string]: unknown }): event is TankConversationEvent {
+  return (
+    typeof event.event_id === "string" &&
+    typeof event.session_id === "string" &&
+    typeof event.type === "string" &&
+    TANK_EVENT_TYPES.has(event.type) &&
+    typeof event.actor === "string" &&
+    typeof event.source === "string" &&
+    typeof event.created_at === "string" &&
+    typeof event.visibility === "string"
+  );
+}
+
+export function isDurableTankConversationEvent(event: { [key: string]: unknown }): boolean {
+  return isTankConversationEvent(event) && event.visibility !== "live-only";
+}
+
+export function normalizeClientNonce(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function turnIDForClientNonce(clientNonce: string): string {
+  return `turn_${stableIDPart(clientNonce)}`;
+}
+
+export function userItemID(turnID: string): string {
+  return `${turnID}:user`;
+}
+
+export function userSubmissionEvents(args: {
+  sessionID: string;
+  clientNonce: string;
+  text: string;
+  message: unknown;
+  runtime: "claude" | "codex";
+  now?: string;
+}): { turnID: string; userMessage: TankConversationEvent; turnSubmitted: TankConversationEvent } {
+  const createdAt = args.now ?? new Date().toISOString();
+  const turnID = turnIDForClientNonce(args.clientNonce);
+  const producer = { name: `${args.runtime}-runner`, runtime: args.runtime };
+  return {
+    turnID,
+    userMessage: {
+      event_id: `${turnID}:user_message.created`,
+      conversation_id: args.sessionID,
+      session_id: args.sessionID,
+      turn_id: turnID,
+      item_id: userItemID(turnID),
+      client_nonce: args.clientNonce,
+      actor: "user",
+      source: "tank",
+      type: "user_message.created",
+      created_at: createdAt,
+      producer,
+      visibility: "durable",
+      payload: {
+        text: args.text,
+        message: args.message,
+      },
+    },
+    turnSubmitted: {
+      event_id: `${turnID}:turn.submitted`,
+      conversation_id: args.sessionID,
+      session_id: args.sessionID,
+      turn_id: turnID,
+      client_nonce: args.clientNonce,
+      actor: "runner",
+      source: "tank",
+      type: "turn.submitted",
+      created_at: createdAt,
+      producer,
+      visibility: "durable",
+      payload: {
+        status: "submitted",
+      },
+    },
+  };
+}
+
+export function turnEvent(args: {
+  sessionID: string;
+  turnID: string;
+  clientNonce?: string;
+  source: "claude" | "codex";
+  type: "turn.started" | "turn.completed" | "turn.failed" | "turn.interrupted";
+  reason?: string;
+  usage?: unknown;
+  error?: unknown;
+  providerEventID?: string;
+}): TankConversationEvent {
+  const payload: Record<string, unknown> = {};
+  if (args.reason) payload.reason = args.reason;
+  if (args.usage !== undefined) payload.usage = args.usage;
+  if (args.error !== undefined) payload.error = args.error;
+  return {
+    event_id: `${args.turnID}:${args.type}:${args.reason ?? args.providerEventID ?? "runner"}`,
+    conversation_id: args.sessionID,
+    session_id: args.sessionID,
+    turn_id: args.turnID,
+    ...(args.clientNonce ? { client_nonce: args.clientNonce } : {}),
+    actor: "runner",
+    source: args.source,
+    type: args.type,
+    created_at: new Date().toISOString(),
+    producer: {
+      name: `${args.source}-runner`,
+      runtime: args.source,
+      ...(args.providerEventID ? { provider_event_id: args.providerEventID } : {}),
+    },
+    visibility: "durable",
+    ...(Object.keys(payload).length > 0 ? { payload } : {}),
+  };
+}
+
+export function itemEvent(args: {
+  sessionID: string;
+  turnID: string;
+  source: "claude" | "codex";
+  type:
+    | "item.started"
+    | "item.delta"
+    | "item.completed"
+    | "item.failed"
+    | "tool.approval_requested"
+    | "tool.approval_resolved";
+  itemID: string;
+  parentID?: string;
+  actor: TankActor;
+  visibility?: TankVisibility;
+  providerEventID?: string;
+  payload?: Record<string, unknown>;
+}): TankConversationEvent {
+  return {
+    event_id: `${args.turnID}:${args.type}:${stableIDPart(args.itemID)}:${args.providerEventID ?? "runner"}`,
+    conversation_id: args.sessionID,
+    session_id: args.sessionID,
+    turn_id: args.turnID,
+    item_id: args.itemID,
+    parent_id: args.parentID ?? args.turnID,
+    actor: args.actor,
+    source: args.source,
+    type: args.type,
+    created_at: new Date().toISOString(),
+    producer: {
+      name: `${args.source}-runner`,
+      runtime: args.source,
+      ...(args.providerEventID ? { provider_event_id: args.providerEventID } : {}),
+    },
+    visibility: args.visibility ?? "durable",
+    ...(args.payload ? { payload: args.payload } : {}),
+  };
+}
+
+function stableIDPart(value: string): string {
+  const safe = value
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const hash = createHash("sha256").update(value).digest("hex").slice(0, 12);
+  if (safe.length >= 6 && safe.length <= 80) return safe;
+  if (safe.length > 80) return `${safe.slice(0, 64)}-${hash}`;
+  return hash;
+}

--- a/codex-runner/src/cosmos.test.ts
+++ b/codex-runner/src/cosmos.test.ts
@@ -30,6 +30,40 @@ test("canonical: item.completed (the main durable signal)", () => {
   );
 });
 
+test("canonical: durable Tank conversation envelope", () => {
+  assert.equal(
+    isCanonical({
+      event_id: "turn_1:item.started:item_1",
+      session_id: "63",
+      turn_id: "turn_1",
+      item_id: "item_1",
+      actor: "tool",
+      source: "codex",
+      type: "item.started",
+      created_at: "2026-05-12T00:00:00Z",
+      visibility: "durable",
+    } as never),
+    true,
+  );
+});
+
+test("NOT canonical: live-only Tank conversation envelope", () => {
+  assert.equal(
+    isCanonical({
+      event_id: "turn_1:item.delta:item_1",
+      session_id: "63",
+      turn_id: "turn_1",
+      item_id: "item_1",
+      actor: "tool",
+      source: "codex",
+      type: "item.delta",
+      created_at: "2026-05-12T00:00:00Z",
+      visibility: "live-only",
+    } as never),
+    false,
+  );
+});
+
 test("canonical: error (thread-level)", () => {
   assert.equal(isCanonical({ type: "error", message: "boom" } as never), true);
 });

--- a/codex-runner/src/cosmos.ts
+++ b/codex-runner/src/cosmos.ts
@@ -36,6 +36,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { randomUUID } from "node:crypto";
 
 import type { Config } from "./config.js";
+import { isDurableTankConversationEvent } from "./conversation.js";
 
 const CANONICAL_TYPES = new Set<string>([
   "thread.started",
@@ -53,6 +54,7 @@ export interface CodexEvent {
 }
 
 export function isCanonical(event: CodexEvent): boolean {
+  if (isDurableTankConversationEvent(event)) return true;
   return CANONICAL_TYPES.has(event.type);
 }
 
@@ -93,18 +95,30 @@ export function stampEventID(
   written_at: string;
 } {
   const now = Date.now();
-  const uuid = nextSortableEventID(now);
+  const eventID = typeof event.event_id === "string" && event.event_id ? event.event_id : "";
+  const uuid = typeof event.uuid === "string" && event.uuid ? event.uuid : eventID || nextSortableEventID(now);
   const seq = nextTankEventSeq();
+  const writtenAt = new Date(now).toISOString();
+  const tankOrderKey = [
+    String(now).padStart(13, "0"),
+    String(seq).padStart(8, "0"),
+    uuid,
+  ].join("-");
   return {
     ...event,
     uuid,
+    ...(eventID ? { event_id: eventID } : {}),
     tank_event_seq: seq,
-    tank_order_key: [
-      String(now).padStart(13, "0"),
-      String(seq).padStart(8, "0"),
-      uuid,
-    ].join("-"),
-    written_at: new Date(now).toISOString(),
+    tank_order_key: tankOrderKey,
+    written_at: writtenAt,
+    ...(isDurableTankConversationEvent(event)
+      ? {
+          order_key: typeof event.order_key === "string" && event.order_key ? event.order_key : tankOrderKey,
+          sequence: typeof event.sequence === "number" ? event.sequence : seq,
+          created_at:
+            typeof event.created_at === "string" && event.created_at ? event.created_at : writtenAt,
+        }
+      : {}),
   };
 }
 
@@ -127,7 +141,23 @@ export class CosmosSink {
   // so the orchestrator's read endpoint and the SPA's chat pane consume
   // both claude- and codex-runner events out of the same container.
   async upsert(event: CodexEvent & { uuid: string }): Promise<void> {
-    const doc: Record<string, unknown> = {
+    const doc = this.docFromEvent(event);
+    await this.container.items.upsert(doc);
+  }
+
+  async create(event: CodexEvent & { uuid: string }): Promise<"created" | "exists"> {
+    const doc = this.docFromEvent(event);
+    try {
+      await this.container.items.create(doc);
+      return "created";
+    } catch (err) {
+      if (isConflict(err)) return "exists";
+      throw err;
+    }
+  }
+
+  private docFromEvent(event: CodexEvent & { uuid: string }): Record<string, unknown> {
+    return {
       ...event,
       id: event.uuid,
       tank_session_id: this.cfg.sessionId,
@@ -138,6 +168,12 @@ export class CosmosSink {
           ? event.written_at
           : new Date().toISOString(),
     };
-    await this.container.items.upsert(doc);
   }
+}
+
+function isConflict(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const statusCode = (err as { statusCode?: unknown; code?: unknown }).statusCode;
+  const code = (err as { statusCode?: unknown; code?: unknown }).code;
+  return statusCode === 409 || code === 409 || code === "Conflict";
 }

--- a/codex-runner/src/runner.test.ts
+++ b/codex-runner/src/runner.test.ts
@@ -6,8 +6,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { dispatch } from "./runner.js";
+import { dispatch, dispatchCreate } from "./runner.js";
 import { isCanonical, nextSortableEventID, type CodexEvent } from "./cosmos.js";
+import { userSubmissionEvents } from "./conversation.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -24,6 +25,17 @@ function makeWS(order: Order) {
       order.push("ws");
     },
   };
+}
+
+function userMessageEvent() {
+  return userSubmissionEvents({
+    sessionID: "63",
+    clientNonce: "run-123",
+    text: "hello",
+    message: { role: "user", content: "hello" },
+    runtime: "codex",
+    now: "2026-05-12T00:00:00.000Z",
+  }).userMessage;
 }
 
 test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
@@ -70,6 +82,56 @@ test("canonical: cosmos failure suppresses ws broadcast", async () => {
   // replay diverges from what was rendered.
   assert.equal(ok, false);
   assert.deepEqual(order, []);
+});
+
+test("dispatchCreate uses event_id as the durable id for canonical Tank events", async () => {
+  let cosmosEvent: any;
+  let wsEvent: any;
+  const ok = await dispatchCreate(
+    {
+      async upsert() {
+        throw new Error("upsert should not be used for create path");
+      },
+      async create(event) {
+        cosmosEvent = event;
+        return "created";
+      },
+    },
+    {
+      broadcastEvent(event) {
+        wsEvent = event;
+      },
+    },
+    userMessageEvent(),
+  );
+  assert.equal(ok, "created");
+  assert.equal(cosmosEvent.uuid, "turn_run-123:user_message.created");
+  assert.equal(cosmosEvent.event_id, cosmosEvent.uuid);
+  assert.equal(cosmosEvent.order_key, cosmosEvent.tank_order_key);
+  assert.equal(cosmosEvent.sequence, cosmosEvent.tank_event_seq);
+  assert.equal(wsEvent.uuid, cosmosEvent.uuid);
+});
+
+test("dispatchCreate suppresses duplicate client_nonce submissions", async () => {
+  let broadcasted = false;
+  const ok = await dispatchCreate(
+    {
+      async upsert() {
+        throw new Error("upsert should not be used for create path");
+      },
+      async create() {
+        return "exists";
+      },
+    },
+    {
+      broadcastEvent() {
+        broadcasted = true;
+      },
+    },
+    userMessageEvent(),
+  );
+  assert.equal(ok, "exists");
+  assert.equal(broadcasted, false);
 });
 
 test("live-only: turn.started broadcasts without a cosmos write", async () => {

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -29,6 +29,13 @@ import {
   stampEventID,
   type CodexEvent,
 } from "./cosmos.js";
+import {
+  itemEvent,
+  normalizeClientNonce,
+  turnEvent,
+  userSubmissionEvents,
+  type TankConversationEvent,
+} from "./conversation.js";
 import { WSFanout, type ClientFrame } from "./ws.js";
 
 // AsyncQueue — one writer, one consumer. WS frames push; the run loop
@@ -71,6 +78,7 @@ class AsyncQueue<T> {
 // canonical write failed and the broadcast was intentionally skipped.
 interface DispatchSink {
   upsert(event: CodexEvent & { uuid: string }): Promise<void>;
+  create?(event: CodexEvent & { uuid: string }): Promise<"created" | "exists">;
 }
 interface DispatchWS {
   broadcastEvent(event: unknown): void;
@@ -95,6 +103,27 @@ export async function dispatch(
   return true;
 }
 
+export async function dispatchCreate(
+  sink: DispatchSink,
+  ws: DispatchWS,
+  event: CodexEvent,
+): Promise<"created" | "exists" | "failed"> {
+  const stamped = stampEventID(event);
+  if (!isCanonical(stamped)) {
+    ws.broadcastEvent(stamped);
+    return "created";
+  }
+  try {
+    const result = sink.create ? await sink.create(stamped) : (await sink.upsert(stamped), "created");
+    if (result === "exists") return "exists";
+  } catch (err) {
+    console.error("cosmos create failed:", err);
+    return "failed";
+  }
+  ws.broadcastEvent(stamped);
+  return "created";
+}
+
 function isAbortError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const code = (err as { code?: unknown }).code;
@@ -103,6 +132,111 @@ function isAbortError(err: unknown): boolean {
     code === "ABORT_ERR" ||
     /operation was aborted/i.test(err.message)
   );
+}
+
+interface AcceptedTurn {
+  turnID: string;
+  clientNonce: string;
+  turnSeq: number;
+}
+
+function codexProviderEventID(event: CodexEvent): string | undefined {
+  const item = event.item;
+  if (item && typeof item === "object") {
+    const itemID = (item as { id?: unknown }).id;
+    if (typeof itemID === "string" && itemID) return itemID;
+  }
+  for (const key of ["turn_id", "thread_id", "id", "uuid"]) {
+    const value = event[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+function codexItemPayload(item: Record<string, unknown>): Record<string, unknown> {
+  return {
+    kind: typeof item.type === "string" && item.type ? item.type : "item",
+    title:
+      typeof item.command === "string"
+        ? item.command
+        : typeof item.tool === "string"
+          ? item.tool
+          : typeof item.type === "string"
+            ? item.type
+            : "item",
+    text: typeof item.text === "string" ? item.text : undefined,
+    command: item.command,
+    arguments: item.arguments,
+    result: item.result,
+    error: item.error,
+    raw_item: item,
+  };
+}
+
+function canonicalEventsForCodexEvent(
+  cfg: Config,
+  turn: AcceptedTurn,
+  event: CodexEvent,
+): TankConversationEvent[] {
+  const providerID = codexProviderEventID(event);
+  if (event.type === "turn.completed") {
+    return [
+      turnEvent({
+        sessionID: cfg.sessionId,
+        turnID: turn.turnID,
+        clientNonce: turn.clientNonce,
+        source: "codex",
+        type: "turn.completed",
+        usage: event.usage,
+        providerEventID: providerID,
+      }),
+    ];
+  }
+  if (event.type === "turn.failed" || event.type === "error") {
+    return [
+      turnEvent({
+        sessionID: cfg.sessionId,
+        turnID: turn.turnID,
+        clientNonce: turn.clientNonce,
+        source: "codex",
+        type: "turn.failed",
+        reason: "provider_failure",
+        error: event.error ?? event.message ?? event,
+        providerEventID: providerID,
+      }),
+    ];
+  }
+  if (event.type !== "item.started" && event.type !== "item.updated" && event.type !== "item.completed") {
+    return [];
+  }
+  const item = event.item;
+  if (!item || typeof item !== "object") return [];
+  const itemRecord = item as Record<string, unknown>;
+  const itemID =
+    typeof itemRecord.id === "string" && itemRecord.id ? itemRecord.id : `${turn.turnID}:item:${providerID ?? event.type}`;
+  const itemFailed = itemRecord.error !== undefined;
+  const actor = itemRecord.type === "agent_message" || itemRecord.type === "reasoning" ? "assistant" : "tool";
+  const type =
+    event.type === "item.started"
+      ? "item.started"
+      : event.type === "item.updated"
+        ? "item.delta"
+        : itemFailed
+          ? "item.failed"
+          : "item.completed";
+  return [
+    itemEvent({
+      sessionID: cfg.sessionId,
+      turnID: turn.turnID,
+      source: "codex",
+      type,
+      itemID,
+      actor,
+      providerEventID: providerID,
+      visibility: event.type === "item.updated" ? "live-only" : "durable",
+      payload: codexItemPayload(itemRecord),
+    }),
+  ];
 }
 
 export class Runner {
@@ -145,13 +279,20 @@ export class Runner {
       if (next.done) break;
       const { text: input, clientNonce } = next.value;
       const turnSeq = ++this.turnSeq;
-      const persisted = await dispatch(this.sink, this.ws, {
-        type: "tank.user_message",
-        message: input,
-        tank_turn_seq: turnSeq,
-        ...(clientNonce ? { client_nonce: clientNonce } : {}),
-      });
-      if (!persisted) continue;
+      const turn = await this.recordUserSubmission(input, clientNonce, turnSeq);
+      if (!turn) continue;
+
+      await dispatch(
+        this.sink,
+        this.ws,
+        turnEvent({
+          sessionID: this.cfg.sessionId,
+          turnID: turn.turnID,
+          clientNonce: turn.clientNonce,
+          source: "codex",
+          type: "turn.started",
+        }),
+      );
 
       this.currentAbort = new AbortController();
       // If the outer signal aborts mid-turn, also abort the in-flight
@@ -166,21 +307,29 @@ export class Runner {
         });
         for await (const event of streamed.events) {
           if (signal.aborted) break;
-          await dispatch(this.sink, this.ws, {
+          const codexEvent = {
             ...(event as CodexEvent),
             tank_turn_seq: turnSeq,
-          });
+          };
+          await dispatch(this.sink, this.ws, codexEvent);
+          for (const canonicalEvent of canonicalEventsForCodexEvent(this.cfg, turn, codexEvent)) {
+            await dispatch(this.sink, this.ws, canonicalEvent);
+          }
         }
       } catch (err) {
         const interrupted = this.currentAbort.signal.aborted && isAbortError(err);
         if (interrupted) {
-          if (!signal.aborted || this.interruptRequested) {
-            await dispatch(this.sink, this.ws, {
+          await dispatch(this.sink, this.ws, {
+            ...turnEvent({
+              sessionID: this.cfg.sessionId,
+              turnID: turn.turnID,
+              clientNonce: turn.clientNonce,
+              source: "codex",
               type: "turn.interrupted",
               reason: this.interruptRequested ? "client_interrupt" : "runner_shutdown",
-              tank_turn_seq: turnSeq,
-            });
-          }
+            }),
+            tank_turn_seq: turnSeq,
+          } as CodexEvent);
           console.info("codex turn interrupted");
           continue;
         }
@@ -189,6 +338,19 @@ export class Runner {
         // surfaced as an exception rather than a turn.failed).
         const errMessage =
           err instanceof Error ? err.message : String(err);
+        await dispatch(
+          this.sink,
+          this.ws,
+          turnEvent({
+            sessionID: this.cfg.sessionId,
+            turnID: turn.turnID,
+            clientNonce: turn.clientNonce,
+            source: "codex",
+            type: "turn.failed",
+            reason: "provider_failure",
+            error: errMessage,
+          }),
+        );
         await dispatch(this.sink, this.ws, {
           type: "error",
           message: errMessage,
@@ -231,5 +393,39 @@ export class Runner {
       this.interruptRequested = true;
       this.currentAbort?.abort();
     }
+  }
+
+  private async recordUserSubmission(
+    text: string,
+    rawClientNonce: unknown,
+    turnSeq: number,
+  ): Promise<AcceptedTurn | null> {
+    const clientNonce = normalizeClientNonce(rawClientNonce);
+    if (!clientNonce) {
+      await dispatch(this.sink, this.ws, {
+        type: "error",
+        message: "client_nonce is required for user submissions",
+        tank_turn_seq: turnSeq,
+      });
+      return null;
+    }
+    const { turnID, userMessage, turnSubmitted } = userSubmissionEvents({
+      sessionID: this.cfg.sessionId,
+      clientNonce,
+      text,
+      message: { role: "user", content: text },
+      runtime: "codex",
+    });
+    const userResult = await dispatchCreate(this.sink, this.ws, {
+      ...userMessage,
+      tank_turn_seq: turnSeq,
+    });
+    if (userResult === "failed") return null;
+    const submittedResult = await dispatchCreate(this.sink, this.ws, {
+      ...turnSubmitted,
+      tank_turn_seq: turnSeq,
+    });
+    if (submittedResult !== "created") return null;
+    return { turnID, clientNonce, turnSeq };
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1920,6 +1920,14 @@ function isCodexToolishItemType(itemType: string): boolean {
 }
 
 function tankUserMessageText(event: JsonObject): string {
+  if (isJsonObject(event.payload)) {
+    if (typeof event.payload.text === "string") return event.payload.text.trim();
+    if (typeof event.payload.message === "string") return event.payload.message.trim();
+    if (isJsonObject(event.payload.message)) {
+      const content = event.payload.message.content;
+      if (typeof content === "string") return content.trim();
+    }
+  }
   if (typeof event.message === "string") return event.message.trim();
   if (isJsonObject(event.message)) {
     const content = event.message.content;
@@ -1937,6 +1945,26 @@ function tankUserMessageText(event: JsonObject): string {
     }
   }
   return "";
+}
+
+function isCanonicalConversationEvent(event: JsonObject): boolean {
+  return (
+    typeof event.event_id === "string" &&
+    typeof event.session_id === "string" &&
+    typeof event.visibility === "string" &&
+    typeof event.actor === "string" &&
+    typeof event.source === "string"
+  );
+}
+
+function applyCanonicalConversationEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
+  if (event.type === "user_message.created") {
+    return applyTankUserMessageEvent(entries, event);
+  }
+  // Phase 2 producers write canonical turn/item lifecycle for the future
+  // reducer. The legacy pane still renders provider-shaped events, so avoid
+  // showing duplicate lifecycle meta rows until Phase 3 switches projection.
+  return entries;
 }
 
 function applyTankUserMessageEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
@@ -2220,6 +2248,9 @@ function applyProviderEvent(
   mode: SessionMode,
   event: JsonObject,
 ): TranscriptEntry[] {
+  if (isCanonicalConversationEvent(event)) {
+    return applyCanonicalConversationEvent(entries, event);
+  }
   if (event.type === "tank.user_message") {
     return applyTankUserMessageEvent(entries, event);
   }
@@ -2267,7 +2298,7 @@ function sdkHistoryTerminalForRun(
   let afterRunUserMessage = false;
   for (const event of events) {
     if (!isJsonObject(event)) continue;
-    if (event.type === "tank.user_message") {
+    if (event.type === "tank.user_message" || event.type === "user_message.created") {
       if (afterRunUserMessage) return undefined;
       if (event.client_nonce === clientNonce) afterRunUserMessage = true;
       continue;


### PR DESCRIPTION
## Summary
- add shared Tank conversation event helpers to both Claude and Codex runners
- persist user submissions as canonical `user_message.created` + `turn.submitted` before model execution, with deterministic `client_nonce`-based ids
- emit canonical turn/item lifecycle events, explicit interrupt/failure reasons, and needs-input approval events while keeping current SPA rendering compatible until Phase 3

## #402 phase checkpoint
This is the Phase 2 runner producer contract slice. After this merges, the next implementation step should be Phase 3: replacing the scattered frontend UI projection with the reducer over canonical Tank events.

## External pattern checkpoint
- CloudCLI: copied persistent, cross-device, agent-agnostic session framing; runners now treat Tank/Cosmos as durable producer state instead of browser-local state.
- Slack: copied durable history + event delivery discipline; canonical events are persisted before WS broadcast and duplicate `client_nonce` submissions are suppressed at create time.
- Discord: copied opaque ordered replay/dedupe discipline; producer-stamped ids/order metadata are shared between Cosmos and live broadcast.
- AI SDK UI: kept submitted/streaming/ready/error vocabulary as the reducer target, with Tank-specific stopped/needs-input terminal and pause states.
- OpenAI Codex App Server: copied thread/turn/item lifecycle and explicit approval/needs-input pause events.

## Tests
- `go test ./...` in `backend-go`
- `npm test` in `frontend`
- `npm run build` in `frontend`
- `npm run build` and `npm test` in `agent-runner`
- `npm run build` and `npm test` in `codex-runner`

Refs #402