### PR TITLE
Mint Tank attestations for GitHub MCP

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_internal.go
+++ b/backend-go/cmd/tank-operator/handlers_internal.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
@@ -73,46 +75,111 @@ func requireInternalCaller(k8s kubernetes.Interface, allowedSubjects map[string]
 	}
 }
 
-// handleInternalResolveCaller resolves a caller's identity by pod IP.
-func (s *appServer) handleInternalResolveCaller(w http.ResponseWriter, r *http.Request) {
-	protect := requireInternalCaller(s.k8s, s.internalAllowedSubjects)
-	protect(s.doInternalResolveCaller)(w, r)
+func (s *appServer) handleInternalJWKS(w http.ResponseWriter, r *http.Request) {
+	if s.minter == nil {
+		writeError(w, http.StatusInternalServerError, "JWT minter not configured")
+		return
+	}
+	jwks, err := s.minter.PublicJWKS(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load public signing key: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, jwks)
 }
 
-func (s *appServer) doInternalResolveCaller(w http.ResponseWriter, r *http.Request) {
-	podIP := r.URL.Query().Get("pod_ip")
-	if podIP == "" {
-		writeError(w, http.StatusBadRequest, "missing pod_ip")
-		return
-	}
-
-	email, podName, err := s.mgr.FindPodByIP(r.Context(), podIP)
+func (s *appServer) handleInternalGitHubAttestation(w http.ResponseWriter, r *http.Request) {
+	token, err := auth.ParseSAToken(r)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "no session pod with IP: "+podIP)
+		writeError(w, auth.ErrorStatus(err), err.Error())
 		return
 	}
 
+	subject, err := auth.ValidateSAToken(r.Context(), s.k8s, token, []string{"tank-operator"})
+	if err != nil {
+		writeError(w, auth.ErrorStatus(err), err.Error())
+		return
+	}
+	if subject.Namespace != s.namespace || subject.Name != s.sessionServiceAccount {
+		writeError(w, http.StatusForbidden, "caller is not the Tank session service account")
+		return
+	}
+	podName := subject.ExtraValue("authentication.kubernetes.io/pod-name")
+	podUID := subject.ExtraValue("authentication.kubernetes.io/pod-uid")
+	if podName == "" || podUID == "" {
+		writeError(w, http.StatusForbidden, "service account token is not bound to a session pod")
+		return
+	}
+	pod, err := s.k8s.CoreV1().Pods(s.namespace).Get(r.Context(), podName, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, http.StatusForbidden, "session pod not found")
+		return
+	}
+	if pod.Spec.ServiceAccountName != s.sessionServiceAccount || string(pod.UID) != podUID {
+		writeError(w, http.StatusForbidden, "service account token does not match session pod")
+		return
+	}
+	if pod.Labels["app.kubernetes.io/managed-by"] != "tank-operator" {
+		writeError(w, http.StatusForbidden, "pod is not managed by Tank")
+		return
+	}
+	sessionID := strings.TrimSpace(pod.Labels["tank-operator/session-id"])
+	sessionScope := strings.TrimSpace(pod.Labels["tank-operator/session-scope"])
+	expectedScope := strings.TrimSpace(s.sessionScope)
+	if expectedScope == "" {
+		expectedScope = "default"
+	}
+	if sessionID == "" || sessionScope == "" || sessionScope != expectedScope {
+		writeError(w, http.StatusForbidden, "pod is not in the active Tank session scope")
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(pod.Annotations["tank-operator/owner-email"]))
+	if email == "" {
+		writeError(w, http.StatusForbidden, "session pod is missing owner identity")
+		return
+	}
 	hostEmail := os.Getenv("HOST_EMAIL")
 	superAdmins := parseEmailSet(envDefault("SUPER_ADMIN_EMAILS", hostEmail))
 	var installationID *int64
 
-	if s.profiles != nil {
-		profile, profErr := s.profiles.GetOrCreate(r.Context(), email)
-		if profErr == nil {
-			installationID = profile.InstallationID
-		}
+	if s.profiles == nil {
+		writeError(w, http.StatusInternalServerError, "profile store not configured")
+		return
+	}
+	profile, err := s.profiles.GetOrCreate(r.Context(), email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "profile lookup failed: "+err.Error())
+		return
+	}
+	installationID = profile.InstallationID
+
+	isHost := strings.EqualFold(email, hostEmail)
+	if !isHost && installationID == nil {
+		writeError(w, http.StatusForbidden, "GitHub App installation required for Tank session")
+		return
+	}
+	if s.minter == nil {
+		writeError(w, http.StatusInternalServerError, "JWT minter not configured")
+		return
 	}
 
-	tankUIHost := envDefault("TANK_UI_HOST", "https://tank.romaine.life")
-	_ = tankUIHost
+	attestation, expiresAt, err := s.minter.MintGitHubMCPAttestation(auth.GitHubMCPAttestationSubject{
+		Email:          email,
+		InstallationID: installationID,
+		IsHost:         isHost,
+		IsSuperAdmin:   superAdmins[strings.ToLower(strings.TrimSpace(email))],
+		SessionScope:   sessionScope,
+		SessionID:      sessionID,
+		PodName:        podName,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to mint GitHub MCP attestation: "+err.Error())
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"email":           email,
-		"installation_id": installationID,
-		"is_host":         strings.EqualFold(email, hostEmail),
-		"is_super_admin":  superAdmins[strings.ToLower(strings.TrimSpace(email))],
-		"host_email":      hostEmail,
-		"pod_name":        podName,
+		"token":      attestation,
+		"expires_at": expiresAt.UTC().Format(time.RFC3339),
 	})
 }
 

--- a/backend-go/cmd/tank-operator/handlers_internal_test.go
+++ b/backend-go/cmd/tank-operator/handlers_internal_test.go
@@ -1,14 +1,23 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/profiles"
 )
 
 func TestRequireInternalCallerUsesTankOperatorAudience(t *testing.T) {
@@ -72,4 +81,137 @@ func TestRequireInternalCallerRejectsDefaultServiceAccountAudience(t *testing.T)
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
+}
+
+func TestHandleInternalGitHubAttestationMintsTankJWT(t *testing.T) {
+	t.Setenv("HOST_EMAIL", "host@example.test")
+	t.Setenv("SUPER_ADMIN_EMAILS", "owner@example.test")
+	installationID := int64(987)
+	jwtKey, err := auth.NewInMemoryJWT("test-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	k8s := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "session-12",
+			Namespace: "tank-operator-sessions",
+			UID:       types.UID("pod-uid-12"),
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "tank-operator",
+				"tank-operator/session-id":     "12",
+				"tank-operator/session-scope":  "slot-a",
+			},
+			Annotations: map[string]string{
+				"tank-operator/owner-email": "owner@example.test",
+			},
+		},
+		Spec: corev1.PodSpec{ServiceAccountName: "claude-session"},
+	})
+	k8s.Fake.PrependReactor("create", "tokenreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
+		review := action.(ktesting.CreateAction).GetObject().(*authv1.TokenReview)
+		if len(review.Spec.Audiences) != 1 || review.Spec.Audiences[0] != "tank-operator" {
+			t.Fatalf("audiences=%#v, want tank-operator audience", review.Spec.Audiences)
+		}
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{
+				Authenticated: true,
+				User: authv1.UserInfo{
+					Username: "system:serviceaccount:tank-operator-sessions:claude-session",
+					Extra: map[string]authv1.ExtraValue{
+						"authentication.kubernetes.io/pod-name": {"session-12"},
+						"authentication.kubernetes.io/pod-uid":  {"pod-uid-12"},
+					},
+				},
+			},
+		}, nil
+	})
+	server := &appServer{
+		k8s:                   k8s,
+		namespace:             "tank-operator-sessions",
+		sessionScope:          "slot-a",
+		sessionServiceAccount: "claude-session",
+		profiles: testProfilesStore{
+			"owner@example.test": {InstallationID: &installationID},
+		},
+		minter: auth.NewMinter(jwtKey, jwtKey, "owner@example.test"),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/github/attestation", nil)
+	req.Header.Set("Authorization", "Bearer session-token")
+	rec := httptest.NewRecorder()
+
+	server.handleInternalGitHubAttestation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Token == "" || body.ExpiresAt == "" {
+		t.Fatalf("response = %#v", body)
+	}
+	claims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(body.Token, claims, func(token *jwt.Token) (any, error) {
+		return jwtKey.PublicKey(context.Background(), "test-kid")
+	}, jwt.WithAudience(auth.GitHubMCPAttestationAudience), jwt.WithIssuer("tank-operator"))
+	if err != nil || !parsed.Valid {
+		t.Fatalf("attestation did not verify: token=%v err=%v", parsed, err)
+	}
+	if got, want := claims["owner_email"], "owner@example.test"; got != want {
+		t.Fatalf("owner_email = %v, want %q", got, want)
+	}
+	if got, want := claims["github_installation_id"], float64(987); got != want {
+		t.Fatalf("github_installation_id = %v, want %v", got, want)
+	}
+	if got, want := claims["session_scope"], "slot-a"; got != want {
+		t.Fatalf("session_scope = %v, want %q", got, want)
+	}
+}
+
+func TestHandleInternalGitHubAttestationRejectsUnboundSAToken(t *testing.T) {
+	jwtKey, err := auth.NewInMemoryJWT("test-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	k8s := fake.NewSimpleClientset()
+	k8s.Fake.PrependReactor("create", "tokenreviews", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{
+				Authenticated: true,
+				User: authv1.UserInfo{
+					Username: "system:serviceaccount:tank-operator-sessions:claude-session",
+				},
+			},
+		}, nil
+	})
+	server := &appServer{
+		k8s:                   k8s,
+		namespace:             "tank-operator-sessions",
+		sessionScope:          "slot-a",
+		sessionServiceAccount: "claude-session",
+		profiles:              testProfilesStore{},
+		minter:                auth.NewMinter(jwtKey, jwtKey, ""),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/github/attestation", nil)
+	req.Header.Set("Authorization", "Bearer session-token")
+	rec := httptest.NewRecorder()
+
+	server.handleInternalGitHubAttestation(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+type testProfilesStore map[string]profiles.Profile
+
+func (s testProfilesStore) GetOrCreate(_ context.Context, email string) (profiles.Profile, error) {
+	if profile, ok := s[email]; ok {
+		return profile, nil
+	}
+	return profiles.Profile{Email: email}, nil
 }

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -67,6 +67,8 @@ func main() {
 
 	// 9. Init Manager.
 	namespace := envDefault("SESSIONS_NAMESPACE", compat.SessionsNamespace)
+	sessionServiceAccount := envDefault("SESSION_SERVICE_ACCOUNT", compat.SessionServiceAccount)
+	tankOperatorInternalURL := envDefault("TANK_OPERATOR_INTERNAL_URL", "http://tank-operator.tank-operator.svc.cluster.local")
 
 	// Session image tags come from the chart's values.yaml session.*
 	// keys, bumped per-commit to fingerprinted tags by the
@@ -91,13 +93,14 @@ func main() {
 	mgr := sessions.NewManager(k8sClient, restCfg, namespace, sessionReg, eventBus, sessions.ManagerOptions{
 		ManifestOpts: compat.ManifestOptions{
 			SessionsNamespace:        namespace,
-			SessionServiceAccount:    envDefault("SESSION_SERVICE_ACCOUNT", compat.SessionServiceAccount),
+			SessionServiceAccount:    sessionServiceAccount,
 			SessionConfigMap:         envDefault("SESSION_CONFIGMAP", compat.SessionConfigMap),
 			ArgoCDTrackingApp:        envDefault("ARGOCD_TRACKING_APP", "tank-operator-sessions"),
 			SessionImage:             sessionImage,
 			CodexSessionImage:        codexSessionImage,
 			PiSessionImage:           piSessionImage,
 			SessionScope:             sessionScope,
+			TankOperatorInternalURL:  tankOperatorInternalURL,
 			GitHubAppSecret:          envDefault("GITHUB_APP_SECRET", compat.DefaultGitHubAppSecret),
 			SessionAzureConfigSecret: envDefault("SESSION_AZURE_CONFIG_SECRET", compat.DefaultSessionAzureConfigSecret),
 			// Pass the orchestrator's Cosmos config through to the pod's
@@ -131,7 +134,7 @@ func main() {
 	// 12. Parse internal allowed subjects.
 	// Accepts both "ns/name=email" and plain "ns/name" entries.
 	internalSubjects := parseInternalSubjects(
-		envDefault("INTERNAL_API_ALLOWED_SUBJECTS", "mcp-github/mcp-github,mcp-tank-operator/mcp-tank-operator,mcp-glimmung/mcp-glimmung"),
+		envDefault("INTERNAL_API_ALLOWED_SUBJECTS", "mcp-tank-operator/mcp-tank-operator,mcp-glimmung/mcp-glimmung"),
 	)
 
 	// 13. Register all routes.
@@ -148,6 +151,8 @@ func main() {
 		verifier:                verifier,
 		minter:                  minter,
 		namespace:               namespace,
+		sessionScope:            sessionScope,
+		sessionServiceAccount:   sessionServiceAccount,
 		internalAllowedSubjects: internalSubjects,
 	}
 	srv.registerRoutes(mux)

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -27,6 +27,9 @@ type appServer struct {
 	verifier      *auth.Verifier
 	minter        *auth.Minter
 	namespace     string
+	sessionScope  string
+
+	sessionServiceAccount string
 
 	// internalAllowedSubjects maps "namespace/serviceaccount" → email for internal SA auth.
 	internalAllowedSubjects map[string]string
@@ -47,6 +50,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	// GitHub install.
 	mux.HandleFunc("GET /api/github/install/url", s.handleGitHubInstallURL)
 	mux.HandleFunc("GET /api/github/install/callback", s.handleGitHubInstallCallback)
+	mux.HandleFunc("GET /.well-known/jwks.json", s.handleInternalJWKS)
 
 	// Sessions CRUD.
 	mux.HandleFunc("POST /api/sessions", s.handleCreateSession)
@@ -86,8 +90,9 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/sessions/{session_id}/cli-process", s.handleCLIProcess)
 	mux.HandleFunc("GET /api/sessions/{session_id}/sandbox-agent/v1/processes/{process_id}/terminal/ws", s.handleSandboxTerminalProxy)
 
-	// Internal API (SA token auth).
-	mux.HandleFunc("GET /api/internal/resolve-caller", s.handleInternalResolveCaller)
+	// Internal API.
+	mux.HandleFunc("GET /api/internal/jwks", s.handleInternalJWKS)
+	mux.HandleFunc("POST /api/internal/github/attestation", s.handleInternalGitHubAttestation)
 	mux.HandleFunc("GET /api/internal/sessions", s.handleInternalListSessions)
 	mux.HandleFunc("POST /api/internal/sessions", s.handleInternalCreateSession)
 	mux.HandleFunc("DELETE /api/internal/sessions/{session_id}", s.handleInternalDeleteSession)

--- a/backend-go/internal/auth/auth_test.go
+++ b/backend-go/internal/auth/auth_test.go
@@ -89,6 +89,60 @@ func TestMinterIssuesVerifiableSession(t *testing.T) {
 	}
 }
 
+func TestMinterIssuesGitHubMCPAttestation(t *testing.T) {
+	jwtKey := newTestJWT(t)
+	minter := NewMinter(jwtKey, jwtKey, "user@example.com")
+	installationID := int64(42)
+	tok, expiresAt, err := minter.MintGitHubMCPAttestation(GitHubMCPAttestationSubject{
+		Email:          "USER@example.com",
+		InstallationID: &installationID,
+		IsHost:         false,
+		IsSuperAdmin:   true,
+		SessionScope:   "slot-a",
+		SessionID:      "12",
+		PodName:        "session-12",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Until(expiresAt) <= 0 || time.Until(expiresAt) > GitHubMCPAttestationTTL {
+		t.Fatalf("expiresAt = %s", expiresAt)
+	}
+
+	claims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(tok, claims, func(token *jwt.Token) (any, error) {
+		return jwtKey.PublicKey(context.Background(), "test-kid")
+	}, jwt.WithAudience(GitHubMCPAttestationAudience), jwt.WithIssuer("tank-operator"))
+	if err != nil || !parsed.Valid {
+		t.Fatalf("attestation did not verify: token=%v err=%v", parsed, err)
+	}
+	if got, want := claims["owner_email"], "user@example.com"; got != want {
+		t.Fatalf("owner_email = %v, want %q", got, want)
+	}
+	if got, want := claims["github_installation_id"], float64(42); got != want {
+		t.Fatalf("github_installation_id = %v, want %v", got, want)
+	}
+	if got, want := claims["session_scope"], "slot-a"; got != want {
+		t.Fatalf("session_scope = %v, want %q", got, want)
+	}
+}
+
+func TestMinterPublishesJWKS(t *testing.T) {
+	jwtKey := newTestJWT(t)
+	minter := NewMinter(jwtKey, jwtKey, "user@example.com")
+	jwks, err := minter.PublicJWKS(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("jwks key count = %d, want 1", len(jwks.Keys))
+	}
+	key := jwks.Keys[0]
+	if key.Kid != "test-kid" || key.Kty != "RSA" || key.Alg != "RS256" || key.N == "" || key.E == "" {
+		t.Fatalf("unexpected jwk = %#v", key)
+	}
+}
+
 func TestInstallStateRoundtrips(t *testing.T) {
 	jwtKey := newTestJWT(t)
 	minter := NewMinter(jwtKey, jwtKey, "user@example.com")

--- a/backend-go/internal/auth/inmemory_signer.go
+++ b/backend-go/internal/auth/inmemory_signer.go
@@ -41,3 +41,7 @@ func (m *InMemoryJWT) PublicKey(_ context.Context, kid string) (*rsa.PublicKey, 
 	}
 	return m.pub, nil
 }
+
+func (m *InMemoryJWT) CurrentJWK(_ context.Context) (JWK, error) {
+	return rsaPublicJWK(m.kid, m.pub), nil
+}

--- a/backend-go/internal/auth/jwk.go
+++ b/backend-go/internal/auth/jwk.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"math/big"
+	"strings"
+)
+
+type JWK struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+type JWKProvider interface {
+	CurrentJWK(ctx context.Context) (JWK, error)
+}
+
+func rsaPublicJWK(kid string, pub *rsa.PublicKey) JWK {
+	return JWK{
+		Kty: "RSA",
+		Use: "sig",
+		Kid: kid,
+		Alg: "RS256",
+		N:   b64URL(pub.N.Bytes()),
+		E:   b64URL(big.NewInt(int64(pub.E)).Bytes()),
+	}
+}
+
+func b64URL(b []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+}

--- a/backend-go/internal/auth/k8sauth.go
+++ b/backend-go/internal/auth/k8sauth.go
@@ -15,10 +15,21 @@ import (
 type K8sSubject struct {
 	Namespace string
 	Name      string
+	Extra     map[string][]string
 }
 
 func (s K8sSubject) Qualified() string {
 	return s.Namespace + "/" + s.Name
+}
+
+func (s K8sSubject) ExtraValue(keys ...string) string {
+	for _, key := range keys {
+		values := s.Extra[key]
+		if len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
 }
 
 // ValidateSAToken validates a Kubernetes ServiceAccount bearer token via
@@ -43,7 +54,11 @@ func ValidateSAToken(ctx context.Context, k8s kubernetes.Interface, token string
 	if len(parts) != 4 || parts[0] != "system" || parts[1] != "serviceaccount" {
 		return K8sSubject{}, errHTTP{status: http.StatusUnauthorized, message: "unexpected token subject: " + username}
 	}
-	return K8sSubject{Namespace: parts[2], Name: parts[3]}, nil
+	extra := make(map[string][]string, len(result.Status.User.Extra))
+	for key, values := range result.Status.User.Extra {
+		extra[key] = append([]string(nil), values...)
+	}
+	return K8sSubject{Namespace: parts[2], Name: parts[3], Extra: extra}, nil
 }
 
 // ParseSAToken extracts Bearer token from Authorization header.

--- a/backend-go/internal/auth/keyvault_signer.go
+++ b/backend-go/internal/auth/keyvault_signer.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/big"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -119,6 +117,18 @@ func (j *KeyVaultJWT) PublicKey(ctx context.Context, kid string) (*rsa.PublicKey
 	return pub, nil
 }
 
+func (j *KeyVaultJWT) CurrentJWK(ctx context.Context) (JWK, error) {
+	kid, err := j.currentKIDCached(ctx)
+	if err != nil {
+		return JWK{}, err
+	}
+	pub, err := j.PublicKey(ctx, kid)
+	if err != nil {
+		return JWK{}, err
+	}
+	return rsaPublicJWK(kid, pub), nil
+}
+
 func (j *KeyVaultJWT) currentKIDCached(ctx context.Context) (string, error) {
 	j.currentMu.Lock()
 	defer j.currentMu.Unlock()
@@ -170,8 +180,4 @@ func jwkToRSAPublic(jwk *azkeys.JSONWebKey) (*rsa.PublicKey, error) {
 		return nil, fmt.Errorf("JWK exponent is zero")
 	}
 	return &rsa.PublicKey{N: n, E: e}, nil
-}
-
-func b64URL(b []byte) string {
-	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
 }

--- a/backend-go/internal/auth/mint.go
+++ b/backend-go/internal/auth/mint.go
@@ -14,10 +14,13 @@ import (
 )
 
 const (
-	SessionTTL      = 7 * 24 * time.Hour
-	installStateTTL = 10 * time.Minute
-	installAudience = "tank-operator/github-install"
-	mintTimeout     = 10 * time.Second
+	SessionTTL                   = 7 * 24 * time.Hour
+	GitHubMCPAttestationTTL      = 5 * time.Minute
+	GitHubMCPAttestationAudience = "mcp-github-tank"
+	gitHubMCPAttestationIssuer   = "tank-operator"
+	installStateTTL              = 10 * time.Minute
+	installAudience              = "tank-operator/github-install"
+	mintTimeout                  = 10 * time.Second
 )
 
 // Minter signs session and install-state JWTs via a remote Signer (Key Vault
@@ -60,6 +63,70 @@ func (m *Minter) MintSession(sub, email, name string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), mintTimeout)
 	defer cancel()
 	return m.signer.MintJWT(ctx, claims)
+}
+
+type GitHubMCPAttestationSubject struct {
+	Email          string
+	InstallationID *int64
+	IsHost         bool
+	IsSuperAdmin   bool
+	SessionScope   string
+	SessionID      string
+	PodName        string
+}
+
+func (m *Minter) MintGitHubMCPAttestation(subject GitHubMCPAttestationSubject) (string, time.Time, error) {
+	if m.signer == nil {
+		return "", time.Time{}, fmt.Errorf("JWT signer not configured")
+	}
+	email := strings.ToLower(strings.TrimSpace(subject.Email))
+	sessionScope := strings.TrimSpace(subject.SessionScope)
+	sessionID := strings.TrimSpace(subject.SessionID)
+	podName := strings.TrimSpace(subject.PodName)
+	if email == "" || sessionScope == "" || sessionID == "" || podName == "" {
+		return "", time.Time{}, fmt.Errorf("missing GitHub MCP attestation subject field")
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(GitHubMCPAttestationTTL)
+	claims := jwt.MapClaims{
+		"iss":            gitHubMCPAttestationIssuer,
+		"aud":            GitHubMCPAttestationAudience,
+		"sub":            "tank-session:" + sessionScope + ":" + sessionID,
+		"email":          email,
+		"owner_email":    email,
+		"is_host":        subject.IsHost,
+		"is_super_admin": subject.IsSuperAdmin,
+		"session_scope":  sessionScope,
+		"session_id":     sessionID,
+		"pod_name":       podName,
+		"iat":            now.Unix(),
+		"nbf":            now.Add(-5 * time.Second).Unix(),
+		"exp":            expiresAt.Unix(),
+	}
+	if subject.InstallationID != nil {
+		claims["github_installation_id"] = *subject.InstallationID
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), mintTimeout)
+	defer cancel()
+	token, err := m.signer.MintJWT(ctx, claims)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return token, expiresAt, nil
+}
+
+func (m *Minter) PublicJWKS(ctx context.Context) (JWKS, error) {
+	provider, ok := m.signer.(JWKProvider)
+	if !ok {
+		return JWKS{}, fmt.Errorf("JWT signer does not expose a public JWK")
+	}
+	jwk, err := provider.CurrentJWK(ctx)
+	if err != nil {
+		return JWKS{}, err
+	}
+	return JWKS{Keys: []JWK{jwk}}, nil
 }
 
 func (m *Minter) MintInstallState(email string) (string, error) {

--- a/backend-go/internal/compat/compat.go
+++ b/backend-go/internal/compat/compat.go
@@ -87,15 +87,16 @@ var noClaudeHijackModes = map[string]bool{
 }
 
 type ManifestOptions struct {
-	SessionImage          string
-	CodexSessionImage     string
-	PiSessionImage        string
-	SessionsNamespace     string
-	SessionScope          string
-	SessionServiceAccount string
-	SessionConfigMap      string
-	ArgoCDTrackingApp     string
-	SandboxAgentPort      int
+	SessionImage            string
+	CodexSessionImage       string
+	PiSessionImage          string
+	SessionsNamespace       string
+	SessionScope            string
+	SessionServiceAccount   string
+	SessionConfigMap        string
+	ArgoCDTrackingApp       string
+	SandboxAgentPort        int
+	TankOperatorInternalURL string
 	// Optional: in-cluster Service IPs for host alias injection.
 	OAuthGatewayIP  string
 	APIProxyIP      string
@@ -227,6 +228,20 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	claudeVolumeMounts := append([]any{}, configMounts...)
 	volumes := []any{
 		map[string]any{"name": "session-config", "configMap": map[string]any{"name": opts.SessionConfigMap}},
+		map[string]any{
+			"name": "tank-operator-sa-token",
+			"projected": map[string]any{
+				"sources": []any{
+					map[string]any{
+						"serviceAccountToken": map[string]any{
+							"audience":          "tank-operator",
+							"expirationSeconds": 3600,
+							"path":              "token",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Shared /workspace across the user-facing container and the
@@ -332,13 +347,24 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		claudeContainer["envFrom"] = envFrom
 	}
 
+	mcpProxyVolumeMounts := append([]any{}, configMounts...)
+	mcpProxyVolumeMounts = append(mcpProxyVolumeMounts, map[string]any{
+		"name":      "tank-operator-sa-token",
+		"mountPath": "/var/run/secrets/tank-operator",
+		"readOnly":  true,
+	})
+
 	containers := []any{
 		map[string]any{
 			"name":            "mcp-auth-proxy",
 			"image":           sessionImage,
 			"imagePullPolicy": "Always",
 			"command":         []any{"mcp-auth-proxy"},
-			"volumeMounts":    configMounts,
+			"env": []any{
+				map[string]any{"name": "TANK_OPERATOR_INTERNAL_URL", "value": opts.TankOperatorInternalURL},
+				map[string]any{"name": "TANK_SESSION_ATTESTATION_TOKEN_PATH", "value": "/var/run/secrets/tank-operator/token"},
+			},
+			"volumeMounts": mcpProxyVolumeMounts,
 		},
 		claudeContainer,
 	}
@@ -514,6 +540,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 				"app.kubernetes.io/instance":   opts.ArgoCDTrackingApp,
 				"tank-operator/owner":          OwnerLabel(owner),
 				"tank-operator/session-id":     sessionID,
+				"tank-operator/session-scope":  opts.SessionScope,
 				"tank-operator/mode":           mode,
 				"azure.workload.identity/use":  "true",
 			},
@@ -579,6 +606,9 @@ func withManifestDefaults(opts ManifestOptions) ManifestOptions {
 	}
 	if opts.SandboxAgentPort == 0 {
 		opts.SandboxAgentPort = SandboxAgentPort
+	}
+	if opts.TankOperatorInternalURL == "" {
+		opts.TankOperatorInternalURL = "http://tank-operator.tank-operator.svc.cluster.local"
 	}
 	if opts.OAuthGatewayCAConfigMap == "" {
 		opts.OAuthGatewayCAConfigMap = DefaultOAuthGatewayCA

--- a/backend-go/internal/compat/compat_test.go
+++ b/backend-go/internal/compat/compat_test.go
@@ -99,6 +99,9 @@ func TestPodManifestCompatibilityCore(t *testing.T) {
 	if got, want := labels["tank-operator/mode"], CodexGUIMode; got != want {
 		t.Fatalf("mode label = %v, want %q", got, want)
 	}
+	if got, want := labels["tank-operator/session-scope"], "default"; got != want {
+		t.Fatalf("session scope label = %v, want %q", got, want)
+	}
 	annotations := metadata["annotations"].(map[string]any)
 	if got, want := annotations["tank-operator/owner-email"], "nelson@romaine.life"; got != want {
 		t.Fatalf("owner annotation = %v, want %q", got, want)
@@ -114,6 +117,15 @@ func TestPodManifestCompatibilityCore(t *testing.T) {
 	if got, want := containers[0].(map[string]any)["name"], "mcp-auth-proxy"; got != want {
 		t.Fatalf("sidecar container name = %v, want %q", got, want)
 	}
+	mcpProxy := containers[0].(map[string]any)
+	proxyEnv := containerEnv(mcpProxy)
+	if got, want := proxyEnv["TANK_OPERATOR_INTERNAL_URL"], "http://tank-operator.tank-operator.svc.cluster.local"; got != want {
+		t.Fatalf("proxy TANK_OPERATOR_INTERNAL_URL = %v, want %q", got, want)
+	}
+	if got, want := proxyEnv["TANK_SESSION_ATTESTATION_TOKEN_PATH"], "/var/run/secrets/tank-operator/token"; got != want {
+		t.Fatalf("proxy TANK_SESSION_ATTESTATION_TOKEN_PATH = %v, want %q", got, want)
+	}
+	assertVolumeMount(t, mcpProxy, "tank-operator-sa-token")
 	claude := containers[1].(map[string]any)
 	if got, want := claude["name"], "claude"; got != want {
 		t.Fatalf("main container name = %v, want %q", got, want)
@@ -133,12 +145,13 @@ func TestPodManifestCompatibilityCore(t *testing.T) {
 		t.Fatalf("codex-runner image = %v, want %q (same image as the user container; the runner is a multi-stage build into the same image)", got, want)
 	}
 	volumes := spec["volumes"].([]any)
-	// codex_gui adds session-config + workspace emptyDir (shared between
-	// the claude container and the codex-runner sidecar). Codex auth is
-	// proxy-owned, so the real codex-credentials Secret is not mounted.
-	if got, want := len(volumes), 2; got != want {
+	// codex_gui adds session-config + Tank attestation token + workspace
+	// emptyDir. Codex auth is proxy-owned, so the real codex-credentials
+	// Secret is not mounted.
+	if got, want := len(volumes), 3; got != want {
 		t.Fatalf("volume count = %d, want %d", got, want)
 	}
+	assertVolume(t, volumes, "tank-operator-sa-token")
 }
 
 func TestPodManifestCodexUsesAPIProxyWithoutCredentialSecret(t *testing.T) {

--- a/backend-go/internal/compat/testdata/manifest_fixture.json
+++ b/backend-go/internal/compat/testdata/manifest_fixture.json
@@ -51,7 +51,8 @@
         "azure.workload.identity/use": "true",
         "tank-operator/mode": "codex_gui",
         "tank-operator/owner": "u-db1458e0eb6e9e75",
-        "tank-operator/session-id": "12"
+        "tank-operator/session-id": "12",
+        "tank-operator/session-scope": "default"
       },
       "name": "session-12",
       "namespace": "tank-operator-sessions"

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -14,7 +14,7 @@ RUN npx tsc
 RUN npm prune --omit=dev
 
 # Stage 1b: build the codex-runner from codex-runner/. Sibling of
-# agent-runner — drives @openai/codex-sdk for codex_gui sessions instead
+# agent-runner â€” drives @openai/codex-sdk for codex_gui sessions instead
 # of @anthropic-ai/claude-agent-sdk. Baked into all three session images
 # (claude/codex/pi) for build symmetry; only the codex pod spec runs it.
 FROM node:20-alpine AS codex-runner-build
@@ -29,8 +29,8 @@ RUN npm prune --omit=dev
 
 # Stage 2: runtime image. azure-mcp + github-mcp + k8s-mcp run as in-cluster
 # HTTP MCP servers. The container reaches them via the mcp-auth-proxy sidecar
-# on 127.0.0.1, which reads the projected SA token fresh per request and
-# forwards as a Bearer token. No co-located MCP binaries — keep it minimal.
+# on 127.0.0.1, which injects fresh bearer auth per request; GitHub receives a
+# Tank session attestation. No co-located MCP binaries: keep it minimal.
 FROM node:20-alpine
 
 ARG TARGETARCH=amd64
@@ -82,7 +82,7 @@ RUN curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_V
     && chmod +x /usr/local/bin/tofu \
     && rm /tmp/tofu.zip
 
-# helm — every consumed repo ships a chart; without it `helm template` /
+# helm â€” every consumed repo ships a chart; without it `helm template` /
 # `helm get manifest` debugging is missing.
 RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
         | tar -xz -C /tmp \
@@ -90,12 +90,12 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar
     && rm -rf "/tmp/linux-${TARGETARCH}" \
     && chmod +x /usr/local/bin/helm
 
-# yq — pairs with jq for the YAML half of k8s/helm work.
+# yq â€” pairs with jq for the YAML half of k8s/helm work.
 RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}" \
         -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
 
-# uv — fast pip replacement for Python projects. Hardcoded musl x86_64 path because
+# uv â€” fast pip replacement for Python projects. Hardcoded musl x86_64 path because
 # astral-sh/uv release artifacts aren't named with docker's TARGETARCH
 # convention; the image is alpine + amd64 today.
 RUN curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
@@ -129,7 +129,7 @@ RUN pip install --no-cache-dir --break-system-packages \
 # Localhost reverse proxy that injects fresh SA-token bearer auth into
 # outbound HTTP MCP calls. Runs as a sidecar container in the session
 # pod (same image, command "mcp-auth-proxy"). See server.py for the
-# full rationale — TL;DR fixes the 1h SA-token expiry that froze the
+# full rationale â€” TL;DR fixes the 1h SA-token expiry that froze the
 # bearer in env vars.
 COPY claude-container/mcp-auth-proxy /opt/mcp-auth-proxy
 RUN pip install --no-cache-dir --break-system-packages /opt/mcp-auth-proxy

--- a/claude-container/mcp-auth-proxy/pyproject.toml
+++ b/claude-container/mcp-auth-proxy/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mcp-auth-proxy"
 version = "0.1.0"
-description = "Localhost reverse proxy that injects fresh SA-token bearer auth for in-cluster HTTP MCP servers."
+description = "Localhost reverse proxy that injects fresh bearer auth for Tank MCP servers."
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.9",

--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
@@ -1,16 +1,16 @@
-"""Localhost reverse proxy that injects fresh SA-token bearer auth.
+"""Localhost reverse proxy that injects fresh bearer auth.
 
 Sidecar to the claude-container in each session pod. Listens on per-MCP
 localhost ports; .mcp.json points claude at these instead of at the
-in-cluster MCP Services directly. Every request reads the projected
-ServiceAccount token from disk and forwards upstream with
-Authorization: Bearer <fresh>.
+in-cluster MCP Services directly. Most MCPs still receive the projected
+ServiceAccount token. GitHub MCP receives a short-lived Tank session
+attestation minted from a separate audience-scoped pod token.
 
 The bug this exists to fix: kubelet rotates the SA token file in-place
 (eager renewal at ~50 min, well inside the default 1h TTL), but env
 vars set from that file at pod start go stale. The previous wiring
 exported MCP_*_BEARER in the session startup scripts, then substituted
-them into .mcp.json's Authorization headers at harness startup — so any
+them into .mcp.json's Authorization headers at harness startup â€” so any
 MCP call past the 1h boundary 401'd until the session was recreated.
 This proxy reads the file fresh on every request, so token rotation is
 invisible to claude.
@@ -18,7 +18,7 @@ invisible to claude.
 Same shape as api-proxy (the in-cluster header-injecting proxy for
 api.anthropic.com), just localized to the pod because the SA token is
 per-pod identity. Hardcoded LISTENERS map mirrors the entries in
-k8s/session-config/mcp.json — keep them in sync; both sides describe the
+k8s/session-config/mcp.json â€” keep them in sync; both sides describe the
 same set of MCPs from opposite ends.
 
 OAuth discovery short-circuit: Claude CLI's MCP SDK probes several
@@ -27,8 +27,8 @@ well-known paths to discover whether the server speaks OAuth:
 `/.well-known/oauth-protected-resource` (RFC 9728),
 `/.well-known/openid-configuration` (OIDC discovery), and
 `POST /register` (RFC 7591 Dynamic Client Registration).
-Our MCP servers don't speak OAuth — the upstream returns kube-rbac-
-proxy's plain-text "Not Found", which crashes the SDK's JSON parser
+Our MCP servers don't speak OAuth. A plain-text upstream 404 crashes
+the SDK's JSON parser
 ("Unexpected identifier 'Not'") and leaves the connection unrecoverable
 across upstream pod rotations. We answer all of those paths locally
 with a JSON-shaped 404 so the SDK falls through cleanly to the bearer-
@@ -36,25 +36,37 @@ auth POST that this proxy already injects.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
+import time
+from datetime import datetime
 from pathlib import Path
 
 from aiohttp import ClientSession, ClientTimeout, web
 
 log = logging.getLogger(__name__)
 
-TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+SA_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+TANK_ATTESTATION_TOKEN_PATH = Path(
+    os.environ.get(
+        "TANK_SESSION_ATTESTATION_TOKEN_PATH",
+        "/var/run/secrets/tank-operator/token",
+    )
+)
+TANK_OPERATOR_INTERNAL_URL = os.environ.get("TANK_OPERATOR_INTERNAL_URL", "").rstrip("/")
+GITHUB_MCP_PORT = 9992
 
 # (port, upstream URL). Mirrors k8s/session-config/mcp.json. Adding an
 # MCP means: append here, append a port mapping in mcp.json, ship.
 #
 # Port allocation (next free: 9997):
-#   9991 — mcp-azure-personal
-#   9992 — mcp-github
-#   9993 — mcp-k8s
-#   9994 — mcp-argocd
-#   9995 — mcp-glimmung
-#   9996 — mcp-tank-operator
+#   9991 â€” mcp-azure-personal
+#   9992 â€” mcp-github
+#   9993 â€” mcp-k8s
+#   9994 â€” mcp-argocd
+#   9995 â€” mcp-glimmung
+#   9996 â€” mcp-tank-operator
 LISTENERS: list[tuple[int, str]] = [
     (9991, "http://mcp-azure-personal.mcp-azure.svc:80"),
     (9992, "http://mcp-github.mcp-github.svc:80"),
@@ -70,19 +82,89 @@ LISTENERS: list[tuple[int, str]] = [
 _STRIP_REQUEST_HEADERS = frozenset(
     {"host", "authorization", "content-length", "connection", "transfer-encoding"}
 )
-# Same idea on the way back — let aiohttp set framing headers on the
+# Same idea on the way back â€” let aiohttp set framing headers on the
 # response we stream to the client.
 _STRIP_RESPONSE_HEADERS = frozenset(
     {"transfer-encoding", "content-encoding", "connection", "content-length"}
 )
 
 
-def _read_token() -> str:
-    return TOKEN_PATH.read_text().strip()
+def _read_token(path: Path) -> str:
+    return path.read_text().strip()
+
+
+class ServiceAccountTokenProvider:
+    def __init__(self, token_path: Path = SA_TOKEN_PATH) -> None:
+        self._token_path = token_path
+
+    async def token(self) -> str:
+        return _read_token(self._token_path)
+
+
+class TankGitHubAttestationProvider:
+    def __init__(
+        self,
+        http: ClientSession,
+        *,
+        operator_url: str = TANK_OPERATOR_INTERNAL_URL,
+        token_path: Path = TANK_ATTESTATION_TOKEN_PATH,
+        refresh_skew_seconds: float = 30.0,
+    ) -> None:
+        self._http = http
+        self._operator_url = operator_url.rstrip("/")
+        self._token_path = token_path
+        self._refresh_skew_seconds = refresh_skew_seconds
+        self._cached_token = ""
+        self._expires_at = 0.0
+        self._lock = asyncio.Lock()
+
+    async def token(self) -> str:
+        now = time.time()
+        if self._cached_token and self._expires_at > now + self._refresh_skew_seconds:
+            return self._cached_token
+        async with self._lock:
+            now = time.time()
+            if self._cached_token and self._expires_at > now + self._refresh_skew_seconds:
+                return self._cached_token
+            if not self._operator_url:
+                raise RuntimeError("TANK_OPERATOR_INTERNAL_URL is required for GitHub MCP auth")
+            pod_token = _read_token(self._token_path)
+            async with self._http.post(
+                f"{self._operator_url}/api/internal/github/attestation",
+                headers={"Authorization": f"Bearer {pod_token}"},
+                json={},
+            ) as response:
+                if response.status != 200:
+                    detail = (await response.text())[:300]
+                    raise RuntimeError(
+                        f"Tank GitHub MCP attestation request returned {response.status}: {detail}"
+                    )
+                body = await response.json()
+            token = str(body.get("token") or "")
+            expires_at = _parse_expires_at(body.get("expires_at"))
+            if not token or expires_at <= time.time():
+                raise RuntimeError("Tank GitHub MCP attestation response was invalid")
+            self._cached_token = token
+            self._expires_at = expires_at
+            return token
+
+
+def _parse_expires_at(value: object) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value:
+        return 0.0
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text).timestamp()
+    except ValueError:
+        return 0.0
 
 
 # OAuth discovery paths the MCP SDK probes. RFC 8414 (auth server),
-# RFC 9728 (protected resource), and OIDC discovery — the SDK tries
+# RFC 9728 (protected resource), and OIDC discovery â€” the SDK tries
 # all of these before/after a transport failure to decide whether OAuth
 # is available. Answering locally with a JSON-shaped 404 keeps the
 # SDK's parser from crashing on upstream's plain-text "Not Found" body.
@@ -98,7 +180,7 @@ async def _oauth_discovery_not_configured(request: web.Request) -> web.Response:
         {
             "error": "not_found",
             "error_description": (
-                "OAuth not configured on this MCP server; bearer SA-token "
+                "OAuth not configured on this MCP server; bearer "
                 "auth is injected by the mcp-auth-proxy sidecar."
             ),
         },
@@ -106,15 +188,15 @@ async def _oauth_discovery_not_configured(request: web.Request) -> web.Response:
     )
 
 
-def _make_handler(upstream: str, http: ClientSession):
+def _make_handler(upstream: str, http: ClientSession, token_provider):
     upstream = upstream.rstrip("/")
 
     async def handler(request: web.Request) -> web.StreamResponse:
         try:
-            token = _read_token()
-        except OSError:
-            log.exception("could not read SA token at %s", TOKEN_PATH)
-            return web.Response(status=503, text="SA token unavailable")
+            token = await token_provider.token()
+        except Exception:
+            log.exception("could not load bearer token for %s", upstream)
+            return web.Response(status=503, text="bearer token unavailable")
 
         forwarded_headers = {
             k: v for k, v in request.headers.items() if k.lower() not in _STRIP_REQUEST_HEADERS
@@ -156,7 +238,7 @@ async def run() -> None:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
-    # Long total timeout — MCP tool calls can be minutes. Connect timeout
+    # Long total timeout â€” MCP tool calls can be minutes. Connect timeout
     # short so a dead upstream Service surfaces fast instead of hanging
     # the user-visible MCP call.
     http = ClientSession(timeout=ClientTimeout(total=600, sock_connect=5))
@@ -166,19 +248,25 @@ async def run() -> None:
             app = web.Application()
             for discovery_path in _OAUTH_DISCOVERY_PATHS:
                 app.router.add_route("GET", discovery_path, _oauth_discovery_not_configured)
-            # RFC 7591 Dynamic Client Registration — also intercepted so the
-            # SDK gets a JSON 404 rather than kube-rbac-proxy's plain-text one.
+            # RFC 7591 Dynamic Client Registration â€” also intercepted so the
+            # SDK gets a JSON 404 rather than an upstream plain-text one.
             app.router.add_route("POST", "/register", _oauth_discovery_not_configured)
-            app.router.add_route("*", "/{tail:.*}", _make_handler(upstream, http))
+            if port == GITHUB_MCP_PORT:
+                token_provider = TankGitHubAttestationProvider(http)
+            else:
+                token_provider = ServiceAccountTokenProvider()
+            app.router.add_route(
+                "*",
+                "/{tail:.*}",
+                _make_handler(upstream, http, token_provider),
+            )
             runner = web.AppRunner(app)
             await runner.setup()
             site = web.TCPSite(runner, "127.0.0.1", port)
             await site.start()
-            log.info("listening on 127.0.0.1:%d → %s", port, upstream)
+            log.info("listening on 127.0.0.1:%d â†’ %s", port, upstream)
             runners.append(runner)
         # Park forever; container lifecycle owns us.
-        import asyncio
-
         await asyncio.Event().wait()
     finally:
         for runner in runners:

--- a/claude-container/mcp-auth-proxy/tests/test_server.py
+++ b/claude-container/mcp-auth-proxy/tests/test_server.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mcp_auth_proxy.server import TankGitHubAttestationProvider
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: dict | None = None, text: str = "") -> None:
+        self.status = status
+        self._body = body or {}
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def json(self) -> dict:
+        return self._body
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _FakeHTTP:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.calls: list[dict] = []
+
+    def post(self, url: str, *, headers: dict, json: dict):
+        self.calls.append({"url": url, "headers": headers, "json": json})
+        return self.response
+
+
+def test_tank_attestation_provider_exchanges_pod_token(tmp_path) -> None:
+    token_path = tmp_path / "token"
+    token_path.write_text("pod-token\n", encoding="utf-8")
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    http = _FakeHTTP(
+        _FakeResponse(
+            200,
+            {
+                "token": "tank-attestation",
+                "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
+            },
+        )
+    )
+    provider = TankGitHubAttestationProvider(
+        http,
+        operator_url="http://tank-operator",
+        token_path=token_path,
+    )
+
+    token = asyncio.run(provider.token())
+    token_again = asyncio.run(provider.token())
+
+    assert token == "tank-attestation"
+    assert token_again == "tank-attestation"
+    assert len(http.calls) == 1
+    assert http.calls[0] == {
+        "url": "http://tank-operator/api/internal/github/attestation",
+        "headers": {"Authorization": "Bearer pod-token"},
+        "json": {},
+    }
+
+
+def test_tank_attestation_provider_requires_operator_url(tmp_path) -> None:
+    token_path = tmp_path / "token"
+    token_path.write_text("pod-token\n", encoding="utf-8")
+    provider = TankGitHubAttestationProvider(
+        _FakeHTTP(_FakeResponse(200)),
+        operator_url="",
+        token_path=token_path,
+    )
+
+    with pytest.raises(RuntimeError, match="TANK_OPERATOR_INTERNAL_URL"):
+        asyncio.run(provider.token())

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -50,6 +50,10 @@ claude-code-credentials
 {{- if .Values.testEnv.enabled -}}{{ .Release.Name }}{{- else -}}{{ .Values.session.registryScope }}{{- end -}}
 {{- end -}}
 
+{{- define "tank-operator.internalURL" -}}
+{{ printf "http://tank-operator.%s.svc.cluster.local" (include "tank-operator.orchestratorNamespace" .) }}
+{{- end -}}
+
 {{- define "tank-operator.oauthGatewayHost" -}}
 {{- if .Values.testEnv.enabled -}}{{ printf "claude-oauth-gateway.%s.svc.cluster.local" .Release.Name }}{{- else -}}{{ .Values.oauthGateway.serviceHost }}{{- end -}}
 {{- end -}}

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: {{ include "tank-operator.sessionConfigMap" . | quote }}
             - name: SESSION_REGISTRY_SCOPE
               value: {{ include "tank-operator.sessionRegistryScope" . | quote }}
+            - name: TANK_OPERATOR_INTERNAL_URL
+              value: {{ include "tank-operator.internalURL" . | quote }}
             - name: GITHUB_APP_SECRET
               value: {{ include "tank-operator.githubAppSecret" . | quote }}
             - name: CODEX_CREDENTIALS_SECRET
@@ -94,7 +96,7 @@ spec:
             # Used only by the break-glass save-credentials endpoint that
             # captures a logged-in blob from a config-mode pod. Steady-state
             # credential rotation lives in the api-proxy's ext_proc sidecar
-            # (k8s/templates/api-proxy.yaml) — same UAMI, same env.
+            # (k8s/templates/api-proxy.yaml) â€” same UAMI, same env.
             #
             # Token file is mounted by the WI webhook because the pod
             # carries the `azure.workload.identity/use=true` label;
@@ -109,7 +111,7 @@ spec:
             - name: AZURE_AUTHORITY_HOST
               value: https://login.microsoftonline.com/
             # Cosmos DB profile store (#57). Auth is via the same workload
-            # identity as the KV writer above — DefaultAzureCredential picks
+            # identity as the KV writer above â€” DefaultAzureCredential picks
             # up the federated SA-token. Empty COSMOS_ENDPOINT puts the
             # backend's profiles store in degraded "stub" mode (logged
             # warning at startup, in-memory Profile returned for any
@@ -131,22 +133,16 @@ spec:
             # the redirect to complete.
             - name: GITHUB_APP_SLUG
               value: {{ .Values.github.appSlug | quote }}
-            # Cluster operator email (#57 stage 3) — tagged on the
-            # /api/internal/resolve-caller response so mcp-github can
-            # use the host's romaine-life-app installation for
-            # host-owned repos when a non-host caller touches them.
+            # Cluster operator email used when Tank mints GitHub MCP
+            # attestations for the host's sessions.
             - name: HOST_EMAIL
               value: {{ .Values.host.email | quote }}
             # Comma-separated emails that receive explicit super-admin
-            # behavior in MCP servers. Empty falls back to HOST_EMAIL in
-            # the orchestrator for compatibility with single-operator
-            # deployments.
+            # behavior in MCP servers. Empty uses HOST_EMAIL.
             - name: SUPER_ADMIN_EMAILS
               value: {{ .Values.superAdmins.emails | quote }}
             # Comma-separated "namespace/serviceaccount" pairs allowed to call
-            # /api/internal/*. Widened here to include mcp-tank-operator in
-            # addition to mcp-github. Override in per-slot value overlays when
-            # the SA namespace differs.
+            # the general /api/internal/session endpoints.
             - name: INTERNAL_API_ALLOWED_SUBJECTS
               value: {{ .Values.internalApi.allowedSubjects | quote }}
             # Public hostname the orchestrator uses to build session URLs in
@@ -154,7 +150,7 @@ spec:
             - name: TANK_UI_HOST
               value: {{ .Values.internalApi.tankUiHost | quote }}
             # Session-JWT signing key in Key Vault. The orchestrator never
-            # holds the private bytes — it calls KV's Sign operation per mint
+            # holds the private bytes â€” it calls KV's Sign operation per mint
             # via workload identity. See infra/jwt_signing_key.tf.
             - name: JWT_KV_VAULT
               value: {{ .Values.jwt.kvVault | quote }}
@@ -222,7 +218,7 @@ spec:
         - name: claude-credentials
           secret:
             # ESO-managed; the orchestrator's in-process rotation writes
-            # to KV and ESO mirrors KV → here within ~1m. Marked optional
+            # to KV and ESO mirrors KV â†’ here within ~1m. Marked optional
             # so first install doesn't crash-loop the pod before ESO has
             # synced (or before "+ config sub" has seeded credentials).
             secretName: {{ include "tank-operator.claudeCredentialsSecret" . }}

--- a/k8s/templates/rbac.yaml
+++ b/k8s/templates/rbac.yaml
@@ -32,9 +32,8 @@ roleRef:
   kind: Role
   name: tank-operator-sessions-mgr
 ---
-# Orchestrator SA needs auth-delegator so the /api/internal/resolve-caller
-# endpoint can call TokenReview to validate inbound mcp-github SA tokens
-# (#57 stage 3).
+# Orchestrator SA needs auth-delegator so internal endpoints can call
+# TokenReview for audience-scoped service-account tokens.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: romainecr.azurecr.io/tank-operator
   # SHA-pinned. The build workflow rewrites this line on every push to main
   # via a `[skip ci]` follow-up commit, so the cluster reconciles to the
-  # exact image CI just produced — no implicit `:latest` drift.
+  # exact image CI just produced â€” no implicit `:latest` drift.
   tag: "app-b58ef61d9ec16edb28ae4b7eb7a33c2d91ef9d1d67860ec7ba978520964d2678"
   pullPolicy: IfNotPresent
 
@@ -36,7 +36,7 @@ namespaces:
 
 orchestrator:
   # Renamed from `infra-shared` to make explicit that this SA is *not* part of the
-  # cluster's shared workload-identity pool — the orchestrator only needs in-cluster
+  # cluster's shared workload-identity pool â€” the orchestrator only needs in-cluster
   # K8s API auth (projected SA token + RoleBinding).
   serviceAccount: tank-operator
   replicas: 2
@@ -57,7 +57,7 @@ session:
   registryScope: default
   # Idle reaper: a session with no open WebSocket connections for this many
   # seconds is deleted by the orchestrator's background sweep. 7 days is
-  # effectively "manual close only" — the in-app close button is the
+  # effectively "manual close only" â€” the in-app close button is the
   # primary teardown path; this only reaps truly abandoned sessions left
   # running over a long weekend.
   idleTimeoutSeconds: 604800
@@ -101,7 +101,7 @@ apiProxy:
     repository: romainecr.azurecr.io/api-proxy
     # SHA-pinned. The api-proxy build workflow rewrites this line on every
     # push to main via a `[skip ci]` follow-up commit. The 4-space indent
-    # is load-bearing — the bump-tag sed in .github/workflows/api-proxy-build.yml
+    # is load-bearing â€” the bump-tag sed in .github/workflows/api-proxy-build.yml
     # anchors to it so the orchestrator's 2-space `  tag:` line in this same
     # file isn't accidentally rewritten.
     tag: "api-proxy-176138ce2c87da39ab75cf10bf8c03c9daa999fe7579a2c9bec3da45c68b2c92"
@@ -110,7 +110,7 @@ apiProxy:
   serviceAccount: claude-api-proxy
   serviceHost: claude-api-proxy.tank-operator.svc.cluster.local
   configSecret: claude-api-proxy-config
-  # Published to KV by infra/api_proxy.tf — separate UAMI from the
+  # Published to KV by infra/api_proxy.tf â€” separate UAMI from the
   # orchestrator's, scoped to "read+write the credentials KV secret only".
   kvClientIdKey: claude-api-proxy-mi-client-id
 
@@ -123,10 +123,10 @@ codexApiProxy:
 # Anthropic credential rotation: lives in the api-proxy's ext_proc sidecar
 # (api-proxy/src/tank_api_proxy/server.py). The sidecar caches the access
 # token, observes upstream 401s, calls platform.claude.com with the current
-# refresh token to rotate, writes the new blob back to KV. ESO mirrors KV →
+# refresh token to rotate, writes the new blob back to KV. ESO mirrors KV â†’
 # the proxy's mounted Secret on a 1m interval.
 #
-# This values block is named `credentialRefresher` for historical reasons —
+# This values block is named `credentialRefresher` for historical reasons â€”
 # the original design used a CronJob that's since been retired. The block
 # stayed because two consumers still authenticate to KV via the same UAMI:
 #   - api-proxy ext_proc sidecar: KV write of rotated blobs.
@@ -143,7 +143,7 @@ credentialRefresher:
   kvClientIdKey: claude-credentials-refresher-mi-client-id
   kvTenantIdKey: mcp-tenant-id
 
-# Cosmos DB — per-user profile store for multi-user (#57). Provisioned by
+# Cosmos DB â€” per-user profile store for multi-user (#57). Provisioned by
 # infra/cosmos.tf; same workload-identity auth path as the KV writer above
 # (the `claude-credentials-refresher-identity` UAMI carries both roles).
 # Account name is a tofu variable defaulting to `tank-operator-romaine`;
@@ -164,27 +164,21 @@ cosmos:
 github:
   appSlug: tank-operator-romaine-life
 
-# Cluster operator email — the user whose romaine-life-app installation is
-# the "host" fallback when a non-host session pod touches a host-owned repo
-# via mcp-github (#57 stage 3). Empty means no host: every caller goes
-# through the user-facing tank-operator-romaine-life App. Must match the
-# tank-operator/owner-email annotation that session pods carry, which the
-# orchestrator stamps from the signed-in user's email.
+# Tank session owner treated as the host by GitHub MCP attestations. Must match
+# the tank-operator/owner-email annotation that session pods carry.
 host:
   email: nelson@romaine.life
 
 # Comma-separated emails that receive super-admin behavior in MCP servers.
-# Empty means the orchestrator falls back to `host.email`, preserving the
-# single-operator default while making the role first-class configurable.
+# Empty means HOST_EMAIL is used.
 superAdmins:
   emails: nelson@romaine.life
 
 # Comma-separated "namespace/serviceaccount" pairs that may call the
-# /api/internal/* endpoints. The default covers mcp-github and mcp-tank-operator;
-# extend here when adding future in-cluster MCP servers that need the
-# resolve-caller or internal-session APIs.
+# general /api/internal/session endpoints. mcp-github receives Tank session
+# attestations instead of calling these endpoints directly.
 internalApi:
-  allowedSubjects: "mcp-github/mcp-github,mcp-tank-operator/mcp-tank-operator,mcp-glimmung/mcp-glimmung"
+  allowedSubjects: "mcp-tank-operator/mcp-tank-operator,mcp-glimmung/mcp-glimmung"
   # Public hostname used to build session URLs returned by internal session endpoints.
   tankUiHost: "https://tank.romaine.life"
 
@@ -203,8 +197,7 @@ externalSecret:
   # the App credentials moved to the mcp-github Deployment's own ExternalSecret
   # in the standalone mcp-github chart. Session pods never read
   # the App credentials directly; mcp-github mints installation tokens itself
-  # and authenticates session-pod → mcp-github via the projected SA token.
-  # Names retained to avoid a multi-step migration; rename when convenient.
+  # and authenticates session-pod to mcp-github via Tank session attestations.
   githubApp:
     secretName: github-app-creds
     keys:
@@ -213,7 +206,7 @@ externalSecret:
   # Claude Code subscription credentials. Lives ONLY in the orchestrator
   # namespace; session pods cannot read this Secret. KV is the source of
   # truth: the orchestrator's in-process rotation writes to KV, ESO
-  # mirrors KV → this Secret on a 1m interval, and the orchestrator pod
+  # mirrors KV â†’ this Secret on a 1m interval, and the orchestrator pod
   # mounts the Secret as a file. Re-seed via the in-app "+ config sub"
   # flow, or out-of-band by uploading a fresh credentials.json to the
   # KV secret named below.
@@ -236,11 +229,11 @@ externalSecret:
     # /etc/codex-credentials/auth.json.
     secretKey: auth.json
     kvKey: codex-credentials
-  # Auth secrets for the orchestrator's MSAL → backend JWT flow. ENTRA_CLIENT_ID
+  # Auth secrets for the orchestrator's MSAL â†’ backend JWT flow. ENTRA_CLIENT_ID
   # is the audience for verifying Entra ID tokens; ALLOWED_EMAILS
   # (comma-separated) gates which signed-in users can use the app. The session
   # JWT signing key lives in Key Vault as a Key (see jwt.kvVault/kvKeyName below)
-  # — orchestrator pods sign via the KV API per mint, so there is no JWT_SECRET
+  # â€” orchestrator pods sign via the KV API per mint, so there is no JWT_SECRET
   # to mirror into env.
   auth:
     secretName: tank-operator-auth


### PR DESCRIPTION
## Summary
- mint short-lived Tank GitHub MCP attestations from bound session pod service-account tokens
- publish the Tank JWT public key as JWKS for mcp-github verification
- wire session pod manifests and mcp-auth-proxy so only the GitHub MCP listener exchanges for Tank attestations
- remove the mcp-github service account from the general internal API allowlist and delete the resolve-caller route

## Migration notes
- no `/api/internal/resolve-caller` route remains
- GitHub MCP auth now fails closed unless Tank validates a bound session pod token and the caller has the required GitHub installation state
- the remaining `caller_pod_ip` internal helpers are for the separate internal session API used by other MCP tooling, not the mcp-github auth path

## Tests
- `go test ./cmd/tank-operator ./internal/...`
- `uv run --with pytest pytest tests` from `claude-container/mcp-auth-proxy`
- migration guard search for old mcp-github auth path terms

## Not run
- `go test ./...` on Windows: existing `cmd/tank-supervisor` Unix syscall build failure (`Setpgid`, `Getpgid`, `Kill`)
- `helm template`: `helm` is not installed in this local environment