### PR TITLE
Add messaging resume guardrails

### DIFF
--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -6,9 +6,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { dispatch, dispatchCreate } from "./runner.js";
+import {
+  canonicalEventsForClaudeMessage,
+  dispatch,
+  dispatchCreate,
+  type PendingTurn,
+} from "./runner.js";
 import { isCanonical } from "./cosmos.js";
 import { userSubmissionEvents } from "./conversation.js";
+import type { Config } from "./config.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -36,6 +42,31 @@ function userMessageEvent() {
     runtime: "claude",
     now: "2026-05-12T00:00:00.000Z",
   }).userMessage;
+}
+
+function pendingTurn(fields: Partial<PendingTurn> = {}): PendingTurn {
+  return {
+    turnID: "turn-run-123",
+    clientNonce: "run-123",
+    text: "hello",
+    started: true,
+    interrupted: false,
+    terminalEmitted: false,
+    ...fields,
+  };
+}
+
+function cfg(): Config {
+  return {
+    sessionId: "63",
+    ownerEmail: "user@example.com",
+    cosmosEndpoint: "https://example.invalid",
+    cosmosDatabase: "tank-operator",
+    sessionEventsContainer: "session-events",
+    workspace: "/workspace",
+    mcpConfig: "/workspace/.mcp.json",
+    wsPort: 8090,
+  };
 }
 
 test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
@@ -207,4 +238,126 @@ test("system without subtype: not canonical (defensive default)", async () => {
   await dispatch(sink, ws, { type: "system" } as any);
   assert.equal(cosmosCalled, false);
   assert.equal(broadcasted, true);
+});
+
+test("adapter maps Claude assistant text and tool_use blocks to Tank items", () => {
+  const events = canonicalEventsForClaudeMessage(
+    cfg(),
+    pendingTurn(),
+    {
+      type: "assistant",
+      uuid: "claude-msg-1",
+      message: {
+        content: [
+          { type: "text", text: "I will inspect the workspace." },
+          {
+            type: "tool_use",
+            id: "toolu_read",
+            name: "Read",
+            input: { file_path: "README.md" },
+          },
+        ],
+      },
+    },
+    new Set<string>(),
+  );
+
+  assert.deepEqual(events.map((event) => event.type), [
+    "item.completed",
+    "item.started",
+  ]);
+  assert.equal(events[0]?.actor, "assistant");
+  assert.equal(events[0]?.payload?.kind, "message");
+  assert.equal(events[0]?.payload?.text, "I will inspect the workspace.");
+  assert.equal(events[1]?.actor, "tool");
+  assert.equal(events[1]?.item_id, "toolu_read");
+  assert.equal(events[1]?.payload?.title, "Read");
+});
+
+test("adapter maps Claude AskUserQuestion to needs-input lifecycle", () => {
+  const needsInputItemIDs = new Set<string>();
+  const requested = canonicalEventsForClaudeMessage(
+    cfg(),
+    pendingTurn(),
+    {
+      type: "assistant",
+      uuid: "claude-msg-approval",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_ask",
+            name: "AskUserQuestion",
+            input: { question: "Proceed?" },
+          },
+        ],
+      },
+    },
+    needsInputItemIDs,
+  );
+
+  assert.deepEqual(requested.map((event) => event.type), [
+    "item.started",
+    "tool.approval_requested",
+  ]);
+  assert.equal(needsInputItemIDs.has("toolu_ask"), true);
+
+  const resolved = canonicalEventsForClaudeMessage(
+    cfg(),
+    pendingTurn(),
+    {
+      type: "user",
+      uuid: "claude-tool-result",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_ask",
+            content: "yes",
+            is_error: false,
+          },
+        ],
+      },
+    },
+    needsInputItemIDs,
+  );
+
+  assert.deepEqual(resolved.map((event) => event.type), [
+    "item.completed",
+    "tool.approval_resolved",
+  ]);
+  assert.equal(needsInputItemIDs.has("toolu_ask"), false);
+});
+
+test("adapter maps Claude result failures and interrupts to terminal turn events", () => {
+  const failed = canonicalEventsForClaudeMessage(
+    cfg(),
+    pendingTurn(),
+    {
+      type: "result",
+      subtype: "error",
+      result: "provider failed",
+      uuid: "claude-result-failed",
+    },
+    new Set<string>(),
+  );
+  assert.equal(failed.length, 1);
+  assert.equal(failed[0]?.type, "turn.failed");
+  assert.equal(failed[0]?.payload?.reason, "provider_failure");
+  assert.equal(failed[0]?.payload?.error, "provider failed");
+
+  const interrupted = canonicalEventsForClaudeMessage(
+    cfg(),
+    pendingTurn({ interrupted: true }),
+    {
+      type: "result",
+      subtype: "success",
+      result: "stopped",
+      uuid: "claude-result-interrupted",
+    },
+    new Set<string>(),
+  );
+  assert.equal(interrupted.length, 1);
+  assert.equal(interrupted[0]?.type, "turn.interrupted");
+  assert.equal(interrupted[0]?.payload?.reason, "client_interrupt");
 });

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -149,7 +149,7 @@ function userMessageText(content: unknown): string {
   return String(content ?? "");
 }
 
-interface PendingTurn {
+export interface PendingTurn {
   turnID: string;
   clientNonce: string;
   text: string;
@@ -175,7 +175,7 @@ function claudeMessageContent(message: RunnerEvent): unknown[] {
   return [];
 }
 
-function canonicalEventsForClaudeMessage(
+export function canonicalEventsForClaudeMessage(
   cfg: Config,
   turn: PendingTurn | null,
   message: RunnerEvent,

--- a/agent-runner/src/ws.ts
+++ b/agent-runner/src/ws.ts
@@ -7,7 +7,8 @@
 //   server → client: every SDK event, serialized as JSON.
 //   client → server: { type: "user", message: { role: "user", content: ... } }
 //                  | { type: "interrupt" }                         (cancel turn)
-//                  | { type: "ping" }                              (heartbeat)
+//                  | { type: "heartbeat", last_order_key?: string } (heartbeat/ack)
+//                  | { type: "ping" }                              (legacy heartbeat)
 //
 // Authentication is the orchestrator's job (it terminates the user's TLS
 // + JWT before proxying). This server trusts whatever connects.
@@ -17,7 +18,8 @@ import { WebSocketServer, type WebSocket } from "ws";
 export type ClientFrame =
   | { type: "user"; message: { role: "user"; content: unknown }; client_nonce?: string }
   | { type: "interrupt" }
-  | { type: "ping" };
+  | { type: "ping"; sent_at?: number; last_order_key?: string }
+  | { type: "heartbeat"; sent_at?: number; last_order_key?: string };
 
 export class WSFanout {
   private readonly server: WebSocketServer;
@@ -35,8 +37,15 @@ export class WSFanout {
         } catch {
           return;
         }
-        if (frame.type === "ping") {
-          ws.send(JSON.stringify({ type: "pong" }));
+        if (frame.type === "ping" || frame.type === "heartbeat") {
+          ws.send(
+            JSON.stringify({
+              type: frame.type === "heartbeat" ? "heartbeat_ack" : "pong",
+              sent_at: frame.sent_at,
+              last_order_key: frame.last_order_key,
+              server_time: new Date().toISOString(),
+            }),
+          );
           return;
         }
         this.onUserMessage?.(frame);

--- a/backend-go/cmd/tank-operator/handlers_agent_ws.go
+++ b/backend-go/cmd/tank-operator/handlers_agent_ws.go
@@ -18,6 +18,14 @@ import (
 )
 
 const agentRunnerDialTimeout = 10 * time.Second
+const agentWSReplayPageLimit = 1000
+const agentWSReplayMaxPages = 50
+
+type agentWSMessage struct {
+	mt   websocket.MessageType
+	data []byte
+	err  error
+}
 
 // handleAgentWebSocket reverse-proxies the SPA's WebSocket onto the
 // pod's agent-runner (Phase B Node service listening on
@@ -27,7 +35,9 @@ const agentRunnerDialTimeout = 10 * time.Second
 //
 // Bytes are piped raw — no message inspection, no serialization touch.
 // The runner produces the wire format; this handler is a pure pipe so
-// SDK protocol changes don't require orchestrator changes.
+// SDK protocol changes don't require orchestrator changes. Phase 4 adds one
+// orchestrator-owned transport envelope around that pipe: replay missed
+// durable events from Cosmos before flushing buffered live runner frames.
 func (s *appServer) handleAgentWebSocket(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireWSAuth(w, r)
 	if !ok {
@@ -83,9 +93,35 @@ func (s *appServer) handleAgentWebSocket(w http.ResponseWriter, r *http.Request)
 	}
 	defer podConn.Close(websocket.StatusNormalClosure, "")
 
-	// Bidirectional pipe — independent goroutines per direction so neither
-	// blocks the other. First error in either direction (close, network
-	// hiccup, browser disconnect, pod crash) tears down both sides.
+	// Buffer pod frames before replay so any live events produced during the
+	// Cosmos catch-up are delivered after the subscribe ack.
+	podMessages := make(chan agentWSMessage, 1024)
+	go readAgentWSMessages(r.Context(), podConn, podMessages)
+
+	cursor := sessionEventCursorFromRequest(r)
+	replayed, lastOrderKey, replayErr := s.replaySessionEventsToWebSocket(
+		r.Context(),
+		browserConn,
+		sessionID,
+		cursor,
+	)
+	if replayErr != nil {
+		_ = browserConn.Write(r.Context(), websocket.MessageText, mustJSON(map[string]any{
+			"type":    "tank.transport.error",
+			"error":   "replay_failed",
+			"message": replayErr.Error(),
+		}))
+		browserConn.Close(websocket.StatusInternalError, "replay failed")
+		return
+	}
+	_ = browserConn.Write(r.Context(), websocket.MessageText, mustJSON(map[string]any{
+		"type":                  "tank.transport.subscribed",
+		"session_id":            sessionID,
+		"last_order_key":        lastOrderKey,
+		"replayed":              replayed,
+		"heartbeat_interval_ms": 15000,
+	}))
+
 	errCh := make(chan error, 2)
 	go func() {
 		for {
@@ -100,22 +136,69 @@ func (s *appServer) handleAgentWebSocket(w http.ResponseWriter, r *http.Request)
 			}
 		}
 	}()
-	go func() {
-		for {
-			mt, data, err := podConn.Read(r.Context())
-			if err != nil {
-				errCh <- err
+	for {
+		select {
+		case firstErr := <-errCh:
+			if firstErr != nil {
+				slog.Debug("agent-ws pipe ended", "session", sessionID, "err", firstErr)
+			}
+			return
+		case msg, open := <-podMessages:
+			if !open {
 				return
 			}
-			if err := browserConn.Write(r.Context(), mt, data); err != nil {
-				errCh <- err
+			if msg.err != nil {
+				slog.Debug("agent-ws pod reader ended", "session", sessionID, "err", msg.err)
+				return
+			}
+			if err := browserConn.Write(r.Context(), msg.mt, msg.data); err != nil {
+				slog.Debug("agent-ws browser write ended", "session", sessionID, "err", err)
 				return
 			}
 		}
-	}()
-	if firstErr := <-errCh; firstErr != nil {
-		slog.Debug("agent-ws pipe ended", "session", sessionID, "err", firstErr)
 	}
+}
+
+func readAgentWSMessages(ctx context.Context, conn *websocket.Conn, out chan<- agentWSMessage) {
+	defer close(out)
+	for {
+		mt, data, err := conn.Read(ctx)
+		if err != nil {
+			out <- agentWSMessage{err: err}
+			return
+		}
+		out <- agentWSMessage{mt: mt, data: append([]byte(nil), data...)}
+	}
+}
+
+func (s *appServer) replaySessionEventsToWebSocket(
+	ctx context.Context,
+	conn *websocket.Conn,
+	sessionID string,
+	cursor store.SessionEventCursor,
+) (int, string, error) {
+	replayed := 0
+	lastOrderKey := cursor.AfterOrderKey
+	for pageNo := 0; pageNo < agentWSReplayMaxPages; pageNo++ {
+		page, err := s.sessionEvents.ListBySession(ctx, sessionID, cursor, agentWSReplayPageLimit)
+		if err != nil {
+			return replayed, lastOrderKey, err
+		}
+		for _, event := range page.Events {
+			if err := conn.Write(ctx, websocket.MessageText, mustJSON(event)); err != nil {
+				return replayed, lastOrderKey, err
+			}
+			replayed++
+		}
+		if page.NextOrderKey != "" {
+			lastOrderKey = page.NextOrderKey
+		}
+		if !page.HasMore || page.NextOrderKey == "" || page.NextOrderKey == cursor.AfterOrderKey {
+			break
+		}
+		cursor = store.SessionEventCursor{AfterOrderKey: page.NextOrderKey}
+	}
+	return replayed, lastOrderKey, nil
 }
 
 // podHasSDKRunner returns true if the pod spec includes either of the
@@ -191,6 +274,15 @@ func (s *appServer) handleSessionTimeline(w http.ResponseWriter, r *http.Request
 func sessionEventCursorFromRequest(r *http.Request) store.SessionEventCursor {
 	if afterOrderKey := r.URL.Query().Get("after_order_key"); afterOrderKey != "" {
 		return store.SessionEventCursor{AfterOrderKey: afterOrderKey}
+	}
+	if lastOrderKey := r.URL.Query().Get("last_order_key"); lastOrderKey != "" {
+		return store.SessionEventCursor{AfterOrderKey: lastOrderKey}
+	}
+	if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+		return store.SessionEventCursor{AfterOrderKey: cursor}
+	}
+	if cursor := r.URL.Query().Get("last_cursor"); cursor != "" {
+		return store.SessionEventCursor{AfterOrderKey: cursor}
 	}
 	if afterOrderKey := r.URL.Query().Get("after_sequence"); afterOrderKey != "" {
 		return store.SessionEventCursor{AfterOrderKey: afterOrderKey}

--- a/backend-go/cmd/tank-operator/handlers_agent_ws_test.go
+++ b/backend-go/cmd/tank-operator/handlers_agent_ws_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+func TestSessionEventCursorFromRequestAcceptsResumeAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{name: "timeline cursor", url: "/api/sessions/63/timeline?after_order_key=cursor-a", want: "cursor-a"},
+		{name: "websocket last order key", url: "/api/sessions/63/agent-ws?last_order_key=cursor-b", want: "cursor-b"},
+		{name: "generic cursor", url: "/api/sessions/63/agent-ws?cursor=cursor-c", want: "cursor-c"},
+		{name: "last cursor", url: "/api/sessions/63/agent-ws?last_cursor=cursor-d", want: "cursor-d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			got := sessionEventCursorFromRequest(req)
+			if got.AfterOrderKey != tt.want {
+				t.Fatalf("AfterOrderKey = %q, want %q", got.AfterOrderKey, tt.want)
+			}
+		})
+	}
+}
+
+type fakeSessionEventStore struct {
+	pages map[string]store.SessionEventPage
+}
+
+func (s fakeSessionEventStore) ListBySession(_ context.Context, _ string, cursor store.SessionEventCursor, _ int) (store.SessionEventPage, error) {
+	return s.pages[cursor.AfterOrderKey], nil
+}
+
+func TestAgentWSReplayUsesReconnectCursor(t *testing.T) {
+	app := &appServer{
+		sessionEvents: fakeSessionEventStore{
+			pages: map[string]store.SessionEventPage{
+				"cursor-1": {
+					Events: []map[string]any{
+						{"event_id": "e2", "order_key": "cursor-2", "type": "item.completed"},
+						{"event_id": "e3", "order_key": "cursor-3", "type": "turn.completed"},
+					},
+					NextOrderKey: "cursor-3",
+				},
+				"cursor-2": {
+					Events: []map[string]any{
+						{"event_id": "e3", "order_key": "cursor-3", "type": "turn.completed"},
+					},
+					NextOrderKey: "cursor-3",
+				},
+			},
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		replayed, lastOrderKey, err := app.replaySessionEventsToWebSocket(
+			r.Context(),
+			conn,
+			"63",
+			sessionEventCursorFromRequest(r),
+		)
+		if err != nil {
+			t.Errorf("replay events: %v", err)
+			return
+		}
+		_ = conn.Write(r.Context(), websocket.MessageText, mustJSON(map[string]any{
+			"type":           "tank.transport.subscribed",
+			"replayed":       replayed,
+			"last_order_key": lastOrderKey,
+		}))
+	}))
+	defer server.Close()
+
+	first := readReplayMessages(t, server.URL, "cursor-1")
+	if got := eventIDs(first); strings.Join(got, ",") != "e2,e3" {
+		t.Fatalf("first reconnect event ids = %#v, want e2,e3", got)
+	}
+	if got := first[len(first)-1]["last_order_key"]; got != "cursor-3" {
+		t.Fatalf("first reconnect last_order_key = %v, want cursor-3", got)
+	}
+
+	second := readReplayMessages(t, server.URL, "cursor-2")
+	if got := eventIDs(second); strings.Join(got, ",") != "e3" {
+		t.Fatalf("second reconnect event ids = %#v, want e3", got)
+	}
+	if got := second[len(second)-1]["replayed"]; got != float64(1) {
+		t.Fatalf("second reconnect replayed = %v, want 1", got)
+	}
+}
+
+func readReplayMessages(t *testing.T, serverURL, cursor string) []map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + "/?last_order_key=" + cursor
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	var messages []map[string]any
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var msg map[string]any
+		if err := json.Unmarshal(data, &msg); err != nil {
+			t.Fatal(err)
+		}
+		messages = append(messages, msg)
+		if msg["type"] == "tank.transport.subscribed" {
+			return messages
+		}
+	}
+}
+
+func eventIDs(messages []map[string]any) []string {
+	var ids []string
+	for _, msg := range messages {
+		id, _ := msg["event_id"].(string)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}

--- a/backend-go/internal/store/session_events_test.go
+++ b/backend-go/internal/store/session_events_test.go
@@ -110,6 +110,56 @@ func TestPaginateSessionEventsAcceptsLegacyDocumentIDCursor(t *testing.T) {
 	}
 }
 
+func TestPaginateSessionEventsUsesFullCursorWhenOrderKeysCollide(t *testing.T) {
+	events := []map[string]any{
+		{
+			"id":         "same-order-a",
+			"order_key":  "0001",
+			"sequence":   float64(1),
+			"created_at": "2026-05-12T01:00:01Z",
+			"type":       "first",
+		},
+		{
+			"id":         "same-order-b",
+			"order_key":  "0001",
+			"sequence":   float64(2),
+			"created_at": "2026-05-12T01:00:01Z",
+			"type":       "second",
+		},
+		{
+			"id":         "same-order-c",
+			"order_key":  "0001",
+			"sequence":   float64(3),
+			"created_at": "2026-05-12T01:00:01Z",
+			"type":       "third",
+		},
+	}
+	sortSessionEvents(events)
+
+	firstPage := paginateSessionEvents(events, SessionEventCursor{}, 2)
+	if got := eventTypes(firstPage.Events); len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Fatalf("first page types = %#v, want first, second", got)
+	}
+
+	secondPage := paginateSessionEvents(events, SessionEventCursor{AfterOrderKey: firstPage.NextOrderKey}, 2)
+	if got := eventTypes(secondPage.Events); len(got) != 1 || got[0] != "third" {
+		t.Fatalf("second page types = %#v, want third", got)
+	}
+}
+
+func TestPaginateSessionEventsUnknownCursorRestartsFromBeginning(t *testing.T) {
+	events := []map[string]any{
+		{"id": "a", "tank_order_key": "0001", "type": "first"},
+		{"id": "b", "tank_order_key": "0002", "type": "second"},
+	}
+	sortSessionEvents(events)
+
+	page := paginateSessionEvents(events, SessionEventCursor{AfterOrderKey: "missing"}, 10)
+	if got := eventTypes(page.Events); len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Fatalf("page types = %#v, want first, second", got)
+	}
+}
+
 func eventTypes(events []map[string]any) []string {
 	types := make([]string, 0, len(events))
 	for _, event := range events {

--- a/codex-runner/src/runner.test.ts
+++ b/codex-runner/src/runner.test.ts
@@ -6,9 +6,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { dispatch, dispatchCreate } from "./runner.js";
+import {
+  canonicalEventsForCodexEvent,
+  dispatch,
+  dispatchCreate,
+  type AcceptedTurn,
+} from "./runner.js";
 import { isCanonical, nextSortableEventID, type CodexEvent } from "./cosmos.js";
 import { userSubmissionEvents } from "./conversation.js";
+import type { Config } from "./config.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -36,6 +42,27 @@ function userMessageEvent() {
     runtime: "codex",
     now: "2026-05-12T00:00:00.000Z",
   }).userMessage;
+}
+
+function acceptedTurn(fields: Partial<AcceptedTurn> = {}): AcceptedTurn {
+  return {
+    turnID: "turn-run-123",
+    clientNonce: "run-123",
+    turnSeq: 7,
+    ...fields,
+  };
+}
+
+function cfg(): Config {
+  return {
+    sessionId: "63",
+    ownerEmail: "user@example.com",
+    cosmosEndpoint: "https://example.invalid",
+    cosmosDatabase: "tank-operator",
+    sessionEventsContainer: "session-events",
+    workspace: "/workspace",
+    wsPort: 8090,
+  };
 }
 
 test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
@@ -182,4 +209,78 @@ test("generated event ids sort by production order", () => {
   const second = nextSortableEventID(1000);
   const third = nextSortableEventID(1001);
   assert.deepEqual([third, first, second].sort(), [first, second, third]);
+});
+
+test("adapter maps Codex agent messages to durable Tank assistant items", () => {
+  const events = canonicalEventsForCodexEvent(
+    cfg(),
+    acceptedTurn(),
+    {
+      type: "item.completed",
+      item: {
+        id: "item_agent_1",
+        type: "agent_message",
+        text: "All tests passed.",
+      },
+    },
+  );
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, "item.completed");
+  assert.equal(events[0]?.source, "codex");
+  assert.equal(events[0]?.actor, "assistant");
+  assert.equal(events[0]?.item_id, "item_agent_1");
+  assert.equal(events[0]?.visibility, "durable");
+  assert.equal(events[0]?.payload?.kind, "agent_message");
+  assert.equal(events[0]?.payload?.text, "All tests passed.");
+});
+
+test("adapter maps Codex item updates to live-only Tank deltas", () => {
+  const events = canonicalEventsForCodexEvent(
+    cfg(),
+    acceptedTurn(),
+    {
+      type: "item.updated",
+      item: {
+        id: "item_reasoning_1",
+        type: "reasoning",
+        text: "thinking",
+      },
+    },
+  );
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, "item.delta");
+  assert.equal(events[0]?.actor, "assistant");
+  assert.equal(events[0]?.visibility, "live-only");
+});
+
+test("adapter maps Codex terminal events to Tank turn lifecycle", () => {
+  const completed = canonicalEventsForCodexEvent(
+    cfg(),
+    acceptedTurn(),
+    { type: "turn.completed", usage: { input_tokens: 10 } },
+  );
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0]?.type, "turn.completed");
+  assert.deepEqual(completed[0]?.payload?.usage, { input_tokens: 10 });
+
+  const failed = canonicalEventsForCodexEvent(
+    cfg(),
+    acceptedTurn(),
+    { type: "error", message: "quota exceeded" },
+  );
+  assert.equal(failed.length, 1);
+  assert.equal(failed[0]?.type, "turn.failed");
+  assert.equal(failed[0]?.payload?.reason, "provider_failure");
+  assert.equal(failed[0]?.payload?.error, "quota exceeded");
+});
+
+test("adapter explicitly ignores unknown Codex provider event types", () => {
+  const events = canonicalEventsForCodexEvent(
+    cfg(),
+    acceptedTurn(),
+    { type: "future.experimental.event", value: true },
+  );
+  assert.deepEqual(events, []);
 });

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -134,7 +134,7 @@ function isAbortError(err: unknown): boolean {
   );
 }
 
-interface AcceptedTurn {
+export interface AcceptedTurn {
   turnID: string;
   clientNonce: string;
   turnSeq: number;
@@ -173,7 +173,7 @@ function codexItemPayload(item: Record<string, unknown>): Record<string, unknown
   };
 }
 
-function canonicalEventsForCodexEvent(
+export function canonicalEventsForCodexEvent(
   cfg: Config,
   turn: AcceptedTurn,
   event: CodexEvent,

--- a/codex-runner/src/ws.ts
+++ b/codex-runner/src/ws.ts
@@ -7,7 +7,8 @@
 //   server → client: every SDK event, serialized as JSON.
 //   client → server: { type: "user", message: { role: "user", content: ... } }
 //                  | { type: "interrupt" }                         (abort turn)
-//                  | { type: "ping" }                              (heartbeat)
+//                  | { type: "heartbeat", last_order_key?: string } (heartbeat/ack)
+//                  | { type: "ping" }                              (legacy heartbeat)
 //
 // Auth happens upstream at the orchestrator's TLS+JWT termination; this
 // server trusts whatever connects.
@@ -17,7 +18,8 @@ import { WebSocketServer, type WebSocket } from "ws";
 export type ClientFrame =
   | { type: "user"; message: { role: "user"; content: unknown }; client_nonce?: string }
   | { type: "interrupt" }
-  | { type: "ping" };
+  | { type: "ping"; sent_at?: number; last_order_key?: string }
+  | { type: "heartbeat"; sent_at?: number; last_order_key?: string };
 
 export class WSFanout {
   private readonly server: WebSocketServer;
@@ -35,8 +37,15 @@ export class WSFanout {
         } catch {
           return;
         }
-        if (frame.type === "ping") {
-          ws.send(JSON.stringify({ type: "pong" }));
+        if (frame.type === "ping" || frame.type === "heartbeat") {
+          ws.send(
+            JSON.stringify({
+              type: frame.type === "heartbeat" ? "heartbeat_ack" : "pong",
+              sent_at: frame.sent_at,
+              last_order_key: frame.last_order_key,
+              server_time: new Date().toISOString(),
+            }),
+          );
           return;
         }
         this.onUserMessage?.(frame);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -117,6 +117,13 @@ type TranscriptEntry = SandboxTranscriptEntry & {
   clientNonce?: string;
 };
 type SdkTerminalStatus = "done" | "error" | "stopped";
+type SdkConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "connection_lost"
+  | "reconnecting"
+  | "resumed";
 type SdkTerminalResult = {
   status: SdkTerminalStatus;
   detail?: string;
@@ -1817,6 +1824,90 @@ function eventOrderKey(event: JsonObject): string {
   }
   const time = eventTime(event);
   return [time, eventID(event, "event")].join("-");
+}
+
+function eventSequenceCursor(event: JsonObject): string {
+  const sequence = event.sequence ?? event.tank_event_seq;
+  if (typeof sequence === "number" && Number.isFinite(sequence)) {
+    return String(sequence);
+  }
+  if (typeof sequence === "string" && sequence) return sequence;
+  return "";
+}
+
+function eventTimelineTime(event: JsonObject): string {
+  for (const field of ["written_at", "timestamp", "time", "created_at"]) {
+    const value = event[field];
+    if (typeof value === "string" && value) return value;
+  }
+  return "";
+}
+
+function eventTimelineCursor(event: JsonObject): string | null {
+  const order = typeof event.order_key === "string" && event.order_key
+    ? event.order_key
+    : typeof event.tank_order_key === "string" && event.tank_order_key
+      ? event.tank_order_key
+      : "";
+  const time = eventTimelineTime(event);
+  const sequence = eventSequenceCursor(event);
+  const id = eventID(event, "event");
+  if (!order && !time && !sequence && !id) return null;
+  return [order, time, sequence, id].join("\u001f");
+}
+
+function advanceTimelineCursor(current: string | null, next: string | null): string | null {
+  if (!next) return current;
+  if (!current || next > current) return next;
+  return current;
+}
+
+function sdkConnectionLabel(state: SdkConnectionState): string | null {
+  switch (state) {
+    case "connecting":
+      return "Connecting";
+    case "connection_lost":
+      return "Connection lost";
+    case "reconnecting":
+      return "Reconnecting";
+    case "resumed":
+      return "Resumed";
+    case "idle":
+    case "connected":
+      return null;
+  }
+}
+
+function sdkHeartbeatInterval(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 15_000;
+  return Math.min(60_000, Math.max(5_000, value));
+}
+
+function isSdkTimelineEvent(mode: SessionMode, event: JsonObject): boolean {
+  if (isCanonicalConversationEvent(event)) return event.visibility !== "live-only";
+  const type = event.type;
+  if (type === "tank.user_message") return true;
+  if (mode === "codex_gui") {
+    return (
+      type === "thread.started" ||
+      type === "turn.completed" ||
+      type === "turn.failed" ||
+      type === "turn.interrupted" ||
+      type === "item.completed" ||
+      type === "error"
+    );
+  }
+  if (type === "assistant" || type === "user" || type === "result" || type === "rate_limit") {
+    return true;
+  }
+  return (
+    type === "system" &&
+    (event.subtype === "init" ||
+      event.subtype === "compact_boundary" ||
+      event.subtype === "tool_use_summary" ||
+      event.subtype === "permission_denied" ||
+      event.subtype === "plugin_install")
+  );
 }
 
 function codexTurnScope(event: JsonObject): string {
@@ -4096,11 +4187,14 @@ function HeadlessRun({
   const wsRef = useRef<WebSocket | null>(null);
   const runEventsRef = useRef<EventSource | null>(null);
   const historyRefreshRef = useRef<Promise<void> | null>(null);
+  const sdkTimelineCursorRef = useRef<string | null>(null);
   const sessionIdRef = useRef(session.id);
   const runLifecycleFinishTimerRef = useRef<number | null>(null);
   const turnCompleteAudioRef = useRef<HTMLAudioElement | null>(null);
   const runPrefsRef = useRef(runPrefs);
   const stdoutBufferRef = useRef("");
+  const [sdkConnectionState, setSdkConnectionState] =
+    useState<SdkConnectionState>("idle");
   const currentRunRef = useRef<{
     id: string;
     prompt: string;
@@ -4167,7 +4261,15 @@ function HeadlessRun({
     );
     syncSdkRenderedEntries();
   }
+  function advanceSdkTimelineCursor(event: JsonObject): void {
+    if (!isSdkTimelineEvent(session.mode, event)) return;
+    sdkTimelineCursorRef.current = advanceTimelineCursor(
+      sdkTimelineCursorRef.current,
+      eventTimelineCursor(event),
+    );
+  }
   function applySdkRealtimeEvent(event: JsonObject): void {
+    advanceSdkTimelineCursor(event);
     const nextRealtime = applySdkProviderEvent(
       sdkRealtimeEntriesRef.current,
       session.mode,
@@ -4451,15 +4553,23 @@ function HeadlessRun({
         if (sessionIdRef.current !== refreshSessionId) return { replayed: false };
         if (!Array.isArray(body.events)) return { replayed: false };
         events.push(...body.events);
-        if (!body.has_more) break;
+        const previousAfter = afterOrderKey;
         const nextAfter = typeof body.next_order_key === "string" ? body.next_order_key : "";
-        if (!nextAfter || nextAfter === afterOrderKey) break;
-        afterOrderKey = nextAfter;
+        if (nextAfter) {
+          afterOrderKey = nextAfter;
+          sdkTimelineCursorRef.current = advanceTimelineCursor(
+            sdkTimelineCursorRef.current,
+            nextAfter,
+          );
+        }
+        if (!body.has_more) break;
+        if (!nextAfter || nextAfter === previousAfter) break;
       }
 
       let acc: TranscriptEntry[] = [];
       for (const ev of events) {
         if (isJsonObject(ev)) {
+          advanceSdkTimelineCursor(ev);
           acc = applySdkProviderEvent(acc, session.mode, ev, "server");
         }
       }
@@ -4886,12 +4996,14 @@ function HeadlessRun({
     sessionIdRef.current = session.id;
     sdkServerEntriesRef.current = [];
     sdkRealtimeEntriesRef.current = [];
+    sdkTimelineCursorRef.current = null;
     setEntries([]);
     setQueuedMessages([]);
     historyRefreshRef.current = null;
     setHistoryAttempted(false);
     setActiveRunChecked(false);
     setContinueHintVisible(false);
+    setSdkConnectionState("idle");
   }, [session.id]);
 
   // sendByCtrlEnter — when on, plain Enter inserts a newline and only
@@ -5343,6 +5455,7 @@ function HeadlessRun({
     setActiveTool(null);
     setRunning(false);
     setActiveRunId(null);
+    if (session.runtime === "sdk") setSdkConnectionState("idle");
     wsRef.current?.close();
     wsRef.current = null;
     window.setTimeout(() => refreshRunHistoryFromBackend(false), 250);
@@ -5431,7 +5544,11 @@ function HeadlessRun({
     setActiveRunId(run.id);
     setRunStartedAt(startedAt);
     setNow(Date.now());
-    openRunSocket(run, true);
+    if (session.runtime === "sdk") {
+      openSdkRunSocket(run, true);
+    } else {
+      openRunSocket(run, true);
+    }
     return true;
   }
 
@@ -5454,6 +5571,7 @@ function HeadlessRun({
     scheduledWakeupRef.current = false;
     setActiveTool(null);
     setRunning(false);
+    if (session.runtime === "sdk") setSdkConnectionState("idle");
     setActiveRunId(null);
     setRunStatus((prev) => (prev === "running" ? "done" : prev));
   }
@@ -5675,6 +5793,7 @@ function HeadlessRun({
     setActiveTool(null);
     setRunning(false);
     setActiveRunId(null);
+    setSdkConnectionState("idle");
     if (options.closeSocket) {
       if (wsRef.current === options.closeSocket) wsRef.current = null;
       options.closeSocket.close();
@@ -5695,6 +5814,7 @@ function HeadlessRun({
     scheduledWakeupRef.current = false;
     setActiveTool(null);
     setRunning(false);
+    setSdkConnectionState("connection_lost");
     const id = nextEntryId("ws-close");
     appendSdkRealtimeEntries(
       markLocalEntries(
@@ -5734,6 +5854,7 @@ function HeadlessRun({
 
     run.reconnects += 1;
     const delay = Math.min(5000, 250 * 2 ** (run.reconnects - 1));
+    setSdkConnectionState("reconnecting");
     setLastStatusText("Reconnecting");
     void refreshSdkRunHistoryResult(false, false, run.id).then((result) => {
       if (currentRunRef.current?.id !== run.id || run.cancelled) return;
@@ -5743,7 +5864,7 @@ function HeadlessRun({
       }
       window.setTimeout(() => {
         if (currentRunRef.current?.id === run.id && !run.cancelled) {
-          openSdkRunSocket(run, true);
+          openSdkRunSocket(run, run.submitted === true);
         }
       }, delay);
     });
@@ -5753,13 +5874,32 @@ function HeadlessRun({
     run: NonNullable<typeof currentRunRef.current>,
     resume = false,
   ) {
+    setSdkConnectionState(resume ? "reconnecting" : "connecting");
+    const params = new URLSearchParams();
+    if (sdkTimelineCursorRef.current) {
+      params.set("last_order_key", sdkTimelineCursorRef.current);
+    }
+    const query = params.toString();
     const wsUrl =
       `${location.protocol === "https:" ? "wss:" : "ws:"}//${location.host}` +
-      `/api/sessions/${session.id}/agent-ws`;
+      `/api/sessions/${session.id}/agent-ws${query ? `?${query}` : ""}`;
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
-    ws.onopen = () => {
+    let heartbeatTimer: number | null = null;
+    let heartbeatTimeout: number | null = null;
+    const clearHeartbeat = () => {
+      if (heartbeatTimer !== null) {
+        window.clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+      }
+      if (heartbeatTimeout !== null) {
+        window.clearTimeout(heartbeatTimeout);
+        heartbeatTimeout = null;
+      }
+    };
+    const sendUserFrame = () => {
       if (resume && run.submitted) return;
+      if (!run.prompt && resume) return;
       ws.send(
         JSON.stringify({
           type: "user",
@@ -5768,6 +5908,30 @@ function HeadlessRun({
         }),
       );
       run.submitted = true;
+    };
+    const startHeartbeat = (intervalMs: number) => {
+      clearHeartbeat();
+      const sendHeartbeat = () => {
+        if (ws.readyState !== WebSocket.OPEN) return;
+        ws.send(
+          JSON.stringify({
+            type: "heartbeat",
+            sent_at: Date.now(),
+            last_order_key: sdkTimelineCursorRef.current ?? undefined,
+          }),
+        );
+        if (heartbeatTimeout !== null) window.clearTimeout(heartbeatTimeout);
+        heartbeatTimeout = window.setTimeout(() => {
+          if (currentRunRef.current?.id !== run.id || run.cancelled) return;
+          setSdkConnectionState("connection_lost");
+          ws.close(4000, "heartbeat timeout");
+        }, intervalMs * 2);
+      };
+      heartbeatTimer = window.setInterval(sendHeartbeat, intervalMs);
+      sendHeartbeat();
+    };
+    ws.onopen = () => {
+      setSdkConnectionState(resume ? "reconnecting" : "connecting");
     };
     ws.onmessage = (event) => {
       let parsed: unknown;
@@ -5784,6 +5948,34 @@ function HeadlessRun({
         return;
       }
       if (!isJsonObject(parsed)) return;
+      if (parsed.type === "tank.transport.subscribed") {
+        const lastOrderKey = parsed.last_order_key;
+        if (typeof lastOrderKey === "string" && lastOrderKey) {
+          sdkTimelineCursorRef.current = advanceTimelineCursor(
+            sdkTimelineCursorRef.current,
+            lastOrderKey,
+          );
+        }
+        setSdkConnectionState(resume ? "resumed" : "connected");
+        run.reconnects = 0;
+        startHeartbeat(sdkHeartbeatInterval(parsed.heartbeat_interval_ms));
+        if (!resume && !run.submitted) sendUserFrame();
+        return;
+      }
+      if (parsed.type === "heartbeat_ack" || parsed.type === "pong") {
+        if (heartbeatTimeout !== null) {
+          window.clearTimeout(heartbeatTimeout);
+          heartbeatTimeout = null;
+        }
+        setSdkConnectionState((prev) =>
+          prev === "connection_lost" || prev === "reconnecting" ? "connected" : prev,
+        );
+        return;
+      }
+      if (parsed.type === "tank.transport.error") {
+        setSdkConnectionState("connection_lost");
+        return;
+      }
 
       // Bookkeeping for usage/active-tool. Two flavors of SDK events come
       // through this WS: claude's `{type:"assistant"|"user"|"result"}` and
@@ -5858,14 +6050,17 @@ function HeadlessRun({
     };
     ws.onerror = () => {
       if (!run.cancelled) {
+        setSdkConnectionState("connection_lost");
         setLastStatusText("Reconnecting");
       }
     };
     ws.onclose = (event) => {
+      clearHeartbeat();
       if (currentRunRef.current?.id !== run.id || run.cancelled) {
         if (wsRef.current === ws) wsRef.current = null;
         return;
       }
+      setSdkConnectionState("connection_lost");
       reconnectSdkRunSocket(run, event, ws);
     };
   }
@@ -6053,6 +6248,8 @@ function HeadlessRun({
   const verb = activeToolName
     ? `Using ${formatToolLabel(activeToolName)}`
     : STREAM_VERBS[verbIndex];
+  const connectionLabel =
+    session.runtime === "sdk" ? sdkConnectionLabel(sdkConnectionState) : null;
 
   const sendStdin = (text: string) => {
     wsRef.current?.send(JSON.stringify({ stdin: text }));
@@ -6619,6 +6816,9 @@ function HeadlessRun({
               </span>
             )}
           </span>
+          {connectionLabel && (
+            <span className="run-status-connection">{connectionLabel}</span>
+          )}
           {running && (
             <>
               <span className="run-status-elapsed" title="elapsed">

--- a/frontend/src/conversationReducer.test.ts
+++ b/frontend/src/conversationReducer.test.ts
@@ -47,6 +47,33 @@ test("Codex interrupt is stopped state, not provider error", () => {
   assert.equal(state.messages.length, 1);
 });
 
+test("Normal turn reaches ready with one user message and assistant item", () => {
+  const state = reduceConversationEvents([
+    ev("1", "user_message.created", {
+      actor: "user",
+      client_nonce: "run-normal",
+      payload: { text: "summarize" },
+    }),
+    ev("2", "turn.submitted", { client_nonce: "run-normal" }),
+    ev("3", "turn.started", { source: "claude" }),
+    ev("4", "item.completed", {
+      actor: "assistant",
+      source: "claude",
+      item_id: "msg-1",
+      payload: { kind: "message", text: "summary" },
+    }),
+    ev("5", "turn.completed", { source: "claude" }),
+  ]);
+
+  assert.equal(state.runStatus, "ready");
+  assert.equal(state.messages.length, 1);
+  assert.equal(state.messages[0]?.text, "summarize");
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0]?.actor, "assistant");
+  assert.equal(state.items[0]?.text, "summary");
+  assert.equal(state.activeTurnId, null);
+});
+
 test("Tool lifecycle replays to a completed tool item", () => {
   const state = reduceConversationEvents([
     ev("1", "turn.started"),
@@ -110,6 +137,48 @@ test("Approval pause is explicit needs-input state and resumes streaming", () =>
   assert.equal(state.needsInput, false);
   assert.equal(state.runStatus, "streaming");
   assert.equal(state.items[0]?.kind, "approval");
+});
+
+test("Provider error becomes terminal error state without needs-input", () => {
+  const state = reduceConversationEvents([
+    ev("1", "turn.started", { source: "claude" }),
+    ev("2", "tool.approval_requested", {
+      item_id: "approval-1",
+      actor: "tool",
+      payload: { kind: "approval", title: "Run command" },
+    }),
+    ev("3", "turn.failed", {
+      source: "claude",
+      payload: { reason: "provider_failure", error: "quota exceeded" },
+    }),
+  ]);
+
+  assert.equal(state.runStatus, "error");
+  assert.equal(state.failed, true);
+  assert.equal(state.needsInput, false);
+  assert.equal(state.activeTurnId, null);
+});
+
+test("Activity and read-state events drive unread state", () => {
+  const state = reduceConversationEvents([
+    ev("1", "session.activity_updated", {
+      payload: {
+        status: "streaming",
+        needs_input: false,
+        failed: false,
+        active_turn_id: "turn-1",
+        unread_count: 3,
+      },
+    }),
+    ev("2", "read_state.updated", {
+      payload: { last_read_order_key: "0002" },
+    }),
+  ]);
+
+  assert.equal(state.runStatus, "streaming");
+  assert.equal(state.activeTurnId, "turn-1");
+  assert.equal(state.lastReadOrderKey, "0002");
+  assert.equal(state.unreadCount, 0);
 });
 
 test("Replay and live delivery converge through event id dedupe", () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3780,6 +3780,13 @@ textarea.run-files-viewer-editor:focus {
   font-variant-numeric: tabular-nums;
 }
 
+.run-status-connection {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 .run-status-elapsed {
   font-family: var(--font-mono);
   font-size: 0.78rem;


### PR DESCRIPTION
## Summary
- add backend WS replay/cursor tests for SDK reconnect resume behavior
- add Claude and Codex provider adapter contract tests for canonical Tank event mapping
- expand reducer fixtures for normal turns, errors, read-state/activity, duplicate replay/live delivery

## Patterns Re-Checked For #402
- CloudCLI: persistent cloud sessions, cross-device continuity, and agent-agnostic environments
- Slack: durable history with cursor-based pagination and event delivery
- Discord: heartbeat/ack, sequence/cursor discipline, reconnect, and resume
- AI SDK UI: submitted/streaming/ready/error chat states and resumable stream storage/reattach shape
- OpenAI Codex App Server: thread/turn/item primitives and item lifecycle started/delta/completed

## Tests
- go test ./...
- npm test (frontend)
- npm run build && npm test (agent-runner)
- npm run build && npm test (codex-runner)

Refs #402