### PR TITLE
Rename Postgres server to tank-operator-db

### DIFF
--- a/infra/postgres.tf
+++ b/infra/postgres.tf
@@ -29,7 +29,7 @@ resource "random_password" "pg_admin" {
 }
 
 resource "azurerm_postgresql_flexible_server" "tank_operator" {
-  name                = "tank-operator-pg"
+  name                = "tank-operator-db"
   resource_group_name = data.azurerm_resource_group.main.name
 
   # Pinned to westus3 because the subscription's westus2 capacity for


### PR DESCRIPTION
## Summary

The first-apply attempt at `tank-operator-pg` in westus2 hit the regional offer restriction and rolled back, but Azure has retained a phantom name reservation that ARM resource list and the name-availability API both deny exist. Subsequent applies (with location changed to westus3) keep getting `409 Conflict: The resource already exists in location westus2`.

Renaming to `tank-operator-db` sidesteps the stuck reservation. The name only lives in DNS (`<name>.postgres.database.azure.com`) and the FQDN stored in the `tank-operator-pg-host` Key Vault secret. KV secret names themselves are unchanged — they describe *what* they store, not the server name.

After this merges, the workflow will retry apply and should successfully create the server in westus3.