### PR TITLE
Render SDK chat from Tank conversation events

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "tsx --test src/conversationReducer.test.ts",
+    "test": "tsx --test src/*.test.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,8 +80,29 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { authedFetch, bootstrapAuth, getStoredToken, logout, startLogin } from "./auth";
+import {
+  initialConversationState,
+  reduceConversationEvents,
+  type ConversationReducerState,
+} from "./conversationReducer";
+import {
+  projectConversationState,
+  type ConversationViewEntry,
+} from "./conversationProjection";
 import { McpIcon } from "./McpIcon";
+import {
+  applyProviderEvent,
+  isProviderAbortMessage,
+  parseProviderRunHistory,
+  providerFrameEffects,
+  type ToolKind,
+} from "./providerEventAdapters";
 import { ProviderIcon } from "./providerIcons";
+import {
+  isDurableTankConversationEvent,
+  isTankConversationEvent,
+  type TankConversationEvent,
+} from "./tankConversation";
 import { ANSI_256_OVERRIDES, ANSI_STANDARD_OVERRIDES } from "./terminalTheme";
 
 type SessionMode =
@@ -105,7 +126,6 @@ type DefaultSessionMode = Extract<
 type Provider = "anthropic" | "codex" | "pi";
 type SessionInteraction = "gui" | "cli";
 type AgentSessionActivity = "waiting" | "working";
-type ToolKind = "mcp" | "shell";
 type TranscriptEntry = SandboxTranscriptEntry & {
   toolKind?: ToolKind;
   toolServer?: string;
@@ -1700,22 +1720,6 @@ function appendMeta(
   ];
 }
 
-function appendAssistantMessage(
-  entries: TranscriptEntry[],
-  id: string,
-  text: string,
-  time: string = nowIso(),
-): TranscriptEntry[] {
-  if (!text.trim()) return entries;
-  return upsertEntry(entries, {
-    id,
-    kind: "message",
-    role: "assistant",
-    text,
-    time,
-  });
-}
-
 function skillInvocationTitle(name: string): string {
   return `You started ${name} skill`;
 }
@@ -1723,40 +1727,6 @@ function skillInvocationTitle(name: string): string {
 function skillActionText(name: string): string {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)} skill`;
 }
-
-function skillSupplementalText(name: string, text: string): string {
-  const trimmed = text.trim();
-  const triggerPattern = new RegExp(`^[$/]${name}(?:\\s+|\\n+)?`, "i");
-  return trimmed.replace(triggerPattern, "").trim();
-}
-
-function skillNameFromTrigger(text: string): string | null {
-  const trimmed = text.trim();
-  const match = trimmed.match(/^[$/]([A-Za-z0-9_-]{1,64})$/);
-  return match ? match[1] : null;
-}
-
-function hasSkillInvocation(entries: TranscriptEntry[], name: string): boolean {
-  return entries.some(
-    (entry) =>
-      entry.kind === "meta" &&
-      entry.meta?.title === skillInvocationTitle(name),
-  );
-}
-
-function hasUserMessageText(entries: TranscriptEntry[], text: string): boolean {
-  const normalized = text.trim();
-  return Boolean(
-    normalized &&
-      entries.some(
-        (entry) =>
-          entry.kind === "message" &&
-          entry.role === "user" &&
-          entry.text?.trim() === normalized,
-      ),
-  );
-}
-
 
 function appendSkillInvocation(
   entries: TranscriptEntry[],
@@ -1786,22 +1756,6 @@ function appendSkillInvocation(
   );
 }
 
-function describeUsage(usage: unknown): string {
-  if (!isJsonObject(usage)) return "";
-  const input = usage.input_tokens;
-  const cached = usage.cached_input_tokens;
-  const output = usage.output_tokens;
-  const reasoning = usage.reasoning_output_tokens;
-  return [
-    typeof input === "number" ? `input ${input}` : null,
-    typeof cached === "number" ? `cached ${cached}` : null,
-    typeof output === "number" ? `output ${output}` : null,
-    typeof reasoning === "number" ? `reasoning ${reasoning}` : null,
-  ]
-    .filter(Boolean)
-    .join(" · ");
-}
-
 function eventID(event: JsonObject, fallbackPrefix: string): string {
   if (typeof event.uuid === "string" && event.uuid) return event.uuid;
   if (typeof event.id === "string" && event.id) return event.id;
@@ -1813,17 +1767,6 @@ function eventID(event: JsonObject, fallbackPrefix: string): string {
     return event.tank_order_key;
   }
   return `${fallbackPrefix}-${eventTime(event)}-${stableStringHash(shortJson(event))}`;
-}
-
-function eventOrderKey(event: JsonObject): string {
-  if (typeof event.order_key === "string" && event.order_key) {
-    return event.order_key;
-  }
-  if (typeof event.tank_order_key === "string" && event.tank_order_key) {
-    return event.tank_order_key;
-  }
-  const time = eventTime(event);
-  return [time, eventID(event, "event")].join("-");
 }
 
 function eventSequenceCursor(event: JsonObject): string {
@@ -1883,500 +1826,29 @@ function sdkHeartbeatInterval(value: unknown): number {
   return Math.min(60_000, Math.max(5_000, value));
 }
 
-function isSdkTimelineEvent(mode: SessionMode, event: JsonObject): boolean {
-  if (isCanonicalConversationEvent(event)) return event.visibility !== "live-only";
-  const type = event.type;
-  if (type === "tank.user_message") return true;
-  if (mode === "codex_gui") {
-    return (
-      type === "thread.started" ||
-      type === "turn.completed" ||
-      type === "turn.failed" ||
-      type === "turn.interrupted" ||
-      type === "item.completed" ||
-      type === "error"
-    );
-  }
-  if (type === "assistant" || type === "user" || type === "result" || type === "rate_limit") {
-    return true;
-  }
-  return (
-    type === "system" &&
-    (event.subtype === "init" ||
-      event.subtype === "compact_boundary" ||
-      event.subtype === "tool_use_summary" ||
-      event.subtype === "permission_denied" ||
-      event.subtype === "plugin_install")
-  );
-}
-
-function codexTurnScope(event: JsonObject): string {
-  const turnSeq = event.tank_turn_seq;
-  if (typeof turnSeq === "number" && Number.isFinite(turnSeq)) return String(turnSeq);
-  if (typeof turnSeq === "string" && turnSeq) return turnSeq;
-  return eventID(event, "codex-event");
-}
-
-function codexItemEntryId(event: JsonObject, item: JsonObject, fallbackPrefix: string): string {
-  const itemId = typeof item.id === "string" && item.id ? item.id : "";
-  if (itemId) return `${fallbackPrefix}-${codexTurnScope(event)}-${itemId}`;
-  return `${fallbackPrefix}-${eventID(event, fallbackPrefix)}`;
-}
-
-function codexToolEntry(event: JsonObject): TranscriptEntry | null {
-  const item = event.item;
-  if (!isJsonObject(item)) return null;
-  const id = codexItemEntryId(event, item, "codex-tool");
-  const status = codexItemStatus(event, item);
-  const itemType = item.type;
-  const time = eventTime(event);
-
-  if (itemType === "command_execution") {
-    const command = typeof item.command === "string" ? item.command : "command";
-    return {
-      id,
-      kind: "tool",
-      toolKind: "shell",
-      toolName: command,
-      toolInput: command,
-      toolOutput: shortJson(item.aggregated_output),
-      toolStatus: status,
-      time,
-    };
-  }
-
-  if (itemType === "file_change") {
-    return {
-      id,
-      kind: "tool",
-      toolName: "file change",
-      toolInput: shortJson(item.changes),
-      toolStatus: status,
-      time,
-    };
-  }
-
-  if (itemType === "mcp_tool_call") {
-    const server = typeof item.server === "string" ? item.server : "mcp";
-    const tool = typeof item.tool === "string" ? item.tool : "tool";
-    return {
-      id,
-      kind: "tool",
-      toolKind: "mcp",
-      toolServer: server,
-      toolAction: tool,
-      toolName: `${server}.${tool}`,
-      toolInput: shortJson(item.arguments),
-      toolOutput: shortJson(item.result ?? item.error),
-      toolStatus: status,
-      time,
-    };
-  }
-
-  if (itemType === "web_search") {
-    return {
-      id,
-      kind: "tool",
-      toolName: "web search",
-      toolInput: typeof item.query === "string" ? item.query : shortJson(item),
-      toolStatus: status,
-      time,
-    };
-  }
-
-  return null;
-}
-
-function codexItemStatus(event: JsonObject, item: JsonObject): string {
-  if (typeof item.status === "string" && item.status) return item.status;
-  if (event.type === "item.started") return "started";
-  if (event.type === "item.updated") return "running";
-  if (event.type === "item.completed") {
-    return item.error ? "failed" : "completed";
-  }
-  return String(event.type ?? "");
-}
-
-function isCodexAbortMessage(message: unknown): boolean {
-  return typeof message === "string" && /operation was aborted/i.test(message);
-}
-
-function isCodexToolishItemType(itemType: string): boolean {
-  return (
-    itemType === "command_execution" ||
-    itemType === "file_change" ||
-    itemType === "mcp_tool_call" ||
-    itemType === "web_search"
-  );
-}
-
-function tankUserMessageText(event: JsonObject): string {
-  if (isJsonObject(event.payload)) {
-    if (typeof event.payload.text === "string") return event.payload.text.trim();
-    if (typeof event.payload.message === "string") return event.payload.message.trim();
-    if (isJsonObject(event.payload.message)) {
-      const content = event.payload.message.content;
-      if (typeof content === "string") return content.trim();
-    }
-  }
-  if (typeof event.message === "string") return event.message.trim();
-  if (isJsonObject(event.message)) {
-    const content = event.message.content;
-    if (typeof content === "string") return content.trim();
-    if (Array.isArray(content)) {
-      return content
-        .map((block) =>
-          isJsonObject(block) && block.type === "text" && typeof block.text === "string"
-            ? block.text
-            : "",
-        )
-        .filter(Boolean)
-        .join("\n")
-        .trim();
-    }
-  }
-  return "";
-}
-
-function isCanonicalConversationEvent(event: JsonObject): boolean {
-  return (
-    typeof event.event_id === "string" &&
-    typeof event.session_id === "string" &&
-    typeof event.visibility === "string" &&
-    typeof event.actor === "string" &&
-    typeof event.source === "string"
-  );
-}
-
-function applyCanonicalConversationEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
-  if (event.type === "user_message.created") {
-    return applyTankUserMessageEvent(entries, event);
-  }
-  // Phase 2 producers write canonical turn/item lifecycle for the future
-  // reducer. The legacy pane still renders provider-shaped events, so avoid
-  // showing duplicate lifecycle meta rows until Phase 3 switches projection.
-  return entries;
-}
-
-function applyTankUserMessageEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
-  const text = tankUserMessageText(event);
-  if (!text || hasUserMessageText(entries, text)) return entries;
-  const skillName = skillNameFromTrigger(text);
-  if (skillName && hasSkillInvocation(entries, skillName)) return entries;
-  return upsertEntry(entries, {
-    id: `tank-user-message-${eventID(event, "tank-user-message")}`,
-    kind: "message",
-    role: "user",
-    text,
-    time: eventTime(event),
-  });
-}
-
-function applyCodexEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
-  const type = event.type;
-  const time = eventTime(event);
-  if (type === "thread.started") {
-    const threadId = typeof event.thread_id === "string" ? event.thread_id : "";
-    return appendMeta(entries, `codex-thread-${eventID(event, threadId || "codex-thread")}`, "Codex thread started", threadId, "info", time);
-  }
-  if (type === "turn.started") {
-    return appendMeta(entries, `codex-turn-started-${eventID(event, "codex-turn-started")}`, "Turn started", undefined, "info", time);
-  }
-  if (type === "turn.completed") {
-    return appendMeta(entries, `codex-turn-completed-${eventID(event, "codex-turn-completed")}`, "Turn completed", describeUsage(event.usage), "info", time);
-  }
-  if (type === "turn.interrupted") {
-    return appendMeta(
-      entries,
-      `codex-turn-interrupted-${eventID(event, "codex-turn-interrupted")}`,
-      "Turn stopped",
-      typeof event.reason === "string" ? event.reason : undefined,
-      "info",
-      time,
-    );
-  }
-  if (type === "turn.failed" || type === "error") {
-    const error = isJsonObject(event.error) ? event.error.message : event.message;
-    if (isCodexAbortMessage(error)) {
-      return appendMeta(
-        entries,
-        `codex-turn-stopped-${eventID(event, "codex-turn-stopped")}`,
-        "Turn stopped",
-        "The turn was interrupted before completion.",
-        "info",
-        time,
-      );
-    }
-    return appendMeta(
-      entries,
-      `codex-error-${eventID(event, "codex-error")}`,
-      type === "turn.failed" ? "Turn failed" : "Codex error",
-      typeof error === "string" ? error : shortJson(event),
-      "error",
-      time,
-    );
-  }
-  if (type === "item.started" || type === "item.updated" || type === "item.completed") {
-    const item = event.item;
-    if (!isJsonObject(item)) return entries;
-    if (item.type === "agent_message") {
-      return appendAssistantMessage(
-        entries,
-        codexItemEntryId(event, item, "codex-message"),
-        typeof item.text === "string" ? item.text : "",
-        time,
-      );
-    }
-    if (item.type === "reasoning") {
-      const id = codexItemEntryId(event, item, "codex-reasoning");
-      return upsertEntry(entries, {
-        id,
-        kind: "reasoning",
-        time,
-        reasoning: { text: typeof item.text === "string" ? item.text : shortJson(item) },
-      });
-    }
-    const toolEntry = codexToolEntry(event);
-    return toolEntry ? upsertEntry(entries, toolEntry) : entries;
-  }
-  return appendMeta(entries, `codex-event-${eventID(event, "codex-event")}`, String(type || "Codex event"), shortJson(event), "info", time);
-}
-
-function claudeTextFromContent(content: unknown, includeToolResults: boolean): string {
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((block) => {
-      if (!isJsonObject(block)) return "";
-      if (block.type === "text" && typeof block.text === "string") return block.text;
-      if (includeToolResults && block.type === "tool_result") return shortJson(block.content);
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n\n");
-}
-
-function claudeToolEntries(event: JsonObject): TranscriptEntry[] {
-  const message = event.message;
-  if (!isJsonObject(message) || !Array.isArray(message.content)) return [];
-  const time = eventTime(event);
-  return message.content.flatMap((block): TranscriptEntry[] => {
-    if (!isJsonObject(block) || block.type !== "tool_use") return [];
-    const id = typeof block.id === "string" ? block.id : `claude-tool-${Date.now()}`;
-    const toolName = typeof block.name === "string" ? block.name : "tool";
-    const mcpMatch = /^mcp__([^_]+)__(.+)$/.exec(toolName);
-    const toolKind = mcpMatch ? "mcp" : toolName === "Bash" ? "shell" : undefined;
-    return [
-      {
-        id,
-        kind: "tool",
-        toolName,
-        ...(toolKind
-          ? {
-              toolKind,
-              ...(mcpMatch
-                ? {
-                    toolServer: mcpMatch[1],
-                    toolAction: mcpMatch[2],
-                  }
-                : {}),
-            }
-          : {}),
-        toolInput: shortJson(block.input),
-        toolStatus: "started",
-        time,
-      },
-    ];
-  });
-}
-
-function toolResultText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    const text = content
-      .map((b) => (isJsonObject(b) && b.type === "text" && typeof b.text === "string" ? b.text : ""))
-      .filter(Boolean)
-      .join("\n");
-    return text || shortJson(content);
-  }
-  return shortJson(content);
+function isSdkTimelineEvent(event: unknown): event is TankConversationEvent {
+  return isDurableTankConversationEvent(event);
 }
 
 function isScheduleWakeupToolName(name: string | undefined): boolean {
   return (name ?? "").toLowerCase() === "schedulewakeup";
 }
 
-function applyClaudeToolResults(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
-  const message = event.message;
-  if (!isJsonObject(message) || !Array.isArray(message.content)) return entries;
-  const time = eventTime(event);
-  return message.content.reduce<TranscriptEntry[]>((nextEntries, block) => {
-    if (!isJsonObject(block) || block.type !== "tool_result") return nextEntries;
-    const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
-    if (!toolUseId) return nextEntries;
-    const existing = nextEntries.find((entry) => entry.id === toolUseId);
-    return upsertEntry(nextEntries, {
-      id: toolUseId,
-      kind: "tool",
-      toolName: existing?.toolName ?? "tool result",
-      toolInput: existing?.toolInput,
-      toolOutput: toolResultText(block.content),
-      toolStatus: block.is_error === true ? "failed" : "completed",
-      time: existing?.time ?? time,
-    });
-  }, entries);
-}
-
-function applyClaudeEvent(entries: TranscriptEntry[], event: JsonObject): TranscriptEntry[] {
+function sdkTerminalResult(event: unknown): SdkTerminalResult | null {
+  if (!isTankConversationEvent(event)) return null;
   const type = event.type;
-  const time = eventTime(event);
-  // Skip events that have no chat-visible meaning. stream_event is the
-  // SDK's typewriter-partial channel (deltas inside an in-flight turn) —
-  // the final `assistant` event carries the full content, so we silently
-  // drop the partials. Before this filter they fell through to the
-  // fallback appendMeta and briefly rendered as raw JSON until the
-  // history-replay path clobbered them.
-  if (
-    type === "system" ||
-    type === "stream_event" ||
-    type === "rate_limit_event" ||
-    type === "ai-title" ||
-    type === "last-prompt" ||
-    type === "attachment" ||
-    type === "queue-operation"
-  ) {
-    return entries;
-  }
-  if (type === "assistant") {
-    let nextEntries = entries;
-    for (const toolEntry of claudeToolEntries(event)) {
-      nextEntries = upsertEntry(nextEntries, toolEntry);
-    }
-    const message = event.message;
-    const text = isJsonObject(message) ? claudeTextFromContent(message.content, false) : "";
-    if (text) {
-      nextEntries = appendAssistantMessage(
-        nextEntries,
-        typeof event.uuid === "string" ? event.uuid : `claude-message-${Date.now()}`,
-        text,
-        time,
-      );
-    }
-    return nextEntries;
-  }
-  if (type === "user") {
-    // Reconstruct tool results first.
-    let nextEntries = applyClaudeToolResults(entries, event);
-    // Also reconstruct user text messages (initial prompt and follow-ups).
-    // These are stored in the JSONL but not re-emitted by the live stream
-    // (the frontend adds the user bubble directly in startRun). Use text
-    // deduplication so re-running this during live streaming is a no-op.
-    const message = event.message;
-    if (isJsonObject(message)) {
-      const texts: string[] = [];
-      if (typeof message.content === "string") {
-        // Initial prompt stored as a plain string.
-        const t = message.content.trim();
-        if (t) texts.push(t);
-      } else if (Array.isArray(message.content)) {
-        // A user event with tool_result blocks is a tool-response turn; any
-        // text blocks alongside them are echoed context (e.g. agent prompts),
-        // not human input — skip text extraction entirely for those events.
-        const hasToolResults = (message.content as unknown[]).some(
-          (b) => isJsonObject(b) && b.type === "tool_result",
-        );
-        if (!hasToolResults) {
-          for (const block of message.content as unknown[]) {
-            if (!isJsonObject(block) || block.type !== "text") continue;
-            const t = typeof block.text === "string" ? block.text.trim() : "";
-            if (t) texts.push(t);
-          }
-        }
-      }
-      const baseId = eventID(event, "claude-user-message");
-      for (const [index, text] of texts.entries()) {
-        const skillName = skillNameFromTrigger(text);
-        if (skillName && hasSkillInvocation(nextEntries, skillName)) continue;
-        if (hasUserMessageText(nextEntries, text)) continue;
-        nextEntries = upsertEntry(nextEntries, {
-          id: `${baseId}-${index}`,
-          kind: "message",
-          role: "user",
-          text,
-          time,
-        });
-      }
-    }
-    return nextEntries;
-  }
-  if (type === "result") {
-    const isError = event.is_error === true || event.subtype === "error";
-    const result = typeof event.result === "string" ? event.result : "";
-    const id = eventID(event, "claude-result");
-    if (!isError) {
-      if (result && !entries.some((entry) => entry.kind === "message" && entry.text === result)) {
-        return appendAssistantMessage(entries, `claude-result-message-${id}`, result, time);
-      }
-      return entries;
-    }
-    let nextEntries = appendMeta(
-      entries,
-      `claude-result-${id}`,
-      "Claude run failed",
-      result,
-      "error",
-      time,
-    );
-    if (result && !entries.some((entry) => entry.kind === "message" && entry.text === result)) {
-      nextEntries = appendAssistantMessage(nextEntries, `claude-result-message-${id}`, result, time);
-    }
-    return nextEntries;
-  }
-  return appendMeta(entries, `claude-event-${eventID(event, "claude-event")}`, String(type || "Claude event"), shortJson(event), "info", time);
-}
-
-function applyProviderEvent(
-  entries: TranscriptEntry[],
-  mode: SessionMode,
-  event: JsonObject,
-): TranscriptEntry[] {
-  if (isCanonicalConversationEvent(event)) {
-    return applyCanonicalConversationEvent(entries, event);
-  }
-  if (event.type === "tank.user_message") {
-    return applyTankUserMessageEvent(entries, event);
-  }
-  if (event.type === "tank.skill_invocation") {
-    const name = typeof event.name === "string" ? event.name.trim() : "";
-    const trigger = typeof event.trigger === "string" ? event.trigger : "";
-    return name
-      ? appendSkillInvocation(entries, name, skillSupplementalText(name, trigger), eventTime(event))
-      : entries;
-  }
-  if (mode === "codex_gui") return applyCodexEvent(entries, event);
-  return applyClaudeEvent(entries, event);
-}
-
-function sdkTerminalResult(event: JsonObject): SdkTerminalResult | null {
-  const type = event.type;
-  if (type === "result") {
-    const failed = event.is_error === true || event.subtype === "error";
-    return {
-      status: failed ? "error" : "done",
-      detail: typeof event.result === "string" ? event.result : undefined,
-    };
-  }
   if (type === "turn.completed") {
     return { status: "done" };
   }
   if (type === "turn.interrupted") {
     return { status: "stopped" };
   }
-  if (type === "turn.failed" || type === "error") {
-    const error = isJsonObject(event.error) ? event.error.message : event.message;
-    if (isCodexAbortMessage(error)) return { status: "stopped" };
+  if (type === "turn.failed") {
+    const error = event.payload?.error;
+    if (isProviderAbortMessage(error)) return { status: "stopped" };
     return {
       status: "error",
-      detail: typeof error === "string" ? error : shortJson(event),
+      detail: typeof error === "string" ? error : shortJson(event.payload ?? event),
     };
   }
   return null;
@@ -2388,8 +1860,8 @@ function sdkHistoryTerminalForRun(
 ): SdkTerminalResult | undefined {
   let afterRunUserMessage = false;
   for (const event of events) {
-    if (!isJsonObject(event)) continue;
-    if (event.type === "tank.user_message" || event.type === "user_message.created") {
+    if (!isTankConversationEvent(event)) continue;
+    if (event.type === "user_message.created") {
       if (afterRunUserMessage) return undefined;
       if (event.client_nonce === clientNonce) afterRunUserMessage = true;
       continue;
@@ -2504,9 +1976,7 @@ function normalizeToolState(status: string | undefined): string {
     normalized === "running" ||
     normalized === "pending" ||
     normalized === "in_progress" ||
-    normalized === "in-progress" ||
-    normalized === "item.started" ||
-    normalized === "item.updated"
+    normalized === "in-progress"
   ) {
     return "running";
   }
@@ -3021,49 +2491,23 @@ function entryMetaFingerprint(entry: TranscriptEntry): string | null {
   ].join("\u0000");
 }
 
-function annotateEntriesFromEvent(
-  before: TranscriptEntry[],
-  after: TranscriptEntry[],
-  source: "server" | "realtime",
-  event: JsonObject,
-): TranscriptEntry[] {
-  const known = new Set(before.map((entry) => entry.id));
-  const sourceEventId = eventID(event, `${source}-event`);
-  const orderKey = eventOrderKey(event);
-  return after.map((entry) =>
-    known.has(entry.id)
-      ? entry
-      : {
-          ...entry,
-          transcriptSource: source,
-          sourceEventId,
-          orderKey,
-        },
-  );
-}
-
-function applySdkProviderEvent(
-  entries: TranscriptEntry[],
-  mode: SessionMode,
-  event: JsonObject,
-  source: "server" | "realtime",
-): TranscriptEntry[] {
-  return annotateEntriesFromEvent(
-    entries,
-    applyProviderEvent(entries, mode, event),
-    source,
-    event,
-  );
-}
-
 function shouldDropRealtimeEntry(
   entry: TranscriptEntry,
   serverIds: Set<string>,
   serverEventIds: Set<string>,
   serverMetaFingerprints: Set<string>,
+  serverMessageFingerprints: Set<string>,
 ): boolean {
   if (serverIds.has(entry.id)) return true;
   if (entry.sourceEventId && serverEventIds.has(entry.sourceEventId)) return true;
+  const messageFingerprint = entryMessageFingerprint(entry);
+  if (
+    entry.localOnly &&
+    messageFingerprint &&
+    serverMessageFingerprints.has(messageFingerprint)
+  ) {
+    return true;
+  }
   const metaFingerprint = entryMetaFingerprint(entry);
   return Boolean(
     metaFingerprint &&
@@ -3086,6 +2530,11 @@ function pruneRealtimeEntries(
       .map(entryMetaFingerprint)
       .filter((fingerprint): fingerprint is string => fingerprint !== null),
   );
+  const serverMessageFingerprints = new Set(
+    server
+      .map(entryMessageFingerprint)
+      .filter((fingerprint): fingerprint is string => fingerprint !== null),
+  );
   return realtime.filter(
     (entry) =>
       !shouldDropRealtimeEntry(
@@ -3093,6 +2542,7 @@ function pruneRealtimeEntries(
         serverIds,
         serverEventIds,
         serverMetaFingerprints,
+        serverMessageFingerprints,
       ),
   );
 }
@@ -3143,20 +2593,31 @@ function mergeSdkTranscript(
   return dedupeAdjacentAssistantEchoes([...server, ...extra]);
 }
 
-function parseRunHistory(text: string, mode: SessionMode): TranscriptEntry[] {
-  let acc: TranscriptEntry[] = [];
-  for (const line of text.split("\n")) {
-    if (!line.trim()) continue;
-    try {
-      const ev = JSON.parse(line);
-      if (isJsonObject(ev)) {
-        acc = applyProviderEvent(acc, mode, ev);
-      }
-    } catch {
-      /* skip unparseable history lines */
-    }
-  }
-  return acc;
+function orderedConversationEvents(events: TankConversationEvent[]): TankConversationEvent[] {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => {
+      const keyCompare = conversationEventSortKey(a.event).localeCompare(
+        conversationEventSortKey(b.event),
+      );
+      return keyCompare !== 0 ? keyCompare : a.index - b.index;
+    })
+    .map((item) => item.event);
+}
+
+function conversationEventSortKey(event: TankConversationEvent): string {
+  return [
+    event.order_key ?? "",
+    event.created_at,
+    event.sequence == null ? "" : String(event.sequence).padStart(12, "0"),
+    event.event_id,
+  ].join("\u001f");
+}
+
+function conversationEntriesToTranscript(
+  entries: ConversationViewEntry[],
+): TranscriptEntry[] {
+  return entries.map((entry) => entry as TranscriptEntry);
 }
 
 type ActiveRunData = {
@@ -4075,6 +3536,10 @@ function HeadlessRun({
   const [entries, setEntries] = useState<TranscriptEntry[]>([]);
   const sdkServerEntriesRef = useRef<TranscriptEntry[]>([]);
   const sdkRealtimeEntriesRef = useRef<TranscriptEntry[]>([]);
+  const sdkServerEventsRef = useRef<TankConversationEvent[]>([]);
+  const sdkRealtimeEventsRef = useRef<TankConversationEvent[]>([]);
+  const sdkConversationStateRef = useRef<ConversationReducerState>(initialConversationState);
+  const sdkAssistantDurationsRef = useRef<Map<string, number>>(new Map());
   const [running, setRunning] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [editingTitleValue, setEditingTitleValue] = useState("");
@@ -4099,9 +3564,9 @@ function HeadlessRun({
   // interval while running so the bar updates without a per-element timer.
   const [runStartedAt, setRunStartedAt] = useState<number | null>(null);
   const [now, setNow] = useState<number>(() => Date.now());
-  // Context tokens used in the most recent assistant turn — updated via
-  // applyStdoutLine when an `assistant` or `result` event with usage info
-  // arrives. Drives the % ring in the composer footer.
+  // Context tokens used in the most recent assistant turn. Legacy streams
+  // update this from provider stdout; SDK sessions update it from the
+  // canonical conversation projection.
   const [tokensUsed, setTokensUsed] = useState(0);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   // Slash-command palette state. `slashOpen` gates rendering; `slashQuery`
@@ -4233,7 +3698,34 @@ function HeadlessRun({
       orderKey: entry.orderKey ?? `${localOrderKey(nonce)}-${index}`,
     }));
   }
+  function applySdkAssistantDurations(entries: TranscriptEntry[]): TranscriptEntry[] {
+    if (sdkAssistantDurationsRef.current.size === 0) return entries;
+    return entries.map((entry) => {
+      if (entry.kind !== "message" || entry.role !== "assistant") return entry;
+      const durationMs = sdkAssistantDurationsRef.current.get(entry.id);
+      return durationMs == null ? entry : ({ ...entry, durationMs } as TranscriptEntry);
+    });
+  }
+  function reduceSdkConversationState(): ConversationReducerState {
+    return reduceConversationEvents(
+      orderedConversationEvents([
+        ...sdkServerEventsRef.current,
+        ...sdkRealtimeEventsRef.current,
+      ]),
+      initialConversationState,
+    );
+  }
   function syncSdkRenderedEntries(): void {
+    const state = reduceSdkConversationState();
+    sdkConversationStateRef.current = state;
+    const projection = projectConversationState(state);
+    sdkServerEntriesRef.current = applySdkAssistantDurations(
+      conversationEntriesToTranscript(projection.entries),
+    );
+    sdkRealtimeEntriesRef.current = pruneRealtimeEntries(
+      sdkServerEntriesRef.current,
+      sdkRealtimeEntriesRef.current,
+    );
     const merged = mergeSdkTranscript(
       sdkServerEntriesRef.current,
       sdkRealtimeEntriesRef.current,
@@ -4241,15 +3733,61 @@ function HeadlessRun({
     setEntries((prev) =>
       transcriptComparable(prev) === transcriptComparable(merged) ? prev : merged,
     );
+    applySdkProjectionToUi(projection);
   }
-  function replaceSdkServerEntries(
-    serverEntries: TranscriptEntry[],
+  function applySdkProjectionToUi(
+    projection: ReturnType<typeof projectConversationState>,
+  ): void {
+    const total = totalContextTokens(projection.lastUsage as ClaudeUsage | undefined);
+    if (total > 0) setTokensUsed(total);
+
+    const sdkActive =
+      projection.runStatus === "submitted" ||
+      projection.runStatus === "streaming" ||
+      projection.runStatus === "needs_input";
+    if (projection.activeToolName) {
+      setActiveTool(projection.activeToolName, projection.activeItemId);
+    } else if (!sdkActive) {
+      setActiveTool(null);
+    }
+
+    if (currentRunRef.current) {
+      if (sdkActive) {
+        setRunStatus("running");
+        setRunning(true);
+      }
+      return;
+    }
+
+    if (sdkActive) {
+      setRunStatus("running");
+      setRunning(true);
+      setRunStartedAt((startedAt) => startedAt ?? Date.now());
+      setNow(Date.now());
+      return;
+    }
+
+    setRunning(false);
+    setActiveRunId(null);
+    if (projection.runStatus === "error") {
+      setRunStatus("error");
+      setLastStatusText("Error");
+    } else if (projection.runStatus === "stopped") {
+      setRunStatus("done");
+      setLastStatusText("Stopped");
+    } else {
+      setRunStatus((prev) => (prev === "running" ? "done" : prev));
+    }
+  }
+  function replaceSdkServerEvents(
+    serverEvents: TankConversationEvent[],
     clearRealtime = false,
   ): void {
-    sdkServerEntriesRef.current = serverEntries;
-    sdkRealtimeEntriesRef.current = clearRealtime
-      ? []
-      : pruneRealtimeEntries(serverEntries, sdkRealtimeEntriesRef.current);
+    sdkServerEventsRef.current = serverEvents;
+    if (clearRealtime) {
+      sdkRealtimeEventsRef.current = [];
+      sdkRealtimeEntriesRef.current = [];
+    }
     syncSdkRenderedEntries();
   }
   function appendSdkRealtimeEntries(localEntries: TranscriptEntry[]): void {
@@ -4261,40 +3799,29 @@ function HeadlessRun({
     );
     syncSdkRenderedEntries();
   }
-  function advanceSdkTimelineCursor(event: JsonObject): void {
-    if (!isSdkTimelineEvent(session.mode, event)) return;
+  function advanceSdkTimelineCursor(event: unknown): void {
+    if (!isSdkTimelineEvent(event)) return;
     sdkTimelineCursorRef.current = advanceTimelineCursor(
       sdkTimelineCursorRef.current,
-      eventTimelineCursor(event),
+      eventTimelineCursor(event as unknown as JsonObject),
     );
   }
   function applySdkRealtimeEvent(event: JsonObject): void {
+    if (!isTankConversationEvent(event)) return;
     advanceSdkTimelineCursor(event);
-    const nextRealtime = applySdkProviderEvent(
-      sdkRealtimeEntriesRef.current,
-      session.mode,
-      event,
-      "realtime",
-    );
-    sdkRealtimeEntriesRef.current = pruneRealtimeEntries(
-      sdkServerEntriesRef.current,
-      pruneLocalRealtimeEchoes(nextRealtime.slice(-500)),
-    );
+    if (!sdkRealtimeEventsRef.current.some((candidate) => candidate.event_id === event.event_id)) {
+      sdkRealtimeEventsRef.current = [...sdkRealtimeEventsRef.current, event].slice(-1000);
+    }
     syncSdkRenderedEntries();
   }
   function updateSdkLastAssistantDuration(durationMs: number): void {
-    const update = (list: TranscriptEntry[]) => {
-      for (let i = list.length - 1; i >= 0; i -= 1) {
-        if (list[i].kind === "message" && list[i].role === "assistant") {
-          const next = [...list];
-          next[i] = { ...next[i], durationMs } as TranscriptEntry;
-          return next;
-        }
+    for (let i = sdkServerEntriesRef.current.length - 1; i >= 0; i -= 1) {
+      const entry = sdkServerEntriesRef.current[i];
+      if (entry.kind === "message" && entry.role === "assistant") {
+        sdkAssistantDurationsRef.current.set(entry.id, durationMs);
+        break;
       }
-      return list;
-    };
-    sdkRealtimeEntriesRef.current = update(sdkRealtimeEntriesRef.current);
-    sdkServerEntriesRef.current = update(sdkServerEntriesRef.current);
+    }
     syncSdkRenderedEntries();
   }
   const queuedMessageSeqRef = useRef(0);
@@ -4458,8 +3985,8 @@ function HeadlessRun({
     if (historyRefreshRef.current) return;
     const refreshSessionId = session.id;
     // SDK pods have a durable canonical log in Cosmos session-events; hit
-    // that directly. Legacy path tries the structured replay first and falls
-    // back to raw JSONL history. Both feed the same applyProviderEvent.
+    // that directly. Legacy path tries structured run events first and falls
+    // back to adapter-parsed provider JSONL.
     const initial =
       session.runtime === "sdk"
         ? refreshSdkRunHistory(showHint)
@@ -4518,10 +4045,9 @@ function HeadlessRun({
   }
 
   // SDK-runtime history replay. Hits the canonical event log written by the
-  // pod-side agent-runner (Cosmos session-events container, exposed via
-  // /api/sessions/{id}/timeline). Each event is the same shape applyProviderEvent
-  // already consumes — the chat pane was built around Claude's stream-json,
-  // which the SDK is a TypeScript wrapper over the same binary's stdout.
+  // pod-side runner (Cosmos session-events container, exposed via
+  // /api/sessions/{id}/timeline), then renders through the same reducer and
+  // projection path used for live SDK frames.
   function refreshSdkRunHistory(showHint: boolean, clearRealtime = false): Promise<boolean> {
     return refreshSdkRunHistoryResult(showHint, clearRealtime).then(
       (result) => result.replayed,
@@ -4566,18 +4092,18 @@ function HeadlessRun({
         if (!nextAfter || nextAfter === previousAfter) break;
       }
 
-      let acc: TranscriptEntry[] = [];
+      const canonicalEvents: TankConversationEvent[] = [];
       for (const ev of events) {
-        if (isJsonObject(ev)) {
+        if (isTankConversationEvent(ev)) {
           advanceSdkTimelineCursor(ev);
-          acc = applySdkProviderEvent(acc, session.mode, ev, "server");
+          if (ev.visibility !== "live-only") canonicalEvents.push(ev);
         }
       }
       const terminal = clientNonce
         ? sdkHistoryTerminalForRun(events, clientNonce)
         : undefined;
-      if (acc.length === 0) return { replayed: false, terminal };
-      replaceSdkServerEntries(acc, clearRealtime);
+      if (canonicalEvents.length === 0) return { replayed: false, terminal };
+      replaceSdkServerEvents(canonicalEvents, clearRealtime);
       if (showHint) {
         setContinueHintVisible(true);
         window.setTimeout(() => setContinueHintVisible(false), 3000);
@@ -4620,7 +4146,7 @@ function HeadlessRun({
       .then((text) => {
         if (sessionIdRef.current !== refreshSessionId) return;
         if (!text) return;
-        const acc = parseRunHistory(text, session.mode);
+        const acc = parseProviderRunHistory(text, session.mode) as TranscriptEntry[];
         if (acc.length > 0) {
           let behind = false;
           setEntries((prev) => {
@@ -4996,6 +4522,10 @@ function HeadlessRun({
     sessionIdRef.current = session.id;
     sdkServerEntriesRef.current = [];
     sdkRealtimeEntriesRef.current = [];
+    sdkServerEventsRef.current = [];
+    sdkRealtimeEventsRef.current = [];
+    sdkConversationStateRef.current = initialConversationState;
+    sdkAssistantDurationsRef.current = new Map();
     sdkTimelineCursorRef.current = null;
     setEntries([]);
     setQueuedMessages([]);
@@ -5343,33 +4873,14 @@ function HeadlessRun({
       return;
     }
     if (!isJsonObject(providerEvent)) return;
-    // Track context-window usage from claude's stream-json events. The
-    // assistant message and the final result both carry a `usage` block;
-    // the result is the most accurate "final state" so prefer it.
-    const t = (providerEvent as JsonObject).type;
-    if (t === "assistant") {
-      const msg = (providerEvent as JsonObject).message;
-      if (isJsonObject(msg)) {
-        const u = (msg as JsonObject).usage as ClaudeUsage | undefined;
-        const total = totalContextTokens(u);
-        if (total > 0) setTokensUsed(total);
-        // Track active tool — first tool_use block in content, if any.
-        if (Array.isArray(msg.content)) {
-          const toolBlock = (msg.content as unknown[]).find(
-            (b): b is JsonObject => isJsonObject(b) && b.type === "tool_use",
-          );
-          const toolName = toolBlock && typeof toolBlock.name === "string" ? toolBlock.name : null;
-          const toolUseId = toolBlock && typeof toolBlock.id === "string" ? toolBlock.id : null;
-          setActiveTool(toolName, toolUseId);
-        }
-      }
-    } else if (t === "user") {
-      completeActiveTool();
-    } else if (t === "result") {
-      const u = (providerEvent as JsonObject).usage as ClaudeUsage | undefined;
-      const total = totalContextTokens(u);
-      if (total > 0) setTokensUsed(total);
-      setActiveTool(null);
+    const effects = providerFrameEffects(providerEvent);
+    const total = totalContextTokens(effects.usage as ClaudeUsage | undefined);
+    if (total > 0) setTokensUsed(total);
+    if (effects.activeTool) {
+      setActiveTool(effects.activeTool.name, effects.activeTool.id ?? null);
+    }
+    if ("completedToolUseId" in effects) {
+      completeActiveTool(effects.completedToolUseId ?? null);
     }
     setEntries((prev) => applyProviderEvent(prev, session.mode, providerEvent));
   }
@@ -5977,66 +5488,9 @@ function HeadlessRun({
         return;
       }
 
-      // Bookkeeping for usage/active-tool. Two flavors of SDK events come
-      // through this WS: claude's `{type:"assistant"|"user"|"result"}` and
-      // codex's `{type:"item.started"|"item.completed"|"turn.completed"}`.
-      // The chat pane renders both shapes via applyProviderEvent → the
-      // right applyXxxEvent for session.mode; the bookkeeping here also
-      // forks on the shape so the streaming pill + context pie work
-      // regardless of which runtime is streaming.
-      const t = parsed.type;
-      if (t === "assistant") {
-        const msg = parsed.message;
-        if (isJsonObject(msg)) {
-          const u = msg.usage as ClaudeUsage | undefined;
-          const total = totalContextTokens(u);
-          if (total > 0) setTokensUsed(total);
-          if (Array.isArray(msg.content)) {
-            const toolBlock = (msg.content as unknown[]).find(
-              (b): b is JsonObject => isJsonObject(b) && b.type === "tool_use",
-            );
-            const toolName =
-              toolBlock && typeof toolBlock.name === "string" ? toolBlock.name : null;
-            const toolUseId =
-              toolBlock && typeof toolBlock.id === "string" ? toolBlock.id : null;
-            setActiveTool(toolName, toolUseId);
-          }
-        }
-      } else if (t === "user") {
-        completeActiveTool();
-      } else if (t === "result") {
-        const u = parsed.usage as ClaudeUsage | undefined;
-        const total = totalContextTokens(u);
-        if (total > 0) setTokensUsed(total);
-        setActiveTool(null);
-      } else if (t === "item.started" || t === "item.updated") {
-        // Codex flag: a tool-like item (command_execution / file_change /
-        // mcp_tool_call / web_search) is in flight. Show its kind on the
-        // streaming pill the same way Claude's tool_use blocks do.
-        const item = parsed.item;
-        if (isJsonObject(item)) {
-          const itemType = typeof item.type === "string" ? item.type : "";
-          if (isCodexToolishItemType(itemType)) {
-            setActiveTool(itemType, typeof item.id === "string" ? item.id : null);
-          }
-        }
-      } else if (t === "item.completed") {
-        const item = parsed.item;
-        if (isJsonObject(item)) {
-          const itemType = typeof item.type === "string" ? item.type : "";
-          if (isCodexToolishItemType(itemType)) {
-            completeActiveTool(typeof item.id === "string" ? item.id : null);
-          }
-        }
-      } else if (t === "turn.completed") {
-        // Codex's per-turn closing event. Usage rides on the event itself
-        // (not nested under `message` like claude does).
-        const u = parsed.usage as ClaudeUsage | undefined;
-        const total = totalContextTokens(u);
-        if (total > 0) setTokensUsed(total);
-        setActiveTool(null);
-      }
-
+      // SDK chat state is derived only from TankConversationEvent frames.
+      // Raw provider frames may still fan out for audit/debug, but they do
+      // not mutate the chat transcript.
       applySdkRealtimeEvent(parsed);
 
       const terminal = sdkTerminalResult(parsed);

--- a/frontend/src/conversationProjection.test.ts
+++ b/frontend/src/conversationProjection.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { reduceConversationEvents } from "./conversationReducer.ts";
+import { projectConversationState } from "./conversationProjection.ts";
+import type { TankConversationEvent } from "./tankConversation.ts";
+
+function ev(
+  event_id: string,
+  type: TankConversationEvent["type"],
+  fields: Partial<TankConversationEvent> = {},
+): TankConversationEvent {
+  return {
+    event_id,
+    order_key: event_id.padStart(4, "0"),
+    session_id: "63",
+    turn_id: "turn-1",
+    actor: "runner",
+    source: "tank",
+    type,
+    created_at: "2026-05-12T00:00:00.000Z",
+    visibility: "durable",
+    ...fields,
+  };
+}
+
+test("projects canonical user and assistant events into chat messages", () => {
+  const state = reduceConversationEvents([
+    ev("1", "user_message.created", {
+      actor: "user",
+      client_nonce: "run-1",
+      payload: { text: "hello" },
+    }),
+    ev("2", "turn.started", { source: "claude" }),
+    ev("3", "item.completed", {
+      actor: "assistant",
+      source: "claude",
+      item_id: "assistant-1",
+      payload: { kind: "message", text: "world" },
+    }),
+    ev("4", "turn.completed", { source: "claude" }),
+  ]);
+
+  const projection = projectConversationState(state);
+
+  assert.deepEqual(
+    projection.entries.map((entry) =>
+      entry.kind === "message" ? [entry.role, entry.text] : [entry.kind],
+    ),
+    [
+      ["user", "hello"],
+      ["assistant", "world"],
+    ],
+  );
+  assert.equal(projection.runStatus, "ready");
+});
+
+test("projects canonical tool lifecycle and active tool state", () => {
+  const running = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "turn.started", { source: "claude" }),
+      ev("2", "item.started", {
+        actor: "tool",
+        source: "claude",
+        item_id: "toolu-read",
+        payload: {
+          kind: "tool",
+          title: "Read",
+          input: { file_path: "README.md" },
+        },
+      }),
+    ]),
+  );
+
+  assert.equal(running.activeToolName, "Read");
+  assert.equal(running.entries[0]?.kind, "tool");
+  if (running.entries[0]?.kind === "tool") {
+    assert.equal(running.entries[0].toolStatus, "started");
+    assert.match(running.entries[0].toolInput ?? "", /README\.md/);
+  }
+
+  const completed = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "turn.started", { source: "claude" }),
+      ev("2", "item.started", {
+        actor: "tool",
+        source: "claude",
+        item_id: "toolu-read",
+        payload: { kind: "tool", title: "Read" },
+      }),
+      ev("3", "item.completed", {
+        actor: "tool",
+        source: "claude",
+        item_id: "toolu-read",
+        payload: { kind: "tool_result", output: "README contents" },
+      }),
+    ]),
+  );
+
+  assert.equal(completed.activeToolName, null);
+  assert.equal(completed.entries[0]?.kind, "tool");
+  if (completed.entries[0]?.kind === "tool") {
+    assert.equal(completed.entries[0].toolName, "Read");
+    assert.equal(completed.entries[0].toolStatus, "completed");
+    assert.equal(completed.entries[0].toolOutput, "README contents");
+  }
+});
+
+test("canonical duplicate delivery converges before projection", () => {
+  const events = [
+    ev("1", "user_message.created", {
+      actor: "user",
+      client_nonce: "run-1",
+      payload: { text: "once" },
+    }),
+    ev("2", "turn.interrupted", {
+      source: "codex",
+      payload: { reason: "client_interrupt" },
+    }),
+  ];
+
+  const projection = projectConversationState(
+    reduceConversationEvents([...events, ...events]),
+  );
+
+  assert.equal(projection.entries.length, 1);
+  assert.equal(projection.stopped, true);
+  assert.equal(projection.failed, false);
+});

--- a/frontend/src/conversationProjection.ts
+++ b/frontend/src/conversationProjection.ts
@@ -1,0 +1,335 @@
+import type {
+  ConversationItem,
+  ConversationReducerState,
+  ConversationRunStatus,
+} from "./conversationReducer";
+
+export type ConversationViewEntry =
+  | ConversationMessageEntry
+  | ConversationToolEntry
+  | ConversationReasoningEntry
+  | ConversationMetaEntry;
+
+export interface ConversationMessageEntry extends ConversationEntryBase {
+  kind: "message";
+  role: "user" | "assistant" | "system";
+  text: string;
+}
+
+export interface ConversationToolEntry extends ConversationEntryBase {
+  kind: "tool";
+  toolName: string;
+  toolKind?: "mcp" | "shell";
+  toolServer?: string;
+  toolAction?: string;
+  toolInput?: string;
+  toolOutput?: string;
+  toolStatus?: string;
+}
+
+export interface ConversationReasoningEntry extends ConversationEntryBase {
+  kind: "reasoning";
+  reasoning: { text: string };
+}
+
+export interface ConversationMetaEntry extends ConversationEntryBase {
+  kind: "meta";
+  meta: {
+    title: string;
+    detail?: string;
+    severity?: "info" | "error";
+  };
+}
+
+interface ConversationEntryBase {
+  id: string;
+  time: string;
+  sourceEventId?: string;
+  orderKey?: string;
+}
+
+export interface ConversationProjection {
+  entries: ConversationViewEntry[];
+  runStatus: ConversationRunStatus;
+  activeTurnId: string | null;
+  activeItemId: string | null;
+  activeToolName: string | null;
+  needsInput: boolean;
+  failed: boolean;
+  stopped: boolean;
+  lastError: string | null;
+  lastUsage: unknown | null;
+  lastOrderKey: string | null;
+  unreadCount: number;
+}
+
+export function projectConversationState(
+  state: ConversationReducerState,
+): ConversationProjection {
+  const entries = orderProjectedEntries([
+    ...state.messages.flatMap((message, index) => {
+      const text = message.text.trim();
+      if (!text) return [];
+      return [
+        {
+          index,
+          orderKey: message.orderKey,
+          entry: {
+            id: message.id,
+            kind: "message" as const,
+            role: message.role,
+            text,
+            time: message.createdAt ?? "",
+            sourceEventId: message.sourceEventId,
+            orderKey: message.orderKey,
+          },
+        },
+      ];
+    }),
+    ...state.items.flatMap((item, index) => {
+      const entry = projectItem(item);
+      return entry
+        ? [
+            {
+              index: state.messages.length + index,
+              orderKey: item.orderKey,
+              entry,
+            },
+          ]
+        : [];
+    }),
+  ]);
+
+  const activeItem = activeToolItem(state);
+  return {
+    entries,
+    runStatus: state.runStatus,
+    activeTurnId: state.activeTurnId,
+    activeItemId: activeItem?.id ?? state.activeItemId,
+    activeToolName: activeItem ? toolDisplay(activeItem).toolName : null,
+    needsInput: state.needsInput,
+    failed: state.failed,
+    stopped: state.runStatus === "stopped",
+    lastError: state.lastError,
+    lastUsage: state.lastUsage,
+    lastOrderKey: state.lastOrderKey,
+    unreadCount: state.unreadCount,
+  };
+}
+
+function projectItem(item: ConversationItem): ConversationViewEntry | null {
+  if (isAssistantMessageItem(item)) {
+    const text = item.text?.trim() ?? "";
+    if (!text) return null;
+    return {
+      id: item.id,
+      kind: "message",
+      role: "assistant",
+      text,
+      time: item.createdAt ?? "",
+      sourceEventId: item.sourceEventId,
+      orderKey: item.orderKey,
+    };
+  }
+
+  if (item.kind === "reasoning") {
+    const text = item.text?.trim() || stringPayload(item, "text") || "";
+    if (!text) return null;
+    return {
+      id: item.id,
+      kind: "reasoning",
+      reasoning: { text },
+      time: item.createdAt ?? "",
+      sourceEventId: item.sourceEventId,
+      orderKey: item.orderKey,
+    };
+  }
+
+  if (isToolLikeItem(item)) {
+    const display = toolDisplay(item);
+    return {
+      id: item.id,
+      kind: "tool",
+      ...display,
+      toolInput: toolInput(item),
+      toolOutput: toolOutput(item),
+      toolStatus: toolStatus(item),
+      time: item.createdAt ?? "",
+      sourceEventId: item.sourceEventId,
+      orderKey: item.orderKey,
+    };
+  }
+
+  const text = item.text?.trim() ?? "";
+  if (!text) return null;
+  return {
+    id: item.id,
+    kind: "meta",
+    meta: {
+      title: item.title ?? item.kind,
+      detail: text,
+      severity: item.status === "failed" ? "error" : "info",
+    },
+    time: item.createdAt ?? "",
+    sourceEventId: item.sourceEventId,
+    orderKey: item.orderKey,
+  };
+}
+
+function orderProjectedEntries(
+  items: Array<{ entry: ConversationViewEntry; orderKey?: string; index: number }>,
+): ConversationViewEntry[] {
+  return [...items]
+    .sort((a, b) => {
+      const order = compareNullableString(a.orderKey, b.orderKey);
+      return order !== 0 ? order : a.index - b.index;
+    })
+    .map((item) => item.entry);
+}
+
+function compareNullableString(a: string | undefined, b: string | undefined): number {
+  if (a && b) return a.localeCompare(b);
+  if (a) return -1;
+  if (b) return 1;
+  return 0;
+}
+
+function isAssistantMessageItem(item: ConversationItem): boolean {
+  return (
+    item.actor === "assistant" &&
+    (item.kind === "message" || item.kind === "agent_message")
+  );
+}
+
+function isToolLikeItem(item: ConversationItem): boolean {
+  return (
+    item.actor === "tool" ||
+    item.kind === "tool" ||
+    item.kind === "tool_result" ||
+    item.kind === "approval" ||
+    item.kind === "needs_input" ||
+    item.kind === "command_execution" ||
+    item.kind === "file_change" ||
+    item.kind === "mcp_tool_call" ||
+    item.kind === "web_search"
+  );
+}
+
+function activeToolItem(state: ConversationReducerState): ConversationItem | null {
+  const active = state.activeItemId
+    ? state.items.find((item) => item.id === state.activeItemId)
+    : undefined;
+  if (active && isToolLikeItem(active) && isRunningItem(active)) return active;
+  for (let index = state.items.length - 1; index >= 0; index -= 1) {
+    const item = state.items[index];
+    if (isToolLikeItem(item) && isRunningItem(item)) return item;
+  }
+  return null;
+}
+
+function isRunningItem(item: ConversationItem): boolean {
+  return item.status === "started" || item.status === "streaming";
+}
+
+function toolDisplay(item: ConversationItem): Pick<
+  ConversationToolEntry,
+  "toolName" | "toolKind" | "toolServer" | "toolAction"
+> {
+  const raw = recordPayload(item, "raw_item");
+  const rawServer = stringRecordValue(raw, "server");
+  const rawTool = stringRecordValue(raw, "tool");
+  const payloadServer = stringPayload(item, "server");
+  const payloadTool = stringPayload(item, "tool");
+  const server = payloadServer ?? rawServer;
+  const action = payloadTool ?? rawTool;
+
+  if (item.kind === "mcp_tool_call" || server || action) {
+    const toolAction = action ?? item.title ?? "tool";
+    const toolServer = server ?? "mcp";
+    return {
+      toolName: `${toolServer}.${toolAction}`,
+      toolKind: "mcp",
+      toolServer,
+      toolAction,
+    };
+  }
+
+  const name =
+    stringPayload(item, "name") ??
+    item.title ??
+    stringPayload(item, "title") ??
+    stringPayload(item, "command") ??
+    item.kind;
+  const mcpMatch = /^mcp__([^_]+)__(.+)$/.exec(name);
+  if (mcpMatch) {
+    return {
+      toolName: name,
+      toolKind: "mcp",
+      toolServer: mcpMatch[1],
+      toolAction: mcpMatch[2],
+    };
+  }
+  return {
+    toolName: name,
+    ...(item.kind === "command_execution" || name === "Bash" ? { toolKind: "shell" as const } : {}),
+  };
+}
+
+function toolInput(item: ConversationItem): string | undefined {
+  const raw = recordPayload(item, "raw_item");
+  return formatPayloadValue(
+    item.payload?.input ??
+      item.payload?.arguments ??
+      item.payload?.command ??
+      raw?.arguments ??
+      raw?.changes ??
+      raw?.command,
+  );
+}
+
+function toolOutput(item: ConversationItem): string | undefined {
+  const raw = recordPayload(item, "raw_item");
+  return formatPayloadValue(
+    item.payload?.output ??
+      item.payload?.result ??
+      item.payload?.error ??
+      raw?.aggregated_output ??
+      raw?.result ??
+      raw?.error,
+  );
+}
+
+function toolStatus(item: ConversationItem): string {
+  if (item.status === "streaming") return "running";
+  return item.status;
+}
+
+function stringPayload(item: ConversationItem, key: string): string | undefined {
+  const value = item.payload?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function recordPayload(item: ConversationItem, key: string): Record<string, unknown> | undefined {
+  const value = item.payload?.[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringRecordValue(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function formatPayloadValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/frontend/src/conversationReducer.ts
+++ b/frontend/src/conversationReducer.ts
@@ -17,6 +17,8 @@ export interface ConversationMessage {
   turnId?: string;
   clientNonce?: string;
   orderKey?: string;
+  sourceEventId?: string;
+  createdAt?: string;
 }
 
 export interface ConversationItem {
@@ -28,7 +30,10 @@ export interface ConversationItem {
   status: ConversationItemStatus;
   title?: string;
   text?: string;
+  payload?: Record<string, unknown>;
   orderKey?: string;
+  sourceEventId?: string;
+  createdAt?: string;
 }
 
 export interface ConversationReducerState {
@@ -41,6 +46,8 @@ export interface ConversationReducerState {
   activeItemId: string | null;
   needsInput: boolean;
   failed: boolean;
+  lastError: string | null;
+  lastUsage: unknown | null;
   lastOrderKey: string | null;
   lastReadOrderKey: string | null;
   unreadCount: number;
@@ -56,6 +63,8 @@ export const initialConversationState: ConversationReducerState = {
   activeItemId: null,
   needsInput: false,
   failed: false,
+  lastError: null,
+  lastUsage: null,
   lastOrderKey: null,
   lastReadOrderKey: null,
   unreadCount: 0,
@@ -86,6 +95,7 @@ export function conversationReducer(
         runStatus: "submitted",
         activeTurnId: event.turn_id ?? next.activeTurnId,
         failed: false,
+        lastError: null,
       };
     case "turn.started":
       return {
@@ -93,6 +103,7 @@ export function conversationReducer(
         runStatus: "streaming",
         activeTurnId: event.turn_id ?? next.activeTurnId,
         failed: false,
+        lastError: null,
       };
     case "turn.completed":
       return {
@@ -102,6 +113,8 @@ export function conversationReducer(
         activeItemId: null,
         needsInput: false,
         failed: false,
+        lastError: null,
+        lastUsage: event.payload?.usage ?? next.lastUsage,
       };
     case "turn.failed":
       return {
@@ -111,6 +124,8 @@ export function conversationReducer(
         activeItemId: null,
         needsInput: false,
         failed: true,
+        lastError: errorText(event),
+        lastUsage: event.payload?.usage ?? next.lastUsage,
       };
     case "turn.interrupted":
       return {
@@ -120,6 +135,7 @@ export function conversationReducer(
         activeItemId: null,
         needsInput: false,
         failed: false,
+        lastError: null,
       };
     case "item.started":
       return upsertItem(next, event, "started");
@@ -133,7 +149,13 @@ export function conversationReducer(
       );
     case "item.failed":
       return upsertItem(
-        { ...next, runStatus: "error", failed: true },
+        {
+          ...next,
+          runStatus: "error",
+          failed: true,
+          activeItemId: matchingActiveItem(next, event) ? null : next.activeItemId,
+          lastError: errorText(event),
+        },
         event,
         "failed",
       );
@@ -149,11 +171,16 @@ export function conversationReducer(
         "started",
       );
     case "tool.approval_resolved":
-      return {
-        ...next,
-        runStatus: next.activeTurnId ? "streaming" : "ready",
-        needsInput: false,
-      };
+      return upsertItem(
+        {
+          ...next,
+          runStatus: next.activeTurnId ? "streaming" : "ready",
+          activeItemId: matchingActiveItem(next, event) ? null : next.activeItemId,
+          needsInput: false,
+        },
+        event,
+        "completed",
+      );
     case "session.activity_updated":
       return applyActivity(next, event);
     case "read_state.updated":
@@ -183,6 +210,8 @@ function applyUserMessage(
     turnId: event.turn_id,
     clientNonce: event.client_nonce,
     orderKey: event.order_key,
+    sourceEventId: event.event_id,
+    createdAt: event.created_at,
   };
   return {
     ...state,
@@ -202,16 +231,20 @@ function upsertItem(
   const id = event.item_id ?? event.event_id;
   const existing = state.items.find((item) => item.id === id);
   const text = stringPayload(event, appendDelta ? "delta" : "text");
+  const payload = { ...(existing?.payload ?? {}), ...(event.payload ?? {}) };
   const item: ConversationItem = {
     id,
     turnId: event.turn_id,
     parentId: event.parent_id,
     actor: event.actor === "user" ? "runner" : event.actor,
-    kind: stringPayload(event, "kind") ?? defaultItemKind(event),
+    kind: stringPayload(event, "kind") ?? existing?.kind ?? defaultItemKind(event),
     status,
     title: stringPayload(event, "title") ?? existing?.title,
     text: appendDelta ? [existing?.text, text].filter(Boolean).join("") : (text ?? existing?.text),
+    payload,
     orderKey: event.order_key ?? existing?.orderKey,
+    sourceEventId: event.event_id,
+    createdAt: event.created_at || existing?.createdAt,
   };
   const items = existing
     ? state.items.map((candidate) => (candidate.id === id ? item : candidate))
@@ -277,6 +310,17 @@ function numberPayload(event: TankConversationEvent, key: string): number | unde
 function booleanPayload(event: TankConversationEvent, key: string): boolean | undefined {
   const value = event.payload?.[key];
   return typeof value === "boolean" ? value : undefined;
+}
+
+function errorText(event: TankConversationEvent): string | null {
+  const error = event.payload?.error;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  const reason = stringPayload(event, "reason");
+  return reason ?? null;
 }
 
 function isRunStatus(value: string | undefined): value is ConversationRunStatus {

--- a/frontend/src/providerEventAdapters.test.ts
+++ b/frontend/src/providerEventAdapters.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  applyProviderEvent,
+  parseProviderRunHistory,
+  providerFrameEffects,
+} from "./providerEventAdapters.ts";
+
+test("explicitly ignores transient Claude provider frames", () => {
+  const entries = applyProviderEvent([], "claude_gui", {
+    type: "stream_event",
+    event: { type: "content_block_delta" },
+    timestamp: "2026-05-12T00:00:00.000Z",
+  });
+
+  assert.deepEqual(entries, []);
+});
+
+test("extracts legacy Claude usage and active-tool effects behind adapter", () => {
+  const usage = { input_tokens: 12, cache_creation_input_tokens: 3 };
+  const effects = providerFrameEffects({
+    type: "assistant",
+    message: {
+      usage,
+      content: [{ type: "tool_use", id: "toolu_1", name: "Bash" }],
+    },
+  });
+
+  assert.deepEqual(effects, {
+    usage,
+    activeTool: { name: "Bash", id: "toolu_1" },
+  });
+});
+
+test("adapts Codex tool items and surfaces unknown Codex drift explicitly", () => {
+  const toolEntries = applyProviderEvent([], "codex_gui", {
+    type: "item.completed",
+    tank_turn_seq: 7,
+    item: {
+      id: "cmd-1",
+      type: "command_execution",
+      command: "npm test",
+      aggregated_output: "ok",
+    },
+    created_at: "2026-05-12T00:00:00.000Z",
+  });
+
+  assert.equal(toolEntries[0]?.kind, "tool");
+  assert.equal(toolEntries[0]?.toolKind, "shell");
+  assert.equal(toolEntries[0]?.toolName, "npm test");
+  assert.equal(toolEntries[0]?.toolOutput, "ok");
+
+  const unknownEntries = applyProviderEvent([], "codex_gui", {
+    type: "future.codex.event",
+    payload: { value: true },
+    created_at: "2026-05-12T00:00:00.000Z",
+  });
+
+  assert.equal(unknownEntries[0]?.kind, "meta");
+  assert.equal(unknownEntries[0]?.meta?.title, "future.codex.event");
+});
+
+test("parses legacy provider JSONL through adapter boundary", () => {
+  const history = [
+    JSON.stringify({
+      type: "assistant",
+      uuid: "msg-1",
+      message: { content: [{ type: "text", text: "hello" }] },
+      created_at: "2026-05-12T00:00:00.000Z",
+    }),
+    "not json",
+    JSON.stringify({ type: "stream_event" }),
+  ].join("\n");
+
+  const entries = parseProviderRunHistory(history, "claude_gui");
+
+  assert.deepEqual(
+    entries.map((entry) => [entry.kind, entry.kind === "message" ? entry.text : ""]),
+    [["message", "hello"]],
+  );
+});

--- a/frontend/src/providerEventAdapters.ts
+++ b/frontend/src/providerEventAdapters.ts
@@ -1,0 +1,713 @@
+import type { TranscriptEntry as SandboxTranscriptEntry } from "@sandbox-agent/react";
+import { isTankConversationEvent, type TankConversationEvent } from "./tankConversation";
+
+export type ToolKind = "mcp" | "shell";
+
+export type ProviderTranscriptEntry = SandboxTranscriptEntry & {
+  toolKind?: ToolKind;
+  toolServer?: string;
+  toolAction?: string;
+  transcriptSource?: "server" | "realtime";
+  sourceEventId?: string;
+  orderKey?: string;
+  localOnly?: boolean;
+  clientNonce?: string;
+};
+
+export type JsonObject = Record<string, unknown>;
+
+export interface ProviderFrameEffects {
+  usage?: unknown;
+  activeTool?: {
+    name: string | null;
+    id?: string | null;
+  };
+  completedToolUseId?: string | null;
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function applyProviderEvent(
+  entries: ProviderTranscriptEntry[],
+  mode: string,
+  event: JsonObject,
+): ProviderTranscriptEntry[] {
+  if (isTankConversationEvent(event)) {
+    return applyCanonicalConversationEvent(entries, event);
+  }
+  if (event.type === "tank.user_message") {
+    return applyTankUserMessageEvent(entries, event);
+  }
+  if (event.type === "tank.skill_invocation") {
+    const name = typeof event.name === "string" ? event.name.trim() : "";
+    const trigger = typeof event.trigger === "string" ? event.trigger : "";
+    return name
+      ? appendSkillInvocation(entries, name, skillSupplementalText(name, trigger), eventTime(event))
+      : entries;
+  }
+  if (mode === "codex_gui") return applyCodexEvent(entries, event);
+  return applyClaudeEvent(entries, event);
+}
+
+export function parseProviderRunHistory(
+  text: string,
+  mode: string,
+): ProviderTranscriptEntry[] {
+  let acc: ProviderTranscriptEntry[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      if (isJsonObject(event)) {
+        acc = applyProviderEvent(acc, mode, event);
+      }
+    } catch {
+      /* skip unparseable history lines */
+    }
+  }
+  return acc;
+}
+
+export function providerFrameEffects(event: JsonObject): ProviderFrameEffects {
+  const type = event.type;
+  if (type === "assistant") {
+    const message = event.message;
+    if (!isJsonObject(message)) return {};
+    const effects: ProviderFrameEffects = { usage: message.usage };
+    if (Array.isArray(message.content)) {
+      const toolBlock = message.content.find(
+        (block): block is JsonObject => isJsonObject(block) && block.type === "tool_use",
+      );
+      effects.activeTool = {
+        name: toolBlock && typeof toolBlock.name === "string" ? toolBlock.name : null,
+        id: toolBlock && typeof toolBlock.id === "string" ? toolBlock.id : null,
+      };
+    }
+    return effects;
+  }
+  if (type === "user") {
+    return { completedToolUseId: null };
+  }
+  if (type === "result") {
+    return { usage: event.usage, activeTool: { name: null } };
+  }
+  if (type === "item.started" || type === "item.updated") {
+    const item = event.item;
+    if (!isJsonObject(item)) return {};
+    const itemType = typeof item.type === "string" ? item.type : "";
+    if (!isCodexToolishItemType(itemType)) return {};
+    return {
+      activeTool: {
+        name: itemType,
+        id: typeof item.id === "string" ? item.id : null,
+      },
+    };
+  }
+  if (type === "item.completed") {
+    const item = event.item;
+    if (!isJsonObject(item)) return {};
+    const itemType = typeof item.type === "string" ? item.type : "";
+    if (!isCodexToolishItemType(itemType)) return {};
+    return {
+      completedToolUseId: typeof item.id === "string" ? item.id : null,
+    };
+  }
+  if (type === "turn.completed") {
+    return { usage: event.usage, activeTool: { name: null } };
+  }
+  return {};
+}
+
+export function isProviderAbortMessage(message: unknown): boolean {
+  return typeof message === "string" && /operation was aborted/i.test(message);
+}
+
+function applyCanonicalConversationEvent(
+  entries: ProviderTranscriptEntry[],
+  event: TankConversationEvent,
+): ProviderTranscriptEntry[] {
+  if (event.type === "user_message.created") {
+    return applyTankUserMessageEvent(entries, event);
+  }
+  return entries;
+}
+
+function applyTankUserMessageEvent(
+  entries: ProviderTranscriptEntry[],
+  event: TankConversationEvent | JsonObject,
+): ProviderTranscriptEntry[] {
+  const text = tankUserMessageText(event);
+  if (!text || hasUserMessageText(entries, text)) return entries;
+  const skillName = skillNameFromTrigger(text);
+  if (skillName && hasSkillInvocation(entries, skillName)) return entries;
+  return upsertEntry(entries, {
+    id: `tank-user-message-${eventID(event as JsonObject, "tank-user-message")}`,
+    kind: "message",
+    role: "user",
+    text,
+    time: eventTime(event as JsonObject),
+  });
+}
+
+function applyCodexEvent(
+  entries: ProviderTranscriptEntry[],
+  event: JsonObject,
+): ProviderTranscriptEntry[] {
+  const type = event.type;
+  const time = eventTime(event);
+  if (type === "thread.started") {
+    const threadId = typeof event.thread_id === "string" ? event.thread_id : "";
+    return appendMeta(entries, `codex-thread-${eventID(event, threadId || "codex-thread")}`, "Codex thread started", threadId, "info", time);
+  }
+  if (type === "turn.started") {
+    return appendMeta(entries, `codex-turn-started-${eventID(event, "codex-turn-started")}`, "Turn started", undefined, "info", time);
+  }
+  if (type === "turn.completed") {
+    return appendMeta(entries, `codex-turn-completed-${eventID(event, "codex-turn-completed")}`, "Turn completed", describeUsage(event.usage), "info", time);
+  }
+  if (type === "turn.interrupted") {
+    return appendMeta(
+      entries,
+      `codex-turn-interrupted-${eventID(event, "codex-turn-interrupted")}`,
+      "Turn stopped",
+      typeof event.reason === "string" ? event.reason : undefined,
+      "info",
+      time,
+    );
+  }
+  if (type === "turn.failed" || type === "error") {
+    const error = isJsonObject(event.error) ? event.error.message : event.message;
+    if (isProviderAbortMessage(error)) {
+      return appendMeta(
+        entries,
+        `codex-turn-stopped-${eventID(event, "codex-turn-stopped")}`,
+        "Turn stopped",
+        "The turn was interrupted before completion.",
+        "info",
+        time,
+      );
+    }
+    return appendMeta(
+      entries,
+      `codex-error-${eventID(event, "codex-error")}`,
+      type === "turn.failed" ? "Turn failed" : "Codex error",
+      typeof error === "string" ? error : shortJson(event),
+      "error",
+      time,
+    );
+  }
+  if (type === "item.started" || type === "item.updated" || type === "item.completed") {
+    const item = event.item;
+    if (!isJsonObject(item)) return entries;
+    if (item.type === "agent_message") {
+      return appendAssistantMessage(
+        entries,
+        codexItemEntryId(event, item, "codex-message"),
+        typeof item.text === "string" ? item.text : "",
+        time,
+      );
+    }
+    if (item.type === "reasoning") {
+      return upsertEntry(entries, {
+        id: codexItemEntryId(event, item, "codex-reasoning"),
+        kind: "reasoning",
+        time,
+        reasoning: { text: typeof item.text === "string" ? item.text : shortJson(item) },
+      });
+    }
+    const toolEntry = codexToolEntry(event);
+    return toolEntry ? upsertEntry(entries, toolEntry) : entries;
+  }
+  return appendMeta(entries, `codex-event-${eventID(event, "codex-event")}`, String(type || "Codex event"), shortJson(event), "info", time);
+}
+
+function applyClaudeEvent(
+  entries: ProviderTranscriptEntry[],
+  event: JsonObject,
+): ProviderTranscriptEntry[] {
+  const type = event.type;
+  const time = eventTime(event);
+  if (
+    type === "system" ||
+    type === "stream_event" ||
+    type === "rate_limit_event" ||
+    type === "ai-title" ||
+    type === "last-prompt" ||
+    type === "attachment" ||
+    type === "queue-operation"
+  ) {
+    return entries;
+  }
+  if (type === "assistant") {
+    let nextEntries = entries;
+    for (const toolEntry of claudeToolEntries(event)) {
+      nextEntries = upsertEntry(nextEntries, toolEntry);
+    }
+    const message = event.message;
+    const text = isJsonObject(message) ? claudeTextFromContent(message.content, false) : "";
+    if (text) {
+      nextEntries = appendAssistantMessage(
+        nextEntries,
+        typeof event.uuid === "string" ? event.uuid : `claude-message-${Date.now()}`,
+        text,
+        time,
+      );
+    }
+    return nextEntries;
+  }
+  if (type === "user") {
+    let nextEntries = applyClaudeToolResults(entries, event);
+    const message = event.message;
+    if (isJsonObject(message)) {
+      const texts: string[] = [];
+      if (typeof message.content === "string") {
+        const text = message.content.trim();
+        if (text) texts.push(text);
+      } else if (Array.isArray(message.content)) {
+        const hasToolResults = message.content.some(
+          (block) => isJsonObject(block) && block.type === "tool_result",
+        );
+        if (!hasToolResults) {
+          for (const block of message.content) {
+            if (!isJsonObject(block) || block.type !== "text") continue;
+            const text = typeof block.text === "string" ? block.text.trim() : "";
+            if (text) texts.push(text);
+          }
+        }
+      }
+      const baseId = eventID(event, "claude-user-message");
+      for (const [index, text] of texts.entries()) {
+        const skillName = skillNameFromTrigger(text);
+        if (skillName && hasSkillInvocation(nextEntries, skillName)) continue;
+        if (hasUserMessageText(nextEntries, text)) continue;
+        nextEntries = upsertEntry(nextEntries, {
+          id: `${baseId}-${index}`,
+          kind: "message",
+          role: "user",
+          text,
+          time,
+        });
+      }
+    }
+    return nextEntries;
+  }
+  if (type === "result") {
+    const isError = event.is_error === true || event.subtype === "error";
+    const result = typeof event.result === "string" ? event.result : "";
+    const id = eventID(event, "claude-result");
+    if (!isError) {
+      if (result && !entries.some((entry) => entry.kind === "message" && entry.text === result)) {
+        return appendAssistantMessage(entries, `claude-result-message-${id}`, result, time);
+      }
+      return entries;
+    }
+    let nextEntries = appendMeta(
+      entries,
+      `claude-result-${id}`,
+      "Claude run failed",
+      result,
+      "error",
+      time,
+    );
+    if (result && !entries.some((entry) => entry.kind === "message" && entry.text === result)) {
+      nextEntries = appendAssistantMessage(nextEntries, `claude-result-message-${id}`, result, time);
+    }
+    return nextEntries;
+  }
+  return appendMeta(entries, `claude-event-${eventID(event, "claude-event")}`, String(type || "Claude event"), shortJson(event), "info", time);
+}
+
+function upsertEntry(
+  entries: ProviderTranscriptEntry[],
+  entry: ProviderTranscriptEntry,
+): ProviderTranscriptEntry[] {
+  const index = entries.findIndex((candidate) => candidate.id === entry.id);
+  if (index === -1) return [...entries, entry];
+  const next = [...entries];
+  next[index] = { ...next[index], ...entry };
+  return next;
+}
+
+function appendMeta(
+  entries: ProviderTranscriptEntry[],
+  id: string,
+  title: string,
+  detail?: string,
+  severity: "info" | "error" = "info",
+  time: string = nowIso(),
+): ProviderTranscriptEntry[] {
+  return upsertEntry(entries, {
+    id,
+    kind: "meta",
+    meta: { title, detail, severity },
+    time,
+  });
+}
+
+function appendAssistantMessage(
+  entries: ProviderTranscriptEntry[],
+  id: string,
+  text: string,
+  time: string = nowIso(),
+): ProviderTranscriptEntry[] {
+  if (!text.trim()) return entries;
+  return upsertEntry(entries, {
+    id,
+    kind: "message",
+    role: "assistant",
+    text,
+    time,
+  });
+}
+
+function appendSkillInvocation(
+  entries: ProviderTranscriptEntry[],
+  name: string,
+  supplementalText = "",
+  time: string = nowIso(),
+): ProviderTranscriptEntry[] {
+  if (!name) return entries;
+  const suffix = Date.parse(time) || Date.now();
+  const userAction = {
+    id: `skill-action-${name}-${suffix}`,
+    kind: "message" as const,
+    role: "user" as const,
+    text: skillActionText(name),
+    time,
+    messageKind: "skill-action",
+    skillName: name,
+    skillSupplementalText: supplementalText.trim(),
+  } as ProviderTranscriptEntry;
+  return appendMeta(
+    [...entries, userAction],
+    `skill-invocation-${name}-${suffix}`,
+    skillInvocationTitle(name),
+    undefined,
+    "info",
+    time,
+  );
+}
+
+function codexToolEntry(event: JsonObject): ProviderTranscriptEntry | null {
+  const item = event.item;
+  if (!isJsonObject(item)) return null;
+  const id = codexItemEntryId(event, item, "codex-tool");
+  const status = codexItemStatus(event, item);
+  const itemType = item.type;
+  const time = eventTime(event);
+
+  if (itemType === "command_execution") {
+    const command = typeof item.command === "string" ? item.command : "command";
+    return {
+      id,
+      kind: "tool",
+      toolKind: "shell",
+      toolName: command,
+      toolInput: command,
+      toolOutput: shortJson(item.aggregated_output),
+      toolStatus: status,
+      time,
+    };
+  }
+
+  if (itemType === "file_change") {
+    return {
+      id,
+      kind: "tool",
+      toolName: "file change",
+      toolInput: shortJson(item.changes),
+      toolStatus: status,
+      time,
+    };
+  }
+
+  if (itemType === "mcp_tool_call") {
+    const server = typeof item.server === "string" ? item.server : "mcp";
+    const tool = typeof item.tool === "string" ? item.tool : "tool";
+    return {
+      id,
+      kind: "tool",
+      toolKind: "mcp",
+      toolServer: server,
+      toolAction: tool,
+      toolName: `${server}.${tool}`,
+      toolInput: shortJson(item.arguments),
+      toolOutput: shortJson(item.result ?? item.error),
+      toolStatus: status,
+      time,
+    };
+  }
+
+  if (itemType === "web_search") {
+    return {
+      id,
+      kind: "tool",
+      toolName: "web search",
+      toolInput: typeof item.query === "string" ? item.query : shortJson(item),
+      toolStatus: status,
+      time,
+    };
+  }
+
+  return null;
+}
+
+function claudeToolEntries(event: JsonObject): ProviderTranscriptEntry[] {
+  const message = event.message;
+  if (!isJsonObject(message) || !Array.isArray(message.content)) return [];
+  const time = eventTime(event);
+  return message.content.flatMap((block): ProviderTranscriptEntry[] => {
+    if (!isJsonObject(block) || block.type !== "tool_use") return [];
+    const id = typeof block.id === "string" ? block.id : `claude-tool-${Date.now()}`;
+    const toolName = typeof block.name === "string" ? block.name : "tool";
+    const mcpMatch = /^mcp__([^_]+)__(.+)$/.exec(toolName);
+    const toolKind = mcpMatch ? "mcp" : toolName === "Bash" ? "shell" : undefined;
+    return [
+      {
+        id,
+        kind: "tool",
+        toolName,
+        ...(toolKind
+          ? {
+              toolKind,
+              ...(mcpMatch
+                ? {
+                    toolServer: mcpMatch[1],
+                    toolAction: mcpMatch[2],
+                  }
+                : {}),
+            }
+          : {}),
+        toolInput: shortJson(block.input),
+        toolStatus: "started",
+        time,
+      },
+    ];
+  });
+}
+
+function applyClaudeToolResults(
+  entries: ProviderTranscriptEntry[],
+  event: JsonObject,
+): ProviderTranscriptEntry[] {
+  const message = event.message;
+  if (!isJsonObject(message) || !Array.isArray(message.content)) return entries;
+  const time = eventTime(event);
+  return message.content.reduce<ProviderTranscriptEntry[]>((nextEntries, block) => {
+    if (!isJsonObject(block) || block.type !== "tool_result") return nextEntries;
+    const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+    if (!toolUseId) return nextEntries;
+    const existing = nextEntries.find((entry) => entry.id === toolUseId);
+    return upsertEntry(nextEntries, {
+      id: toolUseId,
+      kind: "tool",
+      toolName: existing?.toolName ?? "tool result",
+      toolInput: existing?.toolInput,
+      toolOutput: toolResultText(block.content),
+      toolStatus: block.is_error === true ? "failed" : "completed",
+      time: existing?.time ?? time,
+    });
+  }, entries);
+}
+
+function tankUserMessageText(event: TankConversationEvent | JsonObject): string {
+  const payload = (event as { payload?: unknown }).payload;
+  if (isJsonObject(payload)) {
+    if (typeof payload.text === "string") return payload.text.trim();
+    if (typeof payload.message === "string") return payload.message.trim();
+    if (isJsonObject(payload.message)) {
+      const content = payload.message.content;
+      if (typeof content === "string") return content.trim();
+    }
+  }
+  const message = (event as { message?: unknown }).message;
+  if (typeof message === "string") return message.trim();
+  if (isJsonObject(message)) {
+    const content = message.content;
+    if (typeof content === "string") return content.trim();
+    if (Array.isArray(content)) {
+      return content
+        .map((block) =>
+          isJsonObject(block) && block.type === "text" && typeof block.text === "string"
+            ? block.text
+            : "",
+        )
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+    }
+  }
+  return "";
+}
+
+function claudeTextFromContent(content: unknown, includeToolResults: boolean): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((block) => {
+      if (!isJsonObject(block)) return "";
+      if (block.type === "text" && typeof block.text === "string") return block.text;
+      if (includeToolResults && block.type === "tool_result") return shortJson(block.content);
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function toolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const text = content
+      .map((block) =>
+        isJsonObject(block) && block.type === "text" && typeof block.text === "string"
+          ? block.text
+          : "",
+      )
+      .filter(Boolean)
+      .join("\n");
+    return text || shortJson(content);
+  }
+  return shortJson(content);
+}
+
+function codexItemEntryId(event: JsonObject, item: JsonObject, fallbackPrefix: string): string {
+  const itemId = typeof item.id === "string" && item.id ? item.id : "";
+  if (itemId) return `${fallbackPrefix}-${codexTurnScope(event)}-${itemId}`;
+  return `${fallbackPrefix}-${eventID(event, fallbackPrefix)}`;
+}
+
+function codexTurnScope(event: JsonObject): string {
+  const turnSeq = event.tank_turn_seq;
+  if (typeof turnSeq === "number" && Number.isFinite(turnSeq)) return String(turnSeq);
+  if (typeof turnSeq === "string" && turnSeq) return turnSeq;
+  return eventID(event, "codex-event");
+}
+
+function codexItemStatus(event: JsonObject, item: JsonObject): string {
+  if (typeof item.status === "string" && item.status) return item.status;
+  if (event.type === "item.started") return "started";
+  if (event.type === "item.updated") return "running";
+  if (event.type === "item.completed") {
+    return item.error ? "failed" : "completed";
+  }
+  return String(event.type ?? "");
+}
+
+function isCodexToolishItemType(itemType: string): boolean {
+  return (
+    itemType === "command_execution" ||
+    itemType === "file_change" ||
+    itemType === "mcp_tool_call" ||
+    itemType === "web_search"
+  );
+}
+
+function describeUsage(usage: unknown): string {
+  if (!isJsonObject(usage)) return "";
+  const input = usage.input_tokens;
+  const cached = usage.cached_input_tokens;
+  const output = usage.output_tokens;
+  const reasoning = usage.reasoning_output_tokens;
+  return [
+    typeof input === "number" ? `input ${input}` : null,
+    typeof cached === "number" ? `cached ${cached}` : null,
+    typeof output === "number" ? `output ${output}` : null,
+    typeof reasoning === "number" ? `reasoning ${reasoning}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function skillInvocationTitle(name: string): string {
+  return `You started ${name} skill`;
+}
+
+function skillActionText(name: string): string {
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)} skill`;
+}
+
+function skillSupplementalText(name: string, text: string): string {
+  const trimmed = text.trim();
+  const triggerPattern = new RegExp(`^[$/]${name}(?:\\s+|\\n+)?`, "i");
+  return trimmed.replace(triggerPattern, "").trim();
+}
+
+function skillNameFromTrigger(text: string): string | null {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^[$/]([A-Za-z0-9_-]{1,64})$/);
+  return match ? match[1] : null;
+}
+
+function hasSkillInvocation(entries: ProviderTranscriptEntry[], name: string): boolean {
+  return entries.some(
+    (entry) =>
+      entry.kind === "meta" &&
+      entry.meta?.title === skillInvocationTitle(name),
+  );
+}
+
+function hasUserMessageText(entries: ProviderTranscriptEntry[], text: string): boolean {
+  const normalized = text.trim();
+  return Boolean(
+    normalized &&
+      entries.some(
+        (entry) =>
+          entry.kind === "message" &&
+          entry.role === "user" &&
+          entry.text?.trim() === normalized,
+      ),
+  );
+}
+
+function eventID(event: JsonObject, fallbackPrefix: string): string {
+  if (typeof event.uuid === "string" && event.uuid) return event.uuid;
+  if (typeof event.id === "string" && event.id) return event.id;
+  if (typeof event.event_id === "string" && event.event_id) return event.event_id;
+  if (typeof event.order_key === "string" && event.order_key) {
+    return event.order_key;
+  }
+  if (typeof event.tank_order_key === "string" && event.tank_order_key) {
+    return event.tank_order_key;
+  }
+  return `${fallbackPrefix}-${eventTime(event)}-${stableStringHash(shortJson(event))}`;
+}
+
+function eventTime(event: JsonObject): string {
+  return (
+    normalizeIsoTimestamp(event.written_at) ??
+    normalizeIsoTimestamp(event.timestamp) ??
+    normalizeIsoTimestamp(event.time) ??
+    normalizeIsoTimestamp(event.created_at) ??
+    nowIso()
+  );
+}
+
+function normalizeIsoTimestamp(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function shortJson(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function stableStringHash(value: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/frontend/src/tankConversation.ts
+++ b/frontend/src/tankConversation.ts
@@ -22,6 +22,29 @@ export type TankEventType =
   | "session.activity_updated"
   | "read_state.updated";
 
+const TANK_EVENT_TYPES = new Set<string>([
+  "conversation.started",
+  "conversation.archived",
+  "user_message.created",
+  "turn.submitted",
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.interrupted",
+  "item.started",
+  "item.delta",
+  "item.completed",
+  "item.failed",
+  "tool.approval_requested",
+  "tool.approval_resolved",
+  "session.activity_updated",
+  "read_state.updated",
+]);
+
+const TANK_ACTORS = new Set<string>(["user", "assistant", "system", "tool", "runner"]);
+const TANK_EVENT_SOURCES = new Set<string>(["tank", "claude", "codex", "legacy-run"]);
+const TANK_VISIBILITIES = new Set<string>(["durable", "live-only", "audit-only"]);
+
 export interface TankProducerMetadata {
   name?: string;
   version?: string;
@@ -48,4 +71,26 @@ export interface TankConversationEvent<
   producer?: TankProducerMetadata;
   visibility: TankVisibility;
   payload?: TPayload;
+}
+
+export function isTankConversationEvent(event: unknown): event is TankConversationEvent {
+  if (!event || typeof event !== "object") return false;
+  const candidate = event as Record<string, unknown>;
+  return (
+    typeof candidate.event_id === "string" &&
+    typeof candidate.session_id === "string" &&
+    typeof candidate.type === "string" &&
+    TANK_EVENT_TYPES.has(candidate.type) &&
+    typeof candidate.actor === "string" &&
+    TANK_ACTORS.has(candidate.actor) &&
+    typeof candidate.source === "string" &&
+    TANK_EVENT_SOURCES.has(candidate.source) &&
+    typeof candidate.created_at === "string" &&
+    typeof candidate.visibility === "string" &&
+    TANK_VISIBILITIES.has(candidate.visibility)
+  );
+}
+
+export function isDurableTankConversationEvent(event: unknown): event is TankConversationEvent {
+  return isTankConversationEvent(event) && event.visibility !== "live-only";
 }


### PR DESCRIPTION
## Summary
- render SDK chat from canonical Tank conversation events through reducer/projection state
- keep live/history SDK state on Tank events and use provider parsing only for legacy /run compatibility
- extract Claude/Codex provider parsing into frontend adapter module with drift tests

## Verification
- npm test
- npm run build
- browser smoke at http://127.0.0.1:5173/ with no console errors

Closes #408
Closes #409