### PR TITLE
mcp-auth-proxy: send auth.romaine.life service JWTs to mcp-github

### DIFF
--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
@@ -424,8 +424,9 @@ async def run() -> None:
     metrics_port = int(os.environ.get("MCP_AUTH_PROXY_METRICS_PORT", "9990"))
     metrics_runner = await start_metrics_server(metrics_port)
     runners.append(metrics_runner)
-    # Shared across mcp-tank-operator's outbound calls so the cached
-    # JWT (15-min TTL) is reused across many tool calls in a session.
+    # Shared across mcp-tank-operator and mcp-github outbound calls so
+    # the cached JWT (15-min TTL) is reused across many tool calls in a
+    # session.
     auth_romaine_provider = AuthRomaineServiceProvider(http)
 
     try:
@@ -437,7 +438,15 @@ async def run() -> None:
             # SDK gets a JSON 404 rather than an upstream plain-text one.
             app.router.add_route("POST", "/register", _oauth_discovery_not_configured)
             if port == GITHUB_MCP_PORT:
-                token_provider = TankGitHubAttestationProvider(http)
+                # mcp-github verifies the auth.romaine.life service JWT
+                # against the IdP's JWKS and resolves the caller's GitHub
+                # App installation by calling tank-operator's
+                # /api/internal/github/installation with this same bearer
+                # forwarded. The legacy Tank-attestation path is still
+                # accepted by mcp-github through the transition; once all
+                # session pods are running this proxy build, removing the
+                # /github/attestation endpoint is safe.
+                token_provider = auth_romaine_provider
             else:
                 token_provider = ServiceAccountTokenProvider()
 


### PR DESCRIPTION
## Summary

Switches the Bearer source for mcp-github (port 9992) in the session-pod mcp-auth-proxy from `TankGitHubAttestationProvider` (calls `/api/internal/github/attestation` per session) to the same `AuthRomaineServiceProvider` that already serves mcp-tank-operator (15-min cached `role=service` JWT minted by auth.romaine.life).

End-to-end after deploy:

1. Session pod's auth.romaine.life-aud projected SA token is exchanged for a service JWT by mcp-auth-proxy (already happening for mcp-tank-operator).
2. Same JWT now goes as Bearer to mcp-github.
3. mcp-github (#16 — already merged) verifies it against auth.romaine.life's JWKS and resolves `installation_id` via [tank-operator#512](https://github.com/nelsong6/tank-operator/pull/512)'s new `/api/internal/github/installation` endpoint, forwarding the same JWT.

The legacy `TankGitHubAttestationProvider` class is kept (unused) so an older session-pod image rolling forward to this build doesn't fail at import. The Tank-attestation surface removal (this class + tank-operator `/api/internal/github/attestation` + mcp-github's `TankJWTAuthenticator`) lands in a follow-up after every running session is on this image.

## Test plan

- [x] `uv run --with pytest pytest tests/` — 6/6 pass (unchanged tests; provider unit tests cover both classes)
- [ ] CI: docker build check, Go backend tests, image build
- [ ] Deploy + smoke: spawn a session pod, confirm an mcp-github tool call (e.g., list_pulls) returns the caller's-installation results, and `/github/attestation` request count goes to zero in Grafana

Cf. nelsong6/glimmung auth-sweep step D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)