### PR TITLE
auth: verify auth.romaine.life-issued JWTs alongside KV-minted ones

### DIFF
--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -143,16 +143,28 @@ func main() {
 		CodexAPIProxyHost: os.Getenv("CODEX_API_PROXY_HOST"),
 	})
 
-	// 10. Init auth signer + verifier (RS256, signing key in KV).
+	// 10. Init auth signer + verifier (RS256). Two key sources:
+	//   - KV-backed `tank-operator-jwt-signing` for legacy tank-operator-
+	//     minted JWTs (browser cookies issued by /api/auth/exchange).
+	//   - auth.romaine.life's published JWKS for JWTs the platform IdP
+	//     mints directly (admin bot tokens from /admin/bot-tokens,
+	//     future service-role tokens, anything else issued by
+	//     auth.romaine.life itself).
+	// The chained resolver tries both and short-circuits on the first
+	// success. Key namespaces are disjoint in production — auth.romaine
+	// .life signs with auth-jwt-signing, tank-operator signs with
+	// tank-operator-jwt-signing — so the chain produces a deterministic
+	// answer per kid.
 	jwtKey, err := buildJWTSigner(azCred)
 	if err != nil {
 		slog.Error("JWT signing key failed", "error", err)
 		os.Exit(1)
 	}
-	// Access gate is the role claim on the auth.romaine.life JWT (verified at
-	// exchange time and stamped onto the tank-operator session JWT). The
-	// Verifier just checks role ∈ {admin, user}; no per-tank email allowlist.
-	verifier := auth.NewVerifier(jwtKey)
+	keyResolver := auth.NewChainedKeyResolver(
+		auth.NewRomaineLifeKeyResolver(),
+		jwtKey,
+	)
+	verifier := auth.NewVerifier(keyResolver)
 	minter := auth.NewMinter(jwtKey, jwtKey)
 
 	// 11. Start reaper.

--- a/backend-go/internal/auth/chained_resolver.go
+++ b/backend-go/internal/auth/chained_resolver.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+)
+
+// chainedKeyResolver tries each underlying resolver in order, returning
+// the first one that successfully resolves the kid. Built for the
+// auth.romaine.life cutover: tank-operator now accepts JWTs minted by
+// the platform IdP (auth.romaine.life — JWKS resolver) AND legacy
+// JWTs it minted itself (KV resolver). The two key namespaces are
+// disjoint in production — auth.romaine.life signs with the auth-jwt-
+// signing key in KV, tank-operator's own exchange signs with tank-
+// operator-jwt-signing — so the chain produces a deterministic answer
+// based on which key signed the token.
+//
+// The chain order is: try the JWKS (auth.romaine.life) resolver first,
+// fall back to the KV resolver. Rationale: the JWKS path is becoming
+// the primary path (admin bot tokens, future service-role JWTs, the
+// /api/auth/exchange Stage C retirement) — short-circuiting on JWKS
+// success keeps the common case fast. KV lookups happen in-process
+// after the first fetch but still cost a "kid not in cache" path.
+type chainedKeyResolver struct {
+	resolvers []KeyResolver
+}
+
+// NewChainedKeyResolver returns a resolver that tries each provided
+// resolver in order. Last-error semantics: if every resolver fails,
+// the returned error wraps the last failure.
+func NewChainedKeyResolver(resolvers ...KeyResolver) KeyResolver {
+	return &chainedKeyResolver{resolvers: resolvers}
+}
+
+func (c *chainedKeyResolver) PublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	if len(c.resolvers) == 0 {
+		return nil, errors.New("no key resolvers configured")
+	}
+	var lastErr error
+	for _, r := range c.resolvers {
+		key, err := r.PublicKey(ctx, kid)
+		if err == nil {
+			return key, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("no resolver could verify kid %q: %w", kid, lastErr)
+}
+
+// romaineLifeKeyResolver adapts the existing jwks_remote.go cache into
+// the KeyResolver interface so it composes cleanly with the KV-backed
+// resolver via NewChainedKeyResolver. The cache itself is package-
+// global and shared with ExchangeRomaineLifeToken — both paths see
+// the same key rotation.
+type romaineLifeKeyResolver struct{}
+
+// NewRomaineLifeKeyResolver returns a KeyResolver that fetches public
+// keys from auth.romaine.life's JWKS endpoint (Better Auth's
+// /api/auth/jwks). Caches keys for 10 minutes via the package-global
+// romaineLifeJWKS cache (see jwks_remote.go).
+func NewRomaineLifeKeyResolver() KeyResolver {
+	return romaineLifeKeyResolver{}
+}
+
+func (romaineLifeKeyResolver) PublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	return romaineLifeJWKS.getKey(ctx, authRomaineLifeJWKSURL, kid)
+}

--- a/backend-go/internal/auth/chained_resolver_test.go
+++ b/backend-go/internal/auth/chained_resolver_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+)
+
+type stubResolver struct {
+	keys map[string]*rsa.PublicKey
+	err  error
+}
+
+func (s stubResolver) PublicKey(_ context.Context, kid string) (*rsa.PublicKey, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	key, ok := s.keys[kid]
+	if !ok {
+		return nil, errors.New("kid not found")
+	}
+	return key, nil
+}
+
+func genKey(t *testing.T) *rsa.PublicKey {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return &priv.PublicKey
+}
+
+func TestChainedKeyResolverReturnsFirstHit(t *testing.T) {
+	keyA := genKey(t)
+	first := stubResolver{keys: map[string]*rsa.PublicKey{"kid-a": keyA}}
+	second := stubResolver{keys: map[string]*rsa.PublicKey{"kid-b": genKey(t)}}
+
+	chain := NewChainedKeyResolver(first, second)
+	got, err := chain.PublicKey(context.Background(), "kid-a")
+	if err != nil {
+		t.Fatalf("PublicKey: %v", err)
+	}
+	if got != keyA {
+		t.Errorf("got=%p keyA=%p", got, keyA)
+	}
+}
+
+func TestChainedKeyResolverFallsThroughOnFirstMiss(t *testing.T) {
+	keyB := genKey(t)
+	first := stubResolver{keys: map[string]*rsa.PublicKey{"kid-a": genKey(t)}}
+	second := stubResolver{keys: map[string]*rsa.PublicKey{"kid-b": keyB}}
+
+	chain := NewChainedKeyResolver(first, second)
+	got, err := chain.PublicKey(context.Background(), "kid-b")
+	if err != nil {
+		t.Fatalf("PublicKey: %v", err)
+	}
+	if got != keyB {
+		t.Errorf("got=%p keyB=%p", got, keyB)
+	}
+}
+
+func TestChainedKeyResolverReportsLastErrorOnAllMiss(t *testing.T) {
+	first := stubResolver{err: errors.New("alpha-down")}
+	second := stubResolver{err: errors.New("beta-down")}
+
+	chain := NewChainedKeyResolver(first, second)
+	_, err := chain.PublicKey(context.Background(), "kid-z")
+	if err == nil {
+		t.Fatal("expected error when no resolver matched")
+	}
+	if !errContains(err, "beta-down") {
+		t.Errorf("err=%v, want wrapping the last (beta-down) failure", err)
+	}
+}
+
+func TestChainedKeyResolverEmptyConfigErrors(t *testing.T) {
+	chain := NewChainedKeyResolver()
+	_, err := chain.PublicKey(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected error from empty chain")
+	}
+}
+
+func errContains(err error, substr string) bool {
+	if err == nil {
+		return false
+	}
+	return contains(err.Error(), substr)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Tank-operator's bearer path previously rejected JWTs minted directly by auth.romaine.life — admin bot tokens from auth#35's `/admin/bot-tokens` endpoint and service-role tokens from `/api/auth/exchange/k8s`. The verifier was wired only to the KV-backed `tank-operator-jwt-signing` key, which signs JWTs that *tank-operator* mints via its own `/api/auth/exchange` (browser-cookie path). Auth.romaine.life-issued JWTs have kids under a different KV key (`auth-jwt-signing`), so the lookup 404'd:

```
invalid session token: token is unverifiable: error while executing keyfunc:
kv get key: GET .../keys/tank-operator-jwt-signing/<kid>
RESPONSE 404: KeyNotFound
```

That broke the platform's single-IdP contract — every other relying party ([glimmung#519](https://github.com/nelsong6/glimmung/pull/519), [mcp-glimmung#37](https://github.com/nelsong6/mcp-glimmung/pull/37)) now accepts auth.romaine.life-signed JWTs against the IdP's JWKS, but tank-operator's verifier kept the JWKS path scoped to the one-shot `ExchangeRomaineLifeToken` handler in `jwks_remote.go` and never wired it into `requireAuth`.

## Fix

`ChainedKeyResolver` tries each underlying resolver in order; production wires it as `[romaineLifeKeyResolver, KV-backed]`. The two key namespaces are disjoint by construction so the chain produces a deterministic answer per kid:

- auth.romaine.life-issued kid → JWKS resolver hits, returns the IdP's RSA key.
- tank-operator-minted kid → JWKS resolver misses (not in IdP's JWKS), falls through to KV resolver, returns `tank-operator-jwt-signing/<kid>`.

The browser cookie flow (tank-operator-signed) is unchanged.

## After this PR

An admin bot token minted at `auth.romaine.life/admin` passes `requireAuth`. Combined with #505's admin cross-user reads, a Claude/bot/CLI caller pasting an admin bot token can read any session's timeline:

```
curl -H \"Authorization: Bearer <admin-bot-token>\" \
     https://tank.romaine.life/api/sessions/37/timeline
```

was 401 before, returns 200 after.

## Files

- `backend-go/internal/auth/chained_resolver.go` (new):
  - `ChainedKeyResolver` — tries each `KeyResolver` in order, short-circuits on first success.
  - `romaineLifeKeyResolver` — adapts the existing `romaineLifeJWKS` cache (`jwks_remote.go`) into the `KeyResolver` interface so it composes with the KV-backed signer.
- `backend-go/cmd/tank-operator/main.go` — wires the chained resolver in front of the KV signer.

## Tests

- `TestChainedKeyResolverReturnsFirstHit`
- `TestChainedKeyResolverFallsThroughOnFirstMiss`
- `TestChainedKeyResolverReportsLastErrorOnAllMiss`
- `TestChainedKeyResolverEmptyConfigErrors`

All existing tests pass against the chained resolver (single-resolver test fixtures are unchanged behaviorally; the chain is order-preserving).

## Not in this PR

The natural follow-up is to retire `/api/auth/exchange` and the `tank-operator-jwt-signing` key entirely — let auth.romaine.life mint all JWTs and collapse the chain to a single JWKS-only resolver. Same Stage C shape as glimmung's K8sAuthenticator retirement plan. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)