### PR TITLE
Remove platform-mcp end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ demand. The launcher creates GUI chat and terminal agent sessions backed by
 Kubernetes pods.
 
 The Claude, Codex, and Pi session images are built from `claude-container/`
-in this repo (`Dockerfile`, plus bundled `mcp-auth-proxy`). `platform-mcp` is
-installed from its standalone
-[`nelsong6/platform-mcp`](https://github.com/nelsong6/platform-mcp) repo.
+in this repo (`Dockerfile`, plus bundled `mcp-auth-proxy`).
 Session-facing MCP config, AGENTS/CLAUDE primers, the
 bootstrap shell script, and bundled skill docs live in `k8s/session-config/` and are mounted
 through the chart's `tank-session-config` ConfigMap. [claude-container-build.yml](.github/workflows/claude-container-build.yml)

--- a/backend-go/cmd/tank-operator/handlers_mcp_test.go
+++ b/backend-go/cmd/tank-operator/handlers_mcp_test.go
@@ -11,7 +11,7 @@ func TestParseMCPServerEntries(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{
 		"mcpServers": {
 			"github": {"type": "http", "url": "http://127.0.0.1:9992/"},
-			"platform": {"command": "platform-mcp"},
+			"localfs": {"command": "localfs-mcp"},
 			"broken": "skip me",
 			"k8s": {"url": "http://127.0.0.1:9993/"}
 		}
@@ -36,9 +36,9 @@ func TestParseMCPServerEntries(t *testing.T) {
 			Enabled:   true,
 		},
 		{
-			Name:      "platform",
+			Name:      "localfs",
 			Transport: "stdio",
-			Target:    "platform-mcp",
+			Target:    "localfs-mcp",
 			Source:    "/workspace/.mcp.json",
 			Enabled:   true,
 		},

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -45,7 +45,6 @@ ARG GO_VERSION=1.26.2
 ARG VITE_VERSION=5.4.21
 ARG TYPESCRIPT_VERSION=5.9.3
 ARG TANK_AGENT=claude
-ARG PLATFORM_MCP_REF=main
 
 # ripgrep + make round out the bash surface (rg replaces grep for repo
 # search; make is needed for several of the consumed repos' dev flows).
@@ -122,9 +121,6 @@ RUN npm install -g @sandbox-agent/cli@0.4.2
 RUN pip install --no-cache-dir --break-system-packages \
         "pytest==${PYTEST_VERSION}" \
         "ruff==${RUFF_VERSION}"
-
-RUN pip install --no-cache-dir --break-system-packages \
-        "git+https://github.com/nelsong6/platform-mcp.git@${PLATFORM_MCP_REF}"
 
 # Localhost reverse proxy that injects fresh SA-token bearer auth into
 # outbound HTTP MCP calls. Runs as a sidecar container in the session

--- a/k8s/session-config/mcp.json
+++ b/k8s/session-config/mcp.json
@@ -20,9 +20,6 @@
       "type": "http",
       "url": "http://127.0.0.1:9995/"
     },
-    "platform": {
-      "command": "platform-mcp"
-    },
     "tank-operator": {
       "type": "http",
       "url": "http://127.0.0.1:9996/"


### PR DESCRIPTION
## Summary

`platform-mcp` (Python MCP server, single tool `tofu_plan_summary`) was installed into the session image and registered for both Claude and Codex sessions. Not in active use; removing per `docs/migration-policy.md` end-to-end deletion.

## Changes

| File | Change |
|---|---|
| `claude-container/Dockerfile` | Drop `ARG PLATFORM_MCP_REF` + the `pip install git+...platform-mcp.git@...` step |
| `k8s/session-config/mcp.json` | Drop the `platform` entry — every remaining MCP is HTTP |
| `README.md` | Drop the paragraph pointing at `nelsong6/platform-mcp` |
| `backend-go/cmd/tank-operator/handlers_mcp_test.go` | Replace the `platform` stdio test fixture with neutral `localfs` so the parser still has stdio coverage |

## Side effect on #459

After this lands, `mcp.json` has zero stdio entries, so the codex launch script's HTTP-only jq pipeline (the bug #459 fixes) no longer encounters the stdio shape it broke on. #459 can land or be closed independently; both options leave the system correct.

## What this doesn't touch

The standalone source repo `github.com/nelsong6/platform-mcp` is unchanged. Archive or keep it as you prefer.

## Verification

- `go test ./backend-go/cmd/tank-operator/...` passes (test fixture updated)
- After merge + claude-container rebuild, `which platform-mcp` in a fresh session pod returns nothing; codex launch script's generated `config.toml` has no `[mcp_servers.platform]` block