### PR TITLE
Gate tank-operator PDB on testEnv.enabled=false

### DIFF
--- a/k8s/templates/pdb.yaml
+++ b/k8s/templates/pdb.yaml
@@ -1,4 +1,15 @@
-{{- if .Values.orchestrator.podDisruptionBudget.enabled }}
+{{- /*
+PDB is only rendered for production tank-operator. Test environments
+(Glimmung native-k8s slots, etc.) set testEnv.enabled=true; those run
+with a single replica and the deployment scales to zero between runs,
+so a minAvailable=1 PDB becomes a zombie that AKS's upgrade
+orchestration may interpret as "this pool can't be drained safely."
+
+If a test environment ever legitimately needs disruption protection,
+flip this back to unconditional and revisit the surrounding semantics
+(replica count, scale-to-zero behavior, AKS upgrade interaction).
+*/}}
+{{- if and .Values.orchestrator.podDisruptionBudget.enabled (not .Values.testEnv.enabled) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
## Summary

`k8s/templates/pdb.yaml` rendered the PDB unconditionally. Glimmung slot namespaces (`tank-operator-slot-1` through `-10`) inherit the chart with `testEnv.enabled=true` and scale their Deployments to zero between runs, which left 10 zombie PDBs in the cluster — each selecting zero pods but still reporting `disruptionsAllowed: 0` in `kubectl get pdb -A`.

Gate the PDB on `testEnv.enabled=false` so it only renders for production.

## Why this matters

A zombie PDB with no matching pods doesn't technically block eviction per the Kubernetes spec (the eviction API checks PDBs against their actual pod set), but it's noise in every cluster audit and AKS's drain orchestration runs more defensive pre-flight checks. Cleaner to not generate them at all.

## Cluster-side cleanup

The 10 existing zombies were deleted via `kubectl delete pdb tank-operator -n tank-operator-slot-{1..10}` ahead of this merge. After merge, future Glimmung syncs won't recreate them.

## Test plan

- [x] `helm template tank-operator k8s` — PDB renders (production default)
- [x] `helm template tank-operator k8s --set testEnv.enabled=true` — no PDB rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)