### PR TITLE
Real Prometheus metrics + structured 5xx logging across all services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,23 @@ or cleanup work. Read
 [docs/product-inspirations.md](docs/product-inspirations.md) when making
 product or architecture decisions.
 
+## Observability
+
+Every service in this repo (orchestrator, agent-runner, codex-runner,
+api-proxy, mcp-auth-proxy) exposes Prometheus metrics under the `tank_*`
+namespace and is scraped by the kube-prometheus-stack in the `monitoring`
+namespace. The orchestrator HTTP middleware emits a structured
+`slog.Error` line on every 5xx with `method`, `route`, `email`, and the
+response body's `detail` field — that log is the first stop for any
+"endpoint X returned 500" investigation. The Grafana dashboard
+auto-loads from a ConfigMap; PrometheusRule alerts cover the user-trust
+failure modes (refresh storms, schema-rejected events, SA-token read
+failures). The full taxonomy, cardinality rules, and the "adding a new
+metric" recipe live in [docs/observability.md](docs/observability.md);
+the migration guard at `scripts/check-removed-chat-runtime.mjs` blocks
+re-introduction of the deleted expvar surface (the ad-hoc JSON metrics
+endpoint that preceded `/metrics`).
+
 ## Migration audit checklist (procedural)
 
 The migration-policy doc is not values — it is a checklist. Before declaring

--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
         "@nats-io/jetstream": "^3.4.0",
-        "@nats-io/transport-node": "^3.4.0"
+        "@nats-io/transport-node": "^3.4.0",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -285,6 +286,15 @@
         "node": ">= 18.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
@@ -340,6 +350,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1063,6 +1079,19 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1297,6 +1326,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/toidentifier": {

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@nats-io/jetstream": "^3.4.0",
-    "@nats-io/transport-node": "^3.4.0"
+    "@nats-io/transport-node": "^3.4.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -3,7 +3,14 @@
 // canonical transcript events to the session bus.
 
 import { loadConfig } from "./config.js";
+import { startMetricsServer } from "./metrics.js";
 import { Runner } from "./runner.js";
+
+// Metrics listen port. Bound to a separate listener from any other
+// pod-internal HTTP surface so the kube-prometheus-stack PodMonitor
+// scrape can target it directly. Default matches k8s/templates/
+// values.yaml's runner.metricsPort.
+const DEFAULT_METRICS_PORT = 9095;
 
 async function main(): Promise<void> {
   const cfg = loadConfig();
@@ -18,16 +25,35 @@ async function main(): Promise<void> {
     }),
   );
 
+  const metricsPort = parseMetricsPort(process.env.TANK_RUNNER_METRICS_PORT);
+  const metricsServer = startMetricsServer(metricsPort);
+  console.log(JSON.stringify({ msg: "metrics listening", port: metricsPort }));
+
   const ctrl = new AbortController();
   const shutdown = (sig: NodeJS.Signals) => {
     console.log(JSON.stringify({ msg: "shutdown", signal: sig }));
     ctrl.abort();
+    metricsServer.close();
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
   const runner = new Runner(cfg);
-  await runner.run(ctrl.signal);
+  try {
+    await runner.run(ctrl.signal);
+  } finally {
+    metricsServer.close();
+  }
+}
+
+function parseMetricsPort(raw: string | undefined): number {
+  const trimmed = raw?.trim() ?? "";
+  if (trimmed === "") return DEFAULT_METRICS_PORT;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) {
+    throw new Error(`TANK_RUNNER_METRICS_PORT is not a valid port: ${raw}`);
+  }
+  return Math.trunc(n);
 }
 
 main().catch((err) => {

--- a/agent-runner/src/metrics.test.ts
+++ b/agent-runner/src/metrics.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+
+import {
+  pendingWakeupsGauge,
+  recordTurnStart,
+  recordTurnTerminal,
+  registry,
+  startMetricsServer,
+} from "./metrics.js";
+
+test("metrics endpoint serves prom-format with tank_runner_ counters", async () => {
+  const server = startMetricsServer(0);
+  await once(server, "listening");
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object", "metrics server bound");
+  const port = (addr as { port: number }).port;
+
+  // Drive a counter so the scrape has something to assert.
+  pendingWakeupsGauge.inc();
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/metrics`);
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /tank_runner_pending_wakeups\{mode="claude"\} 1/);
+    assert.match(body, /tank_runner_commands_consumed_total/);
+    assert.match(body, /tank_runner_turn_duration_seconds/);
+  } finally {
+    pendingWakeupsGauge.dec();
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("recordTurnStart + recordTurnTerminal observes a duration", async () => {
+  // Clear any prior observations so this test is deterministic when run
+  // alongside other tests in the same process.
+  await registry.resetMetrics();
+
+  recordTurnStart("turn-123");
+  recordTurnTerminal("turn-123", "completed");
+
+  const dump = await registry.metrics();
+  // The histogram's _count series increments by 1 per Observe regardless
+  // of value, so this is robust against timing flakiness. Label order
+  // is prom-client-internal and not part of our API; the regex matches
+  // any order containing outcome="completed" and mode="claude".
+  assert.match(
+    dump,
+    /tank_runner_turn_duration_seconds_count\{(?=[^}]*outcome="completed")(?=[^}]*mode="claude")[^}]*\} 1/,
+  );
+});
+
+test("recordTurnTerminal without a matching start is a no-op", async () => {
+  await registry.resetMetrics();
+  recordTurnTerminal("never-started", "failed");
+  const dump = await registry.metrics();
+  // Either the metric isn't emitted at all, or its count is 0. The
+  // prom-client default is to emit a 0 value once the metric has been
+  // touched; resetMetrics() clears the per-label state too, so this
+  // line shouldn't appear at all.
+  assert.doesNotMatch(
+    dump,
+    /tank_runner_turn_duration_seconds_count\{(?=[^}]*outcome="failed")(?=[^}]*mode="claude")[^}]*\} [1-9]/,
+  );
+});

--- a/agent-runner/src/metrics.ts
+++ b/agent-runner/src/metrics.ts
@@ -1,0 +1,107 @@
+// Prometheus instrumentation for the pod-side agent runner. The metric
+// taxonomy mirrors the orchestrator's tank_* namespace and is documented
+// in docs/observability.md. Cardinality discipline: no `pod_name`,
+// `session_id`, `turn_id`, or `email` labels — anything that grows per
+// session-pod blows up Prometheus active series at scale.
+//
+// The single mutable label is `mode`, set to "claude" here. The
+// codex-runner ships an identical module with `mode: "codex"`.
+
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from "prom-client";
+import { createServer, type Server } from "node:http";
+
+const RUNNER_MODE = "claude";
+
+export const registry = new Registry();
+registry.setDefaultLabels({ mode: RUNNER_MODE });
+collectDefaultMetrics({ register: registry });
+
+export const commandsConsumedTotal = new Counter({
+  name: "tank_runner_commands_consumed_total",
+  help: "Session commands consumed from the JetStream command subject.",
+  labelNames: ["kind", "result"],
+  registers: [registry],
+});
+
+export const turnDurationSeconds = new Histogram({
+  name: "tank_runner_turn_duration_seconds",
+  help: "End-to-end duration from turn.started to the terminal turn event.",
+  labelNames: ["outcome"],
+  buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
+  registers: [registry],
+});
+
+export const providerErrorTotal = new Counter({
+  name: "tank_runner_provider_error_total",
+  help: "Errors raised by the provider SDK (the query iterator or interrupt() call).",
+  labelNames: ["kind"],
+  registers: [registry],
+});
+
+export const pendingWakeupsGauge = new Gauge({
+  name: "tank_runner_pending_wakeups",
+  help: "Currently-pending ScheduleWakeup timers held in this runner process.",
+  registers: [registry],
+});
+
+export const natsPublishFailureTotal = new Counter({
+  name: "tank_runner_nats_publish_failure_total",
+  help: "Publish attempts to the JetStream session bus that returned an error.",
+  registers: [registry],
+});
+
+// turnStartTimes tracks turn.started timestamps so we can observe a
+// duration when the terminal turn event arrives. The map is per-runner-
+// process and unbounded only if turns leak (no terminal event ever
+// arrives); steady-state size is the active-turn count, at most a
+// handful even under fan-in.
+const turnStartTimes = new Map<string, number>();
+
+export function recordTurnStart(turnID: string): void {
+  if (!turnID) return;
+  turnStartTimes.set(turnID, Date.now());
+}
+
+export function recordTurnTerminal(
+  turnID: string,
+  outcome: "completed" | "failed" | "interrupted",
+): void {
+  if (!turnID) return;
+  const start = turnStartTimes.get(turnID);
+  if (start === undefined) return;
+  turnStartTimes.delete(turnID);
+  turnDurationSeconds.labels(outcome).observe((Date.now() - start) / 1000);
+}
+
+export function startMetricsServer(port: number): Server {
+  const server = createServer((req, res) => {
+    if (!req.url) {
+      res.statusCode = 400;
+      res.end();
+      return;
+    }
+    if (req.url === "/metrics" || req.url.startsWith("/metrics?")) {
+      registry
+        .metrics()
+        .then((body) => {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", registry.contentType);
+          res.end(body);
+        })
+        .catch((err: unknown) => {
+          res.statusCode = 500;
+          res.end(`metrics collection failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      return;
+    }
+    if (req.url === "/healthz") {
+      res.statusCode = 200;
+      res.end("ok");
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  server.listen(port);
+  return server;
+}

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -48,6 +48,14 @@ import {
   commandClientNonce,
   type SessionCommandRecord,
 } from "./sessionCommands.js";
+import {
+  commandsConsumedTotal,
+  natsPublishFailureTotal,
+  pendingWakeupsGauge,
+  providerErrorTotal,
+  recordTurnStart,
+  recordTurnTerminal,
+} from "./metrics.js";
 import { extractWakeup, type WakeupRequest } from "./wakeup.js";
 
 // Pull a single dispatch out as a free function so the session-bus publish
@@ -73,6 +81,7 @@ export async function dispatch(
     await sink.upsert(stamped);
   } catch (err) {
     console.error("session bus publish failed:", err);
+    natsPublishFailureTotal.inc();
     return false;
   }
   return true;
@@ -207,6 +216,7 @@ export class Runner {
       }
     } catch (err) {
       console.error("SDK query exited with error:", err);
+      providerErrorTotal.labels("query").inc();
       await this.failActiveCommandTurn(err);
     } finally {
       signal.removeEventListener("abort", onAbort);
@@ -278,16 +288,20 @@ export class Runner {
   }
 
   private async acceptCommandTurn(record: SessionCommandRecord): Promise<void> {
+    commandsConsumedTotal.labels("submit_turn", "accepted").inc();
     const clientNonce = commandClientNonce(record);
     const prompt = String(record.prompt ?? "").trim();
     if (!prompt) {
+      commandsConsumedTotal.labels("submit_turn", "invalid").inc();
       await this.commandBus.markFailed(record, new Error("submit command missing prompt"));
       return;
     }
     if (await this.finalizeCommandIfAlreadyTerminal(record, clientNonce)) {
+      commandsConsumedTotal.labels("submit_turn", "already_terminal").inc();
       return;
     }
     if (this.commandBus.attemptsExceeded(record)) {
+      commandsConsumedTotal.labels("submit_turn", "attempts_exceeded").inc();
       await this.failCommandRecord(
         record,
         new Error(`session command exceeded ${record.attempt_count ?? "unknown"} claim attempts`),
@@ -296,6 +310,7 @@ export class Runner {
     }
     const pendingTurn = this.acceptTurn(prompt, clientNonce, record);
     if (!pendingTurn) {
+      commandsConsumedTotal.labels("submit_turn", "invalid").inc();
       await this.commandBus.markFailed(record, new Error("session command was not accepted"));
       return;
     }
@@ -310,12 +325,18 @@ export class Runner {
   }
 
   private async acceptInterrupt(record: SessionCommandRecord): Promise<void> {
+    commandsConsumedTotal.labels("interrupt_turn", "accepted").inc();
     const outcome = await this.interruptActiveTurn(
       "client_interrupt",
       record.target_turn_id || record.client_nonce,
     );
     if (outcome === "interrupted") {
-      this.sdkQuery?.interrupt();
+      try {
+        this.sdkQuery?.interrupt();
+      } catch (err) {
+        providerErrorTotal.labels("interrupt").inc();
+        throw err;
+      }
       await this.commandBus.markCompleted(record);
       return;
     }
@@ -327,21 +348,26 @@ export class Runner {
   }
 
   private async acceptInputReply(record: SessionCommandRecord): Promise<void> {
+    commandsConsumedTotal.labels("input_reply", "accepted").inc();
     const targetProviderItemID = inputReplyTargetProviderItemID(record);
     const text = inputReplyText(record);
     if (!targetProviderItemID || !text) {
+      commandsConsumedTotal.labels("input_reply", "invalid").inc();
       await this.commandBus.markFailed(record, new Error("input reply missing target or text"));
       return;
     }
     if (!this.activeTurn || !this.turnMatchesTarget(this.activeTurn, record.target_turn_id || record.client_nonce)) {
+      commandsConsumedTotal.labels("input_reply", "no_active_turn").inc();
       await this.commandBus.markFailed(record, new Error("input reply target turn is not active"));
       return;
     }
     if (!this.needsInputProviderItemIDs.has(targetProviderItemID)) {
+      commandsConsumedTotal.labels("input_reply", "not_waiting_for_input").inc();
       await this.commandBus.markFailed(record, new Error("input reply target is not waiting for input"));
       return;
     }
     if (this.pendingInputReplies.has(targetProviderItemID)) {
+      commandsConsumedTotal.labels("input_reply", "duplicate").inc();
       await this.commandBus.markFailed(record, new Error("input reply already pending for target"));
       return;
     }
@@ -385,6 +411,7 @@ export class Runner {
       this.activeTurn = this.pendingTurns.shift() ?? null;
       if (this.activeTurn && !this.activeTurn.started) {
         this.activeTurn.started = true;
+        recordTurnStart(this.activeTurn.turnID);
         await dispatch(
           this.sink,
           turnEvent({
@@ -440,6 +467,8 @@ export class Runner {
     turn: PendingTurn,
     type: "turn.completed" | "turn.failed" | "turn.interrupted",
   ): Promise<void> {
+    const outcome = type === "turn.completed" ? "completed" : type === "turn.failed" ? "failed" : "interrupted";
+    recordTurnTerminal(turn.turnID, outcome);
     await this.failPendingInputRepliesForTurn(turn, new Error(type));
     if (!turn.commandRecord) return;
     const record = turn.commandRecord;
@@ -509,7 +538,9 @@ export class Runner {
 
   private scheduleWakeup(req: WakeupRequest): void {
     const delayMs = Math.max(0, req.delayMs);
+    pendingWakeupsGauge.inc();
     setTimeout(() => {
+      pendingWakeupsGauge.dec();
       void this.commandBus
         .enqueueWakeupSubmitTurn({
           prompt: req.prompt,

--- a/api-proxy/pyproject.toml
+++ b/api-proxy/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     # actually persist rotations back to KV (otherwise we'd leak rotations
     # on every restart — see _persist_to_kv comment).
     "aiohttp>=3.10",
+    # Prometheus client for /metrics. The aiohttp listener that serves
+    # /metrics is wired in tank_api_proxy.metrics.start_metrics_server.
+    "prometheus-client>=0.20",
 ]
 
 [build-system]

--- a/api-proxy/src/tank_api_proxy/__main__.py
+++ b/api-proxy/src/tank_api_proxy/__main__.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 
+from .metrics import start_metrics_server
 from .server import serve
 
 
@@ -19,7 +20,9 @@ def main() -> None:
 
 async def _run() -> None:
     port = int(os.environ.get("EXT_PROC_PORT", "9000"))
+    metrics_port = int(os.environ.get("METRICS_PORT", "9100"))
     server = await serve(port)
+    metrics_runner = await start_metrics_server(metrics_port)
     stop = asyncio.Event()
 
     def _shutdown(*_: object) -> None:
@@ -36,6 +39,7 @@ async def _run() -> None:
 
     await stop.wait()
     await server.stop(grace=5)
+    await metrics_runner.cleanup()
 
 
 if __name__ == "__main__":

--- a/api-proxy/src/tank_api_proxy/metrics.py
+++ b/api-proxy/src/tank_api_proxy/metrics.py
@@ -1,0 +1,149 @@
+"""Prometheus instrumentation for the api-proxy ext_proc service.
+
+The api-proxy is deployed twice — once for Anthropic (provider="anthropic")
+and once for ChatGPT/Codex (provider="chatgpt-codex"). The two deployments
+share this code and the ``provider`` label distinguishes their metrics at
+scrape time so Grafana can show them on one dashboard.
+
+Cardinality discipline matches the orchestrator's: bounded labels only.
+``provider`` has two values; ``result`` is a small enum; ``status_class``
+is the 2xx/3xx/4xx/5xx bucket. No per-call labels (request_id, user, etc.).
+
+The HTTP listener is separate from the gRPC ext_proc listener so the
+kube-prometheus-stack ServiceMonitor can scrape /metrics independently
+without colliding with the ext_proc port.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from aiohttp import web
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+log = logging.getLogger(__name__)
+
+# Provider label is bound at module import time from PROXY_PROVIDER, the
+# same env var server._config_from_env reads to choose credentials and
+# token URL. Values match the server: "claude" or "codex". Setting it
+# once avoids threading the label through every call site and keeps the
+# series partitioned by deployment.
+PROVIDER = (os.environ.get("PROXY_PROVIDER") or "claude").strip().lower() or "claude"
+
+ext_proc_requests_total = Counter(
+    "tank_api_proxy_requests_total",
+    "Inbound request_headers messages handled by the ext_proc service.",
+    ["provider", "outcome"],
+)
+
+upstream_status_total = Counter(
+    "tank_api_proxy_upstream_status_total",
+    "Upstream :status responses observed via response_headers.",
+    ["provider", "status_class"],
+)
+
+upstream_401_total = Counter(
+    "tank_api_proxy_upstream_401_total",
+    "Upstream 401 responses on injected requests (the refresh-storm signature).",
+    ["provider"],
+)
+
+token_refresh_total = Counter(
+    "tank_api_proxy_token_refresh_total",
+    "Token refresh attempts against the upstream OAuth endpoint.",
+    ["provider", "result"],
+)
+
+refresh_duration_seconds = Histogram(
+    "tank_api_proxy_refresh_duration_seconds",
+    "Wall-clock duration of a token refresh attempt.",
+    ["provider", "result"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+)
+
+kv_persist_total = Counter(
+    "tank_api_proxy_kv_persist_total",
+    "Attempts to write a rotated blob back to Key Vault.",
+    ["provider", "result"],
+)
+
+single_flight_waits_total = Counter(
+    "tank_api_proxy_single_flight_waits_total",
+    "Callers that awaited an already-in-flight refresh task instead of "
+    "starting a new one (the single-flight dedupe success path).",
+    ["provider"],
+)
+
+
+def record_ext_proc_request(outcome: str) -> None:
+    """outcome is one of: injected, passthrough, missing_token."""
+    ext_proc_requests_total.labels(provider=PROVIDER, outcome=outcome).inc()
+
+
+def record_upstream_status(status: int | None) -> None:
+    if status is None:
+        return
+    bucket = _status_class(status)
+    upstream_status_total.labels(provider=PROVIDER, status_class=bucket).inc()
+    if status == 401:
+        upstream_401_total.labels(provider=PROVIDER).inc()
+
+
+def record_refresh(result: str, duration_seconds: float | None = None) -> None:
+    """result is one of: success, http_error, request_failed, no_refresh_token."""
+    token_refresh_total.labels(provider=PROVIDER, result=result).inc()
+    if duration_seconds is not None:
+        refresh_duration_seconds.labels(provider=PROVIDER, result=result).observe(duration_seconds)
+
+
+def record_kv_persist(result: str) -> None:
+    """result is one of: success, failure, skipped."""
+    kv_persist_total.labels(provider=PROVIDER, result=result).inc()
+
+
+def record_single_flight_wait() -> None:
+    single_flight_waits_total.labels(provider=PROVIDER).inc()
+
+
+def _status_class(status: int) -> str:
+    if 200 <= status < 300:
+        return "2xx"
+    if 300 <= status < 400:
+        return "3xx"
+    if 400 <= status < 500:
+        return "4xx"
+    if 500 <= status < 600:
+        return "5xx"
+    return "unknown"
+
+
+async def _handle_metrics(_: web.Request) -> web.Response:
+    return web.Response(body=generate_latest(), content_type=CONTENT_TYPE_LATEST.split(";")[0], charset="utf-8")
+
+
+async def _handle_healthz(_: web.Request) -> web.Response:
+    return web.Response(text="ok")
+
+
+async def start_metrics_server(port: int) -> web.AppRunner:
+    app = web.Application()
+    app.router.add_get("/metrics", _handle_metrics)
+    app.router.add_get("/healthz", _handle_healthz)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="0.0.0.0", port=port)
+    await site.start()
+    log.info("api-proxy metrics listening on 0.0.0.0:%d (provider=%s)", port, PROVIDER)
+    return runner
+
+
+__all__ = [
+    "PROVIDER",
+    "record_ext_proc_request",
+    "record_kv_persist",
+    "record_refresh",
+    "record_single_flight_wait",
+    "record_upstream_status",
+    "start_metrics_server",
+]

--- a/api-proxy/src/tank_api_proxy/server.py
+++ b/api-proxy/src/tank_api_proxy/server.py
@@ -93,6 +93,14 @@ from envoy.service.ext_proc.v3 import external_processor_pb2_grpc as ext_proc_gr
 from envoy.config.core.v3 import base_pb2
 from envoy.type.v3 import http_status_pb2
 
+from .metrics import (
+    record_ext_proc_request,
+    record_kv_persist,
+    record_refresh,
+    record_single_flight_wait,
+    record_upstream_status,
+)
+
 log = logging.getLogger(__name__)
 
 # Hardcoded into Claude Code's bundled JS. Two distinct client_ids ship in
@@ -309,6 +317,7 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
         # If we overwrite that Authorization with our OAuth Bearer the
         # /worker endpoint 401s — Anthropic rejects the OAuth token there.
         if inbound != PLACEHOLDER_BEARER:
+            record_ext_proc_request("passthrough")
             return (
                 ext_proc_pb2.ProcessingResponse(
                     request_headers=ext_proc_pb2.HeadersResponse()
@@ -316,6 +325,10 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
                 False,
             )
         token = await self._get_access_token()
+        if token == "missing":
+            record_ext_proc_request("missing_token")
+        else:
+            record_ext_proc_request("injected")
         set_headers = [
             base_pb2.HeaderValueOption(
                 header=base_pb2.HeaderValue(
@@ -367,6 +380,7 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
         # if /worker endpoints loop on 401.
         if was_injected:
             status = _peek_status(msg)
+            record_upstream_status(status)
             if status == 401:
                 self._access_invalidated = True
                 # Single-flight: only schedule a refresh if one isn't
@@ -388,6 +402,7 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
         # and the upstream re-401'd, scheduling yet another refresh.
         task = self._refresh_task
         if task is not None and not task.done():
+            record_single_flight_wait()
             try:
                 await task
             except Exception:
@@ -529,8 +544,10 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
             self._reload_from_file()
             if self._cached_refresh is None:
                 log.error("no refresh token available; cannot rotate")
+                record_refresh("no_refresh_token")
                 return
             log.info("calling %s to rotate %s token", self._config.token_url, self._config.provider)
+            refresh_start = time.monotonic()
             try:
                 async with httpx.AsyncClient(timeout=30.0) as http:
                     resp = await http.post(
@@ -544,9 +561,11 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
                     )
             except Exception:
                 log.exception("refresh request crashed; keeping existing tokens")
+                record_refresh("request_failed", time.monotonic() - refresh_start)
                 return
             if resp.status_code != 200:
                 log.error("refresh failed: status=%s body=%s", resp.status_code, resp.text[:500])
+                record_refresh("http_error", time.monotonic() - refresh_start)
                 return
             data = resp.json()
             new_access = data["access_token"]
@@ -575,6 +594,7 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
                 new_access[:12],
                 expires_in,
             )
+            record_refresh("success", time.monotonic() - refresh_start)
             await self._persist_to_kv(expires_in)
 
     async def _persist_to_kv(self, expires_in: int) -> None:
@@ -591,6 +611,7 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
         just log and move on.
         """
         if not self._kv_url or self._cached_blob is None:
+            record_kv_persist("skipped")
             return
         try:
             cred = DefaultAzureCredential()
@@ -603,10 +624,12 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
                     self._config.kv_secret_name,
                     expires_in,
                 )
+                record_kv_persist("success")
             finally:
                 await cred.close()
         except Exception:
             log.exception("KV write failed; tokens stay in memory only")
+            record_kv_persist("failure")
 
 
 def _peek_header(msg: ext_proc_pb2.HttpHeaders, name: str) -> str | None:

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -147,7 +147,7 @@ func main() {
 	mgr.StartReaper(ctx)
 	if sessionBus != nil {
 		go func() {
-			if err := sessionBus.RunEventPersister(ctx, sessionEventsStore, expvarPersisterMetrics{}); err != nil {
+			if err := sessionBus.RunEventPersister(ctx, sessionEventsStore, promPersisterMetrics{}); err != nil {
 				slog.Error("session bus event persister stopped", "error", err)
 			}
 		}()
@@ -179,10 +179,14 @@ func main() {
 	}
 	srv.registerRoutes(mux)
 
-	// 14. Listen and serve.
+	// 14. Listen and serve. Every request flows through
+	// httpInstrumentationMiddleware so 5xx errors carry method, route,
+	// email, and the underlying detail field to slog — the missing
+	// context that made "/api/sessions/activity returned 500"
+	// undebuggable from logs.
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           httpInstrumentationMiddleware(mux),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	slog.Info("starting tank-operator go server", "addr", addr)
@@ -244,10 +248,11 @@ func buildPostgresPool(azCred *azidentity.DefaultAzureCredential) *pgxpool.Pool 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	pool, err := pgstore.NewPool(ctx, pgstore.Config{
-		Host:       host,
-		Database:   database,
-		Username:   username,
-		Credential: azCred,
+		Host:         host,
+		Database:     database,
+		Username:     username,
+		Credential:   azCred,
+		QueryMetrics: promPGMetrics{},
 	})
 	if err != nil {
 		slog.Error("postgres pool init failed", "error", err)
@@ -299,12 +304,13 @@ func buildSessionBus(scope string) *sessionbus.Bus {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	bus, err := sessionbus.Connect(ctx, sessionbus.Config{
-		URL:         url,
-		Token:       os.Getenv("NATS_TOKEN"),
-		Stream:      envDefault("NATS_STREAM", "TANK_SESSION_BUS"),
-		Scope:       scope,
-		Replicas:    replicas,
-		WakeMetrics: expvarWakeMetrics{},
+		URL:               url,
+		Token:             os.Getenv("NATS_TOKEN"),
+		Stream:            envDefault("NATS_STREAM", "TANK_SESSION_BUS"),
+		Scope:             scope,
+		Replicas:          replicas,
+		WakeMetrics:       promWakeMetrics{},
+		ConnectionMetrics: promNATSConnectionMetrics{},
 	})
 	if err != nil {
 		slog.Error("session bus unavailable", "error", err)

--- a/backend-go/cmd/tank-operator/middleware.go
+++ b/backend-go/cmd/tank-operator/middleware.go
@@ -58,13 +58,16 @@ func validateSkillName(v string) string {
 }
 
 // requireAuth extracts the user from the request, writes an error and returns
-// false if auth fails.
+// false if auth fails. On success the user's email is stashed on the
+// per-request metadata struct the HTTP middleware threads through so a
+// later 5xx slog line carries the caller's identity.
 func (s *appServer) requireAuth(w http.ResponseWriter, r *http.Request) (user auth.User, ok bool) {
 	user, err := s.verifier.CurrentUser(r)
 	if err != nil {
 		writeError(w, auth.ErrorStatus(err), err.Error())
 		return auth.User{}, false
 	}
+	attachAuthToRequest(r, user)
 	return user, true
 }
 
@@ -75,6 +78,7 @@ func (s *appServer) requireWSAuth(w http.ResponseWriter, r *http.Request) (user 
 		writeError(w, auth.ErrorStatus(err), err.Error())
 		return auth.User{}, false
 	}
+	attachAuthToRequest(r, user)
 	return user, true
 }
 

--- a/backend-go/cmd/tank-operator/middleware_http.go
+++ b/backend-go/cmd/tank-operator/middleware_http.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+)
+
+// requestMetaKey is the context key for the per-request mutable metadata
+// the middleware threads through every handler. requireAuth populates the
+// email field; the middleware reads it after the handler returns to
+// attach context to the request log.
+//
+// We use a pointer to a struct (not a context.WithValue scalar) so the
+// handler can populate fields after auth without rebuilding the request's
+// context — a context.WithValue clone wouldn't be visible to the
+// middleware after the handler returns.
+type requestMetaKey struct{}
+
+type requestMeta struct {
+	email string
+	role  string
+}
+
+func requestMetaFrom(ctx context.Context) *requestMeta {
+	if rm, ok := ctx.Value(requestMetaKey{}).(*requestMeta); ok {
+		return rm
+	}
+	return nil
+}
+
+// attachAuthToRequest stores the authenticated user's email/role on the
+// per-request metadata struct the HTTP middleware threads through every
+// request. requireAuth calls this once it has decoded the JWT. The
+// middleware reads it after the handler returns so 5xx logs include the
+// email of the caller who saw the failure — the missing context that
+// made "/api/sessions/activity returned 500" undebuggable.
+func attachAuthToRequest(r *http.Request, user auth.User) {
+	if rm := requestMetaFrom(r.Context()); rm != nil {
+		rm.email = user.Email
+		rm.role = user.Role
+	}
+}
+
+// instrumentedResponseWriter wraps http.ResponseWriter to capture status
+// code and, on 5xx, a bounded slice of the response body so the
+// middleware can extract the `detail` field for structured logging.
+//
+// We only buffer body bytes once we've seen a 5xx status — happy-path
+// requests pay zero allocation overhead beyond the wrapper itself.
+type instrumentedResponseWriter struct {
+	http.ResponseWriter
+	status      int
+	bytes       int
+	bodyCapture *bytes.Buffer
+}
+
+// maxBodyCaptureBytes caps how much of a 5xx response body we buffer for
+// the slog. The detail field is rarely more than a few hundred bytes.
+const maxBodyCaptureBytes = 4 * 1024
+
+func (w *instrumentedResponseWriter) WriteHeader(status int) {
+	if w.status != 0 {
+		return
+	}
+	w.status = status
+	if status >= 500 {
+		w.bodyCapture = &bytes.Buffer{}
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *instrumentedResponseWriter) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.bytes += n
+	if w.bodyCapture != nil && w.bodyCapture.Len() < maxBodyCaptureBytes {
+		remaining := maxBodyCaptureBytes - w.bodyCapture.Len()
+		if len(p) <= remaining {
+			w.bodyCapture.Write(p)
+		} else {
+			w.bodyCapture.Write(p[:remaining])
+		}
+	}
+	return n, err
+}
+
+// Flush forwards the call to the wrapped writer when it supports it.
+// SSE handlers depend on Flush; without this passthrough the wrapper
+// silently breaks every streaming endpoint.
+func (w *instrumentedResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// Hijack forwards to the wrapped writer's Hijacker (WebSocket upgrades on
+// the terminal proxy and the SSE-but-not-quite paths). Without this the
+// gorilla/coder websocket libraries can't take over the connection and
+// every terminal upgrade returns 500.
+func (w *instrumentedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, errors.New("response writer does not support hijacking")
+}
+
+// statusClass buckets a status code into "2xx"/"3xx"/"4xx"/"5xx" so the
+// counter cardinality stays at routes * methods * 4 instead of routes *
+// methods * ~50 actual status codes seen in practice.
+func statusClass(status int) string {
+	switch {
+	case status >= 200 && status < 300:
+		return "2xx"
+	case status >= 300 && status < 400:
+		return "3xx"
+	case status >= 400 && status < 500:
+		return "4xx"
+	case status >= 500 && status < 600:
+		return "5xx"
+	default:
+		return "unknown"
+	}
+}
+
+// routeFromRequest returns the Go 1.22 ServeMux pattern the request
+// matched ("GET /api/sessions/{session_id}"), or "<unmatched>" if no
+// pattern is associated. The pattern label is the cardinality-bounded
+// alternative to logging raw URL paths (which would explode on every
+// distinct session_id).
+func routeFromRequest(r *http.Request) string {
+	if r.Pattern != "" {
+		return r.Pattern
+	}
+	return "<unmatched>"
+}
+
+// httpInstrumentationMiddleware wraps the orchestrator mux to record
+// request/duration metrics and emit a structured slog.Error on every 5xx.
+// The 5xx logline carries method, route, status, email (when the handler
+// authenticated), duration_ms, and the response body's `detail` field —
+// enough to root-cause without an SSH session into the pod.
+//
+// Cardinality budget (per docs/observability.md):
+//   - tank_http_requests_total: routes * methods * 4 (status classes)
+//   - tank_http_request_duration_seconds: routes * methods * 11 buckets
+//
+// status_class is deliberately omitted from the duration histogram —
+// adding it would 4x the histogram series with no operational signal,
+// since 4xx/5xx latency rarely tells a different story than 2xx latency
+// for this app's request surface.
+func httpInstrumentationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		meta := &requestMeta{}
+		ctx := context.WithValue(r.Context(), requestMetaKey{}, meta)
+		r = r.WithContext(ctx)
+
+		iw := &instrumentedResponseWriter{ResponseWriter: w}
+		start := time.Now()
+		next.ServeHTTP(iw, r)
+		duration := time.Since(start)
+
+		status := iw.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		route := routeFromRequest(r)
+		method := r.Method
+		class := statusClass(status)
+
+		httpRequestsTotal.WithLabelValues(method, route, class).Inc()
+		httpRequestDurationSeconds.WithLabelValues(method, route).Observe(duration.Seconds())
+
+		if status >= 500 {
+			logServerError(r, method, route, status, duration, meta, iw.bodyCapture)
+		}
+	})
+}
+
+func logServerError(r *http.Request, method, route string, status int, duration time.Duration, meta *requestMeta, body *bytes.Buffer) {
+	detail := extractDetailField(body)
+	attrs := []any{
+		"method", method,
+		"route", route,
+		"status", status,
+		"duration_ms", duration.Milliseconds(),
+	}
+	if meta != nil && meta.email != "" {
+		attrs = append(attrs, "email", meta.email)
+	}
+	if meta != nil && meta.role != "" {
+		attrs = append(attrs, "role", meta.role)
+	}
+	if detail != "" {
+		attrs = append(attrs, "detail", detail)
+	}
+	// Some endpoints get hit unauthenticated by browsers (preflights,
+	// SSE reconnects before token refresh, etc.). Logging the user-agent
+	// helps separate "real user-visible 5xx" from "noisy bot" without
+	// adding a metric label.
+	if ua := r.UserAgent(); ua != "" {
+		attrs = append(attrs, "user_agent", ua)
+	}
+	slog.Error("http server error", attrs...)
+}
+
+// extractDetailField pulls the "detail" string out of a JSON 5xx body the
+// orchestrator writes via writeError. If the body isn't JSON or doesn't
+// carry a detail, we return the raw body trimmed to its first line. This
+// catches both writeError() and any handler that uses http.Error()
+// directly so the slog line is useful regardless of the response shape.
+func extractDetailField(body *bytes.Buffer) string {
+	if body == nil || body.Len() == 0 {
+		return ""
+	}
+	raw := body.Bytes()
+	var probe struct {
+		Detail string `json:"detail"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &probe); err == nil {
+		if probe.Detail != "" {
+			return probe.Detail
+		}
+		if probe.Error != "" {
+			return probe.Error
+		}
+	}
+	first := raw
+	if idx := bytes.IndexByte(first, '\n'); idx >= 0 {
+		first = first[:idx]
+	}
+	return string(bytes.TrimSpace(first))
+}
+

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -1,34 +1,119 @@
 package main
 
 import (
-	"expvar"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
 )
 
+// Observability is a real Prometheus surface scraped by the
+// kube-prometheus-stack via the ServiceMonitor in k8s/templates/.
+// docs/observability.md is the contract: counter names, label budgets,
+// and the cardinality rules ("no pod_name, no session_id, no email as
+// metric labels"). Anything added here must respect the same budget or
+// the cluster's Prometheus instance will pay the bill in RAM.
+//
+// The previous ad-hoc counter surface was deleted in the observability
+// cutover — scripts/check-removed-chat-runtime.mjs blocks reintroduction.
+
+// --- HTTP request-path metrics ---
+
 var (
-	sessionEventStreamOpenTotal       = expvar.NewInt("tank_session_event_stream_open_total")
-	sessionEventStreamReconnectTotal  = expvar.NewInt("tank_session_event_stream_reconnect_total")
-	sessionEventStreamResyncTotal     = expvar.NewInt("tank_session_event_stream_resync_required_total")
-	sessionEventStreamErrorTotal      = expvar.NewInt("tank_session_event_stream_error_total")
-	sessionEventTimelineFailureTotal  = expvar.NewInt("tank_session_event_timeline_failure_total")
-	sessionEventStreamLastLagMillis   = expvar.NewInt("tank_session_event_stream_last_lag_ms")
-	sessionEventStreamMaxLagMillis    = expvar.NewInt("tank_session_event_stream_max_lag_ms")
-	sessionEventStreamEmittedTotal    = expvar.NewInt("tank_session_event_stream_emitted_total")
-	sessionEventStreamHeartbeatTotal  = expvar.NewInt("tank_session_event_stream_heartbeat_total")
-	sessionEventWakeSubscribeFailures = expvar.NewInt("tank_session_event_wake_subscribe_failure_total")
+	// httpRequestsTotal counts every request that reaches the orchestrator
+	// mux. status_class is bucketed (2xx/3xx/4xx/5xx) instead of full
+	// status code to keep cardinality bounded at routes * methods * 4.
+	httpRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_http_requests_total",
+			Help: "Total HTTP requests handled by tank-operator, labeled by route, method, and status class.",
+		},
+		[]string{"method", "route", "status_class"},
+	)
+
+	// httpRequestDurationSeconds is the latency histogram. It deliberately
+	// omits status_class — that label would multiply series by 4 with no
+	// operational gain (4xx/5xx latency rarely tells a different story than
+	// 2xx latency for this app's surface).
+	httpRequestDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "tank_http_request_duration_seconds",
+			Help:    "Latency of HTTP requests handled by tank-operator.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "route"},
+	)
+)
+
+// --- Session-event stream metrics (the names match what the prior
+// counter surface exposed, so dashboards reading the old series keep
+// rendering against the new collectors). ---
+
+var (
+	sessionEventStreamOpenTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_stream_open_total",
+		Help: "Times the per-session SSE event stream opened (durable transcript replay).",
+	})
+	sessionEventStreamReconnectTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_stream_reconnect_total",
+		Help: "Times a session SSE event stream reconnected with a resumable cursor.",
+	})
+	sessionEventStreamResyncTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_stream_resync_required_total",
+		Help: "Times a session SSE event stream required full resync (cursor not found in the durable ledger).",
+	})
+	sessionEventStreamErrorTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_stream_error_total",
+		Help: "Errors emitted while serving the per-session SSE event stream.",
+	})
+	sessionEventTimelineFailureTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_timeline_failure_total",
+		Help: "Failures of the GET /timeline snapshot used by the SPA to bootstrap a session.",
+	})
+	sessionEventStreamEmittedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_stream_emitted_total",
+		Help: "Events emitted to a connected SSE consumer (post-filter).",
+	})
+	sessionEventStreamHeartbeatTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_stream_heartbeat_total",
+		Help: "Heartbeat frames written on idle SSE streams.",
+	})
+	sessionEventWakeSubscribeFailures = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_wake_subscribe_failure_total",
+		Help: "Failures setting up the per-session NATS wake subscription that drives SSE streams.",
+	})
+
+	// sessionEventStreamLagSeconds is a histogram of producer→browser lag.
+	// Replaces the prior last/max gauges, which couldn't be aggregated
+	// usefully across replicas. Buckets target the live-render path's
+	// expected latency band (10ms–10s).
+	sessionEventStreamLagSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "tank_session_event_stream_lag_seconds",
+		Help:    "End-to-end lag from durable event creation to SSE emission.",
+		Buckets: []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+	})
 
 	// Persister: schema rejections are permanent — anything malformed will
 	// fail the same way on retry. The persister terminates these and
 	// increments this counter. Steady-state expectation is zero; any
 	// non-zero value means a producer is emitting non-Tank events to the
 	// bus and the cutover guard in conversation-contract.yml missed it.
-	sessionEventPersistSchemaRejectedTotal = expvar.NewInt("tank_session_event_persist_schema_rejected_total")
+	sessionEventPersistSchemaRejectedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_persist_schema_rejected_total",
+		Help: "Bus events the persister terminated because they failed Tank-event schema validation (producer-side regression).",
+	})
 	// Transient persister failures (Postgres connection blips, network
 	// hiccups, etc.). These are retried up to the JetStream MaxDeliver
 	// bound; the counter helps distinguish them from schema rejections
 	// so alerts on the rejection counter aren't masked by infrastructure
 	// noise.
-	sessionEventPersistTransientFailureTotal = expvar.NewInt("tank_session_event_persist_transient_failure_total")
+	sessionEventPersistTransientFailureTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_persist_transient_failure_total",
+		Help: "Persister failures the persister chose to NAK for retry (infrastructure-side, retryable).",
+	})
 
 	// Wake-publish failures. The bus records here before returning the
 	// error to the caller, which keeps the silent
@@ -37,52 +122,124 @@ var (
 	// zero value means NATS is unreachable / overloaded, in which case
 	// SSE clients won't notice changes until the next heartbeat (15s for
 	// per-session events, 30s for the per-owner session list).
-	sessionEventWakePublishFailureTotal = expvar.NewInt("tank_session_event_wake_publish_failure_total")
-	sessionListWakePublishFailureTotal  = expvar.NewInt("tank_session_list_wake_publish_failure_total")
+	sessionEventWakePublishFailureTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_wake_publish_failure_total",
+		Help: "Per-session SSE wake publishes that failed against NATS.",
+	})
+	sessionListWakePublishFailureTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_list_wake_publish_failure_total",
+		Help: "Per-owner session-list-change wake publishes that failed against NATS.",
+	})
 )
 
+// --- Postgres query tracer metrics ---
+
+var (
+	pgQueriesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_pg_queries_total",
+			Help: "Postgres queries executed by tank-operator, labeled by operation type and outcome.",
+		},
+		[]string{"operation", "outcome"},
+	)
+	pgQueryDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "tank_pg_query_duration_seconds",
+			Help:    "Latency of Postgres queries executed by tank-operator.",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
+		},
+		[]string{"operation"},
+	)
+)
+
+// --- NATS connection metrics ---
+
+var (
+	natsDisconnectTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_nats_disconnect_total",
+		Help: "Times the NATS client transitioned from connected to disconnected.",
+	})
+	natsReconnectTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_nats_reconnect_total",
+		Help: "Times the NATS client reconnected to a server.",
+	})
+	natsAsyncErrorTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_nats_async_error_total",
+		Help: "Async errors raised on the NATS connection (slow consumer, permission, etc.).",
+	})
+)
+
+// recordSessionEventStreamError is kept as a function so callers don't
+// import this package's symbols directly — same pattern as before the
+// prometheus cutover.
 func recordSessionEventStreamError() {
-	sessionEventStreamErrorTotal.Add(1)
+	sessionEventStreamErrorTotal.Inc()
 }
 
 func recordSessionEventTimelineFailure() {
-	sessionEventTimelineFailureTotal.Add(1)
+	sessionEventTimelineFailureTotal.Inc()
 }
 
 func recordSessionEventPersistSchemaRejected() {
-	sessionEventPersistSchemaRejectedTotal.Add(1)
+	sessionEventPersistSchemaRejectedTotal.Inc()
 }
 
 func recordSessionEventPersistTransientFailure() {
-	sessionEventPersistTransientFailureTotal.Add(1)
+	sessionEventPersistTransientFailureTotal.Inc()
 }
 
-// expvarPersisterMetrics wires the persister's PersisterMetrics interface
-// (defined in internal/sessionbus) to the package-level expvar counters
-// above. The interface stays in the internal package so the persister
-// doesn't need to import expvar directly.
-type expvarPersisterMetrics struct{}
+// promPersisterMetrics satisfies sessionbus.PersisterMetrics so the bus
+// can increment the schema/transient-failure counters without importing
+// prometheus directly.
+type promPersisterMetrics struct{}
 
-func (expvarPersisterMetrics) RecordSchemaRejected() {
+func (promPersisterMetrics) RecordSchemaRejected() {
 	recordSessionEventPersistSchemaRejected()
 }
 
-func (expvarPersisterMetrics) RecordTransientFailure() {
+func (promPersisterMetrics) RecordTransientFailure() {
 	recordSessionEventPersistTransientFailure()
 }
 
-// expvarWakeMetrics wires sessionbus.WakeMetrics into the package-level
-// expvar counters above so the bus can record wake-publish failures
-// without importing expvar directly.
-type expvarWakeMetrics struct{}
+// promWakeMetrics satisfies sessionbus.WakeMetrics so the bus can increment
+// wake-publish failure counters without importing prometheus directly.
+type promWakeMetrics struct{}
 
-func (expvarWakeMetrics) RecordSessionEventWakePublishFailed() {
-	sessionEventWakePublishFailureTotal.Add(1)
+func (promWakeMetrics) RecordSessionEventWakePublishFailed() {
+	sessionEventWakePublishFailureTotal.Inc()
 }
 
-func (expvarWakeMetrics) RecordSessionListWakePublishFailed() {
-	sessionListWakePublishFailureTotal.Add(1)
+func (promWakeMetrics) RecordSessionListWakePublishFailed() {
+	sessionListWakePublishFailureTotal.Inc()
 }
+
+// promNATSConnectionMetrics satisfies sessionbus.ConnectionMetrics so the
+// bus can record connection lifecycle events without importing prometheus.
+type promNATSConnectionMetrics struct{}
+
+func (promNATSConnectionMetrics) RecordDisconnect() { natsDisconnectTotal.Inc() }
+func (promNATSConnectionMetrics) RecordReconnect()  { natsReconnectTotal.Inc() }
+func (promNATSConnectionMetrics) RecordAsyncError() { natsAsyncErrorTotal.Inc() }
+
+// promPGMetrics satisfies pgstore.SQLMetrics so the QueryTracer can
+// record per-operation counters and duration without importing
+// prometheus from the pgstore package.
+type promPGMetrics struct{}
+
+func (promPGMetrics) RecordQuery(operation, outcome string, duration time.Duration) {
+	pgQueriesTotal.WithLabelValues(operation, outcome).Inc()
+	pgQueryDurationSeconds.WithLabelValues(operation).Observe(duration.Seconds())
+}
+
+// Compile-time interface conformance checks. If a future refactor renames
+// a method on the sessionbus / pgstore interfaces, this won't silently
+// fall back to "no metrics emitted" — it will fail to build.
+var (
+	_ sessionbus.PersisterMetrics  = promPersisterMetrics{}
+	_ sessionbus.WakeMetrics       = promWakeMetrics{}
+	_ sessionbus.ConnectionMetrics = promNATSConnectionMetrics{}
+	_ pgstore.SQLMetrics           = promPGMetrics{}
+)
 
 func recordSessionEventLag(event map[string]any) {
 	eventTime := eventTimestamp(event)
@@ -93,11 +250,7 @@ func recordSessionEventLag(event map[string]any) {
 	if lag < 0 {
 		lag = 0
 	}
-	lagMillis := lag.Milliseconds()
-	sessionEventStreamLastLagMillis.Set(lagMillis)
-	if lagMillis > sessionEventStreamMaxLagMillis.Value() {
-		sessionEventStreamMaxLagMillis.Set(lagMillis)
-	}
+	sessionEventStreamLagSeconds.Observe(lag.Seconds())
 }
 
 func eventTimestamp(event map[string]any) time.Time {

--- a/backend-go/cmd/tank-operator/observability_test.go
+++ b/backend-go/cmd/tank-operator/observability_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// TestMetricsEndpointServesPrometheus boots the production mux and asserts
+// /metrics returns the Prom text exposition with at least the
+// tank_session_event_stream_open_total counter defined. /debug/vars (the
+// old expvar surface) must return 404.
+func TestMetricsEndpointServesPrometheus(t *testing.T) {
+	srv := newTestServerForHTTPMiddleware()
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want 200", rr.Code)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	if !bytes.Contains(body, []byte("tank_session_event_stream_open_total")) {
+		t.Fatalf("/metrics body missing tank_ metric, got first 400 bytes: %q", string(body[:min(len(body), 400)]))
+	}
+
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/debug/vars", nil))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("GET /debug/vars status = %d, want 404 (expvar surface deleted)", rr.Code)
+	}
+}
+
+// TestServerErrorLogsContext asserts the middleware emits a structured
+// slog.Error with method, route, status, and the response body's `detail`
+// field when a handler returns 5xx. This is the property that fixed the
+// "/api/sessions/activity 500 had no logs" diagnostic gap.
+func TestServerErrorLogsContext(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /boom", func(w http.ResponseWriter, _ *http.Request) {
+		writeError(w, http.StatusInternalServerError, "synthetic failure for test")
+	})
+	mux.HandleFunc("GET /ok", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	var buf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prevLogger)
+
+	wrapped := httpInstrumentationMiddleware(mux)
+
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/boom", nil))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("boom status = %d, want 500", rr.Code)
+	}
+
+	logged := buf.String()
+	for _, want := range []string{
+		`"level":"ERROR"`,
+		`"msg":"http server error"`,
+		`"method":"GET"`,
+		`"route":"GET /boom"`,
+		`"status":500`,
+		`"detail":"synthetic failure for test"`,
+	} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("slog output missing %s; got: %s", want, logged)
+		}
+	}
+
+	buf.Reset()
+	rr = httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/ok", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ok status = %d, want 200", rr.Code)
+	}
+	if strings.Contains(buf.String(), `"level":"ERROR"`) {
+		t.Errorf("2xx request emitted an ERROR log: %s", buf.String())
+	}
+}
+
+// TestHTTPMetricsRecordsRequest asserts the request counter and duration
+// histogram both increment after a single request. We compare scrape
+// output before and after the test request.
+func TestHTTPMetricsRecordsRequest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /counted", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.Handle("GET /metrics", promhttp.Handler())
+	wrapped := httpInstrumentationMiddleware(mux)
+
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/counted", nil))
+
+	rr = httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body, _ := io.ReadAll(rr.Body)
+	if !bytes.Contains(body, []byte(`tank_http_requests_total{method="GET",route="GET /counted",status_class="2xx"}`)) {
+		t.Fatalf("expected request counter for GET /counted; got: %s", string(body))
+	}
+	if !bytes.Contains(body, []byte(`tank_http_request_duration_seconds_bucket{method="GET",route="GET /counted"`)) {
+		t.Fatalf("expected duration histogram buckets for GET /counted; got: %s", string(body))
+	}
+}
+
+// TestStatusClass covers the bucket boundaries the HTTP middleware uses
+// when labeling the request counter.
+func TestStatusClass(t *testing.T) {
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{200, "2xx"},
+		{204, "2xx"},
+		{301, "3xx"},
+		{400, "4xx"},
+		{404, "4xx"},
+		{500, "5xx"},
+		{599, "5xx"},
+		{99, "unknown"},
+		{600, "unknown"},
+	}
+	for _, tc := range cases {
+		if got := statusClass(tc.status); got != tc.want {
+			t.Errorf("statusClass(%d) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+// newTestServerForHTTPMiddleware constructs the minimal handler chain the
+// observability tests use to assert end-to-end behavior of /metrics and
+// /debug/vars. It deliberately doesn't call registerRoutes because that
+// would drag the full orchestrator dependency graph (k8s client,
+// auth.Verifier, Postgres pool) into a unit test.
+func newTestServerForHTTPMiddleware() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", promhttp.Handler())
+	return httpInstrumentationMiddleware(mux)
+}

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"expvar"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,9 +57,9 @@ type sessionCommandBus interface {
 }
 
 func (s *appServer) registerRoutes(mux *http.ServeMux) {
-	// Health / config.
+	// Health / config / metrics.
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
-	mux.Handle("GET /debug/vars", expvar.Handler())
+	mux.Handle("GET /metrics", promhttp.Handler())
 	mux.HandleFunc("GET /api/config", s.handleConfig)
 	mux.HandleFunc("GET /api/design/selection/latest", s.handleGetLatestDesignSelection)
 	mux.HandleFunc("POST /api/design/selection", s.handlePostDesignSelection)

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
@@ -46,6 +48,10 @@ require (
 	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.66.1 // indirect
+	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -20,6 +20,10 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -108,6 +112,14 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
+github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
+github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
+github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
+github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
+github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/backend-go/internal/pgstore/client.go
+++ b/backend-go/internal/pgstore/client.go
@@ -37,11 +37,17 @@ const MaxConnLifetime = 50 * time.Minute
 // Config describes how to reach the Postgres Flexible Server. Username is the
 // AAD principal name as it appears in the server's `pg_authid` (for a UAMI,
 // this is the UAMI's display name, e.g. `claude-credentials-refresher-identity`).
+//
+// QueryMetrics is optional; when non-nil every query the pool runs is
+// observed by the tracer (operation + outcome + duration). Production
+// always supplies a Prometheus-backed implementation through
+// cmd/tank-operator/observability.go. Tests can pass nil to opt out.
 type Config struct {
-	Host       string
-	Database   string
-	Username   string
-	Credential azcore.TokenCredential
+	Host         string
+	Database     string
+	Username     string
+	Credential   azcore.TokenCredential
+	QueryMetrics SQLMetrics
 }
 
 // NewPool builds a pgxpool.Pool wired with AAD authentication. The pool
@@ -74,6 +80,9 @@ func NewPool(ctx context.Context, cfg Config) (*pgxpool.Pool, error) {
 	poolConfig.MaxConnLifetime = MaxConnLifetime
 	poolConfig.MaxConns = 10
 	poolConfig.MinConns = 1
+	if cfg.QueryMetrics != nil {
+		poolConfig.ConnConfig.Tracer = NewQueryTracer(cfg.QueryMetrics)
+	}
 
 	credential := cfg.Credential
 	poolConfig.BeforeConnect = func(ctx context.Context, c *pgx.ConnConfig) error {

--- a/backend-go/internal/pgstore/tracer.go
+++ b/backend-go/internal/pgstore/tracer.go
@@ -1,0 +1,195 @@
+package pgstore
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// QueryTracer is the pgx tracer the orchestrator installs on its pool to
+// emit per-query Prometheus metrics. It is intentionally outcome-only:
+// the only labels are the bounded "operation" (a stable keyword pulled
+// from the SQL text) and "outcome" ("ok" / "error"). Per-statement,
+// per-table, and per-error labels are forbidden — they would let any
+// query introduced in a future commit blow up Prometheus cardinality.
+//
+// The matching collectors are registered in cmd/tank-operator/observability.go;
+// the tracer reaches them through the SQLMetrics interface so this package
+// doesn't import prometheus.
+type QueryTracer struct {
+	metrics SQLMetrics
+}
+
+// SQLMetrics is the narrow interface the tracer needs to record outcomes.
+// It is satisfied by the prom* type in cmd/tank-operator/observability.go.
+type SQLMetrics interface {
+	RecordQuery(operation string, outcome string, duration time.Duration)
+}
+
+// NewQueryTracer constructs a tracer. metrics may be nil in tests, in
+// which case the tracer becomes a no-op.
+func NewQueryTracer(metrics SQLMetrics) *QueryTracer {
+	return &QueryTracer{metrics: metrics}
+}
+
+type traceQueryContextKey struct{}
+
+type traceQueryContext struct {
+	start     time.Time
+	operation string
+}
+
+// TraceQueryStart is the pgx callback invoked before a query executes. We
+// stash the start time and a bounded operation keyword in the context;
+// TraceQueryEnd reads them back. Returning the context (not the data
+// pointer) is the documented pgx contract.
+func (t *QueryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	if t == nil || t.metrics == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, traceQueryContextKey{}, &traceQueryContext{
+		start:     time.Now(),
+		operation: operationFromSQL(data.SQL),
+	})
+}
+
+// TraceQueryEnd is the pgx callback invoked after a query finishes.
+func (t *QueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	if t == nil || t.metrics == nil {
+		return
+	}
+	state, ok := ctx.Value(traceQueryContextKey{}).(*traceQueryContext)
+	if !ok {
+		return
+	}
+	outcome := "ok"
+	if data.Err != nil {
+		outcome = "error"
+	}
+	t.metrics.RecordQuery(state.operation, outcome, time.Since(state.start))
+}
+
+// operationFromSQL extracts a bounded keyword from a SQL statement so the
+// "operation" metric label stays at a small fixed cardinality. The
+// returned value is one of:
+//
+//	select_session_events, insert_session_events, update_session_events,
+//	delete_session_events, select_profiles, insert_profiles,
+//	update_profiles, select_sessions, insert_sessions, update_sessions,
+//	delete_sessions, select_session_counters, upsert_session_counters,
+//	select_conversation_read_state, upsert_conversation_read_state,
+//	migration, advisory_lock, advisory_unlock, ping, other.
+//
+// "other" is the catch-all for anything not on the allowlist; an alert on
+// `tank_pg_queries_total{operation="other"} > 0` surfaces unmapped SQL
+// added by future commits without letting the cardinality grow with each
+// new query string.
+func operationFromSQL(sql string) string {
+	trimmed := strings.TrimSpace(sql)
+	if trimmed == "" {
+		return "other"
+	}
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, "select pg_advisory_lock"):
+		return "advisory_lock"
+	case strings.HasPrefix(lower, "select pg_advisory_unlock"):
+		return "advisory_unlock"
+	case strings.HasPrefix(lower, "create table"),
+		strings.HasPrefix(lower, "create index"),
+		strings.HasPrefix(lower, "alter table"),
+		strings.HasPrefix(lower, "drop "):
+		return "migration"
+	case lower == "select 1", lower == "select 1;":
+		return "ping"
+	}
+	verb := firstWord(lower)
+	table := tableFromSQL(lower, verb)
+	if table == "" {
+		return "other"
+	}
+	switch verb {
+	case "select":
+		return "select_" + table
+	case "insert":
+		return "insert_" + table
+	case "update":
+		return "update_" + table
+	case "delete":
+		return "delete_" + table
+	case "with":
+		return "select_" + table
+	}
+	return "other"
+}
+
+func firstWord(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' || s[i] == '\n' || s[i] == '\t' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// knownTables is the closed set of tables the operationFromSQL extractor
+// will match. Adding a new table here is an explicit choice — the alert
+// on `operation="other"` surfaces any unrecognized SQL before the new
+// table's queries become invisible.
+var knownTables = []string{
+	"session_events",
+	"profiles",
+	"sessions",
+	"session_counters",
+	"conversation_read_state",
+}
+
+// tableFromSQL pulls the first known table name out of a SELECT/INSERT/
+// UPDATE/DELETE statement. The match is substring-based and case-folded;
+// we never invent a table name from caller-controlled SQL text. If no
+// known table appears, the caller falls back to "other" — which makes
+// unmapped SQL surface as a single low-cardinality bucket rather than
+// distinct labels per query.
+func tableFromSQL(lower, verb string) string {
+	switch verb {
+	case "insert":
+		idx := strings.Index(lower, "into ")
+		if idx < 0 {
+			return ""
+		}
+		return firstKnownTable(lower[idx+len("into "):])
+	case "update":
+		return firstKnownTable(lower[len("update "):])
+	case "delete":
+		idx := strings.Index(lower, "from ")
+		if idx < 0 {
+			return ""
+		}
+		return firstKnownTable(lower[idx+len("from "):])
+	case "select", "with":
+		idx := strings.Index(lower, "from ")
+		if idx < 0 {
+			return ""
+		}
+		return firstKnownTable(lower[idx+len("from "):])
+	}
+	return ""
+}
+
+func firstKnownTable(after string) string {
+	after = strings.TrimSpace(after)
+	if after == "" {
+		return ""
+	}
+	for _, table := range knownTables {
+		if strings.HasPrefix(after, table) {
+			rest := after[len(table):]
+			if rest == "" || rest[0] == ' ' || rest[0] == '\n' || rest[0] == '\t' || rest[0] == ',' || rest[0] == '(' {
+				return table
+			}
+		}
+	}
+	return ""
+}

--- a/backend-go/internal/pgstore/tracer_test.go
+++ b/backend-go/internal/pgstore/tracer_test.go
@@ -1,0 +1,37 @@
+package pgstore
+
+import "testing"
+
+func TestOperationFromSQL(t *testing.T) {
+	cases := map[string]string{
+		"":                                                                                               "other",
+		"SELECT 1":                                                                                       "ping",
+		"SELECT pg_advisory_lock($1)":                                                                    "advisory_lock",
+		"SELECT pg_advisory_unlock($1)":                                                                  "advisory_unlock",
+		"CREATE TABLE IF NOT EXISTS profiles (email text)":                                               "migration",
+		"CREATE INDEX IF NOT EXISTS profiles_email ON profiles (email)":                                  "migration",
+		"ALTER TABLE profiles ADD COLUMN x text":                                                         "migration",
+		"DROP TABLE profiles":                                                                            "migration",
+		"SELECT payload FROM session_events WHERE tank_session_id = $1":                                  "select_session_events",
+		"WITH x AS (SELECT 1) SELECT * FROM session_events":                                              "select_session_events",
+		"INSERT INTO session_events (tank_session_id, order_key) VALUES ($1, $2)":                        "insert_session_events",
+		"UPDATE profiles SET github_login = $1 WHERE email = $2":                                         "update_profiles",
+		"DELETE FROM sessions WHERE email = $1":                                                          "delete_sessions",
+		"SELECT email FROM profiles":                                                                     "select_profiles",
+		"INSERT INTO sessions (email, session_scope, session_id) VALUES ($1, $2, $3)":                    "insert_sessions",
+		"UPDATE conversation_read_state SET last_read_order_key = $1":                                    "update_conversation_read_state",
+		"SELECT next_session_number FROM session_counters WHERE session_scope = $1":                      "select_session_counters",
+		"SELECT 1 FROM unknown_table WHERE id = $1":                                                      "other",
+		// Subquery shapes ("SELECT ... FROM (SELECT ...) sub") return
+		// "other" by design — the extractor refuses to parse nested SQL
+		// to keep cardinality predictable. The "operation=other"
+		// PrometheusRule surfaces unmapped SQL the orchestrator started
+		// running.
+		"SELECT count(*) FROM (SELECT * FROM session_events) sub": "other",
+	}
+	for sql, want := range cases {
+		if got := operationFromSQL(sql); got != want {
+			t.Errorf("operationFromSQL(%q) = %q, want %q", sql, got, want)
+		}
+	}
+}

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -28,7 +28,27 @@ type Config struct {
 	// silent `_ = b.PublishSessionListWake(...)` patterns in mutation
 	// paths still produce telemetry.
 	WakeMetrics WakeMetrics
+	// ConnectionMetrics is optional. When set, the bus wires the NATS
+	// disconnect / reconnect / async-error connection callbacks to the
+	// supplied counters so an operator can tell whether session-bus
+	// drops are happening (the failure mode behind both "SSE went
+	// silent" and the wake-publish failures above).
+	ConnectionMetrics ConnectionMetrics
 }
+
+// ConnectionMetrics receives counters for NATS connection lifecycle
+// events. The bus wires these to nats.Options callbacks at Connect time.
+type ConnectionMetrics interface {
+	RecordDisconnect()
+	RecordReconnect()
+	RecordAsyncError()
+}
+
+type noopConnectionMetrics struct{}
+
+func (noopConnectionMetrics) RecordDisconnect() {}
+func (noopConnectionMetrics) RecordReconnect()  {}
+func (noopConnectionMetrics) RecordAsyncError() {}
 
 type EventStore interface {
 	Upsert(context.Context, map[string]any) error
@@ -36,7 +56,7 @@ type EventStore interface {
 
 // PersisterMetrics receives counters from the schema-rejection / transient-
 // failure split in the persister. Steady-state expectation: zero schema
-// rejections. Wired to expvar in cmd/tank-operator/observability.go.
+// rejections. Wired to prometheus in cmd/tank-operator/observability.go.
 type PersisterMetrics interface {
 	RecordSchemaRejected()
 	RecordTransientFailure()
@@ -50,7 +70,7 @@ func (noopPersisterMetrics) RecordTransientFailure() {}
 // WakeMetrics receives counters for wake-publish failures. The bus records
 // here before returning the error to the caller; callers that silently
 // drop the error (Manager.PublishSessionListWake on lifecycle mutations)
-// still get visibility into "NATS is down". Wired to expvar in
+// still get visibility into "NATS is down". Wired to prometheus in
 // cmd/tank-operator/observability.go.
 type WakeMetrics interface {
 	RecordSessionEventWakePublishFailed()
@@ -76,10 +96,33 @@ func Connect(ctx context.Context, cfg Config) (*Bus, error) {
 	if url == "" {
 		return nil, fmt.Errorf("NATS_URL is required")
 	}
+	connMetrics := cfg.ConnectionMetrics
+	if connMetrics == nil {
+		connMetrics = noopConnectionMetrics{}
+	}
 	opts := []nats.Option{
 		nats.Name("tank-operator"),
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(2 * time.Second),
+		// Connection callbacks drive the tank_nats_* counters.
+		// DisconnectErrHandler fires on every drop (with or without an
+		// error attached); ReconnectHandler fires on the first
+		// successful redial. ErrorHandler covers slow-consumer warnings
+		// and permission errors that don't surface as Connect failures.
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			connMetrics.RecordDisconnect()
+			if err != nil {
+				slog.Warn("nats disconnected", "error", err)
+			}
+		}),
+		nats.ReconnectHandler(func(_ *nats.Conn) {
+			connMetrics.RecordReconnect()
+			slog.Info("nats reconnected")
+		}),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			connMetrics.RecordAsyncError()
+			slog.Warn("nats async error", "error", err)
+		}),
 	}
 	if token := strings.TrimSpace(cfg.Token); token != "" {
 		opts = append(opts, nats.Token(token))

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -33,6 +33,15 @@ const (
 	SessionServiceAccount = "claude-session"
 	SessionConfigMap      = "tank-session-config"
 	SandboxAgentPort      = 2468
+	// Per-container metrics ports inside session pods. The
+	// k8s/templates/podmonitor-sessions.yaml PodMonitor scrapes each by
+	// the named container port (mcp-auth-proxy: "metrics", runners:
+	// "runner-metrics"). Numbers are documented in docs/observability.md;
+	// changing them requires bumping both the values here and the
+	// PodMonitor port-name references.
+	MCPAuthProxyMetricsPort = 9990
+	AgentRunnerMetricsPort  = 9095
+	CodexRunnerMetricsPort  = 9096
 	// No DefaultSessionImage constants. The Helm chart owns image tags
 	// (k8s/values.yaml's session.* keys are bumped per-commit to
 	// fingerprinted tags by .github/workflows/claude-container-build.yml),
@@ -355,6 +364,14 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			"env": []any{
 				map[string]any{"name": "TANK_OPERATOR_INTERNAL_URL", "value": opts.TankOperatorInternalURL},
 				map[string]any{"name": "TANK_SESSION_ATTESTATION_TOKEN_PATH", "value": "/var/run/secrets/tank-operator/token"},
+				map[string]any{"name": "MCP_AUTH_PROXY_METRICS_PORT", "value": itoa(MCPAuthProxyMetricsPort)},
+			},
+			// The metrics port is exposed as a named container port so the
+			// k8s/templates/podmonitor-sessions.yaml PodMonitor can scrape
+			// it by name without hard-coding numbers. Listens on 0.0.0.0;
+			// the proxy's MCP listeners stay on 127.0.0.1.
+			"ports": []any{
+				map[string]any{"name": "metrics", "containerPort": MCPAuthProxyMetricsPort},
 			},
 			"volumeMounts": mcpProxyVolumeMounts,
 		},
@@ -426,6 +443,9 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			})
 		}
 
+		runnerEnv = append(runnerEnv, map[string]any{
+			"name": "TANK_RUNNER_METRICS_PORT", "value": itoa(AgentRunnerMetricsPort),
+		})
 		runnerContainer := map[string]any{
 			"name":            "agent-runner",
 			"image":           sessionImage,
@@ -433,6 +453,9 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			"command":         []any{"bash", "/opt/tank/agent-runner-launch.sh"},
 			"env":             runnerEnv,
 			"volumeMounts":    runnerVolumeMounts,
+			"ports": []any{
+				map[string]any{"name": "runner-metrics", "containerPort": AgentRunnerMetricsPort},
+			},
 		}
 		if len(envFrom) > 0 {
 			runnerContainer["envFrom"] = envFrom
@@ -502,6 +525,9 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 				map[string]any{"name": "CODEX_CA_CERTIFICATE", "value": "/etc/oauth-gateway-ca/ca.crt"},
 			)
 		}
+		codexRunnerEnv = append(codexRunnerEnv, map[string]any{
+			"name": "TANK_RUNNER_METRICS_PORT", "value": itoa(CodexRunnerMetricsPort),
+		})
 		codexRunnerContainer := map[string]any{
 			"name":            "codex-runner",
 			"image":           sessionImage,
@@ -509,6 +535,9 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			"command":         []any{"bash", "/opt/tank/codex-runner-launch.sh"},
 			"env":             codexRunnerEnv,
 			"volumeMounts":    runnerVolumeMounts,
+			"ports": []any{
+				map[string]any{"name": "runner-metrics", "containerPort": CodexRunnerMetricsPort},
+			},
 		}
 		if len(envFrom) > 0 {
 			codexRunnerContainer["envFrom"] = envFrom

--- a/claude-container/mcp-auth-proxy/pyproject.toml
+++ b/claude-container/mcp-auth-proxy/pyproject.toml
@@ -5,6 +5,7 @@ description = "Localhost reverse proxy that injects fresh bearer auth for Tank M
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.9",
+    "prometheus-client>=0.20",
 ]
 
 [build-system]

--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/metrics.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/metrics.py
@@ -1,0 +1,123 @@
+"""Prometheus instrumentation for the in-pod mcp-auth-proxy sidecar.
+
+This sidecar runs in every session pod (Claude, Codex, Pi modes) and is
+responsible for injecting fresh bearer auth on every outbound MCP call.
+The cluster-side kube-prometheus-stack picks the /metrics endpoint up via
+a PodMonitor (k8s/templates/podmonitor-sessions.yaml).
+
+Cardinality discipline: labels are bounded by the fixed LISTENERS map in
+server.py — six MCP servers today. We never label by session_id, pod
+name, user, or request URL.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from aiohttp import web
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+log = logging.getLogger(__name__)
+
+# Inbound proxy request counters/histogram. The mcp_server label is the
+# upstream Kubernetes Service name (without the namespace) — bounded by
+# the LISTENERS map in server.py.
+proxy_requests_total = Counter(
+    "tank_mcp_auth_proxy_requests_total",
+    "Inbound proxy requests handled by the mcp-auth-proxy sidecar.",
+    ["mcp_server", "status_class"],
+)
+
+proxy_upstream_duration_seconds = Histogram(
+    "tank_mcp_auth_proxy_upstream_duration_seconds",
+    "Wall-clock duration of upstream MCP calls (proxy → MCP server).",
+    ["mcp_server"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300),
+)
+
+# Token read counters. SA token reads happen on every request — a non-
+# zero failure rate means kubelet's projected token volume is broken,
+# which is a session-pod-level failure mode users see as "MCP suddenly
+# stopped working".
+sa_token_read_total = Counter(
+    "tank_mcp_auth_proxy_sa_token_read_total",
+    "Reads of the projected ServiceAccount token file used for MCP bearer auth.",
+    ["result"],
+)
+
+# GitHub-specific attestation token. Cached and refreshed by the
+# orchestrator's /api/internal/github/attestation; this metric tracks
+# the local refresh path so we can tell "GitHub MCP is broken because
+# the attestation mint failed" apart from "GitHub MCP is broken because
+# the upstream server is down".
+github_attestation_total = Counter(
+    "tank_mcp_auth_proxy_github_attestation_total",
+    "Calls to the orchestrator's /api/internal/github/attestation endpoint.",
+    ["result"],
+)
+
+
+def _status_class(status: int) -> str:
+    if 200 <= status < 300:
+        return "2xx"
+    if 300 <= status < 400:
+        return "3xx"
+    if 400 <= status < 500:
+        return "4xx"
+    if 500 <= status < 600:
+        return "5xx"
+    return "unknown"
+
+
+def record_proxy_request(mcp_server: str, status: int) -> None:
+    proxy_requests_total.labels(mcp_server=mcp_server, status_class=_status_class(status)).inc()
+
+
+def record_sa_token_read(result: str) -> None:
+    """result is one of: success, failure."""
+    sa_token_read_total.labels(result=result).inc()
+
+
+def record_github_attestation(result: str) -> None:
+    """result is one of: success, http_error, exception, invalid_response, cache_hit."""
+    github_attestation_total.labels(result=result).inc()
+
+
+@asynccontextmanager
+async def upstream_timer(mcp_server: str) -> AsyncIterator[None]:
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        proxy_upstream_duration_seconds.labels(mcp_server=mcp_server).observe(time.monotonic() - start)
+
+
+async def _handle_metrics(_: web.Request) -> web.Response:
+    return web.Response(body=generate_latest(), content_type=CONTENT_TYPE_LATEST.split(";")[0], charset="utf-8")
+
+
+async def _handle_healthz(_: web.Request) -> web.Response:
+    return web.Response(text="ok")
+
+
+async def start_metrics_server(port: int) -> web.AppRunner:
+    app = web.Application()
+    app.router.add_get("/metrics", _handle_metrics)
+    app.router.add_get("/healthz", _handle_healthz)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", port)
+    await site.start()
+    log.info("mcp-auth-proxy metrics listening on 0.0.0.0:%d", port)
+    return runner
+
+
+__all__ = [
+    "record_github_attestation",
+    "record_proxy_request",
+    "record_sa_token_read",
+    "start_metrics_server",
+    "upstream_timer",
+]

--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
@@ -45,6 +45,14 @@ from pathlib import Path
 
 from aiohttp import ClientSession, ClientTimeout, web
 
+from .metrics import (
+    record_github_attestation,
+    record_proxy_request,
+    record_sa_token_read,
+    start_metrics_server,
+    upstream_timer,
+)
+
 log = logging.getLogger(__name__)
 
 SA_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
@@ -98,7 +106,13 @@ class ServiceAccountTokenProvider:
         self._token_path = token_path
 
     async def token(self) -> str:
-        return _read_token(self._token_path)
+        try:
+            value = _read_token(self._token_path)
+        except Exception:
+            record_sa_token_read("failure")
+            raise
+        record_sa_token_read("success")
+        return value
 
 
 class TankGitHubAttestationProvider:
@@ -121,31 +135,43 @@ class TankGitHubAttestationProvider:
     async def token(self) -> str:
         now = time.time()
         if self._cached_token and self._expires_at > now + self._refresh_skew_seconds:
+            record_github_attestation("cache_hit")
             return self._cached_token
         async with self._lock:
             now = time.time()
             if self._cached_token and self._expires_at > now + self._refresh_skew_seconds:
+                record_github_attestation("cache_hit")
                 return self._cached_token
             if not self._operator_url:
+                record_github_attestation("exception")
                 raise RuntimeError("TANK_OPERATOR_INTERNAL_URL is required for GitHub MCP auth")
-            pod_token = _read_token(self._token_path)
-            async with self._http.post(
-                f"{self._operator_url}/api/internal/github/attestation",
-                headers={"Authorization": f"Bearer {pod_token}"},
-                json={},
-            ) as response:
-                if response.status != 200:
-                    detail = (await response.text())[:300]
-                    raise RuntimeError(
-                        f"Tank GitHub MCP attestation request returned {response.status}: {detail}"
-                    )
-                body = await response.json()
+            try:
+                pod_token = _read_token(self._token_path)
+                async with self._http.post(
+                    f"{self._operator_url}/api/internal/github/attestation",
+                    headers={"Authorization": f"Bearer {pod_token}"},
+                    json={},
+                ) as response:
+                    if response.status != 200:
+                        detail = (await response.text())[:300]
+                        record_github_attestation("http_error")
+                        raise RuntimeError(
+                            f"Tank GitHub MCP attestation request returned {response.status}: {detail}"
+                        )
+                    body = await response.json()
+            except RuntimeError:
+                raise
+            except Exception:
+                record_github_attestation("exception")
+                raise
             token = str(body.get("token") or "")
             expires_at = _parse_expires_at(body.get("expires_at"))
             if not token or expires_at <= time.time():
+                record_github_attestation("invalid_response")
                 raise RuntimeError("Tank GitHub MCP attestation response was invalid")
             self._cached_token = token
             self._expires_at = expires_at
+            record_github_attestation("success")
             return token
 
 
@@ -188,14 +214,28 @@ async def _oauth_discovery_not_configured(request: web.Request) -> web.Response:
     )
 
 
+def _mcp_server_label(upstream: str) -> str:
+    """Extract a bounded label from the upstream URL. Example:
+    'http://mcp-azure-personal.mcp-azure.svc:80' → 'mcp-azure-personal'.
+    The fallback is the full host string, which is still bounded by the
+    LISTENERS map but less Grafana-friendly. Cardinality is the count
+    of distinct upstreams (~6), never per-request.
+    """
+    host = upstream.replace("http://", "").replace("https://", "")
+    name = host.split(".", 1)[0]
+    return name or host or "unknown"
+
+
 def _make_handler(upstream: str, http: ClientSession, token_provider):
     upstream = upstream.rstrip("/")
+    mcp_label = _mcp_server_label(upstream)
 
     async def handler(request: web.Request) -> web.StreamResponse:
         try:
             token = await token_provider.token()
         except Exception:
             log.exception("could not load bearer token for %s", upstream)
+            record_proxy_request(mcp_label, 503)
             return web.Response(status=503, text="bearer token unavailable")
 
         forwarded_headers = {
@@ -206,28 +246,32 @@ def _make_handler(upstream: str, http: ClientSession, token_provider):
         body = await request.read()
         url = upstream + request.path_qs
         try:
-            async with http.request(
-                request.method,
-                url,
-                headers=forwarded_headers,
-                data=body,
-                allow_redirects=False,
-            ) as upstream_resp:
-                response = web.StreamResponse(
-                    status=upstream_resp.status,
-                    headers={
-                        k: v
-                        for k, v in upstream_resp.headers.items()
-                        if k.lower() not in _STRIP_RESPONSE_HEADERS
-                    },
-                )
-                await response.prepare(request)
-                async for chunk in upstream_resp.content.iter_any():
-                    await response.write(chunk)
-                await response.write_eof()
-                return response
+            async with upstream_timer(mcp_label):
+                async with http.request(
+                    request.method,
+                    url,
+                    headers=forwarded_headers,
+                    data=body,
+                    allow_redirects=False,
+                ) as upstream_resp:
+                    status = upstream_resp.status
+                    response = web.StreamResponse(
+                        status=status,
+                        headers={
+                            k: v
+                            for k, v in upstream_resp.headers.items()
+                            if k.lower() not in _STRIP_RESPONSE_HEADERS
+                        },
+                    )
+                    await response.prepare(request)
+                    async for chunk in upstream_resp.content.iter_any():
+                        await response.write(chunk)
+                    await response.write_eof()
+            record_proxy_request(mcp_label, status)
+            return response
         except Exception:
             log.exception("upstream request to %s failed", url)
+            record_proxy_request(mcp_label, 502)
             return web.Response(status=502, text="upstream request failed")
 
     return handler
@@ -243,6 +287,13 @@ async def run() -> None:
     # the user-visible MCP call.
     http = ClientSession(timeout=ClientTimeout(total=600, sock_connect=5))
     runners: list[web.AppRunner] = []
+    # Bind metrics on a separate port so the PodMonitor scrape doesn't
+    # clash with the localhost-only MCP listeners. 9990 sits just below
+    # the LISTENERS port range (9991+) so the entire observability +
+    # MCP-proxy port block reads contiguously.
+    metrics_port = int(os.environ.get("MCP_AUTH_PROXY_METRICS_PORT", "9990"))
+    metrics_runner = await start_metrics_server(metrics_port)
+    runners.append(metrics_runner)
     try:
         for port, upstream in LISTENERS:
             app = web.Application()

--- a/codex-runner/package-lock.json
+++ b/codex-runner/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@nats-io/jetstream": "^3.4.0",
         "@nats-io/transport-node": "^3.4.0",
-        "@openai/codex-sdk": "^0.130.0"
+        "@openai/codex-sdk": "^0.130.0",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -208,6 +209,15 @@
         "node": ">=16"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -216,6 +226,34 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/tweetnacl": {

--- a/codex-runner/package.json
+++ b/codex-runner/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@nats-io/jetstream": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
-    "@openai/codex-sdk": "^0.130.0"
+    "@openai/codex-sdk": "^0.130.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/codex-runner/src/index.ts
+++ b/codex-runner/src/index.ts
@@ -3,7 +3,23 @@
 // the session bus. Mirrors agent-runner/src/index.ts with a different SDK underneath.
 
 import { loadConfig } from "./config.js";
+import { startMetricsServer } from "./metrics.js";
 import { Runner } from "./runner.js";
+
+// Metrics port defaults to 9096 (one higher than the claude runner's
+// 9095) so a session pod that briefly co-locates both runners during a
+// rolling restart doesn't collide on the listen socket.
+const DEFAULT_METRICS_PORT = 9096;
+
+function parseMetricsPort(raw: string | undefined): number {
+  const trimmed = raw?.trim() ?? "";
+  if (trimmed === "") return DEFAULT_METRICS_PORT;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) {
+    throw new Error(`TANK_RUNNER_METRICS_PORT is not a valid port: ${raw}`);
+  }
+  return Math.trunc(n);
+}
 
 async function main(): Promise<void> {
   const cfg = loadConfig();
@@ -18,16 +34,25 @@ async function main(): Promise<void> {
     }),
   );
 
+  const metricsPort = parseMetricsPort(process.env.TANK_RUNNER_METRICS_PORT);
+  const metricsServer = startMetricsServer(metricsPort);
+  console.log(JSON.stringify({ msg: "metrics listening", port: metricsPort }));
+
   const ctrl = new AbortController();
   const shutdown = (sig: NodeJS.Signals) => {
     console.log(JSON.stringify({ msg: "shutdown", signal: sig }));
     ctrl.abort();
+    metricsServer.close();
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
   const runner = new Runner(cfg);
-  await runner.run(ctrl.signal);
+  try {
+    await runner.run(ctrl.signal);
+  } finally {
+    metricsServer.close();
+  }
 }
 
 main().catch((err) => {

--- a/codex-runner/src/metrics.test.ts
+++ b/codex-runner/src/metrics.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+
+import {
+  recordTurnStart,
+  recordTurnTerminal,
+  registry,
+  startMetricsServer,
+} from "./metrics.js";
+
+test("metrics endpoint serves prom-format with tank_runner_ counters for codex", async () => {
+  const server = startMetricsServer(0);
+  await once(server, "listening");
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object", "metrics server bound");
+  const port = (addr as { port: number }).port;
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/metrics`);
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /tank_runner_commands_consumed_total/);
+    assert.match(body, /tank_runner_turn_duration_seconds/);
+    assert.match(body, /mode="codex"/);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("recordTurnStart + recordTurnTerminal observes a duration on codex", async () => {
+  await registry.resetMetrics();
+
+  recordTurnStart("codex-turn-1");
+  recordTurnTerminal("codex-turn-1", "completed");
+
+  const dump = await registry.metrics();
+  // Label order is prom-client-internal; match any ordering.
+  assert.match(
+    dump,
+    /tank_runner_turn_duration_seconds_count\{(?=[^}]*outcome="completed")(?=[^}]*mode="codex")[^}]*\} 1/,
+  );
+});

--- a/codex-runner/src/metrics.ts
+++ b/codex-runner/src/metrics.ts
@@ -1,0 +1,102 @@
+// Prometheus instrumentation for the pod-side codex runner. The metric
+// taxonomy mirrors the orchestrator's tank_* namespace and is documented
+// in docs/observability.md. Cardinality discipline: no `pod_name`,
+// `session_id`, `turn_id`, or `email` labels — anything that grows per
+// session-pod blows up Prometheus active series at scale.
+//
+// The single mutable label is `mode`, set to "codex" here. The
+// agent-runner ships an identical module with `mode: "claude"`.
+
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from "prom-client";
+import { createServer, type Server } from "node:http";
+
+const RUNNER_MODE = "codex";
+
+export const registry = new Registry();
+registry.setDefaultLabels({ mode: RUNNER_MODE });
+collectDefaultMetrics({ register: registry });
+
+export const commandsConsumedTotal = new Counter({
+  name: "tank_runner_commands_consumed_total",
+  help: "Session commands consumed from the JetStream command subject.",
+  labelNames: ["kind", "result"],
+  registers: [registry],
+});
+
+export const turnDurationSeconds = new Histogram({
+  name: "tank_runner_turn_duration_seconds",
+  help: "End-to-end duration from turn.started to the terminal turn event.",
+  labelNames: ["outcome"],
+  buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
+  registers: [registry],
+});
+
+export const providerErrorTotal = new Counter({
+  name: "tank_runner_provider_error_total",
+  help: "Errors raised by the provider SDK (the query iterator or interrupt() call).",
+  labelNames: ["kind"],
+  registers: [registry],
+});
+
+export const pendingWakeupsGauge = new Gauge({
+  name: "tank_runner_pending_wakeups",
+  help: "Currently-pending ScheduleWakeup timers held in this runner process.",
+  registers: [registry],
+});
+
+export const natsPublishFailureTotal = new Counter({
+  name: "tank_runner_nats_publish_failure_total",
+  help: "Publish attempts to the JetStream session bus that returned an error.",
+  registers: [registry],
+});
+
+const turnStartTimes = new Map<string, number>();
+
+export function recordTurnStart(turnID: string): void {
+  if (!turnID) return;
+  turnStartTimes.set(turnID, Date.now());
+}
+
+export function recordTurnTerminal(
+  turnID: string,
+  outcome: "completed" | "failed" | "interrupted",
+): void {
+  if (!turnID) return;
+  const start = turnStartTimes.get(turnID);
+  if (start === undefined) return;
+  turnStartTimes.delete(turnID);
+  turnDurationSeconds.labels(outcome).observe((Date.now() - start) / 1000);
+}
+
+export function startMetricsServer(port: number): Server {
+  const server = createServer((req, res) => {
+    if (!req.url) {
+      res.statusCode = 400;
+      res.end();
+      return;
+    }
+    if (req.url === "/metrics" || req.url.startsWith("/metrics?")) {
+      registry
+        .metrics()
+        .then((body) => {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", registry.contentType);
+          res.end(body);
+        })
+        .catch((err: unknown) => {
+          res.statusCode = 500;
+          res.end(`metrics collection failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      return;
+    }
+    if (req.url === "/healthz") {
+      res.statusCode = 200;
+      res.end("ok");
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  server.listen(port);
+  return server;
+}

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -47,6 +47,13 @@ import {
   commandClientNonce,
   type SessionCommandRecord,
 } from "./sessionCommands.js";
+import {
+  commandsConsumedTotal,
+  natsPublishFailureTotal,
+  providerErrorTotal,
+  recordTurnStart,
+  recordTurnTerminal,
+} from "./metrics.js";
 
 // AsyncQueue — one writer, one consumer. Session commands push; the
 // run loop awaits the next value. Same shape as agent-runner's queue.
@@ -104,6 +111,7 @@ export async function dispatch(
     await sink.upsert(stamped);
   } catch (err) {
     console.error("session bus publish failed:", err);
+    natsPublishFailureTotal.inc();
     // Don't broadcast a live event we couldn't persist — the SPA's
     // history-replay would then disagree with what it saw live.
     return false;
@@ -245,6 +253,7 @@ export class Runner {
           turn.stopCommandHeartbeat = this.commandBus.startCommandHeartbeat(commandRecord);
         }
 
+        recordTurnStart(turn.turnID);
         await dispatch(
           this.sink,
           turnEvent({
@@ -321,6 +330,7 @@ export class Runner {
             console.info("codex turn interrupted");
             continue;
           }
+          providerErrorTotal.labels("query").inc();
           const errMessage = err instanceof Error ? err.message : String(err);
           const dispatched = await dispatch(
             this.sink,
@@ -360,6 +370,7 @@ export class Runner {
     void this.commandBus
       .startCommandConsumer(async (record) => {
         if (isInputReplyCommand(record)) {
+          commandsConsumedTotal.labels("input_reply", "unsupported").inc();
           await this.commandBus.markFailed(
             record,
             new Error("input replies are not supported by codex"),
@@ -367,12 +378,15 @@ export class Runner {
           return;
         }
         if (isInterruptCommand(record)) {
+          commandsConsumedTotal.labels("interrupt_turn", "accepted").inc();
           await this.acceptInterrupt(record);
           return;
         }
+        commandsConsumedTotal.labels("submit_turn", "accepted").inc();
         const clientNonce = commandClientNonce(record);
         const prompt = String(record.prompt ?? "").trim();
         if (!prompt) {
+          commandsConsumedTotal.labels("submit_turn", "invalid").inc();
           await this.commandBus.markFailed(record, new Error("submit command missing prompt"));
           return;
         }
@@ -471,6 +485,8 @@ export class Runner {
     turn: AcceptedTurn,
     type: "turn.completed" | "turn.failed" | "turn.interrupted",
   ): Promise<void> {
+    const outcome = type === "turn.completed" ? "completed" : type === "turn.failed" ? "failed" : "interrupted";
+    recordTurnTerminal(turn.turnID, outcome);
     turn.stopCommandHeartbeat?.();
     turn.stopCommandHeartbeat = undefined;
     if (turn.commandRecord) {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,151 @@
+# Observability
+
+Tank-operator publishes Prometheus metrics, structured logs on every 5xx,
+and a hand-built Grafana dashboard. The metric surface is owned end-to-end
+by this repo: orchestrator (Go), pod-side runners (TypeScript), api-proxy
+and mcp-auth-proxy (Python). External MCP servers ship their own metrics
+in their own repos.
+
+## Surfaces
+
+| Subsystem | Endpoint | Scrape source |
+|---|---|---|
+| Orchestrator | `GET /metrics` on the orchestrator Service (port 80, named `http`) | `ServiceMonitor/tank-operator` in `k8s/templates/observability.yaml` |
+| api-proxy (Claude + Codex) | `GET /metrics` on the ext_proc sidecar port `metrics` (9100) | `ServiceMonitor/tank-api-proxy` |
+| Session-pod mcp-auth-proxy | `GET /metrics` on container port `metrics` (9990) | `PodMonitor/tank-session-pods` (endpoint `metrics`) |
+| Session-pod agent-runner | `GET /metrics` on container port `runner-metrics` (9095) | `PodMonitor/tank-session-pods` (endpoint `runner-metrics`) |
+| Session-pod codex-runner | `GET /metrics` on container port `runner-metrics` (9096) | same PodMonitor |
+
+The kube-prometheus-stack operator in the `monitoring` namespace
+auto-discovers all of these. The prior `expvar` JSON surface was deleted
+end-to-end in the observability cutover; see
+`scripts/check-removed-chat-runtime.mjs` for the migration guard that
+blocks reintroduction of the package, its handler, and the old route.
+
+## Metric taxonomy
+
+All metric names are prefixed `tank_`. The full namespace:
+
+- `tank_http_*` — orchestrator request-path metrics (counter +
+  duration histogram). Labels: `method`, `route`, `status_class`. The
+  duration histogram intentionally omits `status_class` to keep series
+  count at routes × methods × 11 buckets ≈ 1000.
+- `tank_pg_*` — orchestrator Postgres query tracer (counter + duration
+  histogram). Labels: `operation`, `outcome`. `operation` is a bounded
+  keyword extracted from the SQL text by `pgstore.operationFromSQL`;
+  unmapped SQL falls into `operation="other"` and triggers an alert.
+- `tank_nats_*` — orchestrator NATS connection lifecycle counters
+  (disconnect, reconnect, async error). No labels.
+- `tank_session_event_*` — session-bus + SSE-stream counters and the
+  `tank_session_event_stream_lag_seconds` histogram. Same names as the
+  prior expvar counters (`_total` suffix added where missing per Prom
+  convention).
+- `tank_runner_*` — pod-side runner counters/histograms. Single label:
+  `mode` ("claude" or "codex"), bound at module import.
+- `tank_api_proxy_*` — api-proxy ext_proc counters/histograms. Single
+  label: `provider` ("claude" or "codex"), bound from `PROXY_PROVIDER`.
+- `tank_mcp_auth_proxy_*` — sidecar counters/histograms. Label
+  `mcp_server` is bounded by the LISTENERS table in `server.py`.
+
+## Cardinality rules
+
+These are the rules that keep Prometheus' active-series count bounded
+regardless of how many sessions, users, or upstream calls happen:
+
+- **Never label by anything that grows per user, per session, or per
+  request.** Forbidden labels (do not add): `pod`, `instance`, `email`,
+  `session_id`, `turn_id`, `user`, `request_id`, `provider_item_id`,
+  any raw URL path.
+- **Status codes are bucketed.** Use the four-value `status_class`
+  label (2xx/3xx/4xx/5xx/unknown), never the full numeric status code.
+- **Routes are matched-pattern, not raw URLs.** The HTTP middleware
+  reads `http.Request.Pattern` (Go 1.22+ ServeMux), which gives one
+  series per registered route, not per `session_id` substitution.
+- **PG operations are an allowlist.** New tables added to
+  `backend-go/internal/pgstore/tracer.go:knownTables` are the only way
+  to label new operations. Anything unmapped lands in `operation="other"`
+  and triggers `TankPgUnmappedOperation`.
+- **Histograms use minimal labels.** The HTTP duration histogram is
+  labeled by `{method, route}` only — 4× series cost of adding
+  `status_class` is not worth the operational signal.
+
+## 5xx logging
+
+Every 5xx response from the orchestrator emits a structured `slog.Error`
+with `method`, `route`, `status`, `duration_ms`, `email` (when the
+handler authenticated), and the response body's `detail` field. The
+middleware lives in `backend-go/cmd/tank-operator/middleware_http.go`;
+the `attachAuthToRequest` hook in `requireAuth` is what plumbs the
+caller's email through the per-request metadata struct so the log line
+carries who saw the failure.
+
+A 5xx with no auth context will still log `method`, `route`, `status`,
+and `detail` — useful for unauthenticated probes that 500 anyway.
+
+The middleware also serves as the contract: a handler that wants its
+500 logged with extra context should write the detail string into
+`writeError`'s message argument (it ends up in the response body, which
+the middleware extracts).
+
+## Alerts
+
+`PrometheusRule/tank-operator` in `k8s/templates/observability.yaml`
+declares one rule group per subsystem:
+
+- **HTTP**: 5xx rate, Postgres p99 latency, unmapped operations.
+- **Session bus**: schema-rejected events (steady-state must be zero),
+  wake-publish failures.
+- **NATS**: disconnect storm (>6/min for 5m).
+- **api-proxy**: upstream 401 rate (refresh-storm signature), refresh
+  failures (any non-success result).
+- **mcp-auth-proxy**: SA token read failures, MCP upstream 5xx rate.
+- **Runners**: provider error rate, pending wakeup queue depth.
+
+Severity is `info` for "diagnostic-only, page nobody", `warning` for
+"a user feature is degraded", `critical` for "user-trust is on the line"
+(refresh-chain dead, schema-rejected events). AlertManager routing
+lives in the kube-prometheus-stack config, not in this chart.
+
+## Dashboard
+
+`k8s/templates/grafana-dashboard.yaml` ships a ConfigMap discovered by
+the Grafana sidecar via the `grafana_dashboard: "1"` label. Panels:
+HTTP request rate, 5xx rate by route, HTTP latency p50/p95/p99,
+Postgres rate/latency, session-event persister failures, NATS
+connection events, api-proxy refresh outcomes + 401 rate,
+mcp-auth-proxy request rate + SA token failures + GitHub attestation,
+runner turn duration + commands consumed.
+
+The dashboard is hand-built JSON. If panel count grows past ~20 we
+should migrate to grafonnet — out of scope today.
+
+## Cost / scaling
+
+On the current cluster (3 × Standard_B2s, kube-prometheus-stack
+deployed with default resource requests):
+
+- Active series added by this surface: ~4k. Most are HTTP histogram
+  buckets (30 routes × 3 methods × 11 buckets ≈ 1000) and the PG
+  histogram buckets.
+- Prometheus RAM cost: ~50–100MB on the existing 1Gi limit.
+- Scrape network: ~5KB/s aggregate at 30s intervals.
+
+At ~50 concurrent session pods, the PodMonitor adds another ~1.5k
+series. At ~500 concurrent sessions Prometheus would push past its
+current 1Gi RAM limit — that's the scaling cliff that triggers the
+migration to managed Prometheus (Azure Monitor Workspace).
+
+## Adding a new metric
+
+1. Decide the label set up front. Apply the cardinality rules above;
+   never use a label that grows per session/user/request.
+2. Register the metric next to its peers in the appropriate file:
+   - Orchestrator: `backend-go/cmd/tank-operator/observability.go`
+   - Runners: `agent-runner/src/metrics.ts` and `codex-runner/src/metrics.ts`
+   - Python services: `tank_api_proxy/metrics.py` or
+     `mcp_auth_proxy/metrics.py`
+3. Add a Grafana panel if it's worth seeing on the dashboard.
+4. Add a PrometheusRule alert if it represents a user-trust failure.
+5. If it's a Postgres query against a new table, add the table name to
+   `pgstore.knownTables` so the operation label resolves to the table
+   instead of `"other"`.

--- a/docs/tank-conversation-protocol.md
+++ b/docs/tank-conversation-protocol.md
@@ -409,10 +409,12 @@ Storage:
 
 Operational counters:
 
-- `/debug/vars` exposes stream opens, reconnects, `resync_required`, stream
-  errors, timeline read failures, emitted events, heartbeats, wake-subscribe
-  failures, and observed SSE event lag.
-- Missing-message investigations should start from those counters and the
+- `/metrics` exposes the `tank_session_event_stream_*` counters
+  (opens, reconnects, `resync_required`, stream errors, timeline read
+  failures, emitted events, heartbeats, wake-subscribe failures) and the
+  `tank_session_event_stream_lag_seconds` histogram. See
+  `docs/observability.md` for the full taxonomy and the Grafana panels.
+- Missing-message investigations should start from those metrics and the
   durable Postgres `session_events` ledger cursor, not from browser-local state.
 
 ## Migration Guardrails

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -60,6 +60,8 @@ kind: Service
 metadata:
   name: claude-api-proxy
   namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: claude-api-proxy
 spec:
   selector:
     app.kubernetes.io/name: claude-api-proxy
@@ -67,6 +69,12 @@ spec:
     - name: https
       port: 443
       targetPort: 8443
+    # /metrics — scraped by the ServiceMonitor in observability.yaml.
+    # Plain HTTP on the ext_proc sidecar's metrics port; the upstream
+    # api.anthropic.com leg keeps using port 443 with the leaf TLS.
+    - name: metrics
+      port: 9100
+      targetPort: metrics
 ---
 {{- /*
 Envoy config. Top-of-config rationale:
@@ -302,7 +310,13 @@ spec:
           ports:
             - name: grpc
               containerPort: 9000
+            - name: metrics
+              containerPort: 9100
           env:
+            - name: PROXY_PROVIDER
+              value: claude
+            - name: METRICS_PORT
+              value: "9100"
             - name: CLAUDE_CREDENTIALS_FILE
               value: /etc/claude-credentials/{{ .Values.externalSecret.claudeCredentials.secretKey }}
             - name: AZURE_KEYVAULT_URL
@@ -360,6 +374,8 @@ kind: Service
 metadata:
   name: codex-api-proxy
   namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: codex-api-proxy
 spec:
   selector:
     app.kubernetes.io/name: codex-api-proxy
@@ -367,6 +383,9 @@ spec:
     - name: https
       port: 443
       targetPort: 8443
+    - name: metrics
+      port: 9100
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -541,9 +560,13 @@ spec:
           ports:
             - name: grpc
               containerPort: 9000
+            - name: metrics
+              containerPort: 9100
           env:
             - name: PROXY_PROVIDER
               value: codex
+            - name: METRICS_PORT
+              value: "9100"
             - name: CODEX_CREDENTIALS_FILE
               value: /etc/codex-credentials/{{ .Values.externalSecret.codexCredentials.secretKey }}
             - name: AZURE_KEYVAULT_URL

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -253,6 +253,8 @@ kind: Service
 metadata:
   name: tank-operator
   namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: tank-operator
 spec:
   selector:
     app.kubernetes.io/name: tank-operator

--- a/k8s/templates/grafana-dashboard.yaml
+++ b/k8s/templates/grafana-dashboard.yaml
@@ -1,0 +1,236 @@
+{{- /*
+Grafana dashboard ConfigMap. The kube-prometheus-stack Grafana sidecar
+discovers dashboards by label selector across all namespaces, so this
+ConfigMap lives in tank-operator's namespace but the dashboard renders
+in the central Grafana instance running in the `monitoring` namespace.
+
+Dashboard JSON is hand-built rather than generated. If panels start to
+drift we should migrate to grafonnet — out of scope for v1.
+
+Only renders when observability.dashboards.enabled is true.
+*/}}
+{{- if and .Values.observability.enabled .Values.observability.dashboards.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tank-operator-grafana
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: tank-operator
+    {{ .Values.observability.dashboards.labelKey }}: {{ .Values.observability.dashboards.labelValue | quote }}
+data:
+  tank-operator.json: |
+    {
+      "title": "Tank Operator",
+      "uid": "tank-operator",
+      "schemaVersion": 39,
+      "version": 1,
+      "tags": ["tank"],
+      "timezone": "browser",
+      "time": { "from": "now-6h", "to": "now" },
+      "refresh": "30s",
+      "panels": [
+        {
+          "id": 1,
+          "title": "HTTP request rate by route+status_class",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_http_requests_total[5m])) by (route, status_class)",
+              "legendFormat": "{{`{{ route }}`}} {{`{{ status_class }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "HTTP 5xx by route (alert source)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_http_requests_total{status_class=\"5xx\"}[5m])) by (route)",
+              "legendFormat": "{{`{{ route }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "HTTP latency p50 / p95 / p99 by route",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, route) (rate(tank_http_request_duration_seconds_bucket[5m])))",
+              "legendFormat": "p50 {{`{{ route }}`}}"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, route) (rate(tank_http_request_duration_seconds_bucket[5m])))",
+              "legendFormat": "p95 {{`{{ route }}`}}"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, route) (rate(tank_http_request_duration_seconds_bucket[5m])))",
+              "legendFormat": "p99 {{`{{ route }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "title": "Postgres query rate + outcome",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_pg_queries_total[5m])) by (operation, outcome)",
+              "legendFormat": "{{`{{ operation }}`}} {{`{{ outcome }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "title": "Postgres p99 latency by operation",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, operation) (rate(tank_pg_query_duration_seconds_bucket[5m])))",
+              "legendFormat": "{{`{{ operation }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "title": "Session-event persister failures (steady-state = 0)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "rate(tank_session_event_persist_schema_rejected_total[5m])",
+              "legendFormat": "schema rejected"
+            },
+            {
+              "expr": "rate(tank_session_event_persist_transient_failure_total[5m])",
+              "legendFormat": "transient failure"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "title": "NATS connection events",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "rate(tank_nats_disconnect_total[5m])",
+              "legendFormat": "disconnect"
+            },
+            {
+              "expr": "rate(tank_nats_reconnect_total[5m])",
+              "legendFormat": "reconnect"
+            },
+            {
+              "expr": "rate(tank_nats_async_error_total[5m])",
+              "legendFormat": "async error"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "title": "api-proxy refresh outcomes by provider",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_api_proxy_token_refresh_total[10m])) by (provider, result)",
+              "legendFormat": "{{`{{ provider }}`}} {{`{{ result }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "title": "api-proxy upstream 401 rate (refresh storm signal)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_api_proxy_upstream_401_total[5m])) by (provider)",
+              "legendFormat": "{{`{{ provider }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "title": "mcp-auth-proxy request rate by mcp_server+status_class",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_mcp_auth_proxy_requests_total[5m])) by (mcp_server, status_class)",
+              "legendFormat": "{{`{{ mcp_server }}`}} {{`{{ status_class }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "title": "mcp-auth-proxy SA token read failures + GitHub attestation",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "rate(tank_mcp_auth_proxy_sa_token_read_total{result=\"failure\"}[5m])",
+              "legendFormat": "SA token read failure"
+            },
+            {
+              "expr": "sum(rate(tank_mcp_auth_proxy_github_attestation_total[5m])) by (result)",
+              "legendFormat": "GH attestation {{`{{ result }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "title": "Runner turn duration p50/p95/p99",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, mode, outcome) (rate(tank_runner_turn_duration_seconds_bucket[10m])))",
+              "legendFormat": "p50 {{`{{ mode }}`}} {{`{{ outcome }}`}}"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, mode, outcome) (rate(tank_runner_turn_duration_seconds_bucket[10m])))",
+              "legendFormat": "p95 {{`{{ mode }}`}} {{`{{ outcome }}`}}"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, mode, outcome) (rate(tank_runner_turn_duration_seconds_bucket[10m])))",
+              "legendFormat": "p99 {{`{{ mode }}`}} {{`{{ outcome }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "title": "Runner commands consumed by kind+result",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_runner_commands_consumed_total[5m])) by (mode, kind, result)",
+              "legendFormat": "{{`{{ mode }}`}} {{`{{ kind }}`}} {{`{{ result }}`}}"
+            }
+          ]
+        }
+      ]
+    }
+{{- end }}

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -1,0 +1,230 @@
+{{- /*
+Observability surface for tank-operator: ServiceMonitor / PodMonitor /
+PrometheusRule resources discovered by the kube-prometheus-stack
+deployed in the `monitoring` namespace.
+
+Conditional on observability.enabled so an environment without the
+Prometheus operator CRDs renders cleanly. docs/observability.md is the
+contract — the metric names referenced in PromQL below must match the
+Counter/Histogram declarations in:
+
+  - backend-go/cmd/tank-operator/observability.go
+  - backend-go/cmd/tank-operator/middleware_http.go
+  - backend-go/internal/pgstore/tracer.go
+  - agent-runner/src/metrics.ts
+  - codex-runner/src/metrics.ts
+  - api-proxy/src/tank_api_proxy/metrics.py
+  - claude-container/mcp-auth-proxy/src/mcp_auth_proxy/metrics.py
+*/}}
+{{- if .Values.observability.enabled }}
+---
+# ServiceMonitor: orchestrator. /metrics on the existing http port (same
+# listener as /api/*). 30s scrape; metrics latency budget allows it.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tank-operator
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: tank-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tank-operator
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.observability.scrapeInterval | default "30s" | quote }}
+      scrapeTimeout: 10s
+---
+# ServiceMonitor: api-proxy deployments (Claude + Codex). Both Services
+# expose the metrics sidecar port; the `provider` label on each metric
+# distinguishes the two at query time.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tank-api-proxy
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: tank-api-proxy
+spec:
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values: [claude-api-proxy, codex-api-proxy]
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.observability.scrapeInterval | default "30s" | quote }}
+      scrapeTimeout: 10s
+---
+# PodMonitor: session pods. The PodMonitor scrapes the mcp-auth-proxy
+# sidecar and (for claude_gui / codex_gui sessions) the runner sidecar.
+# Session pods are ephemeral — scrape interval 15s gives the operator a
+# realistic chance of catching at least one sample from a short-lived
+# session before the pod terminates and its series ages out.
+#
+# Cardinality discipline: we drop the pod / instance labels on the
+# scrape side via metricRelabelings so the per-pod prefix the prom
+# operator auto-injects doesn't grow active series with each new
+# session pod. The metric payload's own labels (mode, mcp_server,
+# outcome, etc.) remain — those are bounded by code.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: tank-session-pods
+  namespace: {{ include "tank-operator.sessionsNamespace" . }}
+  labels:
+    app.kubernetes.io/name: tank-session-pods
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: tank-operator
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 5s
+      metricRelabelings:
+        - action: labeldrop
+          regex: ^(pod|instance|namespace|container|endpoint|service|job)$
+    - port: runner-metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 5s
+      metricRelabelings:
+        - action: labeldrop
+          regex: ^(pod|instance|namespace|container|endpoint|service|job)$
+---
+# PrometheusRule: user-trust failure alerts. Each alert names exactly the
+# class of failure it surfaces; no "high-level" health alerts that fire
+# for unrelated reasons.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tank-operator
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: tank-operator
+spec:
+  groups:
+    - name: tank-operator.http
+      rules:
+        - alert: TankOperatorHTTP5xxRate
+          expr: sum(rate(tank_http_requests_total{status_class="5xx"}[5m])) by (route) > 0.01
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "tank-operator route {{`{{ $labels.route }}`}} is returning 5xx > 0.01 req/s for 5m"
+            runbook: "Inspect orchestrator logs for `http server error` lines on this route; the slog includes method, route, email, and the response detail."
+
+        - alert: TankPgQueryP99High
+          expr: histogram_quantile(0.99, sum by (le, operation) (rate(tank_pg_query_duration_seconds_bucket[5m]))) > 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "tank-operator Postgres p99 latency for operation {{`{{ $labels.operation }}`}} > 1s for 10m"
+
+        - alert: TankPgUnmappedOperation
+          expr: increase(tank_pg_queries_total{operation="other"}[1h]) > 0
+          for: 0m
+          labels:
+            severity: info
+          annotations:
+            summary: "tank-operator ran a Postgres query the operationFromSQL extractor did not recognize"
+            runbook: "Add the new table to pgstore.knownTables and ship a follow-up; otherwise that query is invisible in latency dashboards."
+
+    - name: tank-operator.session-bus
+      rules:
+        - alert: TankSessionEventPersistSchemaRejected
+          expr: tank_session_event_persist_schema_rejected_total > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "session-events persister terminated an event for schema reasons"
+            runbook: "A producer is emitting non-Tank events to the bus. Steady-state expectation is zero. Inspect persister logs for `session bus event terminated: schema rejected`."
+
+        - alert: TankSessionEventWakePublishFailures
+          expr: rate(tank_session_event_wake_publish_failure_total[10m]) > 0
+            or on() rate(tank_session_list_wake_publish_failure_total[10m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "tank-operator wake publishes to NATS are failing"
+            runbook: "SSE clients will lag behind durable state until the next heartbeat. Check NATS health in the nats namespace."
+
+    - name: tank-operator.nats
+      rules:
+        - alert: TankNATSReconnectStorm
+          expr: rate(tank_nats_disconnect_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "tank-operator's NATS client is reconnecting faster than 6/min"
+            runbook: "JetStream session bus is unstable. Check the nats namespace's pod health and ServerCertificate."
+
+    - name: tank-operator.api-proxy
+      rules:
+        - alert: TankApiProxyRefreshStorm
+          expr: rate(tank_api_proxy_upstream_401_total[5m]) > 0.5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "api-proxy ({{`{{ $labels.provider }}`}}) is seeing upstream 401s > 0.5/s for 5m"
+            runbook: "Refresh-storm signature. Check the refresh-token chain in KV; the single-flight gate may be failing to dedupe."
+
+        - alert: TankApiProxyRefreshFailures
+          expr: rate(tank_api_proxy_token_refresh_total{result!="success"}[10m]) > 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "api-proxy ({{`{{ $labels.provider }}`}}) cannot rotate its OAuth refresh chain"
+            runbook: "All inbound requests will eventually 401. Inspect ext-proc logs for `refresh failed` / `refresh request crashed`."
+
+    - name: tank-operator.mcp-auth-proxy
+      rules:
+        - alert: TankMCPAuthProxySATokenReadFailures
+          expr: rate(tank_mcp_auth_proxy_sa_token_read_total{result="failure"}[10m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "mcp-auth-proxy cannot read the projected ServiceAccount token"
+            runbook: "kubelet's projected token volume is broken on this session pod. MCP calls will 503. Restart the pod or investigate kubelet."
+
+        - alert: TankMCPAuthProxyUpstream5xx
+          expr: sum(rate(tank_mcp_auth_proxy_requests_total{status_class="5xx"}[5m])) by (mcp_server) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MCP server {{`{{ $labels.mcp_server }}`}} is returning 5xx > 0.05 req/s for 5m"
+
+    - name: tank-operator.runners
+      rules:
+        - alert: TankRunnerProviderErrorRate
+          expr: rate(tank_runner_provider_error_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "pod-side runner ({{`{{ $labels.mode }}`}}) provider errors > 0.1/s for 5m"
+            runbook: "Inspect the affected session pod's agent-runner / codex-runner logs."
+
+        - alert: TankRunnerPendingWakeupsGrowth
+          expr: max_over_time(tank_runner_pending_wakeups[1h]) > 50
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "ScheduleWakeup queue depth exceeded 50 in the last hour"
+            runbook: "Pod-local setTimeout scheduler is accumulating timers. May indicate a runaway agent loop or a stuck turn."
+{{- end }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -251,3 +251,20 @@ externalSecret:
 jwt:
   kvVault: https://romaine-kv.vault.azure.net/
   kvKeyName: tank-operator-jwt-signing
+
+# Observability templates (ServiceMonitor, PodMonitor, PrometheusRule, Grafana
+# dashboards) ship only when the kube-prometheus-stack operator CRDs are
+# present. Disabled environments render the chart without these resources so
+# `helm template` doesn't fail on a fresh cluster.
+#
+# docs/observability.md is the contract for everything below.
+observability:
+  enabled: true
+  scrapeInterval: 30s
+  # Grafana dashboard ConfigMaps are picked up by the kube-prometheus-stack
+  # Grafana sidecar via the `grafana_dashboard: "1"` label selector.
+  dashboards:
+    enabled: true
+    labelKey: grafana_dashboard
+    labelValue: "1"
+    namespace: monitoring

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -34,6 +34,10 @@ const ignoredRelativePaths = new Set([
   "scripts/check-tank-conversation-contract.mjs",
   "backend-go/cmd/tank-operator/server_static_test.go",
   "frontend/src/migrationPolicy.test.ts",
+  // The observability test asserts /debug/vars returns 404 (the negative
+  // confirmation that the route is gone). Excluded so the migration
+  // guard doesn't fire on its own enforcement.
+  "backend-go/cmd/tank-operator/observability_test.go",
 ]);
 
 const blocked = [
@@ -201,6 +205,22 @@ const blocked = [
   // the per-app gate back.
   { name: "removed ALLOWED_EMAILS env var", pattern: /\bALLOWED_EMAILS\b/ },
   { name: "removed romaine-life-admin-emails KV mount", pattern: /\bromaine-life-admin-emails\b/ },
+  // expvar / /debug/vars deleted in the observability cutover that
+  // replaced ad-hoc expvar counters with a real Prometheus surface
+  // (docs/observability.md). The Go stdlib expvar package and its
+  // /debug/vars HTTP handler are migration-policy.md deletion targets:
+  // nothing in the cluster scraped /debug/vars, and reintroducing
+  // expvar.NewInt next to promauto.NewCounter would split metrics
+  // between two registries silently.
+  { name: "removed expvar package import in backend-go", pattern: /^\s*"expvar"$/m },
+  { name: "removed expvar.NewInt counter", pattern: /\bexpvar\.NewInt\b/ },
+  { name: "removed expvar.NewFloat counter", pattern: /\bexpvar\.NewFloat\b/ },
+  { name: "removed expvar.NewMap counter", pattern: /\bexpvar\.NewMap\b/ },
+  { name: "removed expvar.NewString counter", pattern: /\bexpvar\.NewString\b/ },
+  { name: "removed expvar.Handler mount", pattern: /\bexpvar\.Handler\b/ },
+  { name: "removed /debug/vars HTTP route", pattern: /\/debug\/vars\b/ },
+  { name: "removed expvarPersisterMetrics type", pattern: /\bexpvarPersisterMetrics\b/ },
+  { name: "removed expvarWakeMetrics type", pattern: /\bexpvarWakeMetrics\b/ },
 ];
 
 const failures = [];


### PR DESCRIPTION
## Summary

Replaces the dead `expvar` / `/debug/vars` surface with a real Prometheus surface picked up by the kube-prometheus-stack already deployed in the `monitoring` namespace. Adds an HTTP middleware to the orchestrator that emits a structured `slog.Error` on every 5xx with `method`, `route`, `email`, and the response body's `detail` field — directly fixes the "/api/sessions/activity returned 500 with no logs" diagnostic gap.

## What's instrumented

- **backend-go orchestrator** — `tank_http_*` (request counter + duration histogram), `tank_pg_*` (pgx QueryTracer with bounded operation labels), `tank_nats_*` (connection callbacks), and the existing `tank_session_event_*` counters migrated off expvar.
- **agent-runner / codex-runner** — `tank_runner_commands_consumed_total`, `tank_runner_turn_duration_seconds`, `tank_runner_provider_error_total`, `tank_runner_pending_wakeups`, `tank_runner_nats_publish_failure_total`. Single `mode` label.
- **api-proxy** (deployed as Claude + Codex) — `tank_api_proxy_requests_total`, `tank_api_proxy_upstream_status_total`, `tank_api_proxy_upstream_401_total` (refresh-storm signature), `tank_api_proxy_token_refresh_total` + duration, `tank_api_proxy_kv_persist_total`, `tank_api_proxy_single_flight_waits_total`. `provider` label.
- **mcp-auth-proxy** — `tank_mcp_auth_proxy_requests_total{mcp_server, status_class}`, `tank_mcp_auth_proxy_upstream_duration_seconds`, `tank_mcp_auth_proxy_sa_token_read_total`, `tank_mcp_auth_proxy_github_attestation_total`.

## Cluster wiring

- `ServiceMonitor` for orchestrator + api-proxy Services
- `PodMonitor` for session pods (per-container endpoints: `metrics` for mcp-auth-proxy, `runner-metrics` for runners)
- `PrometheusRule` covering 5xx rate, PG p99, refresh storms, schema rejections, wake-publish failures, SA token failures, NATS reconnect storms
- Grafana dashboard ConfigMap (auto-discovered by the grafana sidecar via `grafana_dashboard: "1"` label)

All gated on `observability.enabled` so a cluster without the operator CRDs renders cleanly.

## Migration (per `docs/migration-policy.md`)

- `expvar` / `/debug/vars` deleted end-to-end from `backend-go`
- `scripts/check-removed-chat-runtime.mjs` blocks reintroduction (`expvar.NewInt`, `expvar.Handler`, `/debug/vars`, etc.)
- `docs/observability.md` is the contract (taxonomy, cardinality rules, alerts, "adding a new metric" recipe)
- `CLAUDE.md` updated; `docs/tank-conversation-protocol.md` no longer references the deleted `/debug/vars`

## Cardinality

No per-pod / per-session / per-user / per-turn labels. ~4k active series added cluster-wide; ~50-100MB on Prometheus. Current Prometheus is at 645Mi of 1Gi limit — comfortably accommodates this. Full math in `docs/observability.md`.

## Test plan

- [x] `go test ./...` — all 12 packages green
- [x] `agent-runner npm test` — 22/22 green (3 new metrics tests)
- [x] `codex-runner npm test` — 18/18 green (2 new metrics tests)
- [x] `helm template tank-operator k8s` — renders; observability resources present
- [x] `helm template tank-operator k8s --set observability.enabled=false` — observability resources skipped
- [x] `node scripts/check-removed-chat-runtime.mjs` — exit 0 (no expvar/`/debug/vars` left)
- [ ] After merge: confirm `up{job="tank-operator"} == 1` in Prometheus; trigger a synthetic 5xx and verify the slog line appears with route/email/detail
- [ ] After merge: confirm Grafana dashboard auto-loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)