### PR TITLE
Fix startLogin URL to point at auth.romaine.life /sign-in/microsoft

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -145,7 +145,12 @@ export async function bootstrapAuth(): Promise<SessionUser | null> {
 export async function startLogin(): Promise<void> {
   const config = await fetchConfig();
   const callbackURL = encodeURIComponent(window.location.origin + window.location.pathname);
-  window.location.href = `${config.auth_url}/api/auth/sign-in/social/microsoft?callbackURL=${callbackURL}`;
+  // auth.romaine.life exposes a GET endpoint at /sign-in/microsoft that
+  // takes callbackURL as a query param, kicks off Better Auth's social
+  // flow, and 302s back to the callback once Microsoft completes. The
+  // Better Auth routes under /api/auth/* are POST-only, so a top-level
+  // GET redirect there 404s.
+  window.location.href = `${config.auth_url}/sign-in/microsoft?callbackURL=${callbackURL}`;
 }
 
 export async function logout(): Promise<void> {


### PR DESCRIPTION
## Problem

\`startLogin\` in [frontend/src/auth.ts](frontend/src/auth.ts:144) redirected to \`\${auth_url}/api/auth/sign-in/social/microsoft?callbackURL=…\` and 404'd at auth.romaine.life. Better Auth's routes under \`/api/auth/*\` are POST-only — a top-level GET redirect there finds nothing.

## Fix

Point at \`\${auth_url}/sign-in/microsoft?callbackURL=…\` — a GET handler [nelsong6/auth#14](https://github.com/nelsong6/auth/pull/14) adds to wrap Better Auth's social flow with a query-param callbackURL.

## Test plan

- [x] \`npm run build\` clean
- [ ] After both this and the auth PR deploy: click Sign in on https://tank.romaine.life, complete Microsoft sign-in, land back on tank signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)