### PR TITLE
mcp-auth-proxy: mcp-azure-personal moved to its own namespace

### DIFF
--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
@@ -97,7 +97,7 @@ AUTH_ROMAINE_FORWARD_HEADER = "X-Auth-Romaine-Token"
 #   9995 â€” mcp-glimmung
 #   9996 â€” mcp-tank-operator
 LISTENERS: list[tuple[int, str]] = [
-    (9991, "http://mcp-azure-personal.mcp-azure.svc:80"),
+    (9991, "http://mcp-azure-personal.mcp-azure-personal.svc:80"),
     (9992, "http://mcp-github.mcp-github.svc:80"),
     (9993, "http://mcp-k8s.mcp-k8s.svc:80"),
     (9994, "http://mcp-argocd.mcp-argocd.svc:80"),
@@ -308,7 +308,7 @@ async def _oauth_discovery_not_configured(request: web.Request) -> web.Response:
 
 def _mcp_server_label(upstream: str) -> str:
     """Extract a bounded label from the upstream URL. Example:
-    'http://mcp-azure-personal.mcp-azure.svc:80' → 'mcp-azure-personal'.
+    'http://mcp-azure-personal.mcp-azure-personal.svc:80' → 'mcp-azure-personal'.
     The fallback is the full host string, which is still bounded by the
     LISTENERS map but less Grafana-friendly. Cardinality is the count
     of distinct upstreams (~6), never per-request.


### PR DESCRIPTION
## Summary

mcp-azure-personal is migrating out of the legacy `mcp-azure` namespace into `mcp-azure-personal` to bring it in line with the slug==namespace convention every other pod-stable MCP follows (mcp-glimmung, mcp-k8s, mcp-argocd). The mismatch was breaking [auth#37](https://github.com/nelsong6/auth/pull/37)'s `serviceConsumerNamespaces` sync.

Updates the `LISTENERS` entry from `http://mcp-azure-personal.mcp-azure.svc:80` → `http://mcp-azure-personal.mcp-azure-personal.svc:80` and refreshes the docstring example.

This is one of three coordinated PRs:
1. [mcp-azure-personal#12](https://github.com/nelsong6/mcp-azure-personal/pull/12) — chart flips namespace.
2. **This PR** — session-pod sidecar DNS update. Land BEFORE #3 so the session-agent image rebuilds with the new endpoint baked in.
3. **infra-bootstrap** ArgoCD app rename — the cluster cutover.

Brief disruption: between #3 firing and a fresh session-pod image rolling out, active sessions still hold the old DNS in their already-built image. Tank-operator's existing recreate-on-image-bump behavior catches new sessions, but mid-session users may need to restart if they hit `mcp-azure-personal` during the window.

## Test plan

- [x] `uv run --with pytest pytest tests/` — 6/6 pass (no behavior change; pure DNS string update)
- [ ] Full Go + image-build CI
- [ ] Post-deploy: new session pod's mcp-auth-proxy logs show `listening on 127.0.0.1:9991 → http://mcp-azure-personal.mcp-azure-personal.svc:80`
- [ ] mcp-azure-personal tool call from a session pod returns successfully

Cf. nelsong6/glimmung auth-sweep rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)