### PR TITLE
mcp-auth-proxy: inject X-Auth-Romaine-Token for mcp-glimmung

### DIFF
--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
@@ -58,6 +58,7 @@ log = logging.getLogger(__name__)
 
 SA_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 GITHUB_MCP_PORT = 9992
+GLIMMUNG_MCP_PORT = 9995
 TANK_OPERATOR_MCP_PORT = 9996
 
 # auth.romaine.life service-principal exchange (see
@@ -380,11 +381,14 @@ async def run() -> None:
             else:
                 token_provider = ServiceAccountTokenProvider()
 
-            # mcp-tank-operator gets the auth.romaine.life service JWT
-            # forwarded so its session-management tools can authenticate
-            # to /api/internal/sessions/* . Other MCPs are unaffected.
+            # mcp-tank-operator and mcp-glimmung both gate their tool
+            # surface on the caller's auth.romaine.life service JWT (read
+            # from X-Auth-Romaine-Token because Authorization is consumed
+            # by kube-rbac-proxy in front of each, which strips it before
+            # forwarding upstream). Inject the header so the upstreams
+            # can attribute every call to the originating user.
             extra_header_provider = None
-            if port == TANK_OPERATOR_MCP_PORT:
+            if port in (TANK_OPERATOR_MCP_PORT, GLIMMUNG_MCP_PORT):
                 async def _provide_auth_romaine_header(
                     provider=auth_romaine_provider,
                 ) -> tuple[str, str]:


### PR DESCRIPTION
## Summary

mcp-glimmung sits behind kube-rbac-proxy, which consumes the inbound `Authorization` header for `TokenReview` and strips it before forwarding upstream. Result: mcp-glimmung's `CallerJWTMiddleware` never sees the inbound JWT, the caller resolves to `None`, and the outbound `bearer_header` falls back to mcp-glimmung's own pod-stable service JWT — silently replacing the user's identity in glimmung's audit log with `pod-mcp-glimmung@service.mcp-glimmung.romaine.life`.

Per [docs/migration-policy.md](https://github.com/nelsong6/glimmung/blob/main/docs/migration-policy.md) and [docs/quality-timeframes.md](https://github.com/nelsong6/glimmung/blob/main/docs/quality-timeframes.md), that fallback is forbidden ("just in case" path, runtime read keeping old behavior alive). This PR is the **upstream half** of removing it — mcp-auth-proxy now injects `X-Auth-Romaine-Token` on outbound calls to mcp-glimmung, mirroring the existing mcp-tank-operator pattern.

**Lands together with a mcp-glimmung PR** that switches the middleware to read from `X-Auth-Romaine-Token`, makes the JWT required (401 if absent for non-`/healthz`), deletes `auth_exchange.py`, and deletes the auth.romaine.life-aud SA token mount.

## Test plan

- [x] `uv run --with pytest pytest tests/` — 4/4 pass (no behavior change in mcp-tank-operator path)
- [ ] Full CI
- [ ] After deploy + mcp-glimmung PR rollout: glimmung audit log shows user emails per session-pod call, not the synthetic mcp-glimmung identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)