### PR TITLE
Remove SDK provider rendering fallback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,10 +91,10 @@ import {
 } from "./conversationProjection";
 import { McpIcon } from "./McpIcon";
 import {
-  applyProviderEvent,
+  applyLegacyProviderEvent,
   isProviderAbortMessage,
-  parseProviderRunHistory,
-  providerFrameEffects,
+  parseLegacyProviderRunHistory,
+  legacyProviderFrameEffects,
   type ToolKind,
 } from "./providerEventAdapters";
 import { ProviderIcon } from "./providerIcons";
@@ -169,9 +169,8 @@ interface Session {
   // Which data-ingestion path the chat pane should use for this session.
   // "sdk" → pod has the agent-runner sidecar; chat pane opens /agent-ws
   // + /timeline. "legacy" → no agent-runner; chat pane uses /run +
-  // /runs/latest/events.json + /run/history. Renderer is the same for
-  // both; only the event source differs. Absent on older pods — treated
-  // as "legacy".
+  // /runs/latest/events.json + /run/history through the legacy provider
+  // adapter. Absent on older pods — treated as "legacy".
   runtime?: "sdk" | "legacy";
   requested_at: string | null;
   created_at: string | null;
@@ -2440,9 +2439,9 @@ function mergeServerRunPrefs(prev: RunPrefs, server: Record<string, unknown>): R
 }
 
 // transcriptComparable returns a stable JSON of the transcript's load-bearing
-// fields, used to short-circuit no-op replay updates. Backend replay paths
-// (`/runs/latest/events.json` then `/run/history`) are the sole source of
-// truth for transcript state across reloads; there is no client-side cache.
+// fields, used to short-circuit no-op replay updates. SDK sessions rebuild
+// from canonical /timeline events; legacy sessions rebuild from
+// /runs/latest/events.json or /run/history. There is no client-side cache.
 function transcriptComparable(entries: TranscriptEntry[]): string {
   return JSON.stringify(
     entries.map((entry) => {
@@ -3981,6 +3980,7 @@ function HeadlessRun({
 
   useEffect(() => {
     if (!activeRunId || session.status !== "Active") return;
+    if (session.runtime === "sdk") return;
     const source = new EventSource(
       `/api/sessions/${encodeURIComponent(session.id)}/runs/${encodeURIComponent(activeRunId)}/events`,
       { withCredentials: true },
@@ -4013,7 +4013,7 @@ function HeadlessRun({
   // handleRunLifecycleEvent is intentionally omitted; it closes over current
   // run refs and state setters, while activeRunId controls subscription scope.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeRunId, session.id, session.status]);
+  }, [activeRunId, session.id, session.runtime, session.status]);
 
   // Auto-send the next queued message once the current run finishes.
   useEffect(() => {
@@ -4050,10 +4050,8 @@ function HeadlessRun({
     return () => main.removeEventListener("scroll", onScroll);
   }, []);
 
-  // History replay — fetch provider JSONL from the pod and replay each event
-  // through the matching provider parser. This is intentionally not limited
-  // to empty localStorage: a run can finish while the tab is closed, leaving
-  // localStorage with a stale partial transcript.
+  // History replay is intentionally not limited to empty transcript state: a
+  // run can finish while the tab is closed, leaving a stale partial transcript.
   const [historyAttempted, setHistoryAttempted] = useState(false);
   const [activeRunChecked, setActiveRunChecked] = useState(false);
   // Toggled briefly when entries are restored (from localStorage OR backend
@@ -4063,9 +4061,8 @@ function HeadlessRun({
     if (session.status !== "Active" || running) return;
     if (historyRefreshRef.current) return;
     const refreshSessionId = session.id;
-    // SDK pods have a durable canonical log in Cosmos session-events; hit
-    // that directly. Legacy path tries structured run events first and falls
-    // back to adapter-parsed provider JSONL.
+    // SDK pods render only the canonical session-events timeline. Legacy path
+    // tries structured run events first and then the provider JSONL adapter.
     const initial =
       session.runtime === "sdk"
         ? refreshSdkRunHistory(showHint)
@@ -4233,7 +4230,7 @@ function HeadlessRun({
       .then((text) => {
         if (sessionIdRef.current !== refreshSessionId) return;
         if (!text) return;
-        const acc = parseProviderRunHistory(text, session.mode) as TranscriptEntry[];
+        const acc = parseLegacyProviderRunHistory(text, session.mode) as TranscriptEntry[];
         if (acc.length > 0) {
           let behind = false;
           setEntries((prev) => {
@@ -4960,7 +4957,7 @@ function HeadlessRun({
       return;
     }
     if (!isJsonObject(providerEvent)) return;
-    const effects = providerFrameEffects(providerEvent);
+    const effects = legacyProviderFrameEffects(providerEvent);
     const total = totalContextTokens(effects.usage as ClaudeUsage | undefined);
     if (total > 0) setTokensUsed(total);
     if (effects.activeTool) {
@@ -4969,7 +4966,7 @@ function HeadlessRun({
     if ("completedToolUseId" in effects) {
       completeActiveTool(effects.completedToolUseId ?? null);
     }
-    setEntries((prev) => applyProviderEvent(prev, session.mode, providerEvent));
+    setEntries((prev) => applyLegacyProviderEvent(prev, session.mode, providerEvent));
   }
 
   function applyStdoutChunk(chunk: string) {
@@ -5056,7 +5053,11 @@ function HeadlessRun({
     if (session.runtime === "sdk") setSdkConnectionState("idle");
     wsRef.current?.close();
     wsRef.current = null;
-    window.setTimeout(() => refreshRunHistoryFromBackend(false), 250);
+    if (session.runtime === "sdk") {
+      void refreshSdkRunHistory(false, true);
+    } else {
+      window.setTimeout(() => refreshRunHistoryFromBackend(false), 250);
+    }
   }
 
   function scheduleLifecycleFinish(

--- a/frontend/src/providerEventAdapters.test.ts
+++ b/frontend/src/providerEventAdapters.test.ts
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
-  applyProviderEvent,
-  parseProviderRunHistory,
-  providerFrameEffects,
+  applyLegacyProviderEvent,
+  parseLegacyProviderRunHistory,
+  legacyProviderFrameEffects,
 } from "./providerEventAdapters.ts";
 
 test("explicitly ignores transient Claude provider frames", () => {
-  const entries = applyProviderEvent([], "claude_gui", {
+  const entries = applyLegacyProviderEvent([], "claude_gui", {
     type: "stream_event",
     event: { type: "content_block_delta" },
     timestamp: "2026-05-12T00:00:00.000Z",
@@ -19,7 +19,7 @@ test("explicitly ignores transient Claude provider frames", () => {
 
 test("extracts legacy Claude usage and active-tool effects behind adapter", () => {
   const usage = { input_tokens: 12, cache_creation_input_tokens: 3 };
-  const effects = providerFrameEffects({
+  const effects = legacyProviderFrameEffects({
     type: "assistant",
     message: {
       usage,
@@ -34,7 +34,7 @@ test("extracts legacy Claude usage and active-tool effects behind adapter", () =
 });
 
 test("adapts Codex tool items and surfaces unknown Codex drift explicitly", () => {
-  const toolEntries = applyProviderEvent([], "codex_gui", {
+  const toolEntries = applyLegacyProviderEvent([], "codex_gui", {
     type: "item.completed",
     tank_turn_seq: 7,
     item: {
@@ -51,7 +51,7 @@ test("adapts Codex tool items and surfaces unknown Codex drift explicitly", () =
   assert.equal(toolEntries[0]?.toolName, "npm test");
   assert.equal(toolEntries[0]?.toolOutput, "ok");
 
-  const unknownEntries = applyProviderEvent([], "codex_gui", {
+  const unknownEntries = applyLegacyProviderEvent([], "codex_gui", {
     type: "future.codex.event",
     payload: { value: true },
     created_at: "2026-05-12T00:00:00.000Z",
@@ -61,8 +61,38 @@ test("adapts Codex tool items and surfaces unknown Codex drift explicitly", () =
   assert.equal(unknownEntries[0]?.meta?.title, "future.codex.event");
 });
 
+test("legacy provider adapter ignores canonical Tank conversation envelopes", () => {
+  const entries = applyLegacyProviderEvent([], "claude_gui", {
+    event_id: "evt-1",
+    session_id: "63",
+    actor: "user",
+    source: "tank",
+    type: "user_message.created",
+    created_at: "2026-05-12T00:00:00.000Z",
+    visibility: "durable",
+    payload: { text: "canonical user message" },
+  });
+
+  assert.deepEqual(entries, []);
+});
+
 test("parses legacy provider JSONL through adapter boundary", () => {
   const history = [
+    JSON.stringify({
+      event_id: "evt-1",
+      session_id: "63",
+      actor: "user",
+      source: "tank",
+      type: "user_message.created",
+      created_at: "2026-05-12T00:00:00.000Z",
+      visibility: "durable",
+      payload: { text: "canonical user message" },
+    }),
+    JSON.stringify({
+      type: "tank.user_message",
+      message: "legacy user message",
+      timestamp: "2026-05-12T00:00:00.000Z",
+    }),
     JSON.stringify({
       type: "assistant",
       uuid: "msg-1",
@@ -73,10 +103,13 @@ test("parses legacy provider JSONL through adapter boundary", () => {
     JSON.stringify({ type: "stream_event" }),
   ].join("\n");
 
-  const entries = parseProviderRunHistory(history, "claude_gui");
+  const entries = parseLegacyProviderRunHistory(history, "claude_gui");
 
   assert.deepEqual(
     entries.map((entry) => [entry.kind, entry.kind === "message" ? entry.text : ""]),
-    [["message", "hello"]],
+    [
+      ["message", "legacy user message"],
+      ["message", "hello"],
+    ],
   );
 });

--- a/frontend/src/providerEventAdapters.ts
+++ b/frontend/src/providerEventAdapters.ts
@@ -1,5 +1,4 @@
 import type { TranscriptEntry as SandboxTranscriptEntry } from "@sandbox-agent/react";
-import { isTankConversationEvent, type TankConversationEvent } from "./tankConversation";
 
 export type ToolKind = "mcp" | "shell";
 
@@ -29,14 +28,12 @@ export function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function applyProviderEvent(
+export function applyLegacyProviderEvent(
   entries: ProviderTranscriptEntry[],
   mode: string,
   event: JsonObject,
 ): ProviderTranscriptEntry[] {
-  if (isTankConversationEvent(event)) {
-    return applyCanonicalConversationEvent(entries, event);
-  }
+  if (isCanonicalTankEnvelope(event)) return entries;
   if (event.type === "tank.user_message") {
     return applyTankUserMessageEvent(entries, event);
   }
@@ -51,7 +48,7 @@ export function applyProviderEvent(
   return applyClaudeEvent(entries, event);
 }
 
-export function parseProviderRunHistory(
+export function parseLegacyProviderRunHistory(
   text: string,
   mode: string,
 ): ProviderTranscriptEntry[] {
@@ -61,7 +58,7 @@ export function parseProviderRunHistory(
     try {
       const event = JSON.parse(line);
       if (isJsonObject(event)) {
-        acc = applyProviderEvent(acc, mode, event);
+        acc = applyLegacyProviderEvent(acc, mode, event);
       }
     } catch {
       /* skip unparseable history lines */
@@ -70,7 +67,7 @@ export function parseProviderRunHistory(
   return acc;
 }
 
-export function providerFrameEffects(event: JsonObject): ProviderFrameEffects {
+export function legacyProviderFrameEffects(event: JsonObject): ProviderFrameEffects {
   const type = event.type;
   if (type === "assistant") {
     const message = event.message;
@@ -124,19 +121,9 @@ export function isProviderAbortMessage(message: unknown): boolean {
   return typeof message === "string" && /operation was aborted/i.test(message);
 }
 
-function applyCanonicalConversationEvent(
-  entries: ProviderTranscriptEntry[],
-  event: TankConversationEvent,
-): ProviderTranscriptEntry[] {
-  if (event.type === "user_message.created") {
-    return applyTankUserMessageEvent(entries, event);
-  }
-  return entries;
-}
-
 function applyTankUserMessageEvent(
   entries: ProviderTranscriptEntry[],
-  event: TankConversationEvent | JsonObject,
+  event: JsonObject,
 ): ProviderTranscriptEntry[] {
   const text = tankUserMessageText(event);
   if (!text || hasUserMessageText(entries, text)) return entries;
@@ -512,7 +499,7 @@ function applyClaudeToolResults(
   }, entries);
 }
 
-function tankUserMessageText(event: TankConversationEvent | JsonObject): string {
+function tankUserMessageText(event: JsonObject): string {
   const payload = (event as { payload?: unknown }).payload;
   if (isJsonObject(payload)) {
     if (typeof payload.text === "string") return payload.text.trim();
@@ -540,6 +527,17 @@ function tankUserMessageText(event: TankConversationEvent | JsonObject): string 
     }
   }
   return "";
+}
+
+function isCanonicalTankEnvelope(event: JsonObject): boolean {
+  return (
+    typeof event.event_id === "string" &&
+    typeof event.session_id === "string" &&
+    typeof event.actor === "string" &&
+    typeof event.source === "string" &&
+    typeof event.created_at === "string" &&
+    typeof event.visibility === "string"
+  );
 }
 
 function claudeTextFromContent(content: unknown, includeToolResults: boolean): string {


### PR DESCRIPTION
Closes #413

## Summary
- keep SDK chat rendering on the canonical /timeline + /agent-ws TankConversationEvent reducer path
- stop SDK sessions from subscribing to legacy run SSE and from falling back to provider JSONL history
- rename the provider rendering adapter as legacy-only and ignore canonical Tank envelopes there

## Verification
- npm test (frontend)
- npm run build (frontend)