### PR TITLE
Wire up mcp-auth UAMI in infra/mcp.tf

### DIFF
--- a/infra/mcp.tf
+++ b/infra/mcp.tf
@@ -96,3 +96,27 @@ module "mcp_tank_operator" {
 
   role_assignments = {}
 }
+
+# ----------------------------------------------------------------------------
+# Per-server: auth
+# ----------------------------------------------------------------------------
+# Admin MCP for auth.romaine.life user management — list/promote/enroll
+# users from a tank-operator session pod instead of clicking through the
+# /admin console. Like mcp_tank_operator, this server's only outbound work
+# is HTTP against auth.romaine.life's admin endpoints, so no Azure
+# role_assignments. The UAMI exists so CI federation + the kv-published
+# client ID land before the mcp-auth chart needs them.
+
+module "mcp_auth" {
+  source = "./mcp-server"
+
+  name                     = "auth"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  resource_group_location  = data.azurerm_resource_group.main.location
+  key_vault_id             = data.azurerm_key_vault.main.id
+  aks_oidc_issuer_url      = local.aks_oidc_issuer_url
+  aks_namespace            = "mcp-auth"
+  aks_service_account_name = "mcp-auth"
+
+  role_assignments = {}
+}


### PR DESCRIPTION
## Summary

Adds the tank-operator-side wiring for the new mcp-auth MCP server (scaffolded in [nelsong6/mcp-auth](https://github.com/nelsong6/mcp-auth), wired up to AKS + CI in [nelsong6/infra-bootstrap#114](https://github.com/nelsong6/infra-bootstrap/pull/114)).

A new \`mcp_auth\` module call in \`infra/mcp.tf\` creates the UAMI for the mcp-auth pod, federates it to the \`mcp-auth/mcp-auth\` K8s SA, and publishes the client ID to KV so the chart's ExternalSecret has something to mount. Same shape as \`mcp_tank_operator\` — no Azure role_assignments since the server's only outbound work is HTTP against auth.romaine.life's /admin endpoints.

## Test plan

- [ ] tofu plan: shows a new UAMI \`mcp-auth\`, federated credential to \`system:serviceaccount:mcp-auth:mcp-auth\`, and the KV secret \`mcp-auth-mi-client-id\`
- [ ] tofu apply: resources land; nothing else changes
- [ ] After mcp-auth chart deploys (via infra-bootstrap#114): the pod's workload identity successfully calls auth.romaine.life with the UAMI-minted federated token

🤖 Generated with [Claude Code](https://claude.com/claude-code)