### PR TITLE
Harden SDK conversation adapters

### DIFF
--- a/agent-runner/src/adapters/claude.test.ts
+++ b/agent-runner/src/adapters/claude.test.ts
@@ -1,0 +1,192 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  canonicalEventsForClaudeMessage,
+  type ClaudeTurnContext,
+} from "./claude.js";
+import type { Config } from "../config.js";
+import { isTankConversationEvent, type TankConversationEvent } from "../conversation.js";
+
+function assertTankEventFixture(event: TankConversationEvent, label = event.type) {
+  assert.equal(isTankConversationEvent(event), true, `${label} should satisfy the Tank envelope`);
+}
+
+function turn(fields: Partial<ClaudeTurnContext> = {}): ClaudeTurnContext {
+  return {
+    turnID: "turn-run-123",
+    clientNonce: "run-123",
+    interrupted: false,
+    terminalEmitted: false,
+    ...fields,
+  };
+}
+
+function cfg(): Config {
+  return {
+    sessionId: "63",
+    ownerEmail: "user@example.com",
+    cosmosEndpoint: "https://example.invalid",
+    cosmosDatabase: "tank-operator",
+    sessionEventsContainer: "session-events",
+    workspace: "/workspace",
+    mcpConfig: "/workspace/.mcp.json",
+    wsPort: 8090,
+  };
+}
+
+test("adapter maps Claude assistant text and tool_use blocks to Tank items", () => {
+  const events = canonicalEventsForClaudeMessage(
+    cfg(),
+    turn(),
+    {
+      type: "assistant",
+      uuid: "claude-msg-1",
+      message: {
+        content: [
+          { type: "text", text: "I will inspect the workspace." },
+          {
+            type: "tool_use",
+            id: "toolu_read",
+            name: "Read",
+            input: { file_path: "README.md" },
+          },
+        ],
+      },
+    },
+    new Set<string>(),
+  );
+
+  assert.deepEqual(events.map((event) => event.type), [
+    "item.completed",
+    "item.started",
+  ]);
+  for (const event of events) assertTankEventFixture(event);
+  assert.equal(events[0]?.actor, "assistant");
+  assert.equal(events[0]?.item_id, "turn-run-123:assistant:claude-msg-1:text:0");
+  assert.equal(events[0]?.payload?.kind, "message");
+  assert.equal(events[0]?.payload?.text, "I will inspect the workspace.");
+  assert.equal(events[1]?.actor, "tool");
+  assert.equal(events[1]?.item_id, "toolu_read");
+  assert.equal(events[1]?.payload?.title, "Read");
+});
+
+test("adapter gives each text block in one Claude message a unique canonical id", () => {
+  const events = canonicalEventsForClaudeMessage(
+    cfg(),
+    turn(),
+    {
+      type: "assistant",
+      uuid: "claude-msg-multi-text",
+      message: {
+        content: [
+          { type: "text", text: "First paragraph." },
+          { type: "text", text: "Second paragraph." },
+        ],
+      },
+    },
+    new Set<string>(),
+  );
+
+  assert.deepEqual(events.map((event) => event.payload?.text), [
+    "First paragraph.",
+    "Second paragraph.",
+  ]);
+  assert.equal(new Set(events.map((event) => event.item_id)).size, 2);
+  assert.equal(new Set(events.map((event) => event.event_id)).size, 2);
+  assert.equal(events[0]?.item_id, "turn-run-123:assistant:claude-msg-multi-text:text:0");
+  assert.equal(events[1]?.item_id, "turn-run-123:assistant:claude-msg-multi-text:text:1");
+  for (const event of events) assertTankEventFixture(event);
+});
+
+test("adapter maps Claude AskUserQuestion to needs-input lifecycle", () => {
+  const needsInputItemIDs = new Set<string>();
+  const requested = canonicalEventsForClaudeMessage(
+    cfg(),
+    turn(),
+    {
+      type: "assistant",
+      uuid: "claude-msg-approval",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_ask",
+            name: "AskUserQuestion",
+            input: { question: "Proceed?" },
+          },
+        ],
+      },
+    },
+    needsInputItemIDs,
+  );
+
+  assert.deepEqual(requested.map((event) => event.type), [
+    "item.started",
+    "tool.approval_requested",
+  ]);
+  for (const event of requested) assertTankEventFixture(event);
+  assert.equal(needsInputItemIDs.has("toolu_ask"), true);
+
+  const resolved = canonicalEventsForClaudeMessage(
+    cfg(),
+    turn(),
+    {
+      type: "user",
+      uuid: "claude-tool-result",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_ask",
+            content: "yes",
+            is_error: false,
+          },
+        ],
+      },
+    },
+    needsInputItemIDs,
+  );
+
+  assert.deepEqual(resolved.map((event) => event.type), [
+    "item.completed",
+    "tool.approval_resolved",
+  ]);
+  for (const event of resolved) assertTankEventFixture(event);
+  assert.equal(needsInputItemIDs.has("toolu_ask"), false);
+});
+
+test("adapter maps Claude result failures and interrupts to terminal turn events", () => {
+  const failed = canonicalEventsForClaudeMessage(
+    cfg(),
+    turn(),
+    {
+      type: "result",
+      subtype: "error",
+      result: "provider failed",
+      uuid: "claude-result-failed",
+    },
+    new Set<string>(),
+  );
+  assert.equal(failed.length, 1);
+  assertTankEventFixture(failed[0]!);
+  assert.equal(failed[0]?.type, "turn.failed");
+  assert.equal(failed[0]?.payload?.reason, "provider_failure");
+  assert.equal(failed[0]?.payload?.error, "provider failed");
+
+  const interrupted = canonicalEventsForClaudeMessage(
+    cfg(),
+    turn({ interrupted: true }),
+    {
+      type: "result",
+      subtype: "success",
+      result: "stopped",
+      uuid: "claude-result-interrupted",
+    },
+    new Set<string>(),
+  );
+  assert.equal(interrupted.length, 1);
+  assertTankEventFixture(interrupted[0]!);
+  assert.equal(interrupted[0]?.type, "turn.interrupted");
+  assert.equal(interrupted[0]?.payload?.reason, "client_interrupt");
+});

--- a/agent-runner/src/adapters/claude.ts
+++ b/agent-runner/src/adapters/claude.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+
+import type { Config } from "../config.js";
+import type { RunnerEvent } from "../cosmos.js";
+import { itemEvent, turnEvent, type TankConversationEvent } from "../conversation.js";
+
+export interface ClaudeTurnContext {
+  turnID: string;
+  clientNonce: string;
+  interrupted: boolean;
+  terminalEmitted: boolean;
+}
+
+export function claudeUserMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (
+          part &&
+          typeof part === "object" &&
+          "type" in part &&
+          (part as { type?: unknown }).type === "text" &&
+          "text" in part
+        ) {
+          return String((part as { text?: unknown }).text ?? "");
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return String(content ?? "");
+}
+
+export function startsClaudeTurn(event: RunnerEvent): boolean {
+  return event.type === "assistant" || event.type === "user" || event.type === "result";
+}
+
+export function canonicalEventsForClaudeMessage(
+  cfg: Config,
+  turn: ClaudeTurnContext | null,
+  message: RunnerEvent,
+  needsInputItemIDs: Set<string>,
+): TankConversationEvent[] {
+  if (!turn) return [];
+  const providerID = providerEventID(message);
+  if (message.type === "assistant") {
+    const events: TankConversationEvent[] = [];
+    for (const [index, block] of claudeMessageContent(message).entries()) {
+      if (!block || typeof block !== "object") continue;
+      const item = block as Record<string, unknown>;
+      if (item.type === "text") {
+        const text = typeof item.text === "string" ? item.text : "";
+        if (!text) continue;
+        events.push(
+          itemEvent({
+            sessionID: cfg.sessionId,
+            turnID: turn.turnID,
+            source: "claude",
+            type: "item.completed",
+            itemID: claudeBlockItemID({
+              turnID: turn.turnID,
+              actorPart: "assistant",
+              providerID,
+              blockType: "text",
+              index,
+              block: item,
+            }),
+            actor: "assistant",
+            providerEventID: providerID,
+            payload: { kind: "message", text },
+          }),
+        );
+      } else if (item.type === "tool_use") {
+        const itemID =
+          typeof item.id === "string" && item.id
+            ? item.id
+            : claudeBlockItemID({
+                turnID: turn.turnID,
+                actorPart: "tool",
+                providerID,
+                blockType: "tool_use",
+                index,
+                block: item,
+              });
+        const name = typeof item.name === "string" ? item.name : "tool";
+        events.push(
+          itemEvent({
+            sessionID: cfg.sessionId,
+            turnID: turn.turnID,
+            source: "claude",
+            type: "item.started",
+            itemID,
+            actor: "tool",
+            providerEventID: providerID,
+            payload: {
+              kind: "tool",
+              title: name,
+              name,
+              input: item.input,
+            },
+          }),
+        );
+        if (name === "AskUserQuestion") {
+          needsInputItemIDs.add(itemID);
+          events.push(
+            itemEvent({
+              sessionID: cfg.sessionId,
+              turnID: turn.turnID,
+              source: "claude",
+              type: "tool.approval_requested",
+              itemID,
+              actor: "tool",
+              providerEventID: providerID,
+              payload: {
+                kind: "needs_input",
+                title: "Ask user question",
+                name,
+                input: item.input,
+              },
+            }),
+          );
+        }
+      }
+    }
+    return events;
+  }
+  if (message.type === "user") {
+    return claudeMessageContent(message).flatMap((block, index): TankConversationEvent[] => {
+      if (!block || typeof block !== "object") return [];
+      const item = block as Record<string, unknown>;
+      if (item.type !== "tool_result") return [];
+      const itemID =
+        typeof item.tool_use_id === "string" && item.tool_use_id
+          ? item.tool_use_id
+          : claudeBlockItemID({
+              turnID: turn.turnID,
+              actorPart: "tool",
+              providerID,
+              blockType: "tool_result",
+              index,
+              block: item,
+            });
+      const failed = item.is_error === true;
+      const completed = itemEvent({
+        sessionID: cfg.sessionId,
+        turnID: turn.turnID,
+        source: "claude",
+        type: failed ? "item.failed" : "item.completed",
+        itemID,
+        actor: "tool",
+        providerEventID: providerID,
+        payload: {
+          kind: "tool_result",
+          output: item.content,
+          is_error: failed,
+        },
+      });
+      if (!needsInputItemIDs.has(itemID)) return [completed];
+      needsInputItemIDs.delete(itemID);
+      return [
+        completed,
+        itemEvent({
+          sessionID: cfg.sessionId,
+          turnID: turn.turnID,
+          source: "claude",
+          type: "tool.approval_resolved",
+          itemID,
+          actor: "tool",
+          providerEventID: providerID,
+          payload: {
+            kind: "needs_input",
+            resolved: true,
+            is_error: failed,
+          },
+        }),
+      ];
+    });
+  }
+  if (message.type === "result") {
+    if (turn.interrupted && turn.terminalEmitted) return [];
+    const failed = message.is_error === true || message.subtype === "error";
+    return [
+      turnEvent({
+        sessionID: cfg.sessionId,
+        turnID: turn.turnID,
+        clientNonce: turn.clientNonce,
+        source: "claude",
+        type: turn.interrupted ? "turn.interrupted" : failed ? "turn.failed" : "turn.completed",
+        reason: turn.interrupted ? "client_interrupt" : failed ? "provider_failure" : undefined,
+        usage: message.usage,
+        error: failed ? message.result ?? message.error : undefined,
+        providerEventID: providerID,
+      }),
+    ];
+  }
+  return [];
+}
+
+function providerEventID(message: RunnerEvent): string | undefined {
+  for (const key of ["uuid", "id", "message_id", "session_id"]) {
+    const value = message[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+function claudeMessageContent(message: RunnerEvent): unknown[] {
+  const body = message.message;
+  if (body && typeof body === "object" && "content" in body) {
+    const content = (body as { content?: unknown }).content;
+    return Array.isArray(content) ? content : [];
+  }
+  return [];
+}
+
+function claudeBlockItemID(args: {
+  turnID: string;
+  actorPart: "assistant" | "tool";
+  providerID: string | undefined;
+  blockType: string;
+  index: number;
+  block: unknown;
+}): string {
+  const messagePart = args.providerID ?? `message_${stableBlockDigest(args.block)}`;
+  return `${args.turnID}:${args.actorPart}:${messagePart}:${args.blockType}:${args.index}`;
+}
+
+function stableBlockDigest(block: unknown): string {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(block) ?? "";
+  } catch {
+    serialized = String(block);
+  }
+  return createHash("sha256").update(serialized).digest("hex").slice(0, 12);
+}

--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -6,15 +6,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import {
-  canonicalEventsForClaudeMessage,
-  dispatch,
-  dispatchCreate,
-  type PendingTurn,
-} from "./runner.js";
+import { dispatch, dispatchCreate } from "./runner.js";
 import { isCanonical } from "./cosmos.js";
 import { isTankConversationEvent, userSubmissionEvents, type TankConversationEvent } from "./conversation.js";
-import type { Config } from "./config.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -55,31 +49,6 @@ function assertStampedTankEvent(event: TankConversationEvent & { order_key?: unk
     true,
     `${event.type} should have a replay order cursor`,
   );
-}
-
-function pendingTurn(fields: Partial<PendingTurn> = {}): PendingTurn {
-  return {
-    turnID: "turn-run-123",
-    clientNonce: "run-123",
-    text: "hello",
-    started: true,
-    interrupted: false,
-    terminalEmitted: false,
-    ...fields,
-  };
-}
-
-function cfg(): Config {
-  return {
-    sessionId: "63",
-    ownerEmail: "user@example.com",
-    cosmosEndpoint: "https://example.invalid",
-    cosmosDatabase: "tank-operator",
-    sessionEventsContainer: "session-events",
-    workspace: "/workspace",
-    mcpConfig: "/workspace/.mcp.json",
-    wsPort: 8090,
-  };
 }
 
 test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
@@ -253,131 +222,4 @@ test("system without subtype: not canonical (defensive default)", async () => {
   await dispatch(sink, ws, { type: "system" } as any);
   assert.equal(cosmosCalled, false);
   assert.equal(broadcasted, true);
-});
-
-test("adapter maps Claude assistant text and tool_use blocks to Tank items", () => {
-  const events = canonicalEventsForClaudeMessage(
-    cfg(),
-    pendingTurn(),
-    {
-      type: "assistant",
-      uuid: "claude-msg-1",
-      message: {
-        content: [
-          { type: "text", text: "I will inspect the workspace." },
-          {
-            type: "tool_use",
-            id: "toolu_read",
-            name: "Read",
-            input: { file_path: "README.md" },
-          },
-        ],
-      },
-    },
-    new Set<string>(),
-  );
-
-  assert.deepEqual(events.map((event) => event.type), [
-    "item.completed",
-    "item.started",
-  ]);
-  for (const event of events) assertTankEventFixture(event);
-  assert.equal(events[0]?.actor, "assistant");
-  assert.equal(events[0]?.payload?.kind, "message");
-  assert.equal(events[0]?.payload?.text, "I will inspect the workspace.");
-  assert.equal(events[1]?.actor, "tool");
-  assert.equal(events[1]?.item_id, "toolu_read");
-  assert.equal(events[1]?.payload?.title, "Read");
-});
-
-test("adapter maps Claude AskUserQuestion to needs-input lifecycle", () => {
-  const needsInputItemIDs = new Set<string>();
-  const requested = canonicalEventsForClaudeMessage(
-    cfg(),
-    pendingTurn(),
-    {
-      type: "assistant",
-      uuid: "claude-msg-approval",
-      message: {
-        content: [
-          {
-            type: "tool_use",
-            id: "toolu_ask",
-            name: "AskUserQuestion",
-            input: { question: "Proceed?" },
-          },
-        ],
-      },
-    },
-    needsInputItemIDs,
-  );
-
-  assert.deepEqual(requested.map((event) => event.type), [
-    "item.started",
-    "tool.approval_requested",
-  ]);
-  for (const event of requested) assertTankEventFixture(event);
-  assert.equal(needsInputItemIDs.has("toolu_ask"), true);
-
-  const resolved = canonicalEventsForClaudeMessage(
-    cfg(),
-    pendingTurn(),
-    {
-      type: "user",
-      uuid: "claude-tool-result",
-      message: {
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "toolu_ask",
-            content: "yes",
-            is_error: false,
-          },
-        ],
-      },
-    },
-    needsInputItemIDs,
-  );
-
-  assert.deepEqual(resolved.map((event) => event.type), [
-    "item.completed",
-    "tool.approval_resolved",
-  ]);
-  for (const event of resolved) assertTankEventFixture(event);
-  assert.equal(needsInputItemIDs.has("toolu_ask"), false);
-});
-
-test("adapter maps Claude result failures and interrupts to terminal turn events", () => {
-  const failed = canonicalEventsForClaudeMessage(
-    cfg(),
-    pendingTurn(),
-    {
-      type: "result",
-      subtype: "error",
-      result: "provider failed",
-      uuid: "claude-result-failed",
-    },
-    new Set<string>(),
-  );
-  assert.equal(failed.length, 1);
-  assertTankEventFixture(failed[0]!);
-  assert.equal(failed[0]?.type, "turn.failed");
-  assert.equal(failed[0]?.payload?.reason, "provider_failure");
-  assert.equal(failed[0]?.payload?.error, "provider failed");
-
-  const interrupted = canonicalEventsForClaudeMessage(
-    cfg(),
-    pendingTurn({ interrupted: true }),
-    {
-      type: "result",
-      subtype: "success",
-      result: "stopped",
-      uuid: "claude-result-interrupted",
-    },
-    new Set<string>(),
-  );
-  assert.equal(interrupted.length, 1);
-  assertTankEventFixture(interrupted[0]!);
-  assert.equal(interrupted[0]?.type, "turn.interrupted");
-  assert.equal(interrupted[0]?.payload?.reason, "client_interrupt");
 });

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -22,10 +22,14 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "node:crypto";
 
+import {
+  canonicalEventsForClaudeMessage,
+  claudeUserMessageText,
+  startsClaudeTurn,
+} from "./adapters/claude.js";
 import type { Config } from "./config.js";
 import { CosmosSink, isCanonical, type RunnerEvent } from "./cosmos.js";
 import {
-  itemEvent,
   normalizeClientNonce,
   turnEvent,
   userSubmissionEvents,
@@ -127,28 +131,6 @@ function isTankEvent(message: RunnerEvent): message is TankConversationEvent {
   return typeof message.event_id === "string" && typeof message.visibility === "string";
 }
 
-function userMessageText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (
-          part &&
-          typeof part === "object" &&
-          "type" in part &&
-          (part as { type?: unknown }).type === "text" &&
-          "text" in part
-        ) {
-          return String((part as { text?: unknown }).text ?? "");
-        }
-        return "";
-      })
-      .filter(Boolean)
-      .join("\n");
-  }
-  return String(content ?? "");
-}
-
 export interface PendingTurn {
   turnID: string;
   clientNonce: string;
@@ -156,161 +138,6 @@ export interface PendingTurn {
   started: boolean;
   interrupted: boolean;
   terminalEmitted: boolean;
-}
-
-function providerEventID(message: RunnerEvent): string | undefined {
-  for (const key of ["uuid", "id", "message_id", "session_id"]) {
-    const value = message[key];
-    if (typeof value === "string" && value) return value;
-  }
-  return undefined;
-}
-
-function claudeMessageContent(message: RunnerEvent): unknown[] {
-  const body = message.message;
-  if (body && typeof body === "object" && "content" in body) {
-    const content = (body as { content?: unknown }).content;
-    return Array.isArray(content) ? content : [];
-  }
-  return [];
-}
-
-export function canonicalEventsForClaudeMessage(
-  cfg: Config,
-  turn: PendingTurn | null,
-  message: RunnerEvent,
-  needsInputItemIDs: Set<string>,
-): TankConversationEvent[] {
-  if (!turn) return [];
-  const providerID = providerEventID(message);
-  if (message.type === "assistant") {
-    const events: TankConversationEvent[] = [];
-    for (const [index, block] of claudeMessageContent(message).entries()) {
-      if (!block || typeof block !== "object") continue;
-      const item = block as Record<string, unknown>;
-      if (item.type === "text") {
-        const text = typeof item.text === "string" ? item.text : "";
-        if (!text) continue;
-        events.push(
-          itemEvent({
-            sessionID: cfg.sessionId,
-            turnID: turn.turnID,
-            source: "claude",
-            type: "item.completed",
-            itemID: `${turn.turnID}:assistant:${providerID ?? index}`,
-            actor: "assistant",
-            providerEventID: providerID,
-            payload: { kind: "message", text },
-          }),
-        );
-      } else if (item.type === "tool_use") {
-        const itemID =
-          typeof item.id === "string" && item.id ? item.id : `${turn.turnID}:tool:${index}`;
-        const name = typeof item.name === "string" ? item.name : "tool";
-        events.push(
-          itemEvent({
-            sessionID: cfg.sessionId,
-            turnID: turn.turnID,
-            source: "claude",
-            type: "item.started",
-            itemID,
-            actor: "tool",
-            providerEventID: providerID,
-            payload: {
-              kind: "tool",
-              title: name,
-              name,
-              input: item.input,
-            },
-          }),
-        );
-        if (name === "AskUserQuestion") {
-          needsInputItemIDs.add(itemID);
-          events.push(
-            itemEvent({
-              sessionID: cfg.sessionId,
-              turnID: turn.turnID,
-              source: "claude",
-              type: "tool.approval_requested",
-              itemID,
-              actor: "tool",
-              providerEventID: providerID,
-              payload: {
-                kind: "needs_input",
-                title: "Ask user question",
-                name,
-                input: item.input,
-              },
-            }),
-          );
-        }
-      }
-    }
-    return events;
-  }
-  if (message.type === "user") {
-    return claudeMessageContent(message).flatMap((block, index): TankConversationEvent[] => {
-      if (!block || typeof block !== "object") return [];
-      const item = block as Record<string, unknown>;
-      if (item.type !== "tool_result") return [];
-      const itemID =
-        typeof item.tool_use_id === "string" && item.tool_use_id
-          ? item.tool_use_id
-          : `${turn.turnID}:tool_result:${index}`;
-      const failed = item.is_error === true;
-      const completed = itemEvent({
-        sessionID: cfg.sessionId,
-        turnID: turn.turnID,
-        source: "claude",
-        type: failed ? "item.failed" : "item.completed",
-        itemID,
-        actor: "tool",
-        providerEventID: providerID,
-        payload: {
-          kind: "tool_result",
-          output: item.content,
-          is_error: failed,
-        },
-      });
-      if (!needsInputItemIDs.has(itemID)) return [completed];
-      needsInputItemIDs.delete(itemID);
-      return [
-        completed,
-        itemEvent({
-          sessionID: cfg.sessionId,
-          turnID: turn.turnID,
-          source: "claude",
-          type: "tool.approval_resolved",
-          itemID,
-          actor: "tool",
-          providerEventID: providerID,
-          payload: {
-            kind: "needs_input",
-            resolved: true,
-            is_error: failed,
-          },
-        }),
-      ];
-    });
-  }
-  if (message.type === "result") {
-    if (turn.interrupted && turn.terminalEmitted) return [];
-    const failed = message.is_error === true || message.subtype === "error";
-    return [
-      turnEvent({
-        sessionID: cfg.sessionId,
-        turnID: turn.turnID,
-        clientNonce: turn.clientNonce,
-        source: "claude",
-        type: turn.interrupted ? "turn.interrupted" : failed ? "turn.failed" : "turn.completed",
-        reason: turn.interrupted ? "client_interrupt" : failed ? "provider_failure" : undefined,
-        usage: message.usage,
-        error: failed ? message.result ?? message.error : undefined,
-        providerEventID: providerID,
-      }),
-    ];
-  }
-  return [];
 }
 
 // AsyncQueue is a one-writer-many-no-readers queue that yields each
@@ -445,7 +272,7 @@ export class Runner {
 
   private async handleClientFrame(frame: ClientFrame): Promise<void> {
     if (frame.type === "user") {
-      const text = userMessageText(frame.message?.content);
+      const text = claudeUserMessageText(frame.message?.content);
       const pendingTurn = await this.recordUserSubmission(text, frame.message, frame.client_nonce);
       if (!pendingTurn) return;
       this.pendingTurns.push(pendingTurn);
@@ -500,7 +327,7 @@ export class Runner {
   }
 
   private async ensureActiveTurn(event: RunnerEvent): Promise<PendingTurn | null> {
-    if (!this.activeTurn && this.pendingTurns.length > 0 && startsProviderTurn(event)) {
+    if (!this.activeTurn && this.pendingTurns.length > 0 && startsClaudeTurn(event)) {
       this.activeTurn = this.pendingTurns.shift() ?? null;
       if (this.activeTurn && !this.activeTurn.started) {
         this.activeTurn.started = true;
@@ -562,8 +389,4 @@ export class Runner {
       parent_tool_use_id: null,
     } as unknown as SDKUserMessage);
   }
-}
-
-function startsProviderTurn(event: RunnerEvent): boolean {
-  return event.type === "assistant" || event.type === "user" || event.type === "result";
 }

--- a/codex-runner/src/adapters/codex.test.ts
+++ b/codex-runner/src/adapters/codex.test.ts
@@ -1,0 +1,155 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import type { Config } from "../config.js";
+import type { CodexEvent } from "../cosmos.js";
+import { isTankConversationEvent } from "../conversation.js";
+import {
+  CodexTankEventAdapter,
+  canonicalEventsForCodexEvent,
+  type CodexAdapterTurn,
+} from "./codex.js";
+
+function cfg(): Config {
+  return {
+    sessionId: "63",
+    ownerEmail: "user@example.com",
+    cosmosEndpoint: "https://example.invalid",
+    cosmosDatabase: "tank-operator",
+    sessionEventsContainer: "session-events",
+    workspace: "/workspace",
+    wsPort: 8090,
+  };
+}
+
+function acceptedTurn(fields: Partial<CodexAdapterTurn> = {}): CodexAdapterTurn {
+  return {
+    turnID: "turn-run-123",
+    clientNonce: "run-123",
+    turnSeq: 7,
+    ...fields,
+  };
+}
+
+function mappedEvent(adapter: CodexTankEventAdapter, event: CodexEvent) {
+  const events = adapter.canonicalEventsForCodexEvent(acceptedTurn(), event);
+  assert.equal(events.length, 1);
+  assert.equal(isTankConversationEvent(events[0]!), true);
+  return events[0]!;
+}
+
+test("maps Codex item updates to live-only Tank deltas with delta payload", () => {
+  const adapter = new CodexTankEventAdapter(cfg());
+  const first = mappedEvent(adapter, {
+    type: "item.updated",
+    item: {
+      id: "item_reasoning_1",
+      type: "reasoning",
+      text: "think",
+    },
+  });
+  const second = mappedEvent(adapter, {
+    type: "item.updated",
+    item: {
+      id: "item_reasoning_1",
+      type: "reasoning",
+      text: "thinking",
+    },
+  });
+
+  assert.equal(first.type, "item.delta");
+  assert.equal(first.actor, "assistant");
+  assert.equal(first.visibility, "live-only");
+  assert.equal(first.payload?.kind, "reasoning");
+  assert.equal(first.payload?.delta, "think");
+  assert.equal(first.payload?.text, undefined);
+  assert.equal(second.payload?.delta, "ing");
+  assert.equal(second.payload?.text, undefined);
+});
+
+test("preserves completed Codex text as durable Tank item text", () => {
+  const event = mappedEvent(new CodexTankEventAdapter(cfg()), {
+    type: "item.completed",
+    item: {
+      id: "item_agent_1",
+      type: "agent_message",
+      text: "All tests passed.",
+    },
+  });
+
+  assert.equal(event.type, "item.completed");
+  assert.equal(event.source, "codex");
+  assert.equal(event.actor, "assistant");
+  assert.equal(event.item_id, "item_agent_1");
+  assert.equal(event.visibility, "durable");
+  assert.equal(event.payload?.kind, "agent_message");
+  assert.equal(event.payload?.text, "All tests passed.");
+  assert.equal(event.payload?.delta, undefined);
+});
+
+test("maps Codex tool items to Tank tool items with command payload", () => {
+  const event = mappedEvent(new CodexTankEventAdapter(cfg()), {
+    type: "item.completed",
+    item: {
+      id: "item_command_1",
+      type: "command_execution",
+      command: "npm test",
+      aggregated_output: "ok",
+      exit_code: 0,
+      status: "completed",
+    },
+  });
+
+  assert.equal(event.type, "item.completed");
+  assert.equal(event.actor, "tool");
+  assert.equal(event.item_id, "item_command_1");
+  assert.equal(event.payload?.kind, "command_execution");
+  assert.equal(event.payload?.title, "npm test");
+  assert.equal(event.payload?.text, "ok");
+  assert.deepEqual(event.payload?.raw_item, {
+    id: "item_command_1",
+    type: "command_execution",
+    command: "npm test",
+    aggregated_output: "ok",
+    exit_code: 0,
+    status: "completed",
+  });
+});
+
+test("maps errored Codex items to Tank item.failed", () => {
+  const event = mappedEvent(new CodexTankEventAdapter(cfg()), {
+    type: "item.completed",
+    item: {
+      id: "item_command_2",
+      type: "command_execution",
+      command: "npm test",
+      error: "failed",
+    },
+  });
+
+  assert.equal(event.type, "item.failed");
+  assert.equal(event.actor, "tool");
+  assert.equal(event.visibility, "durable");
+  assert.equal(event.payload?.error, "failed");
+});
+
+test("maps Codex terminal events to Tank turn lifecycle", () => {
+  const adapter = new CodexTankEventAdapter(cfg());
+  const completed = mappedEvent(adapter, { type: "turn.completed", usage: { input_tokens: 10 } });
+  assert.equal(completed.type, "turn.completed");
+  assert.deepEqual(completed.payload?.usage, { input_tokens: 10 });
+
+  const failed = mappedEvent(adapter, { type: "error", message: "quota exceeded" });
+  assert.equal(failed.type, "turn.failed");
+  assert.equal(failed.payload?.reason, "provider_failure");
+  assert.equal(failed.payload?.error, "quota exceeded");
+});
+
+test("ignores unknown Codex provider event types", () => {
+  const events = canonicalEventsForCodexEvent(
+    cfg(),
+    acceptedTurn(),
+    { type: "future.experimental.event", value: true },
+  );
+  assert.deepEqual(events, []);
+});

--- a/codex-runner/src/adapters/codex.ts
+++ b/codex-runner/src/adapters/codex.ts
@@ -1,0 +1,149 @@
+import type { Config } from "../config.js";
+import type { CodexEvent } from "../cosmos.js";
+import { itemEvent, turnEvent, type TankConversationEvent } from "../conversation.js";
+
+export interface CodexAdapterTurn {
+  turnID: string;
+  clientNonce: string;
+  turnSeq: number;
+}
+
+function codexProviderEventID(event: CodexEvent): string | undefined {
+  const item = event.item;
+  if (item && typeof item === "object") {
+    const itemID = (item as { id?: unknown }).id;
+    if (typeof itemID === "string" && itemID) return itemID;
+  }
+  for (const key of ["turn_id", "thread_id", "id", "uuid"]) {
+    const value = event[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+function codexItemText(item: Record<string, unknown>): string | undefined {
+  if (typeof item.text === "string") return item.text;
+  if (typeof item.aggregated_output === "string") return item.aggregated_output;
+  if (typeof item.message === "string") return item.message;
+  return undefined;
+}
+
+export class CodexTankEventAdapter {
+  private readonly itemTextByID = new Map<string, string>();
+
+  constructor(private readonly cfg: Config) {}
+
+  canonicalEventsForCodexEvent(
+    turn: CodexAdapterTurn,
+    event: CodexEvent,
+  ): TankConversationEvent[] {
+    const providerID = codexProviderEventID(event);
+    if (event.type === "turn.completed") {
+      this.itemTextByID.clear();
+      return [
+        turnEvent({
+          sessionID: this.cfg.sessionId,
+          turnID: turn.turnID,
+          clientNonce: turn.clientNonce,
+          source: "codex",
+          type: "turn.completed",
+          usage: event.usage,
+          providerEventID: providerID,
+        }),
+      ];
+    }
+    if (event.type === "turn.failed" || event.type === "error") {
+      this.itemTextByID.clear();
+      return [
+        turnEvent({
+          sessionID: this.cfg.sessionId,
+          turnID: turn.turnID,
+          clientNonce: turn.clientNonce,
+          source: "codex",
+          type: "turn.failed",
+          reason: "provider_failure",
+          error: event.error ?? event.message ?? event,
+          providerEventID: providerID,
+        }),
+      ];
+    }
+    if (event.type !== "item.started" && event.type !== "item.updated" && event.type !== "item.completed") {
+      return [];
+    }
+    const item = event.item;
+    if (!item || typeof item !== "object") return [];
+    const itemRecord = item as Record<string, unknown>;
+    const itemID =
+      typeof itemRecord.id === "string" && itemRecord.id ? itemRecord.id : `${turn.turnID}:item:${providerID ?? event.type}`;
+    const itemFailed = itemRecord.error !== undefined;
+    const actor = itemRecord.type === "agent_message" || itemRecord.type === "reasoning" ? "assistant" : "tool";
+    const type =
+      event.type === "item.started"
+        ? "item.started"
+        : event.type === "item.updated"
+          ? "item.delta"
+          : itemFailed
+            ? "item.failed"
+            : "item.completed";
+    const payload = this.codexItemPayload(itemID, itemRecord, { delta: event.type === "item.updated" });
+    if (event.type === "item.started") this.rememberItemText(itemID, codexItemText(itemRecord));
+    if (event.type === "item.completed") this.itemTextByID.delete(itemID);
+    return [
+      itemEvent({
+        sessionID: this.cfg.sessionId,
+        turnID: turn.turnID,
+        source: "codex",
+        type,
+        itemID,
+        actor,
+        providerEventID: providerID,
+        visibility: event.type === "item.updated" ? "live-only" : "durable",
+        payload,
+      }),
+    ];
+  }
+
+  private codexItemPayload(
+    itemID: string,
+    item: Record<string, unknown>,
+    opts: { delta?: boolean } = {},
+  ): Record<string, unknown> {
+    const text = codexItemText(item);
+    return {
+      kind: typeof item.type === "string" && item.type ? item.type : "item",
+      title:
+        typeof item.command === "string"
+          ? item.command
+          : typeof item.tool === "string"
+            ? item.tool
+            : typeof item.type === "string"
+              ? item.type
+              : "item",
+      ...(opts.delta ? { delta: this.deltaForItemText(itemID, text) } : { text }),
+      command: item.command,
+      arguments: item.arguments,
+      result: item.result,
+      error: item.error,
+      raw_item: item,
+    };
+  }
+
+  private rememberItemText(itemID: string, text: string | undefined): void {
+    if (text !== undefined) this.itemTextByID.set(itemID, text);
+  }
+
+  private deltaForItemText(itemID: string, text: string | undefined): string | undefined {
+    if (text === undefined) return undefined;
+    const previous = this.itemTextByID.get(itemID) ?? "";
+    this.itemTextByID.set(itemID, text);
+    return previous && text.startsWith(previous) ? text.slice(previous.length) : text;
+  }
+}
+
+export function canonicalEventsForCodexEvent(
+  cfg: Config,
+  turn: CodexAdapterTurn,
+  event: CodexEvent,
+): TankConversationEvent[] {
+  return new CodexTankEventAdapter(cfg).canonicalEventsForCodexEvent(turn, event);
+}

--- a/codex-runner/src/runner.test.ts
+++ b/codex-runner/src/runner.test.ts
@@ -7,14 +7,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  canonicalEventsForCodexEvent,
   dispatch,
   dispatchCreate,
-  type AcceptedTurn,
 } from "./runner.js";
 import { isCanonical, nextSortableEventID, type CodexEvent } from "./cosmos.js";
 import { isTankConversationEvent, userSubmissionEvents, type TankConversationEvent } from "./conversation.js";
-import type { Config } from "./config.js";
 
 type Order = string[];
 function makeSink(order: Order, opts: { throws?: Error } = {}) {
@@ -55,27 +52,6 @@ function assertStampedTankEvent(event: TankConversationEvent & { order_key?: unk
     true,
     `${event.type} should have a replay order cursor`,
   );
-}
-
-function acceptedTurn(fields: Partial<AcceptedTurn> = {}): AcceptedTurn {
-  return {
-    turnID: "turn-run-123",
-    clientNonce: "run-123",
-    turnSeq: 7,
-    ...fields,
-  };
-}
-
-function cfg(): Config {
-  return {
-    sessionId: "63",
-    ownerEmail: "user@example.com",
-    cosmosEndpoint: "https://example.invalid",
-    cosmosDatabase: "tank-operator",
-    sessionEventsContainer: "session-events",
-    workspace: "/workspace",
-    wsPort: 8090,
-  };
 }
 
 test("canonical: cosmos before ws (read-your-writes ordering)", async () => {
@@ -224,82 +200,4 @@ test("generated event ids sort by production order", () => {
   const second = nextSortableEventID(1000);
   const third = nextSortableEventID(1001);
   assert.deepEqual([third, first, second].sort(), [first, second, third]);
-});
-
-test("adapter maps Codex agent messages to durable Tank assistant items", () => {
-  const events = canonicalEventsForCodexEvent(
-    cfg(),
-    acceptedTurn(),
-    {
-      type: "item.completed",
-      item: {
-        id: "item_agent_1",
-        type: "agent_message",
-        text: "All tests passed.",
-      },
-    },
-  );
-
-  assert.equal(events.length, 1);
-  assert.equal(events[0]?.type, "item.completed");
-  assert.equal(events[0]?.source, "codex");
-  assert.equal(events[0]?.actor, "assistant");
-  assert.equal(events[0]?.item_id, "item_agent_1");
-  assert.equal(events[0]?.visibility, "durable");
-  assert.equal(events[0]?.payload?.kind, "agent_message");
-  assert.equal(events[0]?.payload?.text, "All tests passed.");
-  assertTankEventFixture(events[0]!);
-});
-
-test("adapter maps Codex item updates to live-only Tank deltas", () => {
-  const events = canonicalEventsForCodexEvent(
-    cfg(),
-    acceptedTurn(),
-    {
-      type: "item.updated",
-      item: {
-        id: "item_reasoning_1",
-        type: "reasoning",
-        text: "thinking",
-      },
-    },
-  );
-
-  assert.equal(events.length, 1);
-  assert.equal(events[0]?.type, "item.delta");
-  assert.equal(events[0]?.actor, "assistant");
-  assert.equal(events[0]?.visibility, "live-only");
-  assertTankEventFixture(events[0]!);
-});
-
-test("adapter maps Codex terminal events to Tank turn lifecycle", () => {
-  const completed = canonicalEventsForCodexEvent(
-    cfg(),
-    acceptedTurn(),
-    { type: "turn.completed", usage: { input_tokens: 10 } },
-  );
-  assert.equal(completed.length, 1);
-  assertTankEventFixture(completed[0]!);
-  assert.equal(completed[0]?.type, "turn.completed");
-  assert.deepEqual(completed[0]?.payload?.usage, { input_tokens: 10 });
-
-  const failed = canonicalEventsForCodexEvent(
-    cfg(),
-    acceptedTurn(),
-    { type: "error", message: "quota exceeded" },
-  );
-  assert.equal(failed.length, 1);
-  assertTankEventFixture(failed[0]!);
-  assert.equal(failed[0]?.type, "turn.failed");
-  assert.equal(failed[0]?.payload?.reason, "provider_failure");
-  assert.equal(failed[0]?.payload?.error, "quota exceeded");
-});
-
-test("adapter explicitly ignores unknown Codex provider event types", () => {
-  const events = canonicalEventsForCodexEvent(
-    cfg(),
-    acceptedTurn(),
-    { type: "future.experimental.event", value: true },
-  );
-  assert.deepEqual(events, []);
 });

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -22,6 +22,10 @@
 
 import { Codex, type Thread } from "@openai/codex-sdk";
 
+import {
+  CodexTankEventAdapter,
+  type CodexAdapterTurn,
+} from "./adapters/codex.js";
 import type { Config } from "./config.js";
 import {
   CosmosSink,
@@ -30,11 +34,9 @@ import {
   type CodexEvent,
 } from "./cosmos.js";
 import {
-  itemEvent,
   normalizeClientNonce,
   turnEvent,
   userSubmissionEvents,
-  type TankConversationEvent,
 } from "./conversation.js";
 import { WSFanout, type ClientFrame } from "./ws.js";
 
@@ -134,116 +136,14 @@ function isAbortError(err: unknown): boolean {
   );
 }
 
-export interface AcceptedTurn {
-  turnID: string;
-  clientNonce: string;
-  turnSeq: number;
-}
-
-function codexProviderEventID(event: CodexEvent): string | undefined {
-  const item = event.item;
-  if (item && typeof item === "object") {
-    const itemID = (item as { id?: unknown }).id;
-    if (typeof itemID === "string" && itemID) return itemID;
-  }
-  for (const key of ["turn_id", "thread_id", "id", "uuid"]) {
-    const value = event[key];
-    if (typeof value === "string" && value) return value;
-  }
-  return undefined;
-}
-
-function codexItemPayload(item: Record<string, unknown>): Record<string, unknown> {
-  return {
-    kind: typeof item.type === "string" && item.type ? item.type : "item",
-    title:
-      typeof item.command === "string"
-        ? item.command
-        : typeof item.tool === "string"
-          ? item.tool
-          : typeof item.type === "string"
-            ? item.type
-            : "item",
-    text: typeof item.text === "string" ? item.text : undefined,
-    command: item.command,
-    arguments: item.arguments,
-    result: item.result,
-    error: item.error,
-    raw_item: item,
-  };
-}
-
-export function canonicalEventsForCodexEvent(
-  cfg: Config,
-  turn: AcceptedTurn,
-  event: CodexEvent,
-): TankConversationEvent[] {
-  const providerID = codexProviderEventID(event);
-  if (event.type === "turn.completed") {
-    return [
-      turnEvent({
-        sessionID: cfg.sessionId,
-        turnID: turn.turnID,
-        clientNonce: turn.clientNonce,
-        source: "codex",
-        type: "turn.completed",
-        usage: event.usage,
-        providerEventID: providerID,
-      }),
-    ];
-  }
-  if (event.type === "turn.failed" || event.type === "error") {
-    return [
-      turnEvent({
-        sessionID: cfg.sessionId,
-        turnID: turn.turnID,
-        clientNonce: turn.clientNonce,
-        source: "codex",
-        type: "turn.failed",
-        reason: "provider_failure",
-        error: event.error ?? event.message ?? event,
-        providerEventID: providerID,
-      }),
-    ];
-  }
-  if (event.type !== "item.started" && event.type !== "item.updated" && event.type !== "item.completed") {
-    return [];
-  }
-  const item = event.item;
-  if (!item || typeof item !== "object") return [];
-  const itemRecord = item as Record<string, unknown>;
-  const itemID =
-    typeof itemRecord.id === "string" && itemRecord.id ? itemRecord.id : `${turn.turnID}:item:${providerID ?? event.type}`;
-  const itemFailed = itemRecord.error !== undefined;
-  const actor = itemRecord.type === "agent_message" || itemRecord.type === "reasoning" ? "assistant" : "tool";
-  const type =
-    event.type === "item.started"
-      ? "item.started"
-      : event.type === "item.updated"
-        ? "item.delta"
-        : itemFailed
-          ? "item.failed"
-          : "item.completed";
-  return [
-    itemEvent({
-      sessionID: cfg.sessionId,
-      turnID: turn.turnID,
-      source: "codex",
-      type,
-      itemID,
-      actor,
-      providerEventID: providerID,
-      visibility: event.type === "item.updated" ? "live-only" : "durable",
-      payload: codexItemPayload(itemRecord),
-    }),
-  ];
-}
+export type AcceptedTurn = CodexAdapterTurn;
 
 export class Runner {
   private readonly sink: CosmosSink;
   private readonly ws: WSFanout;
   private readonly userQueue = new AsyncQueue<{ text: string; clientNonce?: string }>();
   private readonly codex: Codex;
+  private readonly codexAdapter: CodexTankEventAdapter;
   private thread: Thread | null = null;
   private currentAbort: AbortController | null = null;
   private interruptRequested = false;
@@ -258,6 +158,7 @@ export class Runner {
     // ~/.codex/auth.json (mounted from the codex-credentials secret).
     // No CODEX_API_KEY needed — subscription auth path.
     this.codex = new Codex();
+    this.codexAdapter = new CodexTankEventAdapter(cfg);
   }
 
   // Run until externally aborted. Each iteration awaits one user
@@ -312,7 +213,7 @@ export class Runner {
             tank_turn_seq: turnSeq,
           };
           await dispatch(this.sink, this.ws, codexEvent);
-          for (const canonicalEvent of canonicalEventsForCodexEvent(this.cfg, turn, codexEvent)) {
+          for (const canonicalEvent of this.codexAdapter.canonicalEventsForCodexEvent(turn, codexEvent)) {
             await dispatch(this.sink, this.ws, canonicalEvent);
           }
         }

--- a/docs/tank-conversation-protocol.md
+++ b/docs/tank-conversation-protocol.md
@@ -76,7 +76,9 @@ The JSON Schema is the source of truth for `actor`, `source`, `visibility`,
 and event `type` enums. Changes to those enums must update the schema first;
 `scripts/check-tank-conversation-contract.mjs` and the Go conversation package
 test then verify the frontend, agent-runner, codex-runner, and Go definitions
-match it.
+match it. The same script also validates representative canonical fixtures in
+`schemas/tank-conversation-event.fixtures.json`, including runner-stamped and
+persisted timeline shapes.
 
 Required fields:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,8 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "tsx": "^4.21.0",
         "typescript": "^5.6.3",
         "vite": "^5.4.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,8 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "tsx": "^4.21.0",
     "typescript": "^5.6.3",
     "vite": "^5.4.10"

--- a/frontend/src/conversationReducer.test.ts
+++ b/frontend/src/conversationReducer.test.ts
@@ -99,6 +99,27 @@ test("Tool lifecycle replays to a completed tool item", () => {
   ]);
 });
 
+test("Item deltas append delta payload text", () => {
+  const state = reduceConversationEvents([
+    ev("1", "item.started", {
+      actor: "assistant",
+      source: "codex",
+      item_id: "msg-1",
+      payload: { kind: "agent_message", text: "Hel" },
+    }),
+    ev("2", "item.delta", {
+      actor: "assistant",
+      source: "codex",
+      item_id: "msg-1",
+      payload: { delta: "lo" },
+    }),
+  ]);
+
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0]?.text, "Hello");
+  assert.equal(state.items[0]?.status, "streaming");
+});
+
 test("Duplicate user submissions with the same client nonce do not duplicate bubbles", () => {
   const state = reduceConversationEvents([
     ev("1", "user_message.created", {

--- a/frontend/src/providerEventAdapters.ts
+++ b/frontend/src/providerEventAdapters.ts
@@ -1,5 +1,9 @@
 import type { TranscriptEntry as SandboxTranscriptEntry } from "@sandbox-agent/react";
 
+// Legacy /run compatibility only. SDK sessions should consume canonical
+// TankConversationEvent values through conversationReducer/projection instead
+// of routing provider-shaped Claude/Codex frames through this module.
+
 export type ToolKind = "mcp" | "shell";
 
 export type ProviderTranscriptEntry = SandboxTranscriptEntry & {

--- a/schemas/tank-conversation-event.fixtures.json
+++ b/schemas/tank-conversation-event.fixtures.json
@@ -1,0 +1,438 @@
+{
+  "events": [
+    {
+      "name": "conversation started",
+      "event": {
+        "event_id": "evt-conversation-started",
+        "order_key": "order-0001",
+        "sequence": 1,
+        "conversation_id": "63",
+        "session_id": "63",
+        "actor": "system",
+        "source": "tank",
+        "type": "conversation.started",
+        "created_at": "2026-05-12T00:00:00.000Z",
+        "producer": {
+          "name": "tank-operator",
+          "runtime": "backend-go"
+        },
+        "visibility": "durable",
+        "payload": {
+          "status": "ready"
+        }
+      }
+    },
+    {
+      "name": "conversation archived",
+      "event": {
+        "event_id": "evt-conversation-archived",
+        "order_key": "order-0002",
+        "sequence": 2,
+        "conversation_id": "63",
+        "session_id": "63",
+        "actor": "system",
+        "source": "tank",
+        "type": "conversation.archived",
+        "created_at": "2026-05-12T00:00:01.000Z",
+        "producer": {
+          "name": "tank-operator",
+          "runtime": "backend-go"
+        },
+        "visibility": "durable",
+        "payload": {
+          "reason": "user_requested"
+        }
+      }
+    },
+    {
+      "name": "persisted codex user message with runner and storage stamps",
+      "event": {
+        "event_id": "turn_contract:user_message.created",
+        "uuid": "turn_contract:user_message.created",
+        "id": "turn_contract:user_message.created",
+        "order_key": "1768179840000-00000001-turn_contract:user_message.created",
+        "tank_order_key": "1768179840000-00000001-turn_contract:user_message.created",
+        "sequence": 1,
+        "tank_event_seq": 1,
+        "tank_turn_seq": 1,
+        "conversation_id": "63",
+        "session_id": "63",
+        "tank_session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "turn_contract:user",
+        "client_nonce": "client-nonce-contract",
+        "actor": "user",
+        "source": "tank",
+        "type": "user_message.created",
+        "created_at": "2026-05-12T00:00:02.000Z",
+        "written_at": "2026-05-12T00:00:02.000Z",
+        "producer": {
+          "name": "codex-runner",
+          "runtime": "codex"
+        },
+        "runtime": "codex",
+        "email": "owner@example.com",
+        "visibility": "durable",
+        "payload": {
+          "text": "Investigate issue #402",
+          "message": {
+            "role": "user",
+            "content": "Investigate issue #402"
+          }
+        },
+        "_rid": "cosmos-rid-1",
+        "_self": "dbs/tank/colls/session-events/docs/turn_contract:user_message.created/",
+        "_etag": "\"00000000-0000-0000-0000-000000000001\"",
+        "_attachments": "attachments/",
+        "_ts": 1778544002
+      }
+    },
+    {
+      "name": "turn submitted",
+      "event": {
+        "event_id": "turn_contract:turn.submitted",
+        "order_key": "order-0004",
+        "sequence": 4,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "client_nonce": "client-nonce-contract",
+        "actor": "runner",
+        "source": "tank",
+        "type": "turn.submitted",
+        "created_at": "2026-05-12T00:00:03.000Z",
+        "producer": {
+          "name": "codex-runner",
+          "runtime": "codex"
+        },
+        "visibility": "durable",
+        "payload": {
+          "status": "submitted"
+        }
+      }
+    },
+    {
+      "name": "turn started",
+      "event": {
+        "event_id": "turn_contract:turn.started:runner",
+        "uuid": "turn_contract:turn.started:runner",
+        "order_key": "1768179841000-00000002-turn_contract:turn.started:runner",
+        "tank_order_key": "1768179841000-00000002-turn_contract:turn.started:runner",
+        "sequence": 2,
+        "tank_event_seq": 2,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "client_nonce": "client-nonce-contract",
+        "actor": "runner",
+        "source": "claude",
+        "type": "turn.started",
+        "created_at": "2026-05-12T00:00:04.000Z",
+        "written_at": "2026-05-12T00:00:04.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude"
+        },
+        "visibility": "durable"
+      }
+    },
+    {
+      "name": "turn completed",
+      "event": {
+        "event_id": "turn_contract:turn.completed:provider-result-1",
+        "order_key": "order-0006",
+        "sequence": 6,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "client_nonce": "client-nonce-contract",
+        "actor": "runner",
+        "source": "claude",
+        "type": "turn.completed",
+        "created_at": "2026-05-12T00:00:05.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude",
+          "provider_event_id": "provider-result-1"
+        },
+        "visibility": "durable",
+        "payload": {
+          "usage": {
+            "input_tokens": 10,
+            "output_tokens": 8
+          }
+        }
+      }
+    },
+    {
+      "name": "turn failed",
+      "event": {
+        "event_id": "turn_contract:turn.failed:provider_failure",
+        "order_key": "order-0007",
+        "sequence": 7,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "client_nonce": "client-nonce-contract",
+        "actor": "runner",
+        "source": "codex",
+        "type": "turn.failed",
+        "created_at": "2026-05-12T00:00:06.000Z",
+        "producer": {
+          "name": "codex-runner",
+          "runtime": "codex"
+        },
+        "visibility": "durable",
+        "payload": {
+          "reason": "provider_failure",
+          "error": "quota exceeded"
+        }
+      }
+    },
+    {
+      "name": "turn interrupted",
+      "event": {
+        "event_id": "turn_contract:turn.interrupted:client_interrupt",
+        "order_key": "order-0008",
+        "sequence": 8,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "client_nonce": "client-nonce-contract",
+        "actor": "runner",
+        "source": "claude",
+        "type": "turn.interrupted",
+        "created_at": "2026-05-12T00:00:07.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude"
+        },
+        "visibility": "durable",
+        "payload": {
+          "reason": "client_interrupt"
+        }
+      }
+    },
+    {
+      "name": "item started",
+      "event": {
+        "event_id": "turn_contract:item.started:toolu-read:provider-message-1",
+        "order_key": "order-0009",
+        "sequence": 9,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "toolu-read",
+        "parent_id": "turn_contract",
+        "actor": "tool",
+        "source": "claude",
+        "type": "item.started",
+        "created_at": "2026-05-12T00:00:08.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude",
+          "provider_event_id": "provider-message-1"
+        },
+        "visibility": "durable",
+        "payload": {
+          "kind": "tool",
+          "title": "Read",
+          "name": "Read",
+          "input": {
+            "file_path": "README.md"
+          }
+        }
+      }
+    },
+    {
+      "name": "item delta",
+      "event": {
+        "event_id": "turn_contract:item.delta:assistant-message:provider-item-1",
+        "order_key": "order-0010",
+        "sequence": 10,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "assistant-message",
+        "parent_id": "turn_contract",
+        "actor": "assistant",
+        "source": "codex",
+        "type": "item.delta",
+        "created_at": "2026-05-12T00:00:09.000Z",
+        "producer": {
+          "name": "codex-runner",
+          "runtime": "codex",
+          "provider_event_id": "provider-item-1"
+        },
+        "visibility": "live-only",
+        "payload": {
+          "kind": "agent_message",
+          "delta": "Hello"
+        }
+      }
+    },
+    {
+      "name": "item completed",
+      "event": {
+        "event_id": "turn_contract:item.completed:assistant-message:provider-item-1",
+        "order_key": "order-0011",
+        "sequence": 11,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "assistant-message",
+        "parent_id": "turn_contract",
+        "actor": "assistant",
+        "source": "claude",
+        "type": "item.completed",
+        "created_at": "2026-05-12T00:00:10.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude",
+          "provider_event_id": "provider-item-1"
+        },
+        "visibility": "durable",
+        "payload": {
+          "kind": "message",
+          "text": "Replay and live delivery now converge."
+        }
+      }
+    },
+    {
+      "name": "item failed",
+      "event": {
+        "event_id": "turn_contract:item.failed:toolu-read:provider-item-2",
+        "order_key": "order-0012",
+        "sequence": 12,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "toolu-read",
+        "parent_id": "turn_contract",
+        "actor": "tool",
+        "source": "codex",
+        "type": "item.failed",
+        "created_at": "2026-05-12T00:00:11.000Z",
+        "producer": {
+          "name": "codex-runner",
+          "runtime": "codex",
+          "provider_event_id": "provider-item-2"
+        },
+        "visibility": "durable",
+        "payload": {
+          "kind": "command_execution",
+          "title": "npm test",
+          "error": "exit code 1"
+        }
+      }
+    },
+    {
+      "name": "approval requested",
+      "event": {
+        "event_id": "turn_contract:tool.approval_requested:toolu-question:provider-message-2",
+        "order_key": "order-0013",
+        "sequence": 13,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "toolu-question",
+        "parent_id": "turn_contract",
+        "actor": "tool",
+        "source": "claude",
+        "type": "tool.approval_requested",
+        "created_at": "2026-05-12T00:00:12.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude",
+          "provider_event_id": "provider-message-2"
+        },
+        "visibility": "durable",
+        "payload": {
+          "kind": "needs_input",
+          "title": "Ask user question",
+          "name": "AskUserQuestion",
+          "input": {
+            "question": "Proceed?"
+          }
+        }
+      }
+    },
+    {
+      "name": "approval resolved",
+      "event": {
+        "event_id": "turn_contract:tool.approval_resolved:toolu-question:provider-message-3",
+        "order_key": "order-0014",
+        "sequence": 14,
+        "conversation_id": "63",
+        "session_id": "63",
+        "turn_id": "turn_contract",
+        "item_id": "toolu-question",
+        "parent_id": "turn_contract",
+        "actor": "tool",
+        "source": "claude",
+        "type": "tool.approval_resolved",
+        "created_at": "2026-05-12T00:00:13.000Z",
+        "producer": {
+          "name": "claude-runner",
+          "runtime": "claude",
+          "provider_event_id": "provider-message-3"
+        },
+        "visibility": "durable",
+        "payload": {
+          "kind": "needs_input",
+          "resolved": true,
+          "is_error": false
+        }
+      }
+    },
+    {
+      "name": "activity updated",
+      "event": {
+        "event_id": "evt-session-activity-updated",
+        "order_key": "order-0015",
+        "sequence": 15,
+        "conversation_id": "63",
+        "session_id": "63",
+        "actor": "runner",
+        "source": "tank",
+        "type": "session.activity_updated",
+        "created_at": "2026-05-12T00:00:14.000Z",
+        "producer": {
+          "name": "tank-operator",
+          "runtime": "backend-go"
+        },
+        "visibility": "durable",
+        "payload": {
+          "status": "streaming",
+          "last_order_key": "order-0014",
+          "unread_count": 3,
+          "needs_input": false,
+          "failed": false,
+          "active_turn_id": "turn_contract"
+        }
+      }
+    },
+    {
+      "name": "read state updated",
+      "event": {
+        "event_id": "evt-read-state-updated",
+        "order_key": "order-0016",
+        "sequence": 16,
+        "conversation_id": "63",
+        "session_id": "63",
+        "actor": "runner",
+        "source": "tank",
+        "type": "read_state.updated",
+        "created_at": "2026-05-12T00:00:15.000Z",
+        "producer": {
+          "name": "tank-operator",
+          "runtime": "backend-go"
+        },
+        "visibility": "audit-only",
+        "payload": {
+          "last_read_order_key": "order-0015"
+        }
+      }
+    }
+  ]
+}

--- a/schemas/tank-conversation-event.schema.json
+++ b/schemas/tank-conversation-event.schema.json
@@ -22,7 +22,22 @@
       "type": "string",
       "minLength": 1
     },
+    "uuid": {
+      "description": "Runner-stamped id used for live/history dedupe. For Tank events this normally matches event_id.",
+      "type": "string",
+      "minLength": 1
+    },
+    "id": {
+      "description": "Session-events document id when a persisted event is returned by /timeline.",
+      "type": "string",
+      "minLength": 1
+    },
     "order_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tank_order_key": {
+      "description": "Runner-stamped render-order cursor used before/alongside canonical order_key.",
       "type": "string",
       "minLength": 1
     },
@@ -30,11 +45,31 @@
       "type": "integer",
       "minimum": 0
     },
+    "tank_event_seq": {
+      "description": "Runner-local event sequence stamped before Cosmos/live fanout.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "tank_turn_seq": {
+      "description": "Codex-runner local turn sequence stamped on some events for turn correlation.",
+      "type": "integer",
+      "minimum": 1
+    },
     "conversation_id": {
       "type": "string",
       "minLength": 1
     },
     "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tank_session_id": {
+      "description": "Session-events partition key when a persisted event is returned by /timeline.",
+      "type": "string",
+      "minLength": 1
+    },
+    "email": {
+      "description": "Owner email stamped on persisted session-events documents.",
       "type": "string",
       "minLength": 1
     },
@@ -87,6 +122,16 @@
       "type": "string",
       "format": "date-time"
     },
+    "written_at": {
+      "description": "Runner/storage write timestamp stamped before Cosmos/live fanout.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "runtime": {
+      "description": "Session-events storage runtime stamp.",
+      "type": "string",
+      "enum": ["claude", "codex"]
+    },
     "producer": {
       "type": "object",
       "additionalProperties": false,
@@ -104,6 +149,31 @@
     "payload": {
       "type": "object",
       "additionalProperties": true
+    },
+    "_rid": {
+      "description": "Cosmos DB system property that may be present on persisted timeline documents.",
+      "type": "string",
+      "minLength": 1
+    },
+    "_self": {
+      "description": "Cosmos DB system property that may be present on persisted timeline documents.",
+      "type": "string",
+      "minLength": 1
+    },
+    "_etag": {
+      "description": "Cosmos DB system property that may be present on persisted timeline documents.",
+      "type": "string",
+      "minLength": 1
+    },
+    "_attachments": {
+      "description": "Cosmos DB system property that may be present on persisted timeline documents.",
+      "type": "string",
+      "minLength": 1
+    },
+    "_ts": {
+      "description": "Cosmos DB system property that may be present on persisted timeline documents.",
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/scripts/check-tank-conversation-contract.mjs
+++ b/scripts/check-tank-conversation-contract.mjs
@@ -7,17 +7,23 @@ import { createRequire } from "node:module";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const schemaPath = path.join(repoRoot, "schemas", "tank-conversation-event.schema.json");
+const fixturePath = path.join(repoRoot, "schemas", "tank-conversation-event.fixtures.json");
 const requireFromFrontend = createRequire(path.join(repoRoot, "frontend", "package.json"));
 let ts;
+let Ajv2020;
+let addFormats;
 try {
   ts = requireFromFrontend("typescript");
+  Ajv2020 = requireDefault(requireFromFrontend("ajv/dist/2020"));
+  addFormats = requireDefault(requireFromFrontend("ajv-formats"));
 } catch (err) {
-  console.error("Unable to load TypeScript from frontend/node_modules.");
+  console.error("Unable to load contract check dependencies from frontend/node_modules.");
   console.error("Run `npm ci --prefix frontend` before this contract check.");
   throw err;
 }
 
 const schema = JSON.parse(await fs.readFile(schemaPath, "utf8"));
+const fixtures = JSON.parse(await fs.readFile(fixturePath, "utf8"));
 const expectedEnums = {
   TANK_ACTORS: schemaEnum("actor"),
   TANK_EVENT_SOURCES: schemaEnum("source"),
@@ -47,13 +53,21 @@ for (const relativePath of tsContractFiles) {
   }
 }
 
+const validatedFixtureCount = validateFixtures();
+
 if (failures.length > 0) {
   console.error("Tank conversation contract drift detected:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
 
-console.log("Tank conversation TypeScript enums match schemas/tank-conversation-event.schema.json");
+console.log(
+  `Tank conversation contract matches schemas/tank-conversation-event.schema.json; validated ${validatedFixtureCount} canonical fixtures.`,
+);
+
+function requireDefault(module) {
+  return module.default ?? module;
+}
 
 function schemaEnum(propertyName) {
   const values = schema?.properties?.[propertyName]?.enum;
@@ -78,6 +92,95 @@ function compareArrays(label, actual, expected) {
   if (actual.length === expected.length && actual.some((value, index) => value !== expected[index])) {
     failures.push(`${label}: values match but order differs from the schema`);
   }
+}
+
+function validateFixtures() {
+  const fixtureEvents = fixtures?.events;
+  if (!Array.isArray(fixtureEvents)) {
+    failures.push("schemas/tank-conversation-event.fixtures.json: missing events array");
+    return 0;
+  }
+
+  const ajv = new Ajv2020({ allErrors: true, strict: true, strictRequired: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const fixtureTypes = new Set();
+  let sawRunnerStampedEvent = false;
+  let sawPersistedEvent = false;
+
+  for (const [index, fixture] of fixtureEvents.entries()) {
+    const label = fixtureLabel(fixture, index);
+    const event = fixture?.event;
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      failures.push(`${label}: missing event object`);
+      continue;
+    }
+    if (typeof event.type === "string") fixtureTypes.add(event.type);
+    if (hasRunnerStamps(event)) sawRunnerStampedEvent = true;
+    if (hasStorageStamps(event)) sawPersistedEvent = true;
+    if (!validate(event)) {
+      failures.push(`${label}: ${formatAjvErrors(validate.errors)}`);
+    }
+  }
+
+  for (const eventType of expectedEnums.TANK_EVENT_TYPES) {
+    if (!fixtureTypes.has(eventType)) {
+      failures.push(
+        `schemas/tank-conversation-event.fixtures.json: missing fixture for ${JSON.stringify(eventType)}`,
+      );
+    }
+  }
+  for (const eventType of fixtureTypes) {
+    if (!expectedEnums.TANK_EVENT_TYPES.includes(eventType)) {
+      failures.push(
+        `schemas/tank-conversation-event.fixtures.json: fixture uses unknown type ${JSON.stringify(eventType)}`,
+      );
+    }
+  }
+  if (!sawRunnerStampedEvent) {
+    failures.push("schemas/tank-conversation-event.fixtures.json: expected at least one runner-stamped fixture");
+  }
+  if (!sawPersistedEvent) {
+    failures.push("schemas/tank-conversation-event.fixtures.json: expected at least one persisted timeline fixture");
+  }
+
+  return fixtureEvents.length;
+}
+
+function fixtureLabel(fixture, index) {
+  const name = typeof fixture?.name === "string" && fixture.name ? fixture.name : `fixture ${index + 1}`;
+  return `schemas/tank-conversation-event.fixtures.json:${name}`;
+}
+
+function hasRunnerStamps(event) {
+  return (
+    typeof event.uuid === "string" &&
+    Number.isInteger(event.tank_event_seq) &&
+    typeof event.tank_order_key === "string" &&
+    typeof event.written_at === "string"
+  );
+}
+
+function hasStorageStamps(event) {
+  return (
+    typeof event.id === "string" &&
+    typeof event.tank_session_id === "string" &&
+    typeof event.email === "string" &&
+    typeof event.runtime === "string"
+  );
+}
+
+function formatAjvErrors(errors) {
+  if (!errors || errors.length === 0) return "schema validation failed";
+  return errors
+    .map((error) => {
+      const location = error.instancePath || "/";
+      const allowed = Array.isArray(error.params?.allowedValues)
+        ? `: ${error.params.allowedValues.map((value) => JSON.stringify(value)).join(", ")}`
+        : "";
+      return `${location} ${error.message}${allowed}`;
+    })
+    .join("; ");
 }
 
 function stringArrayConst(sourceFile, constName) {


### PR DESCRIPTION
## Summary
- extract Claude and Codex provider-to-Tank mapping into focused runner adapter modules
- fix Claude multi-text-block item/event id collisions and Codex live delta payloads
- extend the Tank conversation contract check with Ajv fixture validation for runner-stamped and persisted timeline shapes
- mark frontend provider adapters as legacy /run compatibility and add a reducer guard for canonical item.delta payloads

## Verification
- go test ./... (backend-go)
- npm test --prefix frontend
- npm run build --prefix frontend
- node scripts/check-tank-conversation-contract.mjs
- npm run build --prefix agent-runner
- npm test --prefix agent-runner
- npm run build --prefix codex-runner
- npm test --prefix codex-runner
- git diff --cached --check