### PR TITLE
Add backend session activity summaries

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_activity.go
+++ b/backend-go/cmd/tank-operator/handlers_activity.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+const (
+	sessionActivityPageLimit = 1000
+	sessionActivityMaxPages  = 50
+)
+
+type sessionActivityResponse struct {
+	Sessions []sessionActivitySummary `json:"sessions"`
+}
+
+type sessionActivitySummary struct {
+	SessionID    string  `json:"session_id"`
+	Status       string  `json:"status"`
+	LastOrderKey *string `json:"last_order_key"`
+	UnreadCount  int     `json:"unread_count"`
+	NeedsInput   bool    `json:"needs_input"`
+	Failed       bool    `json:"failed"`
+	ActiveTurnID *string `json:"active_turn_id"`
+	UpdatedAt    *string `json:"updated_at"`
+}
+
+type unreadOutputMarker struct {
+	orderKey string
+	id       string
+}
+
+func (s *appServer) handleSessionActivity(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	infos, err := s.mgr.ListSessions(r.Context(), user.Email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	eventStore := s.sessionEvents
+	if eventStore == nil {
+		eventStore = store.StubSessionEventStore{}
+	}
+
+	out := make([]sessionActivitySummary, 0, len(infos))
+	for _, info := range infos {
+		summary := defaultSessionActivity(info)
+		events, err := loadSessionActivityEvents(r.Context(), eventStore, info.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		out = append(out, summarizeSessionActivity(summary, events))
+	}
+
+	writeJSON(w, http.StatusOK, sessionActivityResponse{Sessions: out})
+}
+
+func loadSessionActivityEvents(ctx context.Context, eventStore store.SessionEventStore, sessionID string) ([]map[string]any, error) {
+	cursor := store.SessionEventCursor{}
+	out := make([]map[string]any, 0)
+	for pageNo := 0; pageNo < sessionActivityMaxPages; pageNo++ {
+		page, err := eventStore.ListBySession(ctx, sessionID, cursor, sessionActivityPageLimit)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page.Events...)
+		if !page.HasMore || page.NextOrderKey == "" || page.NextOrderKey == cursor.AfterOrderKey {
+			break
+		}
+		cursor = store.SessionEventCursor{AfterOrderKey: page.NextOrderKey}
+	}
+	return out, nil
+}
+
+func defaultSessionActivity(info sessions.Info) sessionActivitySummary {
+	summary := sessionActivitySummary{
+		SessionID:   info.ID,
+		Status:      "ready",
+		UpdatedAt:   firstActivityTime(info.ReadyAt, info.CreatedAt, info.RequestedAt),
+		UnreadCount: 0,
+	}
+	switch info.Status {
+	case "Failed":
+		summary.Status = "error"
+		summary.Failed = true
+	case "Pending":
+		summary.Status = "submitted"
+	}
+	return summary
+}
+
+func summarizeSessionActivity(summary sessionActivitySummary, events []map[string]any) sessionActivitySummary {
+	var readOrderKey string
+	outputMarkers := make([]unreadOutputMarker, 0)
+
+	for _, event := range events {
+		if !isDurableTankActivityEvent(event) {
+			continue
+		}
+
+		if orderKey := activityEventOrderKey(event); orderKey != "" {
+			summary.LastOrderKey = stringPtr(orderKey)
+		}
+		if updatedAt := activityEventTime(event); updatedAt != "" {
+			summary.UpdatedAt = stringPtr(updatedAt)
+		}
+		if isUnreadOutputEvent(event) {
+			outputMarkers = append(outputMarkers, unreadOutputMarker{
+				orderKey: activityEventOrderKey(event),
+				id:       unreadOutputID(event),
+			})
+		}
+
+		switch activityEventType(event) {
+		case "turn.submitted":
+			summary.Status = "submitted"
+			if activeTurnID := activityOptionalString(event, "turn_id"); activeTurnID != nil {
+				summary.ActiveTurnID = activeTurnID
+			}
+			summary.NeedsInput = false
+			summary.Failed = false
+		case "turn.started":
+			summary.Status = "streaming"
+			if activeTurnID := activityOptionalString(event, "turn_id"); activeTurnID != nil {
+				summary.ActiveTurnID = activeTurnID
+			}
+			summary.NeedsInput = false
+			summary.Failed = false
+		case "turn.completed":
+			summary.Status = "ready"
+			summary.ActiveTurnID = nil
+			summary.NeedsInput = false
+			summary.Failed = false
+		case "turn.failed":
+			summary.Status = "error"
+			summary.ActiveTurnID = nil
+			summary.NeedsInput = false
+			summary.Failed = true
+		case "turn.interrupted":
+			summary.Status = "stopped"
+			summary.ActiveTurnID = nil
+			summary.NeedsInput = false
+			summary.Failed = false
+		case "item.failed":
+			summary.Status = "error"
+			summary.Failed = true
+		case "tool.approval_requested":
+			summary.Status = "needs_input"
+			if activeTurnID := activityOptionalString(event, "turn_id"); activeTurnID != nil {
+				summary.ActiveTurnID = activeTurnID
+			}
+			summary.NeedsInput = true
+		case "tool.approval_resolved":
+			summary.NeedsInput = false
+			if summary.ActiveTurnID != nil {
+				summary.Status = "streaming"
+			} else {
+				summary.Status = "ready"
+			}
+		case "session.activity_updated":
+			applyActivityUpdatedEvent(&summary, event)
+		case "read_state.updated":
+			readOrderKey = activityPayloadString(event, "last_read_order_key")
+			if readOrderKey == "" {
+				readOrderKey = activityEventOrderKey(event)
+			}
+		}
+	}
+
+	summary.UnreadCount = countUnreadOutputs(outputMarkers, readOrderKey)
+	return summary
+}
+
+func applyActivityUpdatedEvent(summary *sessionActivitySummary, event map[string]any) {
+	if status := activityPayloadString(event, "status"); isActivityStatus(status) {
+		summary.Status = status
+	}
+	if needsInput, ok := activityPayloadBool(event, "needs_input"); ok {
+		summary.NeedsInput = needsInput
+		if needsInput {
+			summary.Status = "needs_input"
+		}
+	}
+	if failed, ok := activityPayloadBool(event, "failed"); ok {
+		summary.Failed = failed
+		if failed {
+			summary.Status = "error"
+		}
+	}
+	if activeTurnID := activityPayloadString(event, "active_turn_id"); activeTurnID != "" {
+		summary.ActiveTurnID = stringPtr(activeTurnID)
+	}
+}
+
+func isActivityStatus(status string) bool {
+	switch status {
+	case "ready", "submitted", "streaming", "needs_input", "stopped", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func isDurableTankActivityEvent(event map[string]any) bool {
+	if visibility, _ := event["visibility"].(string); visibility == "live-only" {
+		return false
+	}
+	switch activityEventType(event) {
+	case "conversation.started",
+		"conversation.archived",
+		"user_message.created",
+		"turn.submitted",
+		"turn.started",
+		"turn.completed",
+		"turn.failed",
+		"turn.interrupted",
+		"item.started",
+		"item.delta",
+		"item.completed",
+		"item.failed",
+		"tool.approval_requested",
+		"tool.approval_resolved",
+		"session.activity_updated",
+		"read_state.updated":
+		return true
+	default:
+		return false
+	}
+}
+
+func isUnreadOutputEvent(event map[string]any) bool {
+	if actor, _ := event["actor"].(string); actor == "user" {
+		return false
+	}
+	switch activityEventType(event) {
+	case "item.started",
+		"item.delta",
+		"item.completed",
+		"item.failed",
+		"tool.approval_requested",
+		"tool.approval_resolved",
+		"turn.failed",
+		"turn.interrupted":
+		return true
+	default:
+		return false
+	}
+}
+
+func countUnreadOutputs(markers []unreadOutputMarker, readOrderKey string) int {
+	seen := make(map[string]struct{}, len(markers))
+	for _, marker := range markers {
+		if readOrderKey != "" && (marker.orderKey == "" || marker.orderKey <= readOrderKey) {
+			continue
+		}
+		id := marker.id
+		if id == "" {
+			id = marker.orderKey
+		}
+		if id == "" {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	return len(seen)
+}
+
+func unreadOutputID(event map[string]any) string {
+	for _, field := range []string{"item_id", "turn_id", "event_id", "id", "uuid"} {
+		if value, _ := event[field].(string); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func activityEventType(event map[string]any) string {
+	value, _ := event["type"].(string)
+	return value
+}
+
+func activityEventOrderKey(event map[string]any) string {
+	for _, field := range []string{"order_key", "tank_order_key"} {
+		if value, _ := event[field].(string); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func activityEventTime(event map[string]any) string {
+	for _, field := range []string{"created_at", "written_at", "timestamp", "time"} {
+		if value, _ := event[field].(string); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func activityPayload(event map[string]any) map[string]any {
+	payload, _ := event["payload"].(map[string]any)
+	return payload
+}
+
+func activityPayloadString(event map[string]any, key string) string {
+	value, _ := activityPayload(event)[key].(string)
+	return value
+}
+
+func activityPayloadBool(event map[string]any, key string) (bool, bool) {
+	value, ok := activityPayload(event)[key].(bool)
+	return value, ok
+}
+
+func activityOptionalString(event map[string]any, key string) *string {
+	if value, _ := event[key].(string); value != "" {
+		return stringPtr(value)
+	}
+	return nil
+}
+
+func firstActivityTime(values ...*string) *string {
+	for _, value := range values {
+		if value != nil && *value != "" {
+			return value
+		}
+	}
+	return nil
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/backend-go/cmd/tank-operator/handlers_activity_test.go
+++ b/backend-go/cmd/tank-operator/handlers_activity_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+func TestSummarizeSessionActivityComputesAttentionAndUnread(t *testing.T) {
+	summary := summarizeSessionActivity(
+		sessionActivitySummary{SessionID: "63", Status: "ready"},
+		[]map[string]any{
+			activityEvent("u1", "user_message.created", "001", "user", nil),
+			activityEvent("t1", "turn.started", "002", "runner", map[string]any{"turn_id": "turn-1"}),
+			activityEvent("m1", "item.completed", "003", "assistant", map[string]any{
+				"turn_id": "turn-1",
+				"item_id": "msg-1",
+			}),
+			activityEvent("a1", "tool.approval_requested", "004", "tool", map[string]any{
+				"turn_id": "turn-1",
+				"item_id": "ask-1",
+			}),
+		},
+	)
+
+	if summary.Status != "needs_input" || !summary.NeedsInput {
+		t.Fatalf("status/needs = %q/%v, want needs_input/true", summary.Status, summary.NeedsInput)
+	}
+	if summary.ActiveTurnID == nil || *summary.ActiveTurnID != "turn-1" {
+		t.Fatalf("active turn = %#v, want turn-1", summary.ActiveTurnID)
+	}
+	if summary.UnreadCount != 2 {
+		t.Fatalf("unread = %d, want 2", summary.UnreadCount)
+	}
+	if summary.LastOrderKey == nil || *summary.LastOrderKey != "004" {
+		t.Fatalf("last order = %#v, want 004", summary.LastOrderKey)
+	}
+}
+
+func TestSummarizeSessionActivityAppliesReadState(t *testing.T) {
+	summary := summarizeSessionActivity(
+		sessionActivitySummary{SessionID: "63", Status: "ready"},
+		[]map[string]any{
+			activityEvent("m1", "item.completed", "001", "assistant", map[string]any{"item_id": "msg-1"}),
+			activityEvent("r1", "read_state.updated", "002", "runner", map[string]any{
+				"payload": map[string]any{"last_read_order_key": "001"},
+			}),
+			activityEvent("m2", "item.completed", "003", "assistant", map[string]any{"item_id": "msg-2"}),
+			activityEvent("done", "turn.completed", "004", "runner", map[string]any{"turn_id": "turn-1"}),
+		},
+	)
+
+	if summary.UnreadCount != 1 {
+		t.Fatalf("unread = %d, want 1", summary.UnreadCount)
+	}
+	if summary.Status != "ready" || summary.Failed || summary.NeedsInput {
+		t.Fatalf("state = %#v, want ready/non-attention", summary)
+	}
+}
+
+func TestHandleSessionActivityReturnsOwnedSDKSessionSummaries(t *testing.T) {
+	client := fake.NewSimpleClientset(activitySessionPod("63", "user@example.com"))
+	app := &appServer{
+		verifier: auth.NewVerifier(testJWT(t), "user@example.com"),
+		mgr: sessions.NewManager(
+			client,
+			nil,
+			compat.SessionsNamespace,
+			nil,
+			sessions.NewEventBus(),
+			sessions.ManagerOptions{},
+		),
+		sessionEvents: activityEventStore{events: map[string][]map[string]any{
+			"63": {
+				activityEvent("started", "turn.started", "001", "runner", map[string]any{"turn_id": "turn-1"}),
+			},
+		}},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions/activity", nil)
+	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	response := httptest.NewRecorder()
+
+	app.handleSessionActivity(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", response.Code, response.Body.String())
+	}
+	var body sessionActivityResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Sessions) != 1 {
+		t.Fatalf("sessions = %#v, want one", body.Sessions)
+	}
+	got := body.Sessions[0]
+	if got.SessionID != "63" || got.Status != "streaming" {
+		t.Fatalf("summary = %#v, want session 63 streaming", got)
+	}
+	if got.ActiveTurnID == nil || *got.ActiveTurnID != "turn-1" {
+		t.Fatalf("active turn = %#v, want turn-1", got.ActiveTurnID)
+	}
+}
+
+type activityEventStore struct {
+	events map[string][]map[string]any
+}
+
+func (s activityEventStore) ListBySession(_ context.Context, sessionID string, cursor store.SessionEventCursor, _ int) (store.SessionEventPage, error) {
+	if cursor.AfterOrderKey != "" {
+		return store.SessionEventPage{Events: []map[string]any{}}, nil
+	}
+	events := s.events[sessionID]
+	next := ""
+	if len(events) > 0 {
+		next, _ = events[len(events)-1]["order_key"].(string)
+	}
+	return store.SessionEventPage{Events: events, NextOrderKey: next, HasMore: false}, nil
+}
+
+func activityEvent(eventID, eventType, orderKey, actor string, fields map[string]any) map[string]any {
+	event := map[string]any{
+		"event_id":   eventID,
+		"type":       eventType,
+		"order_key":  orderKey,
+		"actor":      actor,
+		"session_id": "63",
+		"created_at": "2026-05-12T00:00:00Z",
+		"visibility": "durable",
+	}
+	for key, value := range fields {
+		event[key] = value
+	}
+	return event
+}
+
+func activitySessionPod(id, owner string) *corev1.Pod {
+	created := metav1.NewTime(time.Date(2026, 5, 12, 0, 0, 1, 0, time.UTC))
+	ready := metav1.NewTime(time.Date(2026, 5, 12, 0, 0, 3, 0, time.UTC))
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "session-" + id,
+			Namespace:         compat.SessionsNamespace,
+			CreationTimestamp: created,
+			Labels: map[string]string{
+				"tank-operator/owner":      compat.OwnerLabel(owner),
+				"tank-operator/session-id": id,
+				"tank-operator/mode":       "codex_headless",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "mcp-auth-proxy"},
+				{Name: "claude", Ports: []corev1.ContainerPort{{Name: "sandbox-agent", ContainerPort: 2468}}},
+				{Name: "codex-runner"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: ready,
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "mcp-auth-proxy", Ready: true},
+				{Name: "claude", Ready: true},
+				{Name: "codex-runner", Ready: true},
+			},
+		},
+	}
+}

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -51,6 +51,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/sessions", s.handleCreateSession)
 	mux.HandleFunc("POST /api/sessions/run", s.handleCreateAndRunSession)
 	mux.HandleFunc("GET /api/sessions", s.handleListSessions)
+	mux.HandleFunc("GET /api/sessions/activity", s.handleSessionActivity)
 	mux.HandleFunc("GET /api/sessions/events", s.handleSessionsEvents)
 	mux.HandleFunc("DELETE /api/sessions/{session_id}", s.handleDeleteSession)
 	mux.HandleFunc("GET /api/sessions/{session_id}", s.handleGetSession)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -99,6 +99,13 @@ import {
 } from "./providerEventAdapters";
 import { ProviderIcon } from "./providerIcons";
 import {
+  normalizeSessionActivity,
+  sessionActivityChips,
+  sessionActivityDotStatus,
+  sessionActivityStatusLabel,
+  type SessionActivitySummary,
+} from "./sessionActivity";
+import {
   isDurableTankConversationEvent,
   isTankConversationEvent,
   type TankConversationEvent,
@@ -125,7 +132,6 @@ type DefaultSessionMode = Extract<
 >;
 type Provider = "anthropic" | "codex" | "pi";
 type SessionInteraction = "gui" | "cli";
-type AgentSessionActivity = "waiting" | "working";
 type TranscriptEntry = SandboxTranscriptEntry & {
   toolKind?: ToolKind;
   toolServer?: string;
@@ -689,22 +695,20 @@ function defaultModeFor(provider: Provider, interaction: SessionInteraction): De
 
 function sessionStatusDotClass(
   session: Session,
-  activity?: AgentSessionActivity,
+  activity?: SessionActivitySummary,
 ): string {
-  if (session.status === "Active" && HEADLESS_MODES.has(session.mode)) {
-    return `status-dot status-agent-${activity === "working" ? "working" : "waiting"}`;
-  }
-  return `status-dot status-${session.status.toLowerCase()}`;
+  return `status-dot status-${sessionActivityDotStatus(
+    session.status,
+    HEADLESS_MODES.has(session.mode),
+    activity,
+  )}`;
 }
 
 function sessionStatusLabel(
   session: Session,
-  activity?: AgentSessionActivity,
+  activity?: SessionActivitySummary,
 ): string {
-  if (session.status === "Active" && HEADLESS_MODES.has(session.mode)) {
-    return activity === "working" ? "Working" : "Waiting";
-  }
-  return session.status;
+  return sessionActivityStatusLabel(session.status, HEADLESS_MODES.has(session.mode), activity);
 }
 
 function errorMessage(error: unknown): string {
@@ -1402,7 +1406,7 @@ function DemoLanding() {
           <ul className="sessions">
             {demoSessions.map((s) => {
               const isActive = s.id === selected?.id;
-              const statusDotClass = sessionStatusDotClass(s, "waiting");
+              const statusDotClass = sessionStatusDotClass(s);
               const bootLabel = sessionBootLabel(s, Date.now());
               const runtimeLabel = sessionRuntimeLabel(s, Date.now());
               return (
@@ -3522,7 +3526,6 @@ function HeadlessRun({
   runPrefs,
   setRunPref,
   user,
-  onActivityChange,
 }: {
   session: Session;
   visible: boolean;
@@ -3531,7 +3534,6 @@ function HeadlessRun({
   runPrefs: RunPrefs;
   setRunPref: SetRunPref;
   user: SessionUser;
-  onActivityChange?: (id: string, activity: AgentSessionActivity) => void;
 }) {
   const [entries, setEntries] = useState<TranscriptEntry[]>([]);
   const sdkServerEntriesRef = useRef<TranscriptEntry[]>([]);
@@ -3575,12 +3577,6 @@ function HeadlessRun({
   const [slashQuery, setSlashQuery] = useState("");
   const [slashIndex, setSlashIndex] = useState(0);
 
-  useEffect(() => {
-    onActivityChange?.(
-      session.id,
-      running || activeToolName !== null ? "working" : "waiting",
-    );
-  }, [activeToolName, onActivityChange, running, session.id]);
   const [slashCommands, setSlashCommands] = useState<SlashCommand[]>(SLASH_COMMANDS);
   const [mcpOpen, setMcpOpen] = useState(false);
   // @filename mention palette state. paths is lazily loaded from
@@ -6970,7 +6966,7 @@ export function App() {
   // Sessions stay mounted after first activation so chat state and websocket
   // runs survive switching. Unopened sessions do not initialize their panel.
   const [mounted, setMounted] = useState<Set<string>>(() => new Set());
-  const [sessionActivities, setSessionActivities] = useState<Record<string, AgentSessionActivity>>({});
+  const [sessionActivities, setSessionActivities] = useState<Record<string, SessionActivitySummary>>({});
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [interactionMenuOpen, setInteractionMenuOpen] = useState(false);
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
@@ -6988,16 +6984,6 @@ export function App() {
   const initialSessionId = useRef<string | null>(readInitialSessionId());
   const glimmungLaunchContext = useRef<GlimmungLaunchContext | null>(
     readGlimmungLaunchContext()
-  );
-
-  const updateSessionActivity = useCallback(
-    (id: string, activity: AgentSessionActivity) => {
-      setSessionActivities((prev) => {
-        if (prev[id] === activity) return prev;
-        return { ...prev, [id]: activity };
-      });
-    },
-    [],
   );
 
   useEffect(() => {
@@ -7048,8 +7034,28 @@ export function App() {
     }
   }
 
+  async function refreshSessionActivity() {
+    try {
+      const res = await authedFetch("/api/sessions/activity");
+      if (!res.ok) throw new Error(`activity failed: ${res.status}`);
+      const body = (await res.json()) as { sessions?: unknown[] };
+      const next: Record<string, SessionActivitySummary> = {};
+      if (Array.isArray(body.sessions)) {
+        for (const raw of body.sessions) {
+          const activity = normalizeSessionActivity(raw);
+          if (activity) next[activity.session_id] = activity;
+        }
+      }
+      setSessionActivities(next);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
   useEffect(() => {
-    if (user) void refresh();
+    if (!user) return;
+    void refresh();
+    void refreshSessionActivity();
   }, [user]);
 
   useEffect(() => {
@@ -7103,8 +7109,18 @@ export function App() {
 
   useEffect(() => {
     if (!user) return;
+    if (!sessions.some((s) => HEADLESS_MODES.has(s.mode))) return;
+    const t = setInterval(refreshSessionActivity, POLL_INTERVAL_MS);
+    return () => clearInterval(t);
+  }, [sessions, user]);
+
+  useEffect(() => {
+    if (!user) return;
     const source = new EventSource("/api/sessions/events", { withCredentials: true });
-    const refreshSessions = () => void refresh();
+    const refreshSessions = () => {
+      void refresh();
+      void refreshSessionActivity();
+    };
     source.addEventListener("sessions-changed", refreshSessions);
     return () => {
       source.removeEventListener("sessions-changed", refreshSessions);
@@ -7115,7 +7131,9 @@ export function App() {
   useEffect(() => {
     if (!user) return;
     const refreshIfVisible = () => {
-      if (document.visibilityState === "visible") void refresh();
+      if (document.visibilityState !== "visible") return;
+      void refresh();
+      void refreshSessionActivity();
     };
     document.addEventListener("visibilitychange", refreshIfVisible);
     window.addEventListener("focus", refreshIfVisible);
@@ -7153,7 +7171,7 @@ export function App() {
     setSessionActivities((prev) => {
       const existing = new Set(sessions.map((s) => s.id));
       let changed = false;
-      const next: Record<string, AgentSessionActivity> = {};
+      const next: Record<string, SessionActivitySummary> = {};
       for (const [id, activity] of Object.entries(prev)) {
         if (existing.has(id) && !closingIds.has(id)) {
           next[id] = activity;
@@ -7279,6 +7297,7 @@ export function App() {
         writeSessionInteraction(created.id, defaultInteraction);
       }
       await refresh();
+      await refreshSessionActivity();
       activate(created.id);
       startEditing(created.id, created.name);
     } catch (e) {
@@ -7381,6 +7400,7 @@ export function App() {
       const res = await authedFetch(`/api/sessions/${id}`, { method: "DELETE" });
       if (!res.ok) throw new Error(`delete failed: ${res.status}`);
       await refresh();
+      await refreshSessionActivity();
     } catch (e) {
       setClosingIds((prev) => {
         const next = new Set(prev);
@@ -7576,6 +7596,7 @@ export function App() {
               const isActive = active === s.id && !isClosing;
               const statusDotClass = sessionStatusDotClass(s, sessionActivities[s.id]);
               const statusLabel = sessionStatusLabel(s, sessionActivities[s.id]);
+              const activityChips = sessionActivityChips(sessionActivities[s.id]);
               const bootLabel = sessionBootLabel(s, nowMs);
               const runtimeLabel = sessionRuntimeLabel(s, nowMs);
               const skillStateClass = sessionSkillStateClass(s);
@@ -7670,6 +7691,16 @@ export function App() {
                   </div>
                   <div className="session-row-bottom">
                     <ModeChip mode={s.mode} interaction={sessionInteractionForSession(s)} />
+                    {activityChips.map((chip) => (
+                      <span
+                        key={chip.key}
+                        className={`session-activity-chip is-${chip.tone}`}
+                        title={chip.title}
+                        aria-label={chip.title}
+                      >
+                        {chip.label}
+                      </span>
+                    ))}
                     {isClosing && <span className="session-closing-chip">closing</span>}
                     {CONFIG_MODES.has(s.mode) && (
                       <button
@@ -7844,7 +7875,6 @@ export function App() {
                       runPrefs={runPrefs}
                       setRunPref={setRunPref}
                       user={user!}
-                      onActivityChange={updateSessionActivity}
                     />
                   </div>
                 ) : (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -101,6 +101,7 @@
   --status-pending-fg: var(--gray-400);
   --status-agent-working: #fbbf24;
   --status-agent-waiting: #67e8f9;
+  --status-agent-needs-input: #fb923c;
   --skill-test-fg: #bef264;
   --skill-test-bg: rgba(132, 204, 22, 0.16);
   --skill-test-border: rgba(190, 242, 100, 0.24);
@@ -1299,6 +1300,8 @@ button:disabled {
 .status-dot.status-codex-working { background: var(--status-agent-working); }
 .status-dot.status-agent-waiting,
 .status-dot.status-codex-waiting { background: var(--status-agent-waiting); }
+.status-dot.status-agent-needs-input { background: var(--status-agent-needs-input); }
+.status-dot.status-agent-error { background: var(--status-error-fg); }
 
 .mode {
   display: inline-flex;
@@ -1366,6 +1369,43 @@ button:disabled {
   text-transform: lowercase;
   letter-spacing: 0.02em;
   flex-shrink: 0;
+}
+
+.session-activity-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  padding: 0.05rem var(--space-2);
+  border-radius: var(--radius-md);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+.session-activity-chip.is-running {
+  background: rgba(251, 191, 36, 0.14);
+  color: #fcd34d;
+}
+
+.session-activity-chip.is-input {
+  background: rgba(251, 146, 60, 0.14);
+  color: var(--status-agent-needs-input);
+}
+
+.session-activity-chip.is-failed {
+  background: var(--status-error-bg);
+  color: var(--status-error-fg);
+}
+
+.session-activity-chip.is-stopped {
+  background: var(--status-pending-bg);
+  color: var(--status-pending-fg);
+}
+
+.session-activity-chip.is-unread {
+  background: var(--blue-bg);
+  color: var(--accent-fg);
 }
 
 .mode-claude_cli        { background: var(--mode-claude-cli-bg); color: var(--mode-claude-cli-fg); }

--- a/frontend/src/sessionActivity.test.ts
+++ b/frontend/src/sessionActivity.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeSessionActivity,
+  sessionActivityChips,
+  sessionActivityDotStatus,
+  sessionActivityStatusLabel,
+} from "./sessionActivity";
+
+test("normalizes backend session activity summaries", () => {
+  const activity = normalizeSessionActivity({
+    session_id: "63",
+    status: "streaming",
+    last_order_key: "001",
+    unread_count: 3.9,
+    needs_input: false,
+    failed: false,
+    active_turn_id: "turn-1",
+    updated_at: "2026-05-12T00:00:00Z",
+  });
+
+  assert.equal(activity?.session_id, "63");
+  assert.equal(activity?.status, "streaming");
+  assert.equal(activity?.unread_count, 3);
+  assert.equal(activity?.active_turn_id, "turn-1");
+});
+
+test("session activity drives sidebar labels and dots", () => {
+  const needsInput = normalizeSessionActivity({
+    session_id: "63",
+    status: "needs_input",
+    unread_count: 1,
+    needs_input: true,
+    failed: false,
+  });
+
+  assert.equal(sessionActivityDotStatus("Active", true, needsInput ?? undefined), "agent-needs-input");
+  assert.equal(sessionActivityStatusLabel("Active", true, needsInput ?? undefined), "Needs input");
+  assert.deepEqual(
+    sessionActivityChips(needsInput ?? undefined).map((chip) => chip.label),
+    ["input", "1 new"],
+  );
+});
+
+test("non-headless sessions keep pod lifecycle status", () => {
+  const activity = normalizeSessionActivity({
+    session_id: "12",
+    status: "streaming",
+    unread_count: 2,
+  });
+
+  assert.equal(sessionActivityDotStatus("Pending", false, activity ?? undefined), "pending");
+  assert.equal(sessionActivityStatusLabel("Pending", false, activity ?? undefined), "Pending");
+});

--- a/frontend/src/sessionActivity.ts
+++ b/frontend/src/sessionActivity.ts
@@ -1,0 +1,130 @@
+export type ConversationActivityStatus =
+  | "ready"
+  | "submitted"
+  | "streaming"
+  | "needs_input"
+  | "stopped"
+  | "error";
+
+export interface SessionActivitySummary {
+  session_id: string;
+  status: ConversationActivityStatus;
+  last_order_key: string | null;
+  unread_count: number;
+  needs_input: boolean;
+  failed: boolean;
+  active_turn_id: string | null;
+  updated_at: string | null;
+}
+
+export interface SessionActivityChip {
+  key: "state" | "unread";
+  label: string;
+  title: string;
+  tone: "failed" | "input" | "running" | "stopped" | "unread";
+}
+
+export function normalizeSessionActivity(value: unknown): SessionActivitySummary | null {
+  if (!isRecord(value)) return null;
+  const sessionId = stringField(value, "session_id");
+  if (!sessionId) return null;
+  const status = activityStatus(stringField(value, "status")) ?? "ready";
+  return {
+    session_id: sessionId,
+    status,
+    last_order_key: nullableStringField(value, "last_order_key"),
+    unread_count: nonNegativeInt(value.unread_count),
+    needs_input: value.needs_input === true,
+    failed: value.failed === true,
+    active_turn_id: nullableStringField(value, "active_turn_id"),
+    updated_at: nullableStringField(value, "updated_at"),
+  };
+}
+
+export function sessionActivityDotStatus(
+  sessionStatus: string,
+  isHeadless: boolean,
+  activity?: SessionActivitySummary,
+): string {
+  if (!isHeadless || sessionStatus !== "Active") return sessionStatus.toLowerCase();
+  if (activity?.failed || activity?.status === "error") return "agent-error";
+  if (activity?.needs_input || activity?.status === "needs_input") return "agent-needs-input";
+  if (activity?.status === "submitted" || activity?.status === "streaming") {
+    return "agent-working";
+  }
+  return "agent-waiting";
+}
+
+export function sessionActivityStatusLabel(
+  sessionStatus: string,
+  isHeadless: boolean,
+  activity?: SessionActivitySummary,
+): string {
+  if (!isHeadless || sessionStatus !== "Active") return sessionStatus;
+  if (activity?.failed || activity?.status === "error") return "Failed";
+  if (activity?.needs_input || activity?.status === "needs_input") return "Needs input";
+  if (activity?.status === "submitted") return "Submitted";
+  if (activity?.status === "streaming") return "Running";
+  if (activity?.status === "stopped") return "Stopped";
+  return "Waiting";
+}
+
+export function sessionActivityChips(
+  activity?: SessionActivitySummary,
+): SessionActivityChip[] {
+  if (!activity) return [];
+  const chips: SessionActivityChip[] = [];
+  if (activity.failed || activity.status === "error") {
+    chips.push({ key: "state", label: "failed", title: "Failed", tone: "failed" });
+  } else if (activity.needs_input || activity.status === "needs_input") {
+    chips.push({ key: "state", label: "input", title: "Needs input", tone: "input" });
+  } else if (activity.status === "submitted" || activity.status === "streaming") {
+    chips.push({ key: "state", label: "running", title: "Running", tone: "running" });
+  } else if (activity.status === "stopped") {
+    chips.push({ key: "state", label: "stopped", title: "Stopped", tone: "stopped" });
+  }
+
+  if (activity.unread_count > 0) {
+    const capped = activity.unread_count > 99 ? "99+" : String(activity.unread_count);
+    chips.push({
+      key: "unread",
+      label: `${capped} new`,
+      title: `${activity.unread_count} unread update${activity.unread_count === 1 ? "" : "s"}`,
+      tone: "unread",
+    });
+  }
+  return chips;
+}
+
+function activityStatus(value: string | null): ConversationActivityStatus | null {
+  switch (value) {
+    case "ready":
+    case "submitted":
+    case "streaming":
+    case "needs_input":
+    case "stopped":
+    case "error":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, key: string): string | null {
+  const field = value[key];
+  return typeof field === "string" && field ? field : null;
+}
+
+function nullableStringField(value: Record<string, unknown>, key: string): string | null {
+  const field = value[key];
+  return typeof field === "string" && field ? field : null;
+}
+
+function nonNegativeInt(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+}


### PR DESCRIPTION
## Summary
- add GET /api/sessions/activity from durable Tank conversation events plus read-state events
- wire the session sidebar to backend activity summaries for running, needs-input, failed, and unread states
- add backend and frontend activity tests

Fixes #410

## Verification
- go test ./...
- npm test
- npm run build
- browser smoke check at http://127.0.0.1:5173