### PR TITLE
Scope session storage keys by environment

### DIFF
--- a/agent-runner/src/adapters/claude.test.ts
+++ b/agent-runner/src/adapters/claude.test.ts
@@ -25,6 +25,7 @@ function turn(fields: Partial<ClaudeTurnContext> = {}): ClaudeTurnContext {
 function cfg(): Config {
   return {
     sessionId: "63",
+    sessionStorageKey: "63",
     ownerEmail: "user@example.com",
     cosmosEndpoint: "https://example.invalid",
     cosmosDatabase: "tank-operator",

--- a/agent-runner/src/config.ts
+++ b/agent-runner/src/config.ts
@@ -1,6 +1,7 @@
 // Runtime config sourced from env vars. SESSION_ID + POD_OWNER_EMAIL come
 // from the downward API on the pod spec (label tank-operator/session-id,
-// annotation tank-operator/owner-email). COSMOS_* mirror the orchestrator's
+// annotation tank-operator/owner-email). TANK_SESSION_STORAGE_KEY is the
+// scoped Cosmos partition key. COSMOS_* mirror the orchestrator's
 // env. Azure workload-identity envs (AZURE_CLIENT_ID + AZURE_TENANT_ID +
 // AZURE_FEDERATED_TOKEN_FILE) are injected by the WI webhook because the
 // pod carries azure.workload.identity/use=true and the SA's federated
@@ -10,6 +11,7 @@
 
 export interface Config {
   sessionId: string;
+  sessionStorageKey: string;
   ownerEmail: string;
   cosmosEndpoint: string;
   cosmosDatabase: string;
@@ -34,6 +36,7 @@ export function loadConfig(): Config {
   }
   return {
     sessionId,
+    sessionStorageKey: process.env.TANK_SESSION_STORAGE_KEY?.trim() || sessionId,
     ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
     cosmosEndpoint,
     cosmosDatabase: process.env.COSMOS_DATABASE?.trim() || "tank-operator",

--- a/agent-runner/src/cosmos.ts
+++ b/agent-runner/src/cosmos.ts
@@ -84,12 +84,11 @@ export class CosmosSink {
   }
 
   // Write a canonical event to Cosmos. Doc id is the SDK's uuid (v7,
-  // monotonic — naturally sorts by emit order). Partition is the
-  // orchestrator's session_id (the integer "63") not the SDK's internal
-  // session_id — the SPA queries on the integer (it knows the pod-level
-  // id), and runner-process restart may yield a new SDK session within the
-  // same still-live tank-operator session. The SDK's session_id rides along
-  // as a field.
+  // monotonic, so it naturally sorts by emit order). Partition is Tank's
+  // scoped session storage key, not the SDK's internal session_id. The SPA
+  // still addresses sessions by public pod-level id, while runner-process
+  // restarts may yield a new SDK session within the same still-live Tank
+  // session. The SDK's session_id rides along as a field.
   async upsert(message: RunnerEvent & { uuid: string }): Promise<void> {
     const doc = this.docFromMessage(message);
     await this.container.items.upsert(doc);
@@ -112,14 +111,14 @@ export class CosmosSink {
         query:
           "SELECT TOP 1 * FROM c WHERE c.tank_session_id = @session_id AND c.turn_id = @turn_id AND (c.type = @completed OR c.type = @failed OR c.type = @interrupted)",
         parameters: [
-          { name: "@session_id", value: this.cfg.sessionId },
+          { name: "@session_id", value: this.cfg.sessionStorageKey },
           { name: "@turn_id", value: turnID },
           { name: "@completed", value: "turn.completed" },
           { name: "@failed", value: "turn.failed" },
           { name: "@interrupted", value: "turn.interrupted" },
         ],
       },
-      { partitionKey: this.cfg.sessionId },
+      { partitionKey: this.cfg.sessionStorageKey },
     );
     const page = await iterator.fetchNext();
     return page.resources[0] ?? null;
@@ -129,7 +128,8 @@ export class CosmosSink {
     return {
       ...message,
       id: message.uuid,
-      tank_session_id: this.cfg.sessionId,
+      tank_session_id: this.cfg.sessionStorageKey,
+      tank_public_session_id: this.cfg.sessionId,
       email: this.cfg.ownerEmail,
       runtime: "claude",
       written_at:

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -48,17 +48,19 @@ func main() {
 	// 3. Init profile store.
 	profileStore := buildProfileStore(azCred)
 
+	sessionScope := envDefault("SESSION_REGISTRY_SCOPE", "default")
+
 	// 4. Init session registry.
-	sessionReg := buildSessionRegistry(azCred)
+	sessionReg := buildSessionRegistry(azCred, sessionScope)
 
 	// 5. Init turn queue store for durable SDK submissions.
-	turnQueueStore := buildTurnQueueStore(azCred)
+	turnQueueStore := buildTurnQueueStore(azCred, sessionScope)
 
 	// 6. Init session events store for the SDK runners' canonical stream.
-	sessionEventsStore := buildSessionEventStore(azCred)
+	sessionEventsStore := buildSessionEventStore(azCred, sessionScope)
 
 	// 7. Init per-user SDK conversation read-state store.
-	readStateStore := buildConversationReadStateStore(azCred)
+	readStateStore := buildConversationReadStateStore(azCred, sessionScope)
 
 	// 8. Init event bus.
 	eventBus := sessions.NewEventBus()
@@ -95,6 +97,7 @@ func main() {
 			SessionImage:             sessionImage,
 			CodexSessionImage:        codexSessionImage,
 			PiSessionImage:           piSessionImage,
+			SessionScope:             sessionScope,
 			GitHubAppSecret:          envDefault("GITHUB_APP_SECRET", compat.DefaultGitHubAppSecret),
 			SessionAzureConfigSecret: envDefault("SESSION_AZURE_CONFIG_SECRET", compat.DefaultSessionAzureConfigSecret),
 			// Pass the orchestrator's Cosmos config through to the pod's
@@ -211,12 +214,11 @@ func buildProfileStore(azCred *azidentity.DefaultAzureCredential) profilesStore 
 	return store
 }
 
-func buildSessionRegistry(azCred *azidentity.DefaultAzureCredential) sessions.SessionRegistry {
+func buildSessionRegistry(azCred *azidentity.DefaultAzureCredential, scope string) sessions.SessionRegistry {
 	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
 	if endpoint == "" || azCred == nil {
 		return &stubSessionRegistry{}
 	}
-	scope := envDefault("SESSION_REGISTRY_SCOPE", "default")
 	s, err := sessionregistry.NewCosmosStore(
 		endpoint,
 		envDefault("COSMOS_DATABASE", "tank-operator"),
@@ -231,7 +233,7 @@ func buildSessionRegistry(azCred *azidentity.DefaultAzureCredential) sessions.Se
 	return &cosmosSessionRegistryAdapter{s}
 }
 
-func buildSessionEventStore(azCred *azidentity.DefaultAzureCredential) store.SessionEventStore {
+func buildSessionEventStore(azCred *azidentity.DefaultAzureCredential, scope string) store.SessionEventStore {
 	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
 	if endpoint == "" || azCred == nil {
 		return store.StubSessionEventStore{}
@@ -240,6 +242,7 @@ func buildSessionEventStore(azCred *azidentity.DefaultAzureCredential) store.Ses
 		endpoint,
 		envDefault("COSMOS_DATABASE", "tank-operator"),
 		envDefault("COSMOS_SESSION_EVENTS_CONTAINER", "session-events"),
+		scope,
 		azCred,
 	)
 	if err != nil {
@@ -249,7 +252,7 @@ func buildSessionEventStore(azCred *azidentity.DefaultAzureCredential) store.Ses
 	return s
 }
 
-func buildConversationReadStateStore(azCred *azidentity.DefaultAzureCredential) store.ConversationReadStateStore {
+func buildConversationReadStateStore(azCred *azidentity.DefaultAzureCredential, scope string) store.ConversationReadStateStore {
 	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
 	if endpoint == "" || azCred == nil {
 		return store.NewStubConversationReadStateStore()
@@ -258,6 +261,7 @@ func buildConversationReadStateStore(azCred *azidentity.DefaultAzureCredential) 
 		endpoint,
 		envDefault("COSMOS_DATABASE", "tank-operator"),
 		envDefault("COSMOS_PROFILES_CONTAINER", "profiles"),
+		scope,
 		azCred,
 	)
 	if err != nil {
@@ -267,7 +271,7 @@ func buildConversationReadStateStore(azCred *azidentity.DefaultAzureCredential) 
 	return s
 }
 
-func buildTurnQueueStore(azCred *azidentity.DefaultAzureCredential) store.TurnQueueStore {
+func buildTurnQueueStore(azCred *azidentity.DefaultAzureCredential, scope string) store.TurnQueueStore {
 	endpoint := strings.TrimSpace(os.Getenv("COSMOS_ENDPOINT"))
 	if endpoint == "" || azCred == nil {
 		return store.StubTurnQueueStore{}
@@ -276,6 +280,7 @@ func buildTurnQueueStore(azCred *azidentity.DefaultAzureCredential) store.TurnQu
 		endpoint,
 		envDefault("COSMOS_DATABASE", "tank-operator"),
 		envDefault("COSMOS_TURN_QUEUE_CONTAINER", "turn-queue"),
+		scope,
 		azCred,
 	)
 	if err != nil {

--- a/backend-go/internal/compat/compat.go
+++ b/backend-go/internal/compat/compat.go
@@ -91,6 +91,7 @@ type ManifestOptions struct {
 	CodexSessionImage     string
 	PiSessionImage        string
 	SessionsNamespace     string
+	SessionScope          string
 	SessionServiceAccount string
 	SessionConfigMap      string
 	ArgoCDTrackingApp     string
@@ -151,14 +152,21 @@ func NormalizeName(name *string) *string {
 	return &trimmed
 }
 
-func SessionDocID(scope, sessionID string) string {
+func SessionStorageKey(scope, sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	scope = strings.TrimSpace(scope)
 	if scope == "" || scope == "default" {
-		return "session:" + sessionID
+		return sessionID
 	}
-	return "session:" + scope + ":" + sessionID
+	return scope + ":" + sessionID
+}
+
+func SessionDocID(scope, sessionID string) string {
+	return "session:" + SessionStorageKey(scope, sessionID)
 }
 
 func SessionCounterDocID(scope string) string {
+	scope = strings.TrimSpace(scope)
 	if scope == "" || scope == "default" {
 		return "session-counter"
 	}
@@ -190,6 +198,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	opts = withManifestDefaults(opts)
 	mode = NormalizeSessionMode(mode)
 	podName := "session-" + sessionID
+	storageKey := SessionStorageKey(opts.SessionScope, sessionID)
 	argoTrackingID := opts.ArgoCDTrackingApp + ":/Pod:" + opts.SessionsNamespace + "/" + podName
 
 	sessionImage := opts.SessionImage
@@ -355,6 +364,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 					},
 				},
 			},
+			map[string]any{"name": "TANK_SESSION_STORAGE_KEY", "value": storageKey},
 			map[string]any{
 				"name": "POD_OWNER_EMAIL",
 				"valueFrom": map[string]any{
@@ -430,6 +440,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 					},
 				},
 			},
+			map[string]any{"name": "TANK_SESSION_STORAGE_KEY", "value": storageKey},
 			map[string]any{
 				"name": "POD_OWNER_EMAIL",
 				"valueFrom": map[string]any{
@@ -553,6 +564,9 @@ func withManifestDefaults(opts ManifestOptions) ManifestOptions {
 	// that fails the pod loudly when the env vars are missing.
 	if opts.SessionsNamespace == "" {
 		opts.SessionsNamespace = SessionsNamespace
+	}
+	if opts.SessionScope == "" {
+		opts.SessionScope = "default"
 	}
 	if opts.SessionServiceAccount == "" {
 		opts.SessionServiceAccount = SessionServiceAccount

--- a/backend-go/internal/compat/compat_test.go
+++ b/backend-go/internal/compat/compat_test.go
@@ -51,6 +51,12 @@ func TestDocumentIDsAndShapes(t *testing.T) {
 	if got, want := SessionDocID("slot-a", "12"), "session:slot-a:12"; got != want {
 		t.Fatalf("SessionDocID(slot) = %q, want %q", got, want)
 	}
+	if got, want := SessionStorageKey("default", "12"), "12"; got != want {
+		t.Fatalf("SessionStorageKey(default) = %q, want %q", got, want)
+	}
+	if got, want := SessionStorageKey("slot-a", "12"), "slot-a:12"; got != want {
+		t.Fatalf("SessionStorageKey(slot) = %q, want %q", got, want)
+	}
 	if got, want := SessionCounterDocID("default"), "session-counter"; got != want {
 		t.Fatalf("SessionCounterDocID(default) = %q, want %q", got, want)
 	}
@@ -172,6 +178,7 @@ func TestPodManifestSDKRunnersReceiveTurnQueueEnv(t *testing.T) {
 			manifest := PodManifest("12", "nelson@romaine.life", mode, ManifestOptions{
 				SessionImage:                 "claude-image",
 				CodexSessionImage:            "codex-image",
+				SessionScope:                 "slot-a",
 				CosmosEndpoint:               "https://cosmos.example",
 				CosmosDatabase:               "tank-db",
 				CosmosSessionEventsContainer: "events",
@@ -191,6 +198,9 @@ func TestPodManifestSDKRunnersReceiveTurnQueueEnv(t *testing.T) {
 			}
 			if got, want := env["COSMOS_TURN_QUEUE_CONTAINER"], "turns"; got != want {
 				t.Fatalf("COSMOS_TURN_QUEUE_CONTAINER = %v, want %q", got, want)
+			}
+			if got, want := env["TANK_SESSION_STORAGE_KEY"], "slot-a:12"; got != want {
+				t.Fatalf("TANK_SESSION_STORAGE_KEY = %v, want %q", got, want)
 			}
 		})
 	}

--- a/backend-go/internal/sessionregistry/cosmos.go
+++ b/backend-go/internal/sessionregistry/cosmos.go
@@ -18,6 +18,7 @@ type CosmosStore struct {
 }
 
 func NewCosmosStore(endpoint, database, container, scope string, credential azcore.TokenCredential) (*CosmosStore, error) {
+	scope = strings.TrimSpace(scope)
 	if scope == "" {
 		scope = "default"
 	}
@@ -103,6 +104,9 @@ func sessionFromDoc(data []byte) (compat.SessionRecord, error) {
 	sessionID := doc.SessionID
 	if sessionID == "" {
 		sessionID = strings.TrimPrefix(doc.ID, "session:")
+		if scope != "default" {
+			sessionID = strings.TrimPrefix(sessionID, scope+":")
+		}
 	}
 	return compat.SessionRecord{
 		ID:          sessionID,

--- a/backend-go/internal/sessionregistry/cosmos_test.go
+++ b/backend-go/internal/sessionregistry/cosmos_test.go
@@ -46,8 +46,8 @@ func TestSessionFromDocFallsBackForMinimalShape(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.ID != "slot-a:12" {
-		t.Fatalf("id = %q, want Python removeprefix fallback", record.ID)
+	if record.ID != "12" {
+		t.Fatalf("id = %q, want public session id fallback", record.ID)
 	}
 	if record.Scope != "slot-a" {
 		t.Fatalf("scope = %q, want slot-a", record.Scope)

--- a/backend-go/internal/sessionregistry/write.go
+++ b/backend-go/internal/sessionregistry/write.go
@@ -116,11 +116,12 @@ func isConflict(err error) bool {
 // Upsert writes or overwrites a session record in the registry.
 func (s *CosmosStore) Upsert(ctx context.Context, record compat.SessionRecord) error {
 	normalized := strings.ToLower(record.Email)
-	docID := "session:" + record.ID
 	scope := record.Scope
 	if scope == "" {
 		scope = s.scope
 	}
+	record.Email = normalized
+	record.Scope = scope
 	now := time.Now().UTC().Format(time.RFC3339)
 	if record.UpdatedAt == "" {
 		record.UpdatedAt = now
@@ -128,20 +129,7 @@ func (s *CosmosStore) Upsert(ctx context.Context, record compat.SessionRecord) e
 	if record.CreatedAt == "" {
 		record.CreatedAt = now
 	}
-	doc := map[string]any{
-		"id":           docID,
-		"type":         "session",
-		"email":        normalized,
-		"session_id":   record.ID,
-		"mode":         record.Mode,
-		"session_scope": scope,
-		"pod_name":     record.PodName,
-		"name":         record.Name,
-		"visible":      record.Visible,
-		"requested_at": record.RequestedAt,
-		"created_at":   record.CreatedAt,
-		"updated_at":   record.UpdatedAt,
-	}
+	doc := compat.SessionDoc(record)
 	raw, err := json.Marshal(doc)
 	if err != nil {
 		return err
@@ -154,7 +142,7 @@ func (s *CosmosStore) Upsert(ctx context.Context, record compat.SessionRecord) e
 // SetName updates the display name for a session.
 func (s *CosmosStore) SetName(ctx context.Context, email, sessionID string, name *string) error {
 	normalized := strings.ToLower(email)
-	docID := "session:" + sessionID
+	docID := compat.SessionDocID(s.scope, sessionID)
 	pk := azcosmos.NewPartitionKeyString(normalized)
 
 	resp, err := s.container.ReadItem(ctx, pk, docID, nil)
@@ -182,7 +170,7 @@ func (s *CosmosStore) SetName(ctx context.Context, email, sessionID string, name
 // MarkDeleted sets visible=false on the session registry record.
 func (s *CosmosStore) MarkDeleted(ctx context.Context, email, sessionID string) error {
 	normalized := strings.ToLower(email)
-	docID := "session:" + sessionID
+	docID := compat.SessionDocID(s.scope, sessionID)
 	pk := azcosmos.NewPartitionKeyString(normalized)
 
 	resp, err := s.container.ReadItem(ctx, pk, docID, nil)

--- a/backend-go/internal/sessions/manager.go
+++ b/backend-go/internal/sessions/manager.go
@@ -127,6 +127,9 @@ func NewManager(client kubernetes.Interface, restCfg *rest.Config, namespace str
 	if opts.ManifestOpts.SessionsNamespace == "" {
 		opts.ManifestOpts.SessionsNamespace = namespace
 	}
+	if opts.ManifestOpts.SessionScope == "" {
+		opts.ManifestOpts.SessionScope = "default"
+	}
 	m := &Manager{
 		client:         client,
 		restCfg:        restCfg,
@@ -332,6 +335,7 @@ func (m *Manager) Create(ctx context.Context, owner, mode string, glimmungContex
 			ID:          sessionID,
 			Email:       owner,
 			Mode:        mode,
+			Scope:       m.manifestOpts.SessionScope,
 			PodName:     podName,
 			Visible:     true,
 			RequestedAt: requestedAt,

--- a/backend-go/internal/store/read_state.go
+++ b/backend-go/internal/store/read_state.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
 )
 
 // ConversationReadStateStore persists the per-user render cursor for a Tank
@@ -30,9 +32,14 @@ type ConversationReadStateRecord struct {
 
 type cosmosConversationReadStateStore struct {
 	container *azcosmos.ContainerClient
+	scope     string
 }
 
-func NewCosmosConversationReadStateStore(endpoint, database, container string, cred azcore.TokenCredential) (ConversationReadStateStore, error) {
+func NewCosmosConversationReadStateStore(endpoint, database, container, scope string, cred azcore.TokenCredential) (ConversationReadStateStore, error) {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = "default"
+	}
 	client, err := azcosmos.NewClient(endpoint, cred, nil)
 	if err != nil {
 		return nil, err
@@ -41,7 +48,7 @@ func NewCosmosConversationReadStateStore(endpoint, database, container string, c
 	if err != nil {
 		return nil, err
 	}
-	return &cosmosConversationReadStateStore{container: c}, nil
+	return &cosmosConversationReadStateStore{container: c, scope: scope}, nil
 }
 
 func (s *cosmosConversationReadStateStore) Get(ctx context.Context, email, sessionID string) (*ConversationReadStateRecord, error) {
@@ -50,7 +57,7 @@ func (s *cosmosConversationReadStateStore) Get(ctx context.Context, email, sessi
 	if normalized == "" || sessionID == "" {
 		return nil, nil
 	}
-	resp, err := s.container.ReadItem(ctx, azcosmos.NewPartitionKeyString(normalized), readStateDocID(sessionID), nil)
+	resp, err := s.container.ReadItem(ctx, azcosmos.NewPartitionKeyString(normalized), readStateDocID(s.scope, sessionID), nil)
 	if err != nil {
 		if isCosmosNotFound(err) {
 			return nil, nil
@@ -78,7 +85,7 @@ func (s *cosmosConversationReadStateStore) Set(ctx context.Context, email, sessi
 		return ConversationReadStateRecord{}, nil
 	}
 
-	docID := readStateDocID(sessionID)
+	docID := readStateDocID(s.scope, sessionID)
 	pk := azcosmos.NewPartitionKeyString(normalized)
 	for attempt := 0; attempt < 20; attempt++ {
 		resp, readErr := s.container.ReadItem(ctx, pk, docID, nil)
@@ -110,7 +117,7 @@ func (s *cosmosConversationReadStateStore) Set(ctx context.Context, email, sessi
 		if existing != nil && existing.UpdatedAt != "" && existing.LastReadOrderKey == lastReadOrderKey {
 			rec.UpdatedAt = existing.UpdatedAt
 		}
-		raw, err := json.Marshal(readStateDoc(rec))
+		raw, err := json.Marshal(readStateDoc(s.scope, rec))
 		if err != nil {
 			return ConversationReadStateRecord{}, err
 		}
@@ -192,16 +199,23 @@ func readStateMemoryKey(email, sessionID string) (string, string, string) {
 	return normalized + "\x1f" + trimmedSessionID, normalized, trimmedSessionID
 }
 
-func readStateDocID(sessionID string) string {
-	return "read-state:" + strings.TrimSpace(sessionID)
+func readStateDocID(scope, sessionID string) string {
+	return "read-state:" + compat.SessionStorageKey(scope, sessionID)
 }
 
-func readStateDoc(rec ConversationReadStateRecord) map[string]any {
+func readStateDoc(scope string, rec ConversationReadStateRecord) map[string]any {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = "default"
+	}
+	storageKey := compat.SessionStorageKey(scope, rec.SessionID)
 	return map[string]any{
-		"id":                  readStateDocID(rec.SessionID),
+		"id":                  readStateDocID(scope, rec.SessionID),
 		"type":                "conversation_read_state",
 		"email":               normalizeReadStateEmail(rec.Email),
 		"session_id":          strings.TrimSpace(rec.SessionID),
+		"session_scope":       strings.TrimSpace(scope),
+		"session_storage_key": storageKey,
 		"last_read_order_key": strings.TrimSpace(rec.LastReadOrderKey),
 		"updated_at":          rec.UpdatedAt,
 	}

--- a/backend-go/internal/store/read_state_test.go
+++ b/backend-go/internal/store/read_state_test.go
@@ -47,3 +47,24 @@ func TestReadStateRecordFromDocNormalizesFields(t *testing.T) {
 		t.Fatalf("record = %#v", rec)
 	}
 }
+
+func TestReadStateDocIDUsesScopedStorageKey(t *testing.T) {
+	if got, want := readStateDocID("default", "63"), "read-state:63"; got != want {
+		t.Fatalf("default read-state doc id = %q, want %q", got, want)
+	}
+	if got, want := readStateDocID("slot-a", "63"), "read-state:slot-a:63"; got != want {
+		t.Fatalf("slot read-state doc id = %q, want %q", got, want)
+	}
+	doc := readStateDoc("slot-a", ConversationReadStateRecord{
+		Email:            "user@example.com",
+		SessionID:        "63",
+		LastReadOrderKey: "002",
+		UpdatedAt:        "2026-05-12T00:00:00Z",
+	})
+	if got, want := doc["session_id"], "63"; got != want {
+		t.Fatalf("session_id = %q, want public id %q", got, want)
+	}
+	if got, want := doc["session_storage_key"], "slot-a:63"; got != want {
+		t.Fatalf("session_storage_key = %q, want %q", got, want)
+	}
+}

--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
 )
 
 // SessionEventStore reads the canonical SDK events the pod-side
@@ -18,9 +20,9 @@ import (
 // one producer, two consumers (DB reader = SPA history-replay,
 // WS subscriber = SPA live tap).
 //
-// Container partition key is /tank_session_id (the small-integer pod id,
-// not the SDK's UUID). New clients page by the same render-order cursor the
-// SPA sorts on; the document-id cursor remains accepted for older tabs.
+// Container partition key is /tank_session_id (Tank's scoped storage key, not
+// the SDK's UUID). New clients page by the same render-order cursor the SPA
+// sorts on; the document-id cursor remains accepted for older tabs.
 type SessionEventStore interface {
 	ListBySession(ctx context.Context, tankSessionID string, cursor SessionEventCursor, limit int) (SessionEventPage, error)
 }
@@ -38,9 +40,14 @@ type SessionEventPage struct {
 
 type cosmosSessionEventStore struct {
 	container *azcosmos.ContainerClient
+	scope     string
 }
 
-func NewCosmosSessionEventStore(endpoint, database, container string, cred azcore.TokenCredential) (SessionEventStore, error) {
+func NewCosmosSessionEventStore(endpoint, database, container, scope string, cred azcore.TokenCredential) (SessionEventStore, error) {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = "default"
+	}
 	client, err := azcosmos.NewClient(endpoint, cred, nil)
 	if err != nil {
 		return nil, err
@@ -49,14 +56,14 @@ func NewCosmosSessionEventStore(endpoint, database, container string, cred azcor
 	if err != nil {
 		return nil, err
 	}
-	return &cosmosSessionEventStore{container: c}, nil
+	return &cosmosSessionEventStore{container: c, scope: scope}, nil
 }
 
 // ListBySession returns events for one session, strictly after the
 // given render-order cursor. An empty cursor returns from the beginning.
 // limit caps the page size.
 //
-// Single-partition read (tank_session_id is the partition key) so the
+// Single-partition read (tank_session_id is the scoped partition key) so the
 // query is one RU per ~1KB doc — fast and cheap. The /message/* path
 // is excluded from indexing (see infra/cosmos.tf) so large assistant
 // content doesn't inflate index size. Page slicing happens after the Go sort
@@ -64,11 +71,12 @@ func NewCosmosSessionEventStore(endpoint, database, container string, cred azcor
 // skip events when id order and render order diverge.
 func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSessionID string, cursor SessionEventCursor, limit int) (SessionEventPage, error) {
 	limit = normalizeSessionEventLimit(limit)
+	storageKey := compat.SessionStorageKey(s.scope, tankSessionID)
 	query := "SELECT * FROM c WHERE c.tank_session_id = @sid"
 	params := []azcosmos.QueryParameter{
-		{Name: "@sid", Value: tankSessionID},
+		{Name: "@sid", Value: storageKey},
 	}
-	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(tankSessionID), &azcosmos.QueryOptions{QueryParameters: params})
+	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(storageKey), &azcosmos.QueryOptions{QueryParameters: params})
 	out := make([]map[string]any, 0, limit)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -80,6 +88,7 @@ func (s *cosmosSessionEventStore) ListBySession(ctx context.Context, tankSession
 			if err := json.Unmarshal(raw, &doc); err != nil {
 				continue
 			}
+			doc["tank_session_id"] = tankSessionID
 			out = append(out, doc)
 		}
 	}

--- a/backend-go/internal/store/turn_queue.go
+++ b/backend-go/internal/store/turn_queue.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/compat"
 )
 
 // TurnQueueStatus is the lifecycle status of a queued turn.
@@ -54,8 +56,8 @@ type TurnRecord struct {
 
 // TurnQueueStore persists per-session turn descriptors. The orchestrator
 // is the only producer today; the pod-side SDK runners are the consumers.
-// Containers partition on session_id so a session's turn history is
-// one-partition reads.
+// Containers partition on the scoped storage key in session_id so a session's
+// turn history is one-partition reads without cross-slot collisions.
 type TurnQueueStore interface {
 	Enqueue(ctx context.Context, rec TurnRecord) error
 	NextPending(ctx context.Context, sessionID string) (*TurnRecord, error)
@@ -66,9 +68,14 @@ type TurnQueueStore interface {
 
 type cosmosTurnQueueStore struct {
 	container *azcosmos.ContainerClient
+	scope     string
 }
 
-func NewCosmosTurnQueueStore(endpoint, database, container string, cred azcore.TokenCredential) (TurnQueueStore, error) {
+func NewCosmosTurnQueueStore(endpoint, database, container, scope string, cred azcore.TokenCredential) (TurnQueueStore, error) {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = "default"
+	}
 	client, err := azcosmos.NewClient(endpoint, cred, nil)
 	if err != nil {
 		return nil, err
@@ -77,7 +84,7 @@ func NewCosmosTurnQueueStore(endpoint, database, container string, cred azcore.T
 	if err != nil {
 		return nil, err
 	}
-	return &cosmosTurnQueueStore{container: c}, nil
+	return &cosmosTurnQueueStore{container: c, scope: scope}, nil
 }
 
 func (s *cosmosTurnQueueStore) Enqueue(ctx context.Context, rec TurnRecord) error {
@@ -91,12 +98,13 @@ func (s *cosmosTurnQueueStore) Enqueue(ctx context.Context, rec TurnRecord) erro
 		rec.CreatedAt = nowISO()
 	}
 	rec.Email = strings.ToLower(strings.TrimSpace(rec.Email))
-	doc := turnDoc(rec)
+	storageKey := s.storageKey(rec.SessionID)
+	doc := turnDocForStorageKey(rec, storageKey)
 	raw, err := json.Marshal(doc)
 	if err != nil {
 		return err
 	}
-	pk := azcosmos.NewPartitionKeyString(rec.SessionID)
+	pk := azcosmos.NewPartitionKeyString(storageKey)
 	// CreateItem so a re-dispatch with the same turn_id surfaces (409) rather
 	// than silently overwriting an in-flight turn. Re-dispatches should not
 	// happen in normal operation — each user message generates a fresh
@@ -115,12 +123,13 @@ func (s *cosmosTurnQueueStore) Enqueue(ctx context.Context, rec TurnRecord) erro
 }
 
 func (s *cosmosTurnQueueStore) NextPending(ctx context.Context, sessionID string) (*TurnRecord, error) {
+	storageKey := s.storageKey(sessionID)
 	query := "SELECT TOP 1 * FROM c WHERE c.session_id = @session_id AND c.status = @status ORDER BY c.created_at ASC"
 	params := []azcosmos.QueryParameter{
-		{Name: "@session_id", Value: sessionID},
+		{Name: "@session_id", Value: storageKey},
 		{Name: "@status", Value: string(TurnPending)},
 	}
-	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(sessionID), &azcosmos.QueryOptions{QueryParameters: params})
+	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(storageKey), &azcosmos.QueryOptions{QueryParameters: params})
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
@@ -153,7 +162,8 @@ func (s *cosmosTurnQueueStore) MarkFailed(ctx context.Context, sessionID, turnID
 }
 
 func (s *cosmosTurnQueueStore) patchStatus(ctx context.Context, sessionID, turnID string, status TurnQueueStatus, claimedAt, completedAt *string) error {
-	pk := azcosmos.NewPartitionKeyString(sessionID)
+	storageKey := s.storageKey(sessionID)
+	pk := azcosmos.NewPartitionKeyString(storageKey)
 	resp, err := s.container.ReadItem(ctx, pk, "turn:"+turnID, nil)
 	if err != nil {
 		var re *azcore.ResponseError
@@ -173,7 +183,7 @@ func (s *cosmosTurnQueueStore) patchStatus(ctx context.Context, sessionID, turnI
 	if completedAt != nil {
 		rec.CompletedAt = completedAt
 	}
-	raw, err := json.Marshal(turnDoc(rec))
+	raw, err := json.Marshal(turnDocForStorageKey(rec, storageKey))
 	if err != nil {
 		return err
 	}
@@ -181,67 +191,80 @@ func (s *cosmosTurnQueueStore) patchStatus(ctx context.Context, sessionID, turnI
 	return err
 }
 
-// turnDoc shapes the wire JSON. Doc id is `turn:<turn_id>` so the partition
-// (session_id) can hold sibling kinds of docs later without collision.
 func turnDoc(r TurnRecord) map[string]any {
+	return turnDocForStorageKey(r, r.SessionID)
+}
+
+// turnDocForStorageKey shapes the wire JSON. Doc id is `turn:<turn_id>` so the
+// partition (session_id) can hold sibling kinds of docs later without collision.
+func turnDocForStorageKey(r TurnRecord, storageKey string) map[string]any {
+	if storageKey == "" {
+		storageKey = r.SessionID
+	}
 	doc := map[string]any{
-		"id":               "turn:" + r.TurnID,
-		"type":             "turn",
-		"turn_id":          r.TurnID,
-		"session_id":       r.SessionID,
-		"email":            r.Email,
-		"provider":         r.Provider,
-		"source":           r.Source,
-		"client_nonce":     r.ClientNonce,
-		"prompt":           r.Prompt,
-		"follow_up":        r.FollowUp,
-		"status":           string(r.Status),
-		"created_at":       r.CreatedAt,
-		"claimed_at":       r.ClaimedAt,
-		"claim_id":         r.ClaimID,
-		"claimed_by":       r.ClaimedBy,
-		"claim_expires_at": r.ClaimExpiresAt,
-		"attempt_count":    r.AttemptCount,
-		"available_at":     r.AvailableAt,
-		"completed_at":     r.CompletedAt,
-		"last_error":       r.LastError,
-		"model":            r.Model,
-		"permission_mode":  r.PermissionMode,
-		"skill_name":       r.SkillName,
+		"id":                     "turn:" + r.TurnID,
+		"type":                   "turn",
+		"turn_id":                r.TurnID,
+		"session_id":             storageKey,
+		"tank_public_session_id": r.SessionID,
+		"email":                  r.Email,
+		"provider":               r.Provider,
+		"source":                 r.Source,
+		"client_nonce":           r.ClientNonce,
+		"prompt":                 r.Prompt,
+		"follow_up":              r.FollowUp,
+		"status":                 string(r.Status),
+		"created_at":             r.CreatedAt,
+		"claimed_at":             r.ClaimedAt,
+		"claim_id":               r.ClaimID,
+		"claimed_by":             r.ClaimedBy,
+		"claim_expires_at":       r.ClaimExpiresAt,
+		"attempt_count":          r.AttemptCount,
+		"available_at":           r.AvailableAt,
+		"completed_at":           r.CompletedAt,
+		"last_error":             r.LastError,
+		"model":                  r.Model,
+		"permission_mode":        r.PermissionMode,
+		"skill_name":             r.SkillName,
 	}
 	return doc
 }
 
 func turnFromDoc(data []byte) (TurnRecord, error) {
 	var d struct {
-		TurnID         string  `json:"turn_id"`
-		SessionID      string  `json:"session_id"`
-		Email          string  `json:"email"`
-		Provider       string  `json:"provider"`
-		Source         string  `json:"source"`
-		ClientNonce    string  `json:"client_nonce"`
-		Prompt         string  `json:"prompt"`
-		Model          string  `json:"model"`
-		PermissionMode string  `json:"permission_mode"`
-		SkillName      string  `json:"skill_name"`
-		FollowUp       bool    `json:"follow_up"`
-		Status         string  `json:"status"`
-		CreatedAt      string  `json:"created_at"`
-		ClaimedAt      *string `json:"claimed_at"`
-		ClaimID        *string `json:"claim_id"`
-		ClaimedBy      *string `json:"claimed_by"`
-		ClaimExpiresAt *string `json:"claim_expires_at"`
-		AttemptCount   int     `json:"attempt_count"`
-		AvailableAt    *string `json:"available_at"`
-		CompletedAt    *string `json:"completed_at"`
-		LastError      string  `json:"last_error"`
+		TurnID          string  `json:"turn_id"`
+		SessionID       string  `json:"session_id"`
+		PublicSessionID string  `json:"tank_public_session_id"`
+		Email           string  `json:"email"`
+		Provider        string  `json:"provider"`
+		Source          string  `json:"source"`
+		ClientNonce     string  `json:"client_nonce"`
+		Prompt          string  `json:"prompt"`
+		Model           string  `json:"model"`
+		PermissionMode  string  `json:"permission_mode"`
+		SkillName       string  `json:"skill_name"`
+		FollowUp        bool    `json:"follow_up"`
+		Status          string  `json:"status"`
+		CreatedAt       string  `json:"created_at"`
+		ClaimedAt       *string `json:"claimed_at"`
+		ClaimID         *string `json:"claim_id"`
+		ClaimedBy       *string `json:"claimed_by"`
+		ClaimExpiresAt  *string `json:"claim_expires_at"`
+		AttemptCount    int     `json:"attempt_count"`
+		AvailableAt     *string `json:"available_at"`
+		CompletedAt     *string `json:"completed_at"`
+		LastError       string  `json:"last_error"`
 	}
 	if err := json.Unmarshal(data, &d); err != nil {
 		return TurnRecord{}, err
 	}
+	sessionID := d.PublicSessionID
+	if sessionID == "" {
+		sessionID = d.SessionID
+	}
 	return TurnRecord{
 		TurnID:         d.TurnID,
-		SessionID:      d.SessionID,
+		SessionID:      sessionID,
 		Email:          d.Email,
 		Provider:       d.Provider,
 		Source:         d.Source,
@@ -269,12 +292,13 @@ func (s *cosmosTurnQueueStore) ListBySession(ctx context.Context, sessionID stri
 	if limit <= 0 {
 		limit = 50
 	}
+	storageKey := s.storageKey(sessionID)
 	query := "SELECT * FROM c WHERE c.session_id = @session_id ORDER BY c.created_at ASC OFFSET 0 LIMIT @limit"
 	params := []azcosmos.QueryParameter{
-		{Name: "@session_id", Value: sessionID},
+		{Name: "@session_id", Value: storageKey},
 		{Name: "@limit", Value: limit},
 	}
-	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(sessionID), &azcosmos.QueryOptions{QueryParameters: params})
+	pager := s.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(storageKey), &azcosmos.QueryOptions{QueryParameters: params})
 	var out []TurnRecord
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -291,6 +315,10 @@ func (s *cosmosTurnQueueStore) ListBySession(ctx context.Context, sessionID stri
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].CreatedAt < out[j].CreatedAt })
 	return out, nil
+}
+
+func (s *cosmosTurnQueueStore) storageKey(sessionID string) string {
+	return compat.SessionStorageKey(s.scope, sessionID)
 }
 
 // StubTurnQueueStore satisfies the interface when Cosmos is unavailable

--- a/backend-go/internal/store/turn_queue_test.go
+++ b/backend-go/internal/store/turn_queue_test.go
@@ -43,6 +43,9 @@ func TestTurnDocShape(t *testing.T) {
 	if got, want := doc["session_id"], "61"; got != want {
 		t.Fatalf("session_id = %q (must match container partition key /session_id)", got)
 	}
+	if got, want := doc["tank_public_session_id"], "61"; got != want {
+		t.Fatalf("tank_public_session_id = %q, want %q", got, want)
+	}
 	if got, want := doc["status"], "pending"; got != want {
 		t.Fatalf("status = %q, want %q", got, want)
 	}
@@ -81,6 +84,24 @@ func TestTurnDocShape(t *testing.T) {
 	}
 	if doc["completed_at"] != (*string)(nil) {
 		t.Fatalf("completed_at = %v, want nil", doc["completed_at"])
+	}
+}
+
+func TestTurnDocUsesScopedStorageKeyForPartition(t *testing.T) {
+	rec := TurnRecord{
+		TurnID:    "abc123",
+		SessionID: "61",
+		Email:     "nelson@romaine.life",
+		Provider:  "claude",
+		Prompt:    "hello",
+		Status:    TurnPending,
+	}
+	doc := turnDocForStorageKey(rec, "slot-a:61")
+	if got, want := doc["session_id"], "slot-a:61"; got != want {
+		t.Fatalf("session_id = %q, want scoped storage key %q", got, want)
+	}
+	if got, want := doc["tank_public_session_id"], "61"; got != want {
+		t.Fatalf("tank_public_session_id = %q, want public id %q", got, want)
 	}
 }
 

--- a/codex-runner/src/adapters/codex.test.ts
+++ b/codex-runner/src/adapters/codex.test.ts
@@ -13,6 +13,7 @@ import {
 function cfg(): Config {
   return {
     sessionId: "63",
+    sessionStorageKey: "63",
     ownerEmail: "user@example.com",
     cosmosEndpoint: "https://example.invalid",
     cosmosDatabase: "tank-operator",

--- a/codex-runner/src/config.ts
+++ b/codex-runner/src/config.ts
@@ -1,5 +1,5 @@
 // Runtime config sourced from env vars. Mirrors agent-runner/src/config.ts:
-// same downward-API + Cosmos plumbing, different SDK underneath.
+// same downward-API + scoped Cosmos plumbing, different SDK underneath.
 //
 // Auth path: codex-sdk wraps the codex CLI subprocess, which reads
 // ~/.codex/auth.json. The launcher writes a placeholder chatgptAuthTokens
@@ -8,6 +8,7 @@
 
 export interface Config {
   sessionId: string;
+  sessionStorageKey: string;
   ownerEmail: string;
   cosmosEndpoint: string;
   cosmosDatabase: string;
@@ -31,6 +32,7 @@ export function loadConfig(): Config {
   }
   return {
     sessionId,
+    sessionStorageKey: process.env.TANK_SESSION_STORAGE_KEY?.trim() || sessionId,
     ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
     cosmosEndpoint,
     cosmosDatabase: process.env.COSMOS_DATABASE?.trim() || "tank-operator",

--- a/codex-runner/src/cosmos.ts
+++ b/codex-runner/src/cosmos.ts
@@ -137,9 +137,9 @@ export class CosmosSink {
   }
 
   // Write a canonical event. Doc id is the runner-stamped uuid; partition
-  // is the orchestrator's session_id. Matches the shape agent-runner uses,
-  // so the orchestrator's read endpoint and the SPA's chat pane consume
-  // both claude- and codex-runner events out of the same container.
+  // is Tank's scoped session storage key. Matches the shape agent-runner
+  // uses, so the orchestrator's read endpoint and the SPA's chat pane
+  // consume both claude- and codex-runner events out of the same container.
   async upsert(event: CodexEvent & { uuid: string }): Promise<void> {
     const doc = this.docFromEvent(event);
     await this.container.items.upsert(doc);
@@ -162,14 +162,14 @@ export class CosmosSink {
         query:
           "SELECT TOP 1 * FROM c WHERE c.tank_session_id = @session_id AND c.turn_id = @turn_id AND (c.type = @completed OR c.type = @failed OR c.type = @interrupted)",
         parameters: [
-          { name: "@session_id", value: this.cfg.sessionId },
+          { name: "@session_id", value: this.cfg.sessionStorageKey },
           { name: "@turn_id", value: turnID },
           { name: "@completed", value: "turn.completed" },
           { name: "@failed", value: "turn.failed" },
           { name: "@interrupted", value: "turn.interrupted" },
         ],
       },
-      { partitionKey: this.cfg.sessionId },
+      { partitionKey: this.cfg.sessionStorageKey },
     );
     const page = await iterator.fetchNext();
     return page.resources[0] ?? null;
@@ -179,7 +179,8 @@ export class CosmosSink {
     return {
       ...event,
       id: event.uuid,
-      tank_session_id: this.cfg.sessionId,
+      tank_session_id: this.cfg.sessionStorageKey,
+      tank_public_session_id: this.cfg.sessionId,
       email: this.cfg.ownerEmail,
       runtime: "codex",
       written_at:

--- a/runner-shared/turnQueue.d.ts
+++ b/runner-shared/turnQueue.d.ts
@@ -3,6 +3,7 @@ export const TURN_QUEUE_MAX_ATTEMPTS: number;
 
 export interface TurnQueueConfig {
   sessionId: string;
+  sessionStorageKey?: string;
   ownerEmail: string;
   cosmosEndpoint: string;
   cosmosDatabase: string;
@@ -13,6 +14,7 @@ export interface TurnRecord {
   id: string;
   turn_id: string;
   session_id: string;
+  tank_public_session_id?: string;
   email: string;
   provider: "claude" | "codex" | string;
   source?: string;
@@ -67,6 +69,7 @@ export function buildClaimedRecord(
 
 export function buildDelayedTurnRecord(args: {
   sessionID: string;
+  sessionStorageKey?: string;
   email: string;
   provider: "claude" | "codex" | string;
   prompt: string;

--- a/runner-shared/turnQueue.js
+++ b/runner-shared/turnQueue.js
@@ -8,6 +8,7 @@ export class SharedTurnQueue {
     client;
     container;
     runnerID;
+    sessionStorageKey;
     constructor(cfg, provider, deps) {
         this.cfg = cfg;
         this.provider = provider;
@@ -18,7 +19,8 @@ export class SharedTurnQueue {
         this.container = this.client
             .database(cfg.cosmosDatabase)
             .container(cfg.turnQueueContainer);
-        this.runnerID = `${provider}-runner:${cfg.sessionId}:${randomUUID()}`;
+        this.sessionStorageKey = cfg.sessionStorageKey || cfg.sessionId;
+        this.runnerID = `${provider}-runner:${this.sessionStorageKey}:${randomUUID()}`;
     }
     async claimNext() {
         const now = new Date();
@@ -26,7 +28,7 @@ export class SharedTurnQueue {
         const iterator = this.container.items.query({
             query: "SELECT TOP 10 * FROM c WHERE c.session_id = @session_id AND c.provider = @provider AND (c.source = @source_sdk OR c.source = @source_wakeup) AND (c.status = @status_pending OR (c.status = @status_claimed AND IS_DEFINED(c.claim_expires_at) AND c.claim_expires_at <= @now)) AND (NOT IS_DEFINED(c.available_at) OR IS_NULL(c.available_at) OR c.available_at <= @now) ORDER BY c.created_at ASC",
             parameters: [
-                { name: "@session_id", value: this.cfg.sessionId },
+                { name: "@session_id", value: this.sessionStorageKey },
                 { name: "@provider", value: this.provider },
                 { name: "@source_sdk", value: "sdk" },
                 { name: "@source_wakeup", value: "schedule-wakeup" },
@@ -34,7 +36,7 @@ export class SharedTurnQueue {
                 { name: "@status_claimed", value: "claimed" },
                 { name: "@now", value: nowISO },
             ],
-        }, { partitionKey: this.cfg.sessionId });
+        }, { partitionKey: this.sessionStorageKey });
         const page = await iterator.fetchNext();
         for (const record of page.resources) {
             const claimed = await this.claim(record, now);
@@ -46,6 +48,7 @@ export class SharedTurnQueue {
     async enqueueDelayed(args) {
         const record = buildDelayedTurnRecord({
             sessionID: this.cfg.sessionId,
+            sessionStorageKey: this.sessionStorageKey,
             email: this.cfg.ownerEmail,
             provider: this.provider,
             prompt: args.prompt,
@@ -169,7 +172,8 @@ export function buildDelayedTurnRecord(args) {
     return {
         id: `turn:${args.clientNonce}`,
         turn_id: args.clientNonce,
-        session_id: args.sessionID,
+        session_id: args.sessionStorageKey || args.sessionID,
+        tank_public_session_id: args.sessionID,
         email: args.email,
         provider: args.provider,
         source: "schedule-wakeup",


### PR DESCRIPTION
Summary:
- derive a scoped session storage key from SESSION_REGISTRY_SCOPE while keeping public session ids numeric
- pass TANK_SESSION_STORAGE_KEY to session pods and use it for Cosmos partitions/doc ids
- scope registry, turn queue, session events, and conversation read state to avoid slot collisions

Validation:
- go test ./cmd/tank-operator ./internal/compat ./internal/sessions ./internal/sessionregistry ./internal/store
- npm run build && npm test (agent-runner)
- npm run build && npm test (codex-runner)