### PR TITLE
Add Tank conversation contract drift guard

### DIFF
--- a/.github/workflows/conversation-contract.yml
+++ b/.github/workflows/conversation-contract.yml
@@ -1,0 +1,74 @@
+name: Conversation Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'schemas/tank-conversation-event.schema.json'
+      - 'backend-go/internal/conversation/**'
+      - 'frontend/src/tankConversation.ts'
+      - 'frontend/src/*.test.ts'
+      - 'agent-runner/src/**'
+      - 'codex-runner/src/**'
+      - 'scripts/check-tank-conversation-contract.mjs'
+      - 'docs/tank-conversation-protocol.md'
+      - '.github/workflows/conversation-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'schemas/tank-conversation-event.schema.json'
+      - 'backend-go/internal/conversation/**'
+      - 'frontend/src/tankConversation.ts'
+      - 'frontend/src/*.test.ts'
+      - 'agent-runner/src/**'
+      - 'codex-runner/src/**'
+      - 'scripts/check-tank-conversation-contract.mjs'
+      - 'docs/tank-conversation-protocol.md'
+      - '.github/workflows/conversation-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend-go/go.mod
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+
+      - name: Install agent-runner dependencies
+        run: npm ci --prefix agent-runner
+
+      - name: Install codex-runner dependencies
+        run: npm ci --prefix codex-runner
+
+      - name: Check schema drift
+        run: node scripts/check-tank-conversation-contract.mjs
+
+      - name: Test frontend projection contract
+        run: npm test --prefix frontend
+
+      - name: Test agent-runner contract
+        run: |
+          npm run build --prefix agent-runner
+          npm test --prefix agent-runner
+
+      - name: Test codex-runner contract
+        run: |
+          npm run build --prefix codex-runner
+          npm test --prefix codex-runner
+
+      - name: Test Go conversation contract
+        working-directory: backend-go
+        run: go test ./...

--- a/agent-runner/src/conversation.ts
+++ b/agent-runner/src/conversation.ts
@@ -1,26 +1,37 @@
 import { createHash } from "node:crypto";
 
-export type TankActor = "user" | "assistant" | "system" | "tool" | "runner";
-export type TankEventSource = "tank" | "claude" | "codex" | "legacy-run";
-export type TankVisibility = "durable" | "live-only" | "audit-only";
+export const TANK_ACTORS = ["user", "assistant", "system", "tool", "runner"] as const;
 
-export type TankEventType =
-  | "conversation.started"
-  | "conversation.archived"
-  | "user_message.created"
-  | "turn.submitted"
-  | "turn.started"
-  | "turn.completed"
-  | "turn.failed"
-  | "turn.interrupted"
-  | "item.started"
-  | "item.delta"
-  | "item.completed"
-  | "item.failed"
-  | "tool.approval_requested"
-  | "tool.approval_resolved"
-  | "session.activity_updated"
-  | "read_state.updated";
+export type TankActor = (typeof TANK_ACTORS)[number];
+
+export const TANK_EVENT_SOURCES = ["tank", "claude", "codex", "legacy-run"] as const;
+
+export type TankEventSource = (typeof TANK_EVENT_SOURCES)[number];
+
+export const TANK_VISIBILITIES = ["durable", "live-only", "audit-only"] as const;
+
+export type TankVisibility = (typeof TANK_VISIBILITIES)[number];
+
+export const TANK_EVENT_TYPES = [
+  "conversation.started",
+  "conversation.archived",
+  "user_message.created",
+  "turn.submitted",
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.interrupted",
+  "item.started",
+  "item.delta",
+  "item.completed",
+  "item.failed",
+  "tool.approval_requested",
+  "tool.approval_resolved",
+  "session.activity_updated",
+  "read_state.updated",
+] as const;
+
+export type TankEventType = (typeof TANK_EVENT_TYPES)[number];
 
 export interface TankConversationEvent {
   event_id: string;
@@ -47,35 +58,24 @@ export interface TankConversationEvent {
   [key: string]: unknown;
 }
 
-const TANK_EVENT_TYPES = new Set<string>([
-  "conversation.started",
-  "conversation.archived",
-  "user_message.created",
-  "turn.submitted",
-  "turn.started",
-  "turn.completed",
-  "turn.failed",
-  "turn.interrupted",
-  "item.started",
-  "item.delta",
-  "item.completed",
-  "item.failed",
-  "tool.approval_requested",
-  "tool.approval_resolved",
-  "session.activity_updated",
-  "read_state.updated",
-]);
+const TANK_EVENT_TYPE_SET = new Set<string>(TANK_EVENT_TYPES);
+const TANK_ACTOR_SET = new Set<string>(TANK_ACTORS);
+const TANK_EVENT_SOURCE_SET = new Set<string>(TANK_EVENT_SOURCES);
+const TANK_VISIBILITY_SET = new Set<string>(TANK_VISIBILITIES);
 
 export function isTankConversationEvent(event: { [key: string]: unknown }): event is TankConversationEvent {
   return (
     typeof event.event_id === "string" &&
     typeof event.session_id === "string" &&
     typeof event.type === "string" &&
-    TANK_EVENT_TYPES.has(event.type) &&
+    TANK_EVENT_TYPE_SET.has(event.type) &&
     typeof event.actor === "string" &&
+    TANK_ACTOR_SET.has(event.actor) &&
     typeof event.source === "string" &&
+    TANK_EVENT_SOURCE_SET.has(event.source) &&
     typeof event.created_at === "string" &&
-    typeof event.visibility === "string"
+    typeof event.visibility === "string" &&
+    TANK_VISIBILITY_SET.has(event.visibility)
   );
 }
 

--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -13,7 +13,7 @@ import {
   type PendingTurn,
 } from "./runner.js";
 import { isCanonical } from "./cosmos.js";
-import { userSubmissionEvents } from "./conversation.js";
+import { isTankConversationEvent, userSubmissionEvents, type TankConversationEvent } from "./conversation.js";
 import type { Config } from "./config.js";
 
 type Order = string[];
@@ -42,6 +42,19 @@ function userMessageEvent() {
     runtime: "claude",
     now: "2026-05-12T00:00:00.000Z",
   }).userMessage;
+}
+
+function assertTankEventFixture(event: TankConversationEvent, label = event.type) {
+  assert.equal(isTankConversationEvent(event), true, `${label} should satisfy the Tank envelope`);
+}
+
+function assertStampedTankEvent(event: TankConversationEvent & { order_key?: unknown; sequence?: unknown }) {
+  assertTankEventFixture(event);
+  assert.equal(
+    typeof event.order_key === "string" || typeof event.sequence === "number",
+    true,
+    `${event.type} should have a replay order cursor`,
+  );
 }
 
 function pendingTurn(fields: Partial<PendingTurn> = {}): PendingTurn {
@@ -157,6 +170,8 @@ test("dispatchCreate uses event_id as the durable id for canonical Tank events",
   assert.equal(cosmosMessage.order_key, cosmosMessage.tank_order_key);
   assert.equal(cosmosMessage.sequence, cosmosMessage.tank_event_seq);
   assert.equal(wsMessage.uuid, cosmosMessage.uuid);
+  assertStampedTankEvent(cosmosMessage);
+  assertStampedTankEvent(wsMessage);
 });
 
 test("dispatchCreate suppresses duplicate client_nonce submissions", async () => {
@@ -266,6 +281,7 @@ test("adapter maps Claude assistant text and tool_use blocks to Tank items", () 
     "item.completed",
     "item.started",
   ]);
+  for (const event of events) assertTankEventFixture(event);
   assert.equal(events[0]?.actor, "assistant");
   assert.equal(events[0]?.payload?.kind, "message");
   assert.equal(events[0]?.payload?.text, "I will inspect the workspace.");
@@ -300,6 +316,7 @@ test("adapter maps Claude AskUserQuestion to needs-input lifecycle", () => {
     "item.started",
     "tool.approval_requested",
   ]);
+  for (const event of requested) assertTankEventFixture(event);
   assert.equal(needsInputItemIDs.has("toolu_ask"), true);
 
   const resolved = canonicalEventsForClaudeMessage(
@@ -326,6 +343,7 @@ test("adapter maps Claude AskUserQuestion to needs-input lifecycle", () => {
     "item.completed",
     "tool.approval_resolved",
   ]);
+  for (const event of resolved) assertTankEventFixture(event);
   assert.equal(needsInputItemIDs.has("toolu_ask"), false);
 });
 
@@ -342,6 +360,7 @@ test("adapter maps Claude result failures and interrupts to terminal turn events
     new Set<string>(),
   );
   assert.equal(failed.length, 1);
+  assertTankEventFixture(failed[0]!);
   assert.equal(failed[0]?.type, "turn.failed");
   assert.equal(failed[0]?.payload?.reason, "provider_failure");
   assert.equal(failed[0]?.payload?.error, "provider failed");
@@ -358,6 +377,7 @@ test("adapter maps Claude result failures and interrupts to terminal turn events
     new Set<string>(),
   );
   assert.equal(interrupted.length, 1);
+  assertTankEventFixture(interrupted[0]!);
   assert.equal(interrupted[0]?.type, "turn.interrupted");
   assert.equal(interrupted[0]?.payload?.reason, "client_interrupt");
 });

--- a/backend-go/internal/conversation/contract_test.go
+++ b/backend-go/internal/conversation/contract_test.go
@@ -1,0 +1,98 @@
+package conversation
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+type conversationSchema struct {
+	Properties map[string]struct {
+		Enum []string `json:"enum"`
+	} `json:"properties"`
+}
+
+func TestContractEnumsMatchSchema(t *testing.T) {
+	schemaBytes, err := os.ReadFile("../../../schemas/tank-conversation-event.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema conversationSchema
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		schemaProperty string
+		goType         string
+	}{
+		{name: "actor", schemaProperty: "actor", goType: "Actor"},
+		{name: "source", schemaProperty: "source", goType: "Source"},
+		{name: "visibility", schemaProperty: "visibility", goType: "Visibility"},
+		{name: "event type", schemaProperty: "type", goType: "EventType"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := schema.Properties[tt.schemaProperty].Enum
+			if len(expected) == 0 {
+				t.Fatalf("schema property %q has no enum", tt.schemaProperty)
+			}
+			actual := goStringConstants(t, tt.goType)
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("%s enum drift:\nGo:     %#v\nSchema: %#v", tt.name, actual, expected)
+			}
+		})
+	}
+}
+
+func goStringConstants(t *testing.T, typeName string) []string {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "types.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var values []string
+	for _, decl := range file.Decls {
+		genericDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genericDecl.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range genericDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok || !isIdentNamed(valueSpec.Type, typeName) {
+				continue
+			}
+			for _, value := range valueSpec.Values {
+				literal, ok := value.(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					t.Fatalf("%s constant has non-string value: %#v", typeName, value)
+				}
+				unquoted, err := strconv.Unquote(literal.Value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				values = append(values, unquoted)
+			}
+		}
+	}
+
+	if len(values) == 0 {
+		t.Fatalf("found no string constants for %s", typeName)
+	}
+	return values
+}
+
+func isIdentNamed(expr ast.Expr, name string) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == name
+}

--- a/backend-go/internal/conversation/types.go
+++ b/backend-go/internal/conversation/types.go
@@ -1,6 +1,6 @@
 // Package conversation contains Tank's provider-neutral conversation event
-// envelope. Keep these types in sync with
-// schemas/tank-conversation-event.schema.json.
+// envelope. The JSON Schema is the source of truth; contract tests keep these
+// enums in sync with schemas/tank-conversation-event.schema.json.
 package conversation
 
 type Actor string

--- a/codex-runner/src/conversation.ts
+++ b/codex-runner/src/conversation.ts
@@ -1,26 +1,37 @@
 import { createHash } from "node:crypto";
 
-export type TankActor = "user" | "assistant" | "system" | "tool" | "runner";
-export type TankEventSource = "tank" | "claude" | "codex" | "legacy-run";
-export type TankVisibility = "durable" | "live-only" | "audit-only";
+export const TANK_ACTORS = ["user", "assistant", "system", "tool", "runner"] as const;
 
-export type TankEventType =
-  | "conversation.started"
-  | "conversation.archived"
-  | "user_message.created"
-  | "turn.submitted"
-  | "turn.started"
-  | "turn.completed"
-  | "turn.failed"
-  | "turn.interrupted"
-  | "item.started"
-  | "item.delta"
-  | "item.completed"
-  | "item.failed"
-  | "tool.approval_requested"
-  | "tool.approval_resolved"
-  | "session.activity_updated"
-  | "read_state.updated";
+export type TankActor = (typeof TANK_ACTORS)[number];
+
+export const TANK_EVENT_SOURCES = ["tank", "claude", "codex", "legacy-run"] as const;
+
+export type TankEventSource = (typeof TANK_EVENT_SOURCES)[number];
+
+export const TANK_VISIBILITIES = ["durable", "live-only", "audit-only"] as const;
+
+export type TankVisibility = (typeof TANK_VISIBILITIES)[number];
+
+export const TANK_EVENT_TYPES = [
+  "conversation.started",
+  "conversation.archived",
+  "user_message.created",
+  "turn.submitted",
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.interrupted",
+  "item.started",
+  "item.delta",
+  "item.completed",
+  "item.failed",
+  "tool.approval_requested",
+  "tool.approval_resolved",
+  "session.activity_updated",
+  "read_state.updated",
+] as const;
+
+export type TankEventType = (typeof TANK_EVENT_TYPES)[number];
 
 export interface TankConversationEvent {
   event_id: string;
@@ -47,35 +58,24 @@ export interface TankConversationEvent {
   [key: string]: unknown;
 }
 
-const TANK_EVENT_TYPES = new Set<string>([
-  "conversation.started",
-  "conversation.archived",
-  "user_message.created",
-  "turn.submitted",
-  "turn.started",
-  "turn.completed",
-  "turn.failed",
-  "turn.interrupted",
-  "item.started",
-  "item.delta",
-  "item.completed",
-  "item.failed",
-  "tool.approval_requested",
-  "tool.approval_resolved",
-  "session.activity_updated",
-  "read_state.updated",
-]);
+const TANK_EVENT_TYPE_SET = new Set<string>(TANK_EVENT_TYPES);
+const TANK_ACTOR_SET = new Set<string>(TANK_ACTORS);
+const TANK_EVENT_SOURCE_SET = new Set<string>(TANK_EVENT_SOURCES);
+const TANK_VISIBILITY_SET = new Set<string>(TANK_VISIBILITIES);
 
 export function isTankConversationEvent(event: { [key: string]: unknown }): event is TankConversationEvent {
   return (
     typeof event.event_id === "string" &&
     typeof event.session_id === "string" &&
     typeof event.type === "string" &&
-    TANK_EVENT_TYPES.has(event.type) &&
+    TANK_EVENT_TYPE_SET.has(event.type) &&
     typeof event.actor === "string" &&
+    TANK_ACTOR_SET.has(event.actor) &&
     typeof event.source === "string" &&
+    TANK_EVENT_SOURCE_SET.has(event.source) &&
     typeof event.created_at === "string" &&
-    typeof event.visibility === "string"
+    typeof event.visibility === "string" &&
+    TANK_VISIBILITY_SET.has(event.visibility)
   );
 }
 

--- a/codex-runner/src/runner.test.ts
+++ b/codex-runner/src/runner.test.ts
@@ -13,7 +13,7 @@ import {
   type AcceptedTurn,
 } from "./runner.js";
 import { isCanonical, nextSortableEventID, type CodexEvent } from "./cosmos.js";
-import { userSubmissionEvents } from "./conversation.js";
+import { isTankConversationEvent, userSubmissionEvents, type TankConversationEvent } from "./conversation.js";
 import type { Config } from "./config.js";
 
 type Order = string[];
@@ -42,6 +42,19 @@ function userMessageEvent() {
     runtime: "codex",
     now: "2026-05-12T00:00:00.000Z",
   }).userMessage;
+}
+
+function assertTankEventFixture(event: TankConversationEvent, label = event.type) {
+  assert.equal(isTankConversationEvent(event), true, `${label} should satisfy the Tank envelope`);
+}
+
+function assertStampedTankEvent(event: TankConversationEvent & { order_key?: unknown; sequence?: unknown }) {
+  assertTankEventFixture(event);
+  assert.equal(
+    typeof event.order_key === "string" || typeof event.sequence === "number",
+    true,
+    `${event.type} should have a replay order cursor`,
+  );
 }
 
 function acceptedTurn(fields: Partial<AcceptedTurn> = {}): AcceptedTurn {
@@ -137,6 +150,8 @@ test("dispatchCreate uses event_id as the durable id for canonical Tank events",
   assert.equal(cosmosEvent.order_key, cosmosEvent.tank_order_key);
   assert.equal(cosmosEvent.sequence, cosmosEvent.tank_event_seq);
   assert.equal(wsEvent.uuid, cosmosEvent.uuid);
+  assertStampedTankEvent(cosmosEvent);
+  assertStampedTankEvent(wsEvent);
 });
 
 test("dispatchCreate suppresses duplicate client_nonce submissions", async () => {
@@ -233,6 +248,7 @@ test("adapter maps Codex agent messages to durable Tank assistant items", () => 
   assert.equal(events[0]?.visibility, "durable");
   assert.equal(events[0]?.payload?.kind, "agent_message");
   assert.equal(events[0]?.payload?.text, "All tests passed.");
+  assertTankEventFixture(events[0]!);
 });
 
 test("adapter maps Codex item updates to live-only Tank deltas", () => {
@@ -253,6 +269,7 @@ test("adapter maps Codex item updates to live-only Tank deltas", () => {
   assert.equal(events[0]?.type, "item.delta");
   assert.equal(events[0]?.actor, "assistant");
   assert.equal(events[0]?.visibility, "live-only");
+  assertTankEventFixture(events[0]!);
 });
 
 test("adapter maps Codex terminal events to Tank turn lifecycle", () => {
@@ -262,6 +279,7 @@ test("adapter maps Codex terminal events to Tank turn lifecycle", () => {
     { type: "turn.completed", usage: { input_tokens: 10 } },
   );
   assert.equal(completed.length, 1);
+  assertTankEventFixture(completed[0]!);
   assert.equal(completed[0]?.type, "turn.completed");
   assert.deepEqual(completed[0]?.payload?.usage, { input_tokens: 10 });
 
@@ -271,6 +289,7 @@ test("adapter maps Codex terminal events to Tank turn lifecycle", () => {
     { type: "error", message: "quota exceeded" },
   );
   assert.equal(failed.length, 1);
+  assertTankEventFixture(failed[0]!);
   assert.equal(failed[0]?.type, "turn.failed");
   assert.equal(failed[0]?.payload?.reason, "provider_failure");
   assert.equal(failed[0]?.payload?.error, "quota exceeded");

--- a/docs/tank-conversation-protocol.md
+++ b/docs/tank-conversation-protocol.md
@@ -72,6 +72,11 @@ References:
 Every Tank event has a stable envelope. The shared JSON Schema lives at
 `schemas/tank-conversation-event.schema.json`; TypeScript and Go stubs live at
 `frontend/src/tankConversation.ts` and `backend-go/internal/conversation`.
+The JSON Schema is the source of truth for `actor`, `source`, `visibility`,
+and event `type` enums. Changes to those enums must update the schema first;
+`scripts/check-tank-conversation-contract.mjs` and the Go conversation package
+test then verify the frontend, agent-runner, codex-runner, and Go definitions
+match it.
 
 Required fields:
 
@@ -262,6 +267,9 @@ Storage:
 
 - New provider events must map to Tank events, be marked `live-only`, or be
   explicitly ignored with a test.
+- New canonical Tank event types must be added to the JSON Schema first, then
+  to the Go and TypeScript contract constants in the same change. The contract
+  check is expected to fail until every package agrees.
 - Replay and live delivery must produce the same reducer state for the same
   canonical event sequence.
 - `client_nonce` is the idempotency boundary for user submission. The durable

--- a/frontend/src/tankConversation.ts
+++ b/frontend/src/tankConversation.ts
@@ -1,28 +1,16 @@
-export type TankActor = "user" | "assistant" | "system" | "tool" | "runner";
+export const TANK_ACTORS = ["user", "assistant", "system", "tool", "runner"] as const;
 
-export type TankEventSource = "tank" | "claude" | "codex" | "legacy-run";
+export type TankActor = (typeof TANK_ACTORS)[number];
 
-export type TankVisibility = "durable" | "live-only" | "audit-only";
+export const TANK_EVENT_SOURCES = ["tank", "claude", "codex", "legacy-run"] as const;
 
-export type TankEventType =
-  | "conversation.started"
-  | "conversation.archived"
-  | "user_message.created"
-  | "turn.submitted"
-  | "turn.started"
-  | "turn.completed"
-  | "turn.failed"
-  | "turn.interrupted"
-  | "item.started"
-  | "item.delta"
-  | "item.completed"
-  | "item.failed"
-  | "tool.approval_requested"
-  | "tool.approval_resolved"
-  | "session.activity_updated"
-  | "read_state.updated";
+export type TankEventSource = (typeof TANK_EVENT_SOURCES)[number];
 
-const TANK_EVENT_TYPES = new Set<string>([
+export const TANK_VISIBILITIES = ["durable", "live-only", "audit-only"] as const;
+
+export type TankVisibility = (typeof TANK_VISIBILITIES)[number];
+
+export const TANK_EVENT_TYPES = [
   "conversation.started",
   "conversation.archived",
   "user_message.created",
@@ -39,11 +27,14 @@ const TANK_EVENT_TYPES = new Set<string>([
   "tool.approval_resolved",
   "session.activity_updated",
   "read_state.updated",
-]);
+] as const;
 
-const TANK_ACTORS = new Set<string>(["user", "assistant", "system", "tool", "runner"]);
-const TANK_EVENT_SOURCES = new Set<string>(["tank", "claude", "codex", "legacy-run"]);
-const TANK_VISIBILITIES = new Set<string>(["durable", "live-only", "audit-only"]);
+export type TankEventType = (typeof TANK_EVENT_TYPES)[number];
+
+const TANK_EVENT_TYPE_SET = new Set<string>(TANK_EVENT_TYPES);
+const TANK_ACTOR_SET = new Set<string>(TANK_ACTORS);
+const TANK_EVENT_SOURCE_SET = new Set<string>(TANK_EVENT_SOURCES);
+const TANK_VISIBILITY_SET = new Set<string>(TANK_VISIBILITIES);
 
 export interface TankProducerMetadata {
   name?: string;
@@ -80,14 +71,14 @@ export function isTankConversationEvent(event: unknown): event is TankConversati
     typeof candidate.event_id === "string" &&
     typeof candidate.session_id === "string" &&
     typeof candidate.type === "string" &&
-    TANK_EVENT_TYPES.has(candidate.type) &&
+    TANK_EVENT_TYPE_SET.has(candidate.type) &&
     typeof candidate.actor === "string" &&
-    TANK_ACTORS.has(candidate.actor) &&
+    TANK_ACTOR_SET.has(candidate.actor) &&
     typeof candidate.source === "string" &&
-    TANK_EVENT_SOURCES.has(candidate.source) &&
+    TANK_EVENT_SOURCE_SET.has(candidate.source) &&
     typeof candidate.created_at === "string" &&
     typeof candidate.visibility === "string" &&
-    TANK_VISIBILITIES.has(candidate.visibility)
+    TANK_VISIBILITY_SET.has(candidate.visibility)
   );
 }
 

--- a/scripts/check-tank-conversation-contract.mjs
+++ b/scripts/check-tank-conversation-contract.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas", "tank-conversation-event.schema.json");
+const requireFromFrontend = createRequire(path.join(repoRoot, "frontend", "package.json"));
+let ts;
+try {
+  ts = requireFromFrontend("typescript");
+} catch (err) {
+  console.error("Unable to load TypeScript from frontend/node_modules.");
+  console.error("Run `npm ci --prefix frontend` before this contract check.");
+  throw err;
+}
+
+const schema = JSON.parse(await fs.readFile(schemaPath, "utf8"));
+const expectedEnums = {
+  TANK_ACTORS: schemaEnum("actor"),
+  TANK_EVENT_SOURCES: schemaEnum("source"),
+  TANK_VISIBILITIES: schemaEnum("visibility"),
+  TANK_EVENT_TYPES: schemaEnum("type"),
+};
+
+const tsContractFiles = [
+  "frontend/src/tankConversation.ts",
+  "agent-runner/src/conversation.ts",
+  "codex-runner/src/conversation.ts",
+];
+
+const failures = [];
+
+for (const relativePath of tsContractFiles) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  const source = await fs.readFile(absolutePath, "utf8");
+  const sourceFile = ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, true);
+  for (const [constName, expected] of Object.entries(expectedEnums)) {
+    const actual = stringArrayConst(sourceFile, constName);
+    if (!actual) {
+      failures.push(`${relativePath}: missing exported ${constName}`);
+      continue;
+    }
+    compareArrays(`${relativePath}:${constName}`, actual, expected);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Tank conversation contract drift detected:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Tank conversation TypeScript enums match schemas/tank-conversation-event.schema.json");
+
+function schemaEnum(propertyName) {
+  const values = schema?.properties?.[propertyName]?.enum;
+  if (!Array.isArray(values) || values.some((value) => typeof value !== "string")) {
+    throw new Error(`Schema property ${propertyName} does not define a string enum`);
+  }
+  return values;
+}
+
+function compareArrays(label, actual, expected) {
+  if (actual.length !== expected.length) {
+    failures.push(`${label}: expected ${expected.length} values, found ${actual.length}`);
+  }
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+  for (const value of expected) {
+    if (!actualSet.has(value)) failures.push(`${label}: missing ${JSON.stringify(value)}`);
+  }
+  for (const value of actual) {
+    if (!expectedSet.has(value)) failures.push(`${label}: extra ${JSON.stringify(value)}`);
+  }
+  if (actual.length === expected.length && actual.some((value, index) => value !== expected[index])) {
+    failures.push(`${label}: values match but order differs from the schema`);
+  }
+}
+
+function stringArrayConst(sourceFile, constName) {
+  let values = null;
+  visit(sourceFile);
+  return values;
+
+  function visit(node) {
+    if (values) return;
+    if (!ts.isVariableStatement(node)) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+    const isExported = node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+    if (!isExported) return;
+    for (const declaration of node.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== constName) continue;
+      const initializer = unwrapExpression(declaration.initializer);
+      if (!initializer || !ts.isArrayLiteralExpression(initializer)) return;
+      const elements = [];
+      for (const element of initializer.elements) {
+        if (!ts.isStringLiteral(element)) return;
+        elements.push(element.text);
+      }
+      values = elements;
+      return;
+    }
+  }
+}
+
+function unwrapExpression(expression) {
+  let current = expression;
+  while (
+    current &&
+    (ts.isAsExpression(current) ||
+      ts.isSatisfiesExpression?.(current) ||
+      ts.isParenthesizedExpression(current))
+  ) {
+    current = current.expression;
+  }
+  return current;
+}


### PR DESCRIPTION
Closes #412.\n\n## Summary\n- declare the JSON schema as the enum source of truth and add a Node drift check for frontend, agent-runner, and codex-runner contract constants\n- add a Go AST/schema test for backend conversation enum drift\n- tighten runner Tank event guards for actor/source/visibility and validate adapter fixtures against the Tank envelope\n- add a Conversation Contract CI workflow and contributor notes\n\n## Tests\n- node scripts/check-tank-conversation-contract.mjs\n- npm test --prefix frontend\n- npm run build --prefix frontend\n- npm run build --prefix agent-runner\n- npm test --prefix agent-runner\n- npm run build --prefix codex-runner\n- npm test --prefix codex-runner\n- go test ./...