### PR TITLE
Persist SDK conversation read state

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_activity.go
+++ b/backend-go/cmd/tank-operator/handlers_activity.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
 	"github.com/nelsong6/tank-operator/backend-go/internal/store"
@@ -30,6 +32,7 @@ type sessionActivitySummary struct {
 
 type unreadOutputMarker struct {
 	orderKey string
+	cursor   string
 	id       string
 }
 
@@ -58,7 +61,16 @@ func (s *appServer) handleSessionActivity(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		out = append(out, summarizeSessionActivity(summary, events))
+		readState, err := s.getSessionReadState(r, user.Email, info.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		readOrderKey := ""
+		if readState != nil {
+			readOrderKey = readState.LastReadOrderKey
+		}
+		out = append(out, summarizeSessionActivity(summary, events, readOrderKey))
 	}
 
 	writeJSON(w, http.StatusOK, sessionActivityResponse{Sessions: out})
@@ -98,8 +110,7 @@ func defaultSessionActivity(info sessions.Info) sessionActivitySummary {
 	return summary
 }
 
-func summarizeSessionActivity(summary sessionActivitySummary, events []map[string]any) sessionActivitySummary {
-	var readOrderKey string
+func summarizeSessionActivity(summary sessionActivitySummary, events []map[string]any, readOrderKey string) sessionActivitySummary {
 	outputMarkers := make([]unreadOutputMarker, 0)
 
 	for _, event := range events {
@@ -116,6 +127,7 @@ func summarizeSessionActivity(summary sessionActivitySummary, events []map[strin
 		if isUnreadOutputEvent(event) {
 			outputMarkers = append(outputMarkers, unreadOutputMarker{
 				orderKey: activityEventOrderKey(event),
+				cursor:   activityEventCursor(event),
 				id:       unreadOutputID(event),
 			})
 		}
@@ -169,9 +181,12 @@ func summarizeSessionActivity(summary sessionActivitySummary, events []map[strin
 		case "session.activity_updated":
 			applyActivityUpdatedEvent(&summary, event)
 		case "read_state.updated":
-			readOrderKey = activityPayloadString(event, "last_read_order_key")
-			if readOrderKey == "" {
-				readOrderKey = activityEventOrderKey(event)
+			eventReadOrderKey := activityPayloadString(event, "last_read_order_key")
+			if eventReadOrderKey == "" {
+				eventReadOrderKey = activityEventOrderKey(event)
+			}
+			if eventReadOrderKey > readOrderKey {
+				readOrderKey = eventReadOrderKey
 			}
 		}
 	}
@@ -259,7 +274,7 @@ func isUnreadOutputEvent(event map[string]any) bool {
 func countUnreadOutputs(markers []unreadOutputMarker, readOrderKey string) int {
 	seen := make(map[string]struct{}, len(markers))
 	for _, marker := range markers {
-		if readOrderKey != "" && (marker.orderKey == "" || marker.orderKey <= readOrderKey) {
+		if readOrderKey != "" && !unreadMarkerAfterRead(marker, readOrderKey) {
 			continue
 		}
 		id := marker.id
@@ -272,6 +287,19 @@ func countUnreadOutputs(markers []unreadOutputMarker, readOrderKey string) int {
 		seen[id] = struct{}{}
 	}
 	return len(seen)
+}
+
+func unreadMarkerAfterRead(marker unreadOutputMarker, readOrderKey string) bool {
+	if readOrderKey == "" {
+		return true
+	}
+	if strings.Contains(readOrderKey, "\x1f") {
+		return marker.cursor != "" && marker.cursor > readOrderKey
+	}
+	if marker.orderKey != "" {
+		return marker.orderKey > readOrderKey
+	}
+	return marker.cursor > readOrderKey
 }
 
 func unreadOutputID(event map[string]any) string {
@@ -290,6 +318,54 @@ func activityEventType(event map[string]any) string {
 
 func activityEventOrderKey(event map[string]any) string {
 	for _, field := range []string{"order_key", "tank_order_key"} {
+		if value, _ := event[field].(string); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func activityEventCursor(event map[string]any) string {
+	parts := []string{
+		activityEventOrderKey(event),
+		activityEventOrderTime(event),
+		activityEventSequence(event),
+		activityEventDocumentID(event),
+	}
+	return strings.Join(parts, "\x1f")
+}
+
+func activityEventSequence(event map[string]any) string {
+	for _, field := range []string{"sequence", "tank_event_seq"} {
+		switch value := event[field].(type) {
+		case int:
+			return strconv.Itoa(value)
+		case int64:
+			return strconv.FormatInt(value, 10)
+		case float64:
+			if value == float64(int64(value)) {
+				return strconv.FormatInt(int64(value), 10)
+			}
+		case string:
+			if value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func activityEventDocumentID(event map[string]any) string {
+	for _, field := range []string{"id", "uuid", "event_id"} {
+		if value, _ := event[field].(string); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func activityEventOrderTime(event map[string]any) string {
+	for _, field := range []string{"written_at", "timestamp", "time", "created_at"} {
 		if value, _ := event[field].(string); value != "" {
 			return value
 		}

--- a/backend-go/cmd/tank-operator/handlers_activity_test.go
+++ b/backend-go/cmd/tank-operator/handlers_activity_test.go
@@ -33,6 +33,7 @@ func TestSummarizeSessionActivityComputesAttentionAndUnread(t *testing.T) {
 				"item_id": "ask-1",
 			}),
 		},
+		"",
 	)
 
 	if summary.Status != "needs_input" || !summary.NeedsInput {
@@ -60,6 +61,7 @@ func TestSummarizeSessionActivityAppliesReadState(t *testing.T) {
 			activityEvent("m2", "item.completed", "003", "assistant", map[string]any{"item_id": "msg-2"}),
 			activityEvent("done", "turn.completed", "004", "runner", map[string]any{"turn_id": "turn-1"}),
 		},
+		"",
 	)
 
 	if summary.UnreadCount != 1 {
@@ -67,6 +69,23 @@ func TestSummarizeSessionActivityAppliesReadState(t *testing.T) {
 	}
 	if summary.Status != "ready" || summary.Failed || summary.NeedsInput {
 		t.Fatalf("state = %#v, want ready/non-attention", summary)
+	}
+}
+
+func TestSummarizeSessionActivityAppliesPersistedReadState(t *testing.T) {
+	events := []map[string]any{
+		activityEvent("m1", "item.completed", "001", "assistant", map[string]any{"item_id": "msg-1"}),
+		activityEvent("m2", "item.completed", "002", "assistant", map[string]any{"item_id": "msg-2"}),
+		activityEvent("m3", "item.completed", "003", "assistant", map[string]any{"item_id": "msg-3"}),
+	}
+	summary := summarizeSessionActivity(
+		sessionActivitySummary{SessionID: "63", Status: "ready"},
+		events,
+		activityEventCursor(events[1]),
+	)
+
+	if summary.UnreadCount != 1 {
+		t.Fatalf("unread = %d, want 1", summary.UnreadCount)
 	}
 }
 
@@ -110,6 +129,48 @@ func TestHandleSessionActivityReturnsOwnedSDKSessionSummaries(t *testing.T) {
 	}
 	if got.ActiveTurnID == nil || *got.ActiveTurnID != "turn-1" {
 		t.Fatalf("active turn = %#v, want turn-1", got.ActiveTurnID)
+	}
+}
+
+func TestHandleSessionActivityUsesPersistedReadState(t *testing.T) {
+	client := fake.NewSimpleClientset(activitySessionPod("63", "user@example.com"))
+	readStates := store.NewStubConversationReadStateStore()
+	if _, err := readStates.Set(context.Background(), "user@example.com", "63", "001"); err != nil {
+		t.Fatal(err)
+	}
+	app := &appServer{
+		verifier: auth.NewVerifier(testJWT(t), "user@example.com"),
+		mgr: sessions.NewManager(
+			client,
+			nil,
+			compat.SessionsNamespace,
+			nil,
+			sessions.NewEventBus(),
+			sessions.ManagerOptions{},
+		),
+		sessionEvents: activityEventStore{events: map[string][]map[string]any{
+			"63": {
+				activityEvent("m1", "item.completed", "001", "assistant", map[string]any{"item_id": "msg-1"}),
+				activityEvent("m2", "item.completed", "002", "assistant", map[string]any{"item_id": "msg-2"}),
+			},
+		}},
+		readStates: readStates,
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions/activity", nil)
+	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	response := httptest.NewRecorder()
+
+	app.handleSessionActivity(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", response.Code, response.Body.String())
+	}
+	var body sessionActivityResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Sessions) != 1 || body.Sessions[0].UnreadCount != 1 {
+		t.Fatalf("sessions = %#v, want one unread update", body.Sessions)
 	}
 }
 

--- a/backend-go/cmd/tank-operator/handlers_agent_ws.go
+++ b/backend-go/cmd/tank-operator/handlers_agent_ws.go
@@ -255,6 +255,11 @@ func (s *appServer) handleListSessionEvents(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	readState, err := s.getSessionReadState(r, user.Email, sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if page.Events == nil {
 		page.Events = []map[string]any{}
 	}
@@ -264,6 +269,7 @@ func (s *appServer) handleListSessionEvents(w http.ResponseWriter, r *http.Reque
 		"next_order_key":  page.NextOrderKey,
 		"has_more":        page.HasMore,
 		"cursor_semantic": "render_order",
+		"read_state":      sessionReadStateBody(readState),
 	})
 }
 

--- a/backend-go/cmd/tank-operator/handlers_read_state.go
+++ b/backend-go/cmd/tank-operator/handlers_read_state.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+type updateSessionReadStateRequest struct {
+	LastReadOrderKey string `json:"last_read_order_key"`
+}
+
+type sessionReadStateResponse struct {
+	SessionID string                        `json:"session_id"`
+	ReadState *sessionReadStateResponseBody `json:"read_state"`
+}
+
+type sessionReadStateResponseBody struct {
+	LastReadOrderKey string `json:"last_read_order_key"`
+	UpdatedAt        string `json:"updated_at,omitempty"`
+}
+
+func (s *appServer) handleUpdateSessionReadState(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	sessionID := r.PathValue("session_id")
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing session_id")
+		return
+	}
+	if _, err := s.mgr.GetByOwner(r.Context(), user.Email, sessionID); err != nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	var req updateSessionReadStateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
+		return
+	}
+	lastReadOrderKey := strings.TrimSpace(req.LastReadOrderKey)
+	if lastReadOrderKey == "" {
+		writeError(w, http.StatusBadRequest, "last_read_order_key is required")
+		return
+	}
+
+	readStates := s.readStates
+	if readStates == nil {
+		readStates = store.NewStubConversationReadStateStore()
+	}
+	rec, err := readStates.Set(r.Context(), user.Email, sessionID, lastReadOrderKey)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, sessionReadStateResponse{
+		SessionID: sessionID,
+		ReadState: sessionReadStateBody(&rec),
+	})
+}
+
+func (s *appServer) getSessionReadState(r *http.Request, email, sessionID string) (*store.ConversationReadStateRecord, error) {
+	readStates := s.readStates
+	if readStates == nil {
+		return nil, nil
+	}
+	return readStates.Get(r.Context(), email, sessionID)
+}
+
+func sessionReadStateBody(rec *store.ConversationReadStateRecord) *sessionReadStateResponseBody {
+	if rec == nil || rec.LastReadOrderKey == "" {
+		return nil
+	}
+	return &sessionReadStateResponseBody{
+		LastReadOrderKey: rec.LastReadOrderKey,
+		UpdatedAt:        rec.UpdatedAt,
+	}
+}

--- a/backend-go/cmd/tank-operator/handlers_read_state_test.go
+++ b/backend-go/cmd/tank-operator/handlers_read_state_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+func TestHandleUpdateSessionReadStatePersistsMonotonicCursor(t *testing.T) {
+	readStates := store.NewStubConversationReadStateStore()
+	app := readStateTestServer(t, readStates)
+
+	putReadState(t, app, "63", "002")
+	putReadState(t, app, "63", "001")
+
+	rec, err := readStates.Get(context.Background(), "user@example.com", "63")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec == nil || rec.LastReadOrderKey != "002" {
+		t.Fatalf("read state = %#v, want cursor 002", rec)
+	}
+}
+
+func TestHandleListSessionEventsIncludesReadState(t *testing.T) {
+	readStates := store.NewStubConversationReadStateStore()
+	if _, err := readStates.Set(context.Background(), "user@example.com", "63", "cursor-read"); err != nil {
+		t.Fatal(err)
+	}
+	app := readStateTestServer(t, readStates)
+	app.sessionEvents = fakeSessionEventStore{
+		pages: map[string]store.SessionEventPage{
+			"": {
+				Events: []map[string]any{
+					{"event_id": "e1", "order_key": "001", "type": "item.completed"},
+				},
+				NextOrderKey: "001",
+			},
+		},
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions/63/timeline", nil)
+	request.SetPathValue("session_id", "63")
+	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	response := httptest.NewRecorder()
+
+	app.handleListSessionEvents(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", response.Code, response.Body.String())
+	}
+	var body struct {
+		ReadState *sessionReadStateResponseBody `json:"read_state"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.ReadState == nil || body.ReadState.LastReadOrderKey != "cursor-read" {
+		t.Fatalf("read_state = %#v, want cursor-read", body.ReadState)
+	}
+}
+
+func readStateTestServer(t *testing.T, readStates store.ConversationReadStateStore) *appServer {
+	t.Helper()
+	client := fake.NewSimpleClientset(activitySessionPod("63", "user@example.com"))
+	return &appServer{
+		verifier: auth.NewVerifier(testJWT(t), "user@example.com"),
+		mgr: sessions.NewManager(
+			client,
+			nil,
+			compat.SessionsNamespace,
+			nil,
+			sessions.NewEventBus(),
+			sessions.ManagerOptions{},
+		),
+		sessionEvents: store.StubSessionEventStore{},
+		readStates:    readStates,
+	}
+}
+
+func putReadState(t *testing.T, app *appServer, sessionID, cursor string) {
+	t.Helper()
+	body := bytes.NewBufferString(`{"last_read_order_key":` + strconv.Quote(cursor) + `}`)
+	request := httptest.NewRequest(http.MethodPut, "/api/sessions/"+sessionID+"/read-state", body)
+	request.SetPathValue("session_id", sessionID)
+	request.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	response := httptest.NewRecorder()
+
+	app.handleUpdateSessionReadState(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", response.Code, response.Body.String())
+	}
+}

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -64,6 +64,9 @@ func main() {
 	// agent-runner's canonical event stream).
 	sessionEventsStore := buildSessionEventStore(azCred)
 
+	// 6d. Init per-user SDK conversation read-state store.
+	readStateStore := buildConversationReadStateStore(azCred)
+
 	// 7. Init event bus.
 	eventBus := sessions.NewEventBus()
 
@@ -139,6 +142,7 @@ func main() {
 		runEvents:               runEventsStore,
 		turnQueue:               turnQueueStore,
 		sessionEvents:           sessionEventsStore,
+		readStates:              readStateStore,
 		eventBus:                eventBus,
 		verifier:                verifier,
 		minter:                  minter,
@@ -265,6 +269,24 @@ func buildSessionEventStore(azCred *azidentity.DefaultAzureCredential) store.Ses
 	return s
 }
 
+func buildConversationReadStateStore(azCred *azidentity.DefaultAzureCredential) store.ConversationReadStateStore {
+	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
+	if endpoint == "" || azCred == nil {
+		return store.NewStubConversationReadStateStore()
+	}
+	s, err := store.NewCosmosConversationReadStateStore(
+		endpoint,
+		envDefault("COSMOS_DATABASE", "tank-operator"),
+		envDefault("COSMOS_PROFILES_CONTAINER", "profiles"),
+		azCred,
+	)
+	if err != nil {
+		slog.Warn("conversation read-state store disabled", "error", err)
+		return store.NewStubConversationReadStateStore()
+	}
+	return s
+}
+
 func buildTurnQueueStore(azCred *azidentity.DefaultAzureCredential) store.TurnQueueStore {
 	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
 	if endpoint == "" || azCred == nil {
@@ -340,7 +362,7 @@ func (r *stubSessionRegistry) NextSessionID(_ context.Context) (string, error) {
 	r.counter++
 	return fmt.Sprintf("%d", r.counter), nil
 }
-func (r *stubSessionRegistry) Upsert(_ context.Context, _ compat.SessionRecord) error { return nil }
+func (r *stubSessionRegistry) Upsert(_ context.Context, _ compat.SessionRecord) error  { return nil }
 func (r *stubSessionRegistry) SetName(_ context.Context, _, _ string, _ *string) error { return nil }
 func (r *stubSessionRegistry) MarkDeleted(_ context.Context, _, _ string) error        { return nil }
 

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -22,6 +22,7 @@ type appServer struct {
 	runEvents     store.RunEventStore
 	turnQueue     store.TurnQueueStore
 	sessionEvents store.SessionEventStore
+	readStates    store.ConversationReadStateStore
 	eventBus      *sessions.EventBus
 	verifier      *auth.Verifier
 	minter        *auth.Minter
@@ -96,6 +97,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/sessions/{session_id}/agent-ws", s.handleAgentWebSocket)
 	mux.HandleFunc("GET /api/sessions/{session_id}/events", s.handleListSessionEvents)
 	mux.HandleFunc("GET /api/sessions/{session_id}/timeline", s.handleSessionTimeline)
+	mux.HandleFunc("PUT /api/sessions/{session_id}/read-state", s.handleUpdateSessionReadState)
 
 	// CLI / sandbox agent.
 	mux.HandleFunc("POST /api/sessions/{session_id}/cli-process", s.handleCLIProcess)

--- a/backend-go/internal/store/read_state.go
+++ b/backend-go/internal/store/read_state.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// ConversationReadStateStore persists the per-user render cursor for a Tank
+// conversation. The cursor is the same render-order value used by /timeline,
+// not a Cosmos document id.
+type ConversationReadStateStore interface {
+	Get(ctx context.Context, email, sessionID string) (*ConversationReadStateRecord, error)
+	Set(ctx context.Context, email, sessionID, lastReadOrderKey string) (ConversationReadStateRecord, error)
+}
+
+type ConversationReadStateRecord struct {
+	Email            string `json:"email"`
+	SessionID        string `json:"session_id"`
+	LastReadOrderKey string `json:"last_read_order_key"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+type cosmosConversationReadStateStore struct {
+	container *azcosmos.ContainerClient
+}
+
+func NewCosmosConversationReadStateStore(endpoint, database, container string, cred azcore.TokenCredential) (ConversationReadStateStore, error) {
+	client, err := azcosmos.NewClient(endpoint, cred, nil)
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.NewContainer(database, container)
+	if err != nil {
+		return nil, err
+	}
+	return &cosmosConversationReadStateStore{container: c}, nil
+}
+
+func (s *cosmosConversationReadStateStore) Get(ctx context.Context, email, sessionID string) (*ConversationReadStateRecord, error) {
+	normalized := normalizeReadStateEmail(email)
+	sessionID = strings.TrimSpace(sessionID)
+	if normalized == "" || sessionID == "" {
+		return nil, nil
+	}
+	resp, err := s.container.ReadItem(ctx, azcosmos.NewPartitionKeyString(normalized), readStateDocID(sessionID), nil)
+	if err != nil {
+		if isCosmosNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	rec, err := readStateRecordFromDoc(resp.Value)
+	if err != nil {
+		return nil, err
+	}
+	if rec.Email == "" {
+		rec.Email = normalized
+	}
+	if rec.SessionID == "" {
+		rec.SessionID = sessionID
+	}
+	return &rec, nil
+}
+
+func (s *cosmosConversationReadStateStore) Set(ctx context.Context, email, sessionID, lastReadOrderKey string) (ConversationReadStateRecord, error) {
+	normalized := normalizeReadStateEmail(email)
+	sessionID = strings.TrimSpace(sessionID)
+	lastReadOrderKey = strings.TrimSpace(lastReadOrderKey)
+	if normalized == "" || sessionID == "" || lastReadOrderKey == "" {
+		return ConversationReadStateRecord{}, nil
+	}
+
+	docID := readStateDocID(sessionID)
+	pk := azcosmos.NewPartitionKeyString(normalized)
+	for attempt := 0; attempt < 20; attempt++ {
+		resp, readErr := s.container.ReadItem(ctx, pk, docID, nil)
+
+		var existing *ConversationReadStateRecord
+		var etag string
+		exists := false
+		if readErr == nil {
+			rec, err := readStateRecordFromDoc(resp.Value)
+			if err != nil {
+				return ConversationReadStateRecord{}, fmt.Errorf("decode read state: %w", err)
+			}
+			if rec.LastReadOrderKey != "" && rec.LastReadOrderKey >= lastReadOrderKey {
+				return rec, nil
+			}
+			existing = &rec
+			etag = string(resp.ETag)
+			exists = true
+		} else if !isCosmosNotFound(readErr) {
+			return ConversationReadStateRecord{}, fmt.Errorf("read read state: %w", readErr)
+		}
+
+		rec := ConversationReadStateRecord{
+			Email:            normalized,
+			SessionID:        sessionID,
+			LastReadOrderKey: lastReadOrderKey,
+			UpdatedAt:        nowISO(),
+		}
+		if existing != nil && existing.UpdatedAt != "" && existing.LastReadOrderKey == lastReadOrderKey {
+			rec.UpdatedAt = existing.UpdatedAt
+		}
+		raw, err := json.Marshal(readStateDoc(rec))
+		if err != nil {
+			return ConversationReadStateRecord{}, err
+		}
+
+		var writeErr error
+		if exists {
+			opts := &azcosmos.ItemOptions{IfMatchEtag: (*azcore.ETag)(&etag)}
+			_, writeErr = s.container.ReplaceItem(ctx, pk, docID, raw, opts)
+		} else {
+			_, writeErr = s.container.CreateItem(ctx, pk, raw, nil)
+		}
+		if writeErr == nil {
+			return rec, nil
+		}
+		if isCosmosConflict(writeErr) {
+			continue
+		}
+		return ConversationReadStateRecord{}, fmt.Errorf("write read state: %w", writeErr)
+	}
+	return ConversationReadStateRecord{}, fmt.Errorf("could not update read state after 20 retries")
+}
+
+type StubConversationReadStateStore struct {
+	mu      sync.Mutex
+	records map[string]ConversationReadStateRecord
+}
+
+func NewStubConversationReadStateStore() *StubConversationReadStateStore {
+	return &StubConversationReadStateStore{records: map[string]ConversationReadStateRecord{}}
+}
+
+func (s *StubConversationReadStateStore) Get(_ context.Context, email, sessionID string) (*ConversationReadStateRecord, error) {
+	if s == nil {
+		return nil, nil
+	}
+	key, _, _ := readStateMemoryKey(email, sessionID)
+	if key == "" {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[key]
+	if !ok {
+		return nil, nil
+	}
+	return &rec, nil
+}
+
+func (s *StubConversationReadStateStore) Set(_ context.Context, email, sessionID, lastReadOrderKey string) (ConversationReadStateRecord, error) {
+	if s == nil {
+		return ConversationReadStateRecord{}, nil
+	}
+	key, normalized, trimmedSessionID := readStateMemoryKey(email, sessionID)
+	lastReadOrderKey = strings.TrimSpace(lastReadOrderKey)
+	if key == "" || lastReadOrderKey == "" {
+		return ConversationReadStateRecord{}, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.records[key]; ok && existing.LastReadOrderKey >= lastReadOrderKey {
+		return existing, nil
+	}
+	rec := ConversationReadStateRecord{
+		Email:            normalized,
+		SessionID:        trimmedSessionID,
+		LastReadOrderKey: lastReadOrderKey,
+		UpdatedAt:        nowISO(),
+	}
+	s.records[key] = rec
+	return rec, nil
+}
+
+func readStateMemoryKey(email, sessionID string) (string, string, string) {
+	normalized := normalizeReadStateEmail(email)
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if normalized == "" || trimmedSessionID == "" {
+		return "", "", ""
+	}
+	return normalized + "\x1f" + trimmedSessionID, normalized, trimmedSessionID
+}
+
+func readStateDocID(sessionID string) string {
+	return "read-state:" + strings.TrimSpace(sessionID)
+}
+
+func readStateDoc(rec ConversationReadStateRecord) map[string]any {
+	return map[string]any{
+		"id":                  readStateDocID(rec.SessionID),
+		"type":                "conversation_read_state",
+		"email":               normalizeReadStateEmail(rec.Email),
+		"session_id":          strings.TrimSpace(rec.SessionID),
+		"last_read_order_key": strings.TrimSpace(rec.LastReadOrderKey),
+		"updated_at":          rec.UpdatedAt,
+	}
+}
+
+func readStateRecordFromDoc(data []byte) (ConversationReadStateRecord, error) {
+	var doc struct {
+		Email            string `json:"email"`
+		SessionID        string `json:"session_id"`
+		LastReadOrderKey string `json:"last_read_order_key"`
+		UpdatedAt        string `json:"updated_at"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ConversationReadStateRecord{}, err
+	}
+	return ConversationReadStateRecord{
+		Email:            normalizeReadStateEmail(doc.Email),
+		SessionID:        strings.TrimSpace(doc.SessionID),
+		LastReadOrderKey: strings.TrimSpace(doc.LastReadOrderKey),
+		UpdatedAt:        doc.UpdatedAt,
+	}, nil
+}
+
+func normalizeReadStateEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func isCosmosNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}
+
+func isCosmosConflict(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusConflict ||
+		respErr.StatusCode == http.StatusPreconditionFailed
+}

--- a/backend-go/internal/store/read_state_test.go
+++ b/backend-go/internal/store/read_state_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStubConversationReadStateStoreIsMonotonic(t *testing.T) {
+	s := NewStubConversationReadStateStore()
+	if _, err := s.Set(context.Background(), "User@Example.COM", "63", "002"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Set(context.Background(), "user@example.com", "63", "001"); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := s.Get(context.Background(), "user@example.com", "63")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec == nil || rec.LastReadOrderKey != "002" {
+		t.Fatalf("read state = %#v, want cursor 002", rec)
+	}
+
+	if _, err := s.Set(context.Background(), "user@example.com", "63", "003"); err != nil {
+		t.Fatal(err)
+	}
+	rec, err = s.Get(context.Background(), "user@example.com", "63")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec == nil || rec.LastReadOrderKey != "003" {
+		t.Fatalf("read state = %#v, want cursor 003", rec)
+	}
+}
+
+func TestReadStateRecordFromDocNormalizesFields(t *testing.T) {
+	rec, err := readStateRecordFromDoc([]byte(`{
+		"email": "User@Example.COM",
+		"session_id": "63",
+		"last_read_order_key": "002",
+		"updated_at": "2026-05-12T00:00:00Z"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Email != "user@example.com" || rec.SessionID != "63" || rec.LastReadOrderKey != "002" {
+		t.Fatalf("record = %#v", rec)
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3523,6 +3523,7 @@ function HeadlessRun({
   visible,
   onRename,
   onSessionPatch,
+  onSessionActivityChanged,
   runPrefs,
   setRunPref,
   user,
@@ -3531,6 +3532,7 @@ function HeadlessRun({
   visible: boolean;
   onRename: (id: string, name: string | null) => void;
   onSessionPatch: (id: string, patch: Partial<Session>) => void;
+  onSessionActivityChanged: () => void;
   runPrefs: RunPrefs;
   setRunPref: SetRunPref;
   user: SessionUser;
@@ -3649,7 +3651,12 @@ function HeadlessRun({
   const runEventsRef = useRef<EventSource | null>(null);
   const historyRefreshRef = useRef<Promise<void> | null>(null);
   const sdkTimelineCursorRef = useRef<string | null>(null);
+  const sdkLastReadSentRef = useRef<string | null>(null);
+  const sdkReadStateInFlightRef = useRef<string | null>(null);
+  const sdkReadStateTimerRef = useRef<number | null>(null);
   const sessionIdRef = useRef(session.id);
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
   const runLifecycleFinishTimerRef = useRef<number | null>(null);
   const turnCompleteAudioRef = useRef<HTMLAudioElement | null>(null);
   const runPrefsRef = useRef(runPrefs);
@@ -3730,6 +3737,7 @@ function HeadlessRun({
       transcriptComparable(prev) === transcriptComparable(merged) ? prev : merged,
     );
     applySdkProjectionToUi(projection);
+    scheduleSdkReadStateUpdate();
   }
   function applySdkProjectionToUi(
     projection: ReturnType<typeof projectConversationState>,
@@ -3802,6 +3810,67 @@ function HeadlessRun({
       eventTimelineCursor(event as unknown as JsonObject),
     );
   }
+  function scheduleSdkReadStateUpdate(): void {
+    if (session.runtime !== "sdk" || !visibleRef.current) return;
+    if (document.visibilityState !== "visible") return;
+    const cursor = sdkTimelineCursorRef.current;
+    if (!cursor) return;
+    if (sdkLastReadSentRef.current && cursor <= sdkLastReadSentRef.current) return;
+    if (sdkReadStateInFlightRef.current && cursor <= sdkReadStateInFlightRef.current) return;
+    if (sdkReadStateTimerRef.current !== null) {
+      window.clearTimeout(sdkReadStateTimerRef.current);
+    }
+    sdkReadStateTimerRef.current = window.setTimeout(() => {
+      sdkReadStateTimerRef.current = null;
+      void flushSdkReadStateUpdate();
+    }, 400);
+  }
+  async function flushSdkReadStateUpdate(): Promise<void> {
+    if (session.runtime !== "sdk" || !visibleRef.current) return;
+    if (document.visibilityState !== "visible") return;
+    const cursor = sdkTimelineCursorRef.current;
+    if (!cursor) return;
+    if (sdkLastReadSentRef.current && cursor <= sdkLastReadSentRef.current) return;
+    sdkReadStateInFlightRef.current = cursor;
+    try {
+      const res = await authedFetch(
+        `/api/sessions/${encodeURIComponent(session.id)}/read-state`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ last_read_order_key: cursor }),
+        },
+      );
+      if (!res.ok) return;
+      const body = (await res.json().catch(() => null)) as {
+        read_state?: { last_read_order_key?: unknown } | null;
+      } | null;
+      const serverCursor =
+        typeof body?.read_state?.last_read_order_key === "string" &&
+        body.read_state.last_read_order_key
+          ? body.read_state.last_read_order_key
+          : cursor;
+      sdkLastReadSentRef.current = advanceTimelineCursor(
+        sdkLastReadSentRef.current,
+        serverCursor,
+      );
+      onSessionActivityChanged();
+    } catch {
+      // Replay/live updates can retry from the latest cursor; backend writes
+      // are monotonic.
+    } finally {
+      if (sdkReadStateInFlightRef.current === cursor) {
+        sdkReadStateInFlightRef.current = null;
+      }
+      const latest = sdkTimelineCursorRef.current;
+      if (
+        latest &&
+        (!sdkLastReadSentRef.current || latest > sdkLastReadSentRef.current)
+      ) {
+        scheduleSdkReadStateUpdate();
+      }
+    }
+  }
   function applySdkRealtimeEvent(event: JsonObject): void {
     if (!isTankConversationEvent(event)) return;
     advanceSdkTimelineCursor(event);
@@ -3872,8 +3941,22 @@ function HeadlessRun({
         window.clearTimeout(runLifecycleFinishTimerRef.current);
         runLifecycleFinishTimerRef.current = null;
       }
+      if (sdkReadStateTimerRef.current !== null) {
+        window.clearTimeout(sdkReadStateTimerRef.current);
+        sdkReadStateTimerRef.current = null;
+      }
     };
   }, []);
+
+  useEffect(() => {
+    visibleRef.current = visible;
+    if (!visible && sdkReadStateTimerRef.current !== null) {
+      window.clearTimeout(sdkReadStateTimerRef.current);
+      sdkReadStateTimerRef.current = null;
+      return;
+    }
+    if (visible) scheduleSdkReadStateUpdate();
+  }, [session.id, visible]);
 
   useEffect(() => {
     if (!visible || session.status !== "Active") return;
@@ -4071,8 +4154,16 @@ function HeadlessRun({
           events?: unknown[];
           next_order_key?: string;
           has_more?: boolean;
+          read_state?: { last_read_order_key?: unknown } | null;
         };
         if (sessionIdRef.current !== refreshSessionId) return { replayed: false };
+        const lastReadOrderKey = body.read_state?.last_read_order_key;
+        if (typeof lastReadOrderKey === "string" && lastReadOrderKey) {
+          sdkLastReadSentRef.current = advanceTimelineCursor(
+            sdkLastReadSentRef.current,
+            lastReadOrderKey,
+          );
+        }
         if (!Array.isArray(body.events)) return { replayed: false };
         events.push(...body.events);
         const previousAfter = afterOrderKey;
@@ -7872,6 +7963,7 @@ export function App() {
                       visible={active === s.id}
                       onRename={renameSession}
                       onSessionPatch={patchSession}
+                      onSessionActivityChanged={() => void refreshSessionActivity()}
                       runPrefs={runPrefs}
                       setRunPref={setRunPref}
                       user={user!}


### PR DESCRIPTION
## Summary
- add per-user SDK conversation read-state storage keyed by email + session id, with monotonic cursor writes
- return read_state from timeline and use it in session activity unread counts
- mark visible SDK panes read from the latest canonical render cursor without hidden mounted panes clearing unread state

Closes #411

## Verification
- go test ./...
- npm test (frontend)
- npm run build (frontend)
- helm template tank-operator ./k8s (not run: helm is not installed locally)