### PR TITLE
internal: add github installation lookup endpoint

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_internal.go
+++ b/backend-go/cmd/tank-operator/handlers_internal.go
@@ -155,6 +155,58 @@ func (s *appServer) handleInternalGitHubAttestation(w http.ResponseWriter, r *ht
 	})
 }
 
+// handleInternalGitHubInstallation resolves the caller's actor_email to a
+// {installation_id, is_host, is_super_admin} triple by reading the user's
+// profile row. The canonical lookup mcp-github performs on every request
+// after it switches off the Tank-attestation surface — replaces the
+// per-request /github/attestation flow with a stateless lookup that returns
+// just the routing inputs, leaving JWT minting to auth.romaine.life.
+//
+// Returns {} when the email has no profile (treated as "no installation"
+// on the caller side — mcp-github will reject the request rather than
+// silently falling back to the host minter).
+//
+// Cf. nelsong6/glimmung sweep step D.
+func (s *appServer) handleInternalGitHubInstallation(w http.ResponseWriter, r *http.Request) {
+	user := s.requireServicePrincipal(w, r, "GET /api/internal/github/installation")
+	if user == nil {
+		return
+	}
+
+	email := strings.ToLower(strings.TrimSpace(user.ActorEmail))
+	if email == "" {
+		writeError(w, http.StatusBadRequest, "service token missing actor_email")
+		return
+	}
+
+	if s.profiles == nil {
+		writeError(w, http.StatusInternalServerError, "profile store not configured")
+		return
+	}
+	profile, err := s.profiles.GetOrCreate(r.Context(), email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "profile lookup failed: "+err.Error())
+		return
+	}
+
+	hostEmail := strings.ToLower(strings.TrimSpace(os.Getenv("HOST_EMAIL")))
+	superAdmins := parseEmailSet(envDefault("SUPER_ADMIN_EMAILS", hostEmail))
+	isHost := hostEmail != "" && email == hostEmail
+	isSuperAdmin := superAdmins[email]
+
+	resp := map[string]any{
+		"email":          email,
+		"is_host":        isHost,
+		"is_super_admin": isSuperAdmin,
+	}
+	if profile.InstallationID != nil {
+		resp["installation_id"] = *profile.InstallationID
+	} else {
+		resp["installation_id"] = nil
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // handleInternalListSessions lists sessions for the caller's actor_email.
 func (s *appServer) handleInternalListSessions(w http.ResponseWriter, r *http.Request) {
 	user := s.requireServicePrincipal(w, r, "GET /api/internal/sessions")

--- a/backend-go/cmd/tank-operator/handlers_internal_test.go
+++ b/backend-go/cmd/tank-operator/handlers_internal_test.go
@@ -154,6 +154,179 @@ func TestHandleInternalGitHubAttestationRejectsUnboundSAToken(t *testing.T) {
 	}
 }
 
+func TestHandleInternalGitHubInstallationResolvesFromProfile(t *testing.T) {
+	t.Setenv("HOST_EMAIL", "host@example.test")
+	t.Setenv("SUPER_ADMIN_EMAILS", "host@example.test, admin@example.test")
+	installationID := int64(424242)
+	jwtKey, err := auth.NewInMemoryJWT("svc-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := auth.NewVerifier(jwtKey)
+	tok, err := jwtKey.MintJWT(context.Background(), jwt.MapClaims{
+		"sub":         "svc:tank:session-x",
+		"email":       "pod-session-x@service.tank.romaine.life",
+		"name":        "Service: tank pod-session-x",
+		"role":        "service",
+		"actor_email": "owner@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &appServer{
+		verifier: verifier,
+		profiles: testProfilesStore{
+			"owner@example.test": {InstallationID: &installationID},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/internal/github/installation", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+
+	server.handleInternalGitHubInstallation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := body["email"], "owner@example.test"; got != want {
+		t.Fatalf("email = %v, want %q", got, want)
+	}
+	if got, want := body["installation_id"], float64(424242); got != want {
+		t.Fatalf("installation_id = %v, want %v", got, want)
+	}
+	if got, want := body["is_host"], false; got != want {
+		t.Fatalf("is_host = %v, want %v", got, want)
+	}
+	if got, want := body["is_super_admin"], false; got != want {
+		t.Fatalf("is_super_admin = %v, want %v", got, want)
+	}
+}
+
+func TestHandleInternalGitHubInstallationFlagsHost(t *testing.T) {
+	t.Setenv("HOST_EMAIL", "host@example.test")
+	t.Setenv("SUPER_ADMIN_EMAILS", "host@example.test")
+	jwtKey, err := auth.NewInMemoryJWT("svc-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := auth.NewVerifier(jwtKey)
+	tok, err := jwtKey.MintJWT(context.Background(), jwt.MapClaims{
+		"sub":         "svc:tank:session-x",
+		"email":       "pod-session-x@service.tank.romaine.life",
+		"name":        "Service: tank pod-session-x",
+		"role":        "service",
+		"actor_email": "host@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &appServer{
+		verifier: verifier,
+		// Host has no installation row; the response should still flag
+		// is_host=true so mcp-github routes to the host minter without
+		// needing an installation_id.
+		profiles: testProfilesStore{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/internal/github/installation", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+
+	server.handleInternalGitHubInstallation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := body["is_host"], true; got != want {
+		t.Fatalf("is_host = %v, want %v", got, want)
+	}
+	if got, want := body["is_super_admin"], true; got != want {
+		t.Fatalf("is_super_admin = %v, want %v", got, want)
+	}
+	if body["installation_id"] != nil {
+		t.Fatalf("installation_id = %v, want nil for host", body["installation_id"])
+	}
+}
+
+func TestHandleInternalGitHubInstallationReturnsNullForUnknownEmail(t *testing.T) {
+	t.Setenv("HOST_EMAIL", "host@example.test")
+	jwtKey, err := auth.NewInMemoryJWT("svc-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := auth.NewVerifier(jwtKey)
+	tok, err := jwtKey.MintJWT(context.Background(), jwt.MapClaims{
+		"sub":         "svc:tank:session-x",
+		"email":       "pod-session-x@service.tank.romaine.life",
+		"name":        "Service: tank pod-session-x",
+		"role":        "service",
+		"actor_email": "stranger@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &appServer{
+		verifier: verifier,
+		profiles: testProfilesStore{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/internal/github/installation", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+
+	server.handleInternalGitHubInstallation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["installation_id"] != nil {
+		t.Fatalf("installation_id = %v, want nil for unknown email", body["installation_id"])
+	}
+	if got, want := body["is_host"], false; got != want {
+		t.Fatalf("is_host = %v, want %v", got, want)
+	}
+}
+
+func TestHandleInternalGitHubInstallationRejectsNonService(t *testing.T) {
+	jwtKey, err := auth.NewInMemoryJWT("svc-kid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := auth.NewVerifier(jwtKey)
+	tok, err := jwtKey.MintJWT(context.Background(), jwt.MapClaims{
+		"sub":   "u-admin",
+		"email": "admin@example.test",
+		"name":  "Admin",
+		"role":  "admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &appServer{verifier: verifier}
+	req := httptest.NewRequest(http.MethodGet, "/api/internal/github/installation", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+
+	server.handleInternalGitHubInstallation(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHandleInternalSessionTurnTerminalReturnsTerminalEvent(t *testing.T) {
 	server := internalSessionRuntimeServer(t, "12")
 	server.sessionEvents = terminalEventStore{event: map[string]any{

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -128,6 +128,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	// Internal API.
 	mux.HandleFunc("GET /api/internal/jwks", s.handleInternalJWKS)
 	mux.HandleFunc("POST /api/internal/github/attestation", s.handleInternalGitHubAttestation)
+	mux.HandleFunc("GET /api/internal/github/installation", s.handleInternalGitHubInstallation)
 	mux.HandleFunc("GET /api/internal/sessions", s.handleInternalListSessions)
 	mux.HandleFunc("POST /api/internal/sessions", s.handleInternalCreateSession)
 	mux.HandleFunc("DELETE /api/internal/sessions/{session_id}", s.handleInternalDeleteSession)


### PR DESCRIPTION
## Summary

Adds `GET /api/internal/github/installation`. mcp-github will replace its Tank-attestation auth (POST `/api/internal/github/attestation` → JWT carrying `installation_id` + `is_host`) with auth.romaine.life service JWTs plus this stateless lookup, so installation routing decouples from JWT minting.

Shape:

\`\`\`
GET /api/internal/github/installation
Authorization: Bearer <auth.romaine.life service-role JWT>

→ {email, installation_id, is_host, is_super_admin}
\`\`\`

- Gated by `requireServicePrincipal` — only allowed-namespace service-role callers reach it (auth-side `NAMESPACE_TO_CONSUMER` + `serviceSaAllowlist` already enforce this; mcp-github will be a caller once it's a registered consumer).
- Scoped to the caller's `actor_email` — no email query param. Matches the auth-side principle that service principals act on behalf of a specific human; tightens the surface vs. an open lookup.
- Returns `installation_id: null` when no profile row exists. mcp-github will treat that as "reject the request" (no fallback to host minter) — same shape as today's Tank attestation, which 403s before minting if installation is absent and the caller isn't host.

The Tank-attestation surface stays live until mcp-github accepts auth.romaine.life JWTs and mcp-auth-proxy stops calling `/github/attestation`. Removal is a follow-up.

## Test plan

- [x] `go test ./cmd/tank-operator/` — full package passes, 4 new tests for the endpoint
- [ ] Integration: deploy + curl with a stamped service JWT
- [ ] Follow-up PR in mcp-github exercises this endpoint end-to-end

Cf. nelsong6/glimmung auth-sweep step D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)