### PR TITLE
Pin Postgres Flexible Server to westus3

### DIFF
--- a/infra/postgres.tf
+++ b/infra/postgres.tf
@@ -31,7 +31,14 @@ resource "random_password" "pg_admin" {
 resource "azurerm_postgresql_flexible_server" "tank_operator" {
   name                = "tank-operator-pg"
   resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
+
+  # Pinned to westus3 because the subscription's westus2 capacity for
+  # Flexible Server is currently restricted (`LocationIsOfferRestricted`).
+  # westus3 is in the same physical area as westus2; latency from AKS in
+  # westus2 to this DB is comparable to intra-region and egress cost at the
+  # current write volume is sub-dollar. Move back to westus2 if/when the
+  # quota request lands (https://aka.ms/postgres-request-quota-increase).
+  location = "westus3"
 
   version    = "16"
   sku_name   = "B_Standard_B1ms"


### PR DESCRIPTION
## Summary

[#463](https://github.com/nelsong6/tank-operator/pull/463) merged but the apply failed with `LocationIsOfferRestricted` in westus2:

> Subscriptions are restricted from provisioning in location ''westus2''. Try again in a different location.

westus3 is in the same physical area as westus2; cross-region latency from AKS (westus2) to this DB will feel like intra-region at this volume, and egress traffic between the two regions costs sub-dollar/month at the current session-event write rate. If/when the [quota request](https://aka.ms/postgres-request-quota-increase) for westus2 lands, this can move back.

## Verification

The merge of this PR re-triggers the workflow which retries `tofu apply`. The `random_password` + KV admin password secret from the first apply are already in state and unchanged by this edit — only the server location moves.