### PR TITLE
Fix /api/sessions/activity 500 from timestamptz scan

### DIFF
--- a/backend-go/internal/store/read_state.go
+++ b/backend-go/internal/store/read_state.go
@@ -50,7 +50,9 @@ func (s *postgresConversationReadStateStore) Get(ctx context.Context, email, ses
 		return nil, nil
 	}
 	const q = `
-		SELECT last_read_order_key, updated_at
+		SELECT
+			last_read_order_key,
+			COALESCE(to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS updated_at
 		FROM conversation_read_state
 		WHERE email = $1 AND session_scope = $2 AND session_id = $3
 	`
@@ -102,7 +104,9 @@ func (s *postgresConversationReadStateStore) Set(ctx context.Context, email, ses
 				THEN now()
 				ELSE conversation_read_state.updated_at
 			END
-		RETURNING last_read_order_key, updated_at
+		RETURNING
+			last_read_order_key,
+			COALESCE(to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS updated_at
 	`
 	var (
 		storedKey   string


### PR DESCRIPTION
## Summary
- `/api/sessions/activity` was returning 500 for every caller; sidebar rendered "activity failed: 500".
- Root cause: `internal/store/read_state.go` selected the `updated_at` timestamptz column raw and scanned into a Go `string`. pgx v5 binary protocol can't decode `timestamptz (OID 1184)` into `*string`.
- The Cosmos->Postgres migration (#466) added the `to_char(... AT TIME ZONE 'UTC', ...)` cast everywhere else (e.g. `sessionregistry/registry.go:40`) but missed `read_state.go`. Apply the same pattern to both the `Get` SELECT and the `Set` RETURNING.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/store/... ./cmd/tank-operator/...`
- [ ] After deploy: load tank.romaine.life sidebar, confirm sessions render their per-session status and no "activity failed: 500" toast.
- [ ] After deploy: `kubectl logs -n tank-operator deploy/tank-operator` shows no 500s on `/api/sessions/activity`.

Note: existing unit tests use `StubConversationReadStateStore`, so this class of pgx-encoding bug slips through unless we add a real-Postgres integration test. Out of scope here.

Generated with [Claude Code](https://claude.com/claude-code)
