### PR TITLE
Add Postgres Flexible Server for tank-operator (stage 1 of Cosmos migration)

### DIFF
--- a/infra/postgres.tf
+++ b/infra/postgres.tf
@@ -1,0 +1,126 @@
+# ============================================================================
+# Azure Database for PostgreSQL — Flexible Server
+# ============================================================================
+# Replaces the tank-operator-romaine Cosmos account (profiles + session-events
+# ledger). Postgres lets us match the access patterns the inspirations doc
+# expects of a durable history store — indexed queries, real backups via PITR,
+# point-in-time recovery — without paying Cosmos's per-RU write costs.
+#
+# Sized for hobby/portfolio scale: B1ms (1 vCore burstable, 2 GiB RAM), single
+# AZ, no HA tier. ~$15/mo flat vs ~$73/mo Cosmos serverless at current write
+# volume.
+#
+# Auth: both password and AAD enabled at the server level. The orchestrator
+# pod uses AAD only (workload-identity token exchange for the DB). The
+# password is for break-glass admin access and lives in Key Vault. Disabling
+# password auth entirely is a tightening step for a follow-up once AAD-only
+# operations are confirmed.
+# ============================================================================
+
+resource "random_password" "pg_admin" {
+  length      = 32
+  special     = true
+  min_lower   = 1
+  min_upper   = 1
+  min_numeric = 1
+  min_special = 1
+  # The Postgres admin login forbids these characters in passwords.
+  override_special = "!#$%&*+-_=?"
+}
+
+resource "azurerm_postgresql_flexible_server" "tank_operator" {
+  name                = "tank-operator-pg"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+
+  version    = "16"
+  sku_name   = "B_Standard_B1ms"
+  storage_mb = 32768
+  zone       = "1"
+
+  # Public endpoint, gated by AAD auth at the data plane and the
+  # Azure-internal firewall rule below. VNet integration is a later
+  # tightening if private-only access becomes a requirement; for now this
+  # matches how `infra-cosmos-serverless` is exposed.
+  public_network_access_enabled = true
+
+  authentication {
+    active_directory_auth_enabled = true
+    password_auth_enabled         = true
+    tenant_id                     = data.azurerm_client_config.current.tenant_id
+  }
+
+  administrator_login    = "pgadmin"
+  administrator_password = random_password.pg_admin.result
+
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+
+  lifecycle {
+    ignore_changes = [
+      # AZ can be reassigned during planned maintenance; don't fight it.
+      zone,
+    ]
+  }
+}
+
+# AAD admin — the orchestrator's UAMI. Granting it administrator rather than a
+# narrower Postgres role keeps the wiring simple: the same identity that
+# already federates from the orchestrator pod becomes the DB admin, and any
+# schema migration the app runs at startup happens under that identity. If we
+# later want non-admin app roles, they get created via SQL by this admin.
+resource "azurerm_postgresql_flexible_server_active_directory_administrator" "orchestrator" {
+  server_name         = azurerm_postgresql_flexible_server.tank_operator.name
+  resource_group_name = data.azurerm_resource_group.main.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = azurerm_user_assigned_identity.credential_refresher.principal_id
+  principal_name      = azurerm_user_assigned_identity.credential_refresher.name
+  principal_type      = "ServicePrincipal"
+}
+
+resource "azurerm_postgresql_flexible_server_database" "tank_operator" {
+  name      = "tank-operator"
+  server_id = azurerm_postgresql_flexible_server.tank_operator.id
+  collation = "en_US.utf8"
+  charset   = "utf8"
+}
+
+# Firewall: allow Azure-internal traffic. The 0.0.0.0/0.0.0.0 magic rule is
+# the Flexible-Server equivalent of Cosmos's "allow Azure services" — it
+# whitelists traffic from any Azure resource in any subscription, gated by
+# AAD auth at the data plane. AKS outbound flows through the standard LB and
+# reaches this server as Azure-internal.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure_internal" {
+  name             = "allow-azure-internal"
+  server_id        = azurerm_postgresql_flexible_server.tank_operator.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+# Publish the server FQDN so the orchestrator's Helm chart can read it as an
+# ExternalSecret or env var without remote-state plumbing in the app repo.
+resource "azurerm_key_vault_secret" "postgres_host" {
+  name         = "tank-operator-pg-host"
+  value        = azurerm_postgresql_flexible_server.tank_operator.fqdn
+  key_vault_id = data.azurerm_key_vault.main.id
+}
+
+# Break-glass admin password. The orchestrator should never read this; it
+# authenticates via AAD. This is for human ops only — connect with
+# `psql "host=<fqdn> user=pgadmin dbname=tank-operator sslmode=require"`
+# and PGPASSWORD set to this value.
+resource "azurerm_key_vault_secret" "postgres_admin_password" {
+  name         = "tank-operator-pg-admin-password"
+  value        = random_password.pg_admin.result
+  key_vault_id = data.azurerm_key_vault.main.id
+}
+
+output "postgres_fqdn" {
+  value       = azurerm_postgresql_flexible_server.tank_operator.fqdn
+  description = "FQDN of the tank-operator Postgres Flexible Server."
+}
+
+output "postgres_database_name" {
+  value       = azurerm_postgresql_flexible_server_database.tank_operator.name
+  description = "Name of the application database inside the Flexible Server."
+}


### PR DESCRIPTION
## Summary

Stage 1 of migrating tank-operator''s durable history layer from Cosmos DB to Azure Database for PostgreSQL — Flexible Server. This PR is **additive only**: it provisions the Postgres server alongside the existing Cosmos account. No application traffic moves to Postgres in this PR; backend-go and the Helm chart are untouched.

## What''s provisioned

- `azurerm_postgresql_flexible_server.tank_operator` — B1ms (1 vCore burstable / 2 GiB RAM), 32 GiB storage, single zone, no HA tier, version 16
- `azurerm_postgresql_flexible_server_database.tank_operator` — application database
- AAD admin = the orchestrator `credential_refresher` UAMI (same identity that has Cosmos Data Contributor today)
- Public endpoint with the `0.0.0.0/0.0.0.0` Azure-internal firewall rule (matches how `infra-cosmos-serverless` is exposed; gated by AAD auth at the data plane)
- KV secrets: `tank-operator-pg-host` (FQDN, app-readable) and `tank-operator-pg-admin-password` (break-glass only)

## Cost delta

- Adds: ~$15/mo (B1ms compute + 32 GiB storage + 7-day PITR included)
- Removes (after stage 3): ~$73/mo Cosmos
- Net once migration completes: **~$58/mo savings**

This PR alone *adds* $15/mo until stage 3 lands — overlap is intentional so the cutover can be a clean code switch rather than a database migration under load.

## Auth choice

Both password and AAD auth are enabled at the server level. The orchestrator pod uses AAD only — it exchanges its workload-identity-issued token for the DB via the `ossrdbms-aad.database.windows.net` resource. The admin password is for human break-glass via `psql` and lives in Key Vault; the application path never reads it. Disabling password auth entirely is a tightening step for a follow-up once AAD-only operations are confirmed working in production.

## Why public endpoint over VNet integration

VNet integration would require a delegated subnet in the AKS VNet (a cross-repo change to `infra-bootstrap`) and a private DNS zone. For now this matches the existing pattern (Cosmos is also public with AAD-only auth), and tightening to private access is a clean follow-up that doesn''t affect the application code.

## What stages 2 and 3 look like

**Stage 2** (separate PR, backend-go + Helm changes):
- Add `pgx` driver to `backend-go`
- Implement Postgres-backed `store` and `sessionbus` packages mirroring the Cosmos client surface
- Schema migration: `profiles` table (PK email), `session_events` table (composite PK on `tank_session_id` + event id, indexed for the access patterns in `handlers_session_events.go` and `handlers_turns.go`)
- Helm chart picks up the FQDN from the new KV secret via ExternalSecret
- Deploy: backend dual-reads/writes to both Cosmos and Postgres so a rollback is a config flip

**Stage 3** (separate PR):
- Switch reads to Postgres
- Stop writes to Cosmos
- Backfill `profiles` rows from Cosmos to Postgres (small, single-shot; session-events is high-volume but TTL-bounded to 30 days and reconstructible from JetStream replay during cutover)
- Decommission Cosmos resources (cosmos.tf → removed.tf)