### PR TITLE
Scope session-list reads to fix cross-environment sidebar leak

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_session_list_events.go
+++ b/backend-go/cmd/tank-operator/handlers_session_list_events.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -50,7 +51,7 @@ func (s *appServer) handleSessionListTimeline(w http.ResponseWriter, r *http.Req
 	}
 	cursor := sessionListCursorFromRequest(r)
 	if cursor.AfterOrderKey != "" {
-		if ok, err := s.lifecycleEvents.HasOrderKey(r.Context(), owner, cursor.AfterOrderKey); err != nil {
+		if ok, err := s.lifecycleEvents.HasOrderKey(r.Context(), owner, s.sessionScope, cursor.AfterOrderKey); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		} else if !ok {
@@ -64,7 +65,7 @@ func (s *appServer) handleSessionListTimeline(w http.ResponseWriter, r *http.Req
 			limit = n
 		}
 	}
-	page, err := s.lifecycleEvents.ListByOwner(r.Context(), owner, cursor, limit)
+	page, err := s.lifecycleEvents.ListByOwner(r.Context(), owner, s.sessionScope, cursor, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -89,7 +90,7 @@ func (s *appServer) writeSessionListStreamPage(ctx context.Context, w http.Respo
 	if s.lifecycleEvents == nil {
 		return false, 0, nil
 	}
-	page, err := s.lifecycleEvents.ListByOwner(ctx, owner, *cursor, listEventStreamPageLimit)
+	page, err := s.lifecycleEvents.ListByOwner(ctx, owner, s.sessionScope, *cursor, listEventStreamPageLimit)
 	if err != nil {
 		return false, 0, err
 	}
@@ -111,17 +112,35 @@ func (s *appServer) writeSessionListStreamPage(ctx context.Context, w http.Respo
 
 // emitSessionListPayload forwards a NATS payload to the connected client.
 // Payloads are already JSON-marshaled lifecycleevents.Event documents;
-// we re-decode just enough to extract order_key for the SSE `id:` line
-// and to advance the cursor so a mid-stream reconnect resumes correctly.
+// we re-decode just enough to extract order_key + session_scope for the
+// SSE `id:` line, the cursor advance, and the defensive scope guard.
 //
 // A payload whose order_key is ≤ the cursor was either already streamed
 // during catch-up or is a duplicate of a row we just emitted — skip it
 // rather than re-rendering the same transition on the client.
+//
+// A payload whose session_scope does not match this orchestrator's
+// configured scope is dropped with a counter increment. The (email,
+// scope) NATS subject already makes this physically unreachable in
+// steady state; the check exists so a producer-side regression (wrong
+// scope passed to PublishSessionListEvent) cannot silently mutate
+// sidebar state on connected clients, and shows up as a non-zero rate
+// on tank_session_list_cross_scope_events_dropped_total instead.
 func (s *appServer) emitSessionListPayload(w http.ResponseWriter, cursor *lifecycleevents.Cursor, payload []byte) {
 	var probe struct {
-		OrderKey string `json:"order_key"`
+		OrderKey     string `json:"order_key"`
+		SessionScope string `json:"session_scope"`
 	}
 	if err := json.Unmarshal(payload, &probe); err != nil {
+		return
+	}
+	if scope := strings.TrimSpace(probe.SessionScope); scope != "" && scope != s.sessionScope {
+		sessionListCrossScopeEventsDroppedTotal.Inc()
+		slog.Warn("session list payload dropped: scope mismatch",
+			"expected_scope", s.sessionScope,
+			"payload_scope", scope,
+			"order_key", probe.OrderKey,
+		)
 		return
 	}
 	orderKey := strings.TrimSpace(probe.OrderKey)

--- a/backend-go/cmd/tank-operator/handlers_session_list_events_test.go
+++ b/backend-go/cmd/tank-operator/handlers_session_list_events_test.go
@@ -17,10 +17,14 @@ import (
 // the handler side. Returns canned pages from in-memory storage; cursor
 // behavior matches the Postgres semantics enough to exercise the
 // HasOrderKey -> resync_required path.
+//
+// Storage is keyed by (owner, scope) so the scope-isolation tests can
+// seed two scopes for the same owner and assert ListByOwner /
+// HasOrderKey never cross the boundary.
 type fakeLifecycleStore struct {
 	mu     sync.Mutex
-	rows   map[string][]lifecycleevents.Event // keyed by owner
-	ledger map[string]struct{}                // set of "owner|order_key" present in the ledger
+	rows   map[string][]lifecycleevents.Event // keyed by owner|scope
+	ledger map[string]struct{}                // set of "owner|scope|order_key" present in the ledger
 }
 
 func newFakeLifecycleStore() *fakeLifecycleStore {
@@ -33,9 +37,10 @@ func newFakeLifecycleStore() *fakeLifecycleStore {
 func (f *fakeLifecycleStore) seed(owner string, events ...lifecycleevents.Event) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.rows[owner] = append(f.rows[owner], events...)
 	for _, e := range events {
-		f.ledger[owner+"|"+e.OrderKey] = struct{}{}
+		key := owner + "|" + e.SessionScope
+		f.rows[key] = append(f.rows[key], e)
+		f.ledger[owner+"|"+e.SessionScope+"|"+e.OrderKey] = struct{}{}
 	}
 }
 
@@ -43,10 +48,10 @@ func (f *fakeLifecycleStore) Append(_ context.Context, _ lifecycleevents.Event) 
 	panic("unused in handler tests")
 }
 
-func (f *fakeLifecycleStore) ListByOwner(_ context.Context, owner string, cursor lifecycleevents.Cursor, limit int) (lifecycleevents.Page, error) {
+func (f *fakeLifecycleStore) ListByOwner(_ context.Context, owner, scope string, cursor lifecycleevents.Cursor, limit int) (lifecycleevents.Page, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	src := f.rows[owner]
+	src := f.rows[owner+"|"+scope]
 	out := make([]lifecycleevents.Event, 0, len(src))
 	for _, e := range src {
 		if cursor.AfterOrderKey != "" && e.OrderKey <= cursor.AfterOrderKey {
@@ -82,13 +87,13 @@ func cursorPosition(cursor lifecycleevents.Cursor, src []lifecycleevents.Event) 
 	return 0
 }
 
-func (f *fakeLifecycleStore) HasOrderKey(_ context.Context, owner, orderKey string) (bool, error) {
+func (f *fakeLifecycleStore) HasOrderKey(_ context.Context, owner, scope, orderKey string) (bool, error) {
 	if strings.TrimSpace(orderKey) == "" {
 		return true, nil
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	_, ok := f.ledger[owner+"|"+orderKey]
+	_, ok := f.ledger[owner+"|"+scope+"|"+orderKey]
 	return ok, nil
 }
 
@@ -161,6 +166,113 @@ func TestSessionListTimelineRejectsUnknownCursor(t *testing.T) {
 	srv.handleSessionListTimeline(resp, req)
 	if resp.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409 (unknown cursor must surface as conflict)", resp.Code)
+	}
+}
+
+// TestSessionListTimelineDoesNotCrossScopes is the regression gate for
+// the bug class that drove tank-operator#83's follow-up: prod and slot
+// orchestrators share one Postgres + NATS broker, the writes were
+// correctly scoped on session_scope, but the read paths joined only on
+// email. Symptom: a slot's session.created event rendered in prod's
+// sidebar; a slot's session.deleted purged a prod row of the same id.
+//
+// Seed two scopes with overlapping session_ids, fetch the timeline as
+// the prod orchestrator (sessionScope="default"), and assert the slot's
+// rows are unreachable on the read path.
+func TestSessionListTimelineDoesNotCrossScopes(t *testing.T) {
+	store := newFakeLifecycleStore()
+	store.seed("u@example.com",
+		lifecycleevents.Event{
+			OrderKey: "1", Email: "u@example.com", SessionScope: "default",
+			SessionID: "8", Type: lifecycleevents.EventTypeCreated, EventID: "default-created",
+			Payload: map[string]any{"mode": "claude_gui"},
+		},
+		lifecycleevents.Event{
+			OrderKey: "2", Email: "u@example.com", SessionScope: "tank-operator-slot-0",
+			SessionID: "8", Type: lifecycleevents.EventTypeCreated, EventID: "slot-created",
+			Payload: map[string]any{"mode": "claude_gui"},
+		},
+	)
+	srv := newTestAppServer(t, store)
+	req := authedListTimelineRequest(t, "")
+	resp := httptest.NewRecorder()
+	srv.handleSessionListTimeline(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Events) != 1 {
+		t.Fatalf("events = %d, want 1 (only the default-scope row should be visible to a default-scope orchestrator)", len(body.Events))
+	}
+	if got := body.Events[0]["event_id"]; got != "default-created" {
+		t.Fatalf("event_id = %v, want default-created (slot-created leaked through)", got)
+	}
+	if got := body.Events[0]["session_scope"]; got != "default" {
+		t.Fatalf("session_scope = %v, want default", got)
+	}
+}
+
+// TestSessionListTimelineRejectsCursorFromOtherScope locks in the
+// cursor-resync gate. A cursor from a different scope must be treated
+// as unknown — same shape as "cursor predates the ledger" — so the SPA
+// resyncs from scratch instead of silently returning an empty page or
+// crossing the partition. The browser's auto-reconnect path uses this
+// to recover after the orchestrator scope changed under a long-lived
+// session.
+func TestSessionListTimelineRejectsCursorFromOtherScope(t *testing.T) {
+	store := newFakeLifecycleStore()
+	store.seed("u@example.com",
+		lifecycleevents.Event{
+			OrderKey: "42", Email: "u@example.com", SessionScope: "tank-operator-slot-0",
+			SessionID: "8", Type: lifecycleevents.EventTypeCreated, EventID: "slot-created",
+		},
+	)
+	srv := newTestAppServer(t, store)
+
+	// Cursor exists in the ledger but only under "tank-operator-slot-0";
+	// the default-scope orchestrator must treat it as unknown.
+	req := authedListTimelineRequest(t, "42")
+	resp := httptest.NewRecorder()
+	srv.handleSessionListTimeline(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (cursor in another scope must trigger resync)", resp.Code)
+	}
+}
+
+// TestSessionListPayloadDropsCrossScope confirms the subscriber-side
+// defensive guard: even if a publisher regression lands a wrong-scope
+// payload on a same-email subject, the SSE handler must drop it before
+// emitting to the client. The (email, scope) subject shape makes this
+// physically unreachable in steady state — this test guards against
+// future producer bugs that would re-introduce the silent state
+// mutation.
+func TestSessionListPayloadDropsCrossScope(t *testing.T) {
+	srv := newTestAppServer(t, newFakeLifecycleStore())
+	cursor := &lifecycleevents.Cursor{}
+
+	// Payload from a different scope arriving on the prod subscriber.
+	wrongScope := lifecycleevents.Event{
+		OrderKey: "9", Email: "u@example.com", SessionScope: "tank-operator-slot-0",
+		SessionID: "8", Type: lifecycleevents.EventTypeDeleted, EventID: "wrong",
+	}
+	payload, err := json.Marshal(wrongScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	srv.emitSessionListPayload(resp, cursor, payload)
+
+	if resp.Body.Len() != 0 {
+		t.Fatalf("emit wrote %d bytes, want 0 (cross-scope payload must drop): %q", resp.Body.Len(), resp.Body.String())
+	}
+	if cursor.AfterOrderKey != "" {
+		t.Fatalf("cursor advanced to %q, want \"\" (dropped payload must not move the cursor)", cursor.AfterOrderKey)
 	}
 }
 

--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -86,7 +86,7 @@ func (s *appServer) handleSessionsEvents(w http.ResponseWriter, r *http.Request)
 
 	cursor := sessionListCursorFromRequest(r)
 	if s.lifecycleEvents != nil {
-		if ok, err := s.lifecycleEvents.HasOrderKey(r.Context(), owner, cursor.AfterOrderKey); err != nil {
+		if ok, err := s.lifecycleEvents.HasOrderKey(r.Context(), owner, s.sessionScope, cursor.AfterOrderKey); err != nil {
 			recordSessionListStreamError()
 			writeSSEJSONEvent(w, "stream-error", "", map[string]any{
 				"reason": "cursor_check_failed",
@@ -99,6 +99,7 @@ func (s *appServer) handleSessionsEvents(w http.ResponseWriter, r *http.Request)
 			slog.Warn("session list stream resync required",
 				"caller", user.Email,
 				"owner", owner,
+				"scope", s.sessionScope,
 				"last_order_key", cursor.AfterOrderKey,
 			)
 			writeSSEJSONEvent(w, "resync_required", "", map[string]any{
@@ -119,10 +120,10 @@ func (s *appServer) handleSessionsEvents(w http.ResponseWriter, r *http.Request)
 		sessionListStreamReconnectTotal.Inc()
 	}
 
-	natsCh, unsubscribe, err := s.sessionBus.SubscribeSessionListEvents(r.Context(), owner)
+	natsCh, unsubscribe, err := s.sessionBus.SubscribeSessionListEvents(r.Context(), owner, s.sessionScope)
 	if err != nil {
 		recordSessionListStreamError()
-		slog.Warn("session list events subscribe failed", "caller", user.Email, "owner", owner, "error", err)
+		slog.Warn("session list events subscribe failed", "caller", user.Email, "owner", owner, "scope", s.sessionScope, "error", err)
 		writeSSEJSONEvent(w, "stream-error", "", map[string]any{
 			"reason": "subscribe_failed",
 			"detail": err.Error(),

--- a/backend-go/cmd/tank-operator/handlers_turns_test.go
+++ b/backend-go/cmd/tank-operator/handlers_turns_test.go
@@ -65,11 +65,11 @@ func (*recordingSessionBus) SubscribeWakes(context.Context, string) (<-chan stru
 // tank-operator#83. Tests don't drive the sidebar SSE so the recorder
 // no-ops both; replace these stubs with capturing variants in dedicated
 // session-list tests when those land.
-func (*recordingSessionBus) PublishSessionListEvent(context.Context, string, []byte) error {
+func (*recordingSessionBus) PublishSessionListEvent(context.Context, string, string, []byte) error {
 	return nil
 }
 
-func (*recordingSessionBus) SubscribeSessionListEvents(context.Context, string) (<-chan []byte, func(), error) {
+func (*recordingSessionBus) SubscribeSessionListEvents(context.Context, string, string) (<-chan []byte, func(), error) {
 	return make(chan []byte), func() {}, nil
 }
 

--- a/backend-go/cmd/tank-operator/lifecycle_emitter.go
+++ b/backend-go/cmd/tank-operator/lifecycle_emitter.go
@@ -18,7 +18,7 @@ import (
 // PublishSessionListEvent. Kept as an interface here so unit tests can
 // substitute an in-memory recorder.
 type lifecycleListEventPublisher interface {
-	PublishSessionListEvent(ctx context.Context, email string, payload []byte) error
+	PublishSessionListEvent(ctx context.Context, email, scope string, payload []byte) error
 }
 
 // lifecycleEmitter bridges chat-event upserts into sidebar
@@ -188,12 +188,13 @@ func (e *lifecycleEmitter) EmitChatActivityDelta(ctx context.Context, event map[
 		e.metrics.RecordActivityFailure()
 		return fmt.Errorf("lifecycle emitter: marshal wire payload: %w", err)
 	}
-	if err := e.publisher.PublishSessionListEvent(ctx, owner, wirePayload); err != nil {
+	if err := e.publisher.PublishSessionListEvent(ctx, owner, e.scope, wirePayload); err != nil {
 		// Non-fatal: durable row already written; sidebar will catch up
 		// on cursor-resume.
 		slog.Warn("lifecycle emitter: publish failed",
 			"session_id", publicID,
 			"owner", owner,
+			"scope", e.scope,
 			"order_key", assigned.OrderKey,
 			"error", err,
 		)

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -243,6 +243,18 @@ var (
 		Name: "tank_session_list_stream_heartbeat_total",
 		Help: "Heartbeat frames written on idle sidebar SSE streams.",
 	})
+	// sessionListCrossScopeEventsDroppedTotal fires when a payload arrives
+	// on the per-(owner, scope) NATS subject whose embedded session_scope
+	// does not match this orchestrator's configured scope. The subject
+	// shape itself prevents cross-scope delivery in steady state, so any
+	// non-zero rate here is a producer-side regression: someone published
+	// to the right subject with the wrong scope inside the payload, which
+	// would silently mutate sidebar state on the client before this guard
+	// was added. PrometheusRule alerts on rate > 0 over 10 minutes.
+	sessionListCrossScopeEventsDroppedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_list_cross_scope_events_dropped_total",
+		Help: "Session-list NATS payloads dropped because the embedded session_scope did not match the local orchestrator scope.",
+	})
 )
 
 // --- Pod-informer producer metrics. ---

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -58,8 +58,8 @@ type sessionCommandBus interface {
 	PublishCommand(context.Context, sessionbus.Command) error
 	PublishSessionEventWake(context.Context, string) error
 	SubscribeWakes(context.Context, string) (<-chan struct{}, func(), error)
-	PublishSessionListEvent(context.Context, string, []byte) error
-	SubscribeSessionListEvents(context.Context, string) (<-chan []byte, func(), error)
+	PublishSessionListEvent(ctx context.Context, email, scope string, payload []byte) error
+	SubscribeSessionListEvents(ctx context.Context, email, scope string) (<-chan []byte, func(), error)
 }
 
 func (s *appServer) registerRoutes(mux *http.ServeMux) {

--- a/backend-go/internal/lifecycleevents/store.go
+++ b/backend-go/internal/lifecycleevents/store.go
@@ -28,19 +28,27 @@ type Store interface {
 	// publish on NATS" decision.
 	Append(ctx context.Context, event Event) (assigned Event, alreadyExists bool, err error)
 
-	// ListByOwner returns events for one owner strictly after cursor in
-	// ascending order_key, up to limit. The page contains at most `limit`
-	// rows; HasMore signals there's at least one further row. Used by both
-	// the snapshot bootstrap (GET /api/sessions/timeline) and the catch-up
-	// pass that runs at SSE-stream open before the NATS subscription.
-	ListByOwner(ctx context.Context, owner string, cursor Cursor, limit int) (Page, error)
+	// ListByOwner returns events for one (owner, scope) strictly after
+	// cursor in ascending order_key, up to limit. The page contains at
+	// most `limit` rows; HasMore signals there's at least one further
+	// row. Used by both the snapshot bootstrap (GET
+	// /api/sessions/timeline) and the catch-up pass that runs at
+	// SSE-stream open before the NATS subscription.
+	//
+	// Scope is mandatory: the durable partition is (email, session_scope,
+	// order_key), and an email-only read was the bug class behind
+	// tank-operator#83's cross-environment leak — slot lifecycle events
+	// rendering in prod's sidebar because the read forgot the same
+	// session_scope column the write path enforces.
+	ListByOwner(ctx context.Context, owner, scope string, cursor Cursor, limit int) (Page, error)
 
 	// HasOrderKey is the cursor-validation hook used by the SSE handler.
 	// An empty order_key counts as valid (snapshot bootstrap). A non-empty
-	// order_key that no row matches forces a resync_required SSE event so
-	// the client re-fetches /api/sessions instead of silently skipping a
-	// gap.
-	HasOrderKey(ctx context.Context, owner, orderKey string) (bool, error)
+	// order_key that no row matches inside (owner, scope) forces a
+	// resync_required SSE event so the client re-fetches the timeline
+	// instead of silently skipping a gap. Old cursors from the pre-#83
+	// cross-scope read window naturally miss here and trigger resync.
+	HasOrderKey(ctx context.Context, owner, scope, orderKey string) (bool, error)
 
 	// LatestActivity returns the most recent session.activity_changed
 	// payload for one session, or nil if none exists yet. Used by both
@@ -140,33 +148,36 @@ func (s *postgresStore) Append(ctx context.Context, event Event) (Event, bool, e
 	}
 }
 
-func (s *postgresStore) ListByOwner(ctx context.Context, owner string, cursor Cursor, limit int) (Page, error) {
+func (s *postgresStore) ListByOwner(ctx context.Context, owner, scope string, cursor Cursor, limit int) (Page, error) {
 	limit = normalizeLimit(limit)
 	owner = normalizeOwner(owner)
-	if owner == "" {
+	scope = strings.TrimSpace(scope)
+	if owner == "" || scope == "" {
 		return Page{}, nil
 	}
 
 	// Read limit+1 to set HasMore without a second COUNT — mirrors the
-	// session_events pagination shape.
+	// session_events pagination shape. WHERE filters on
+	// (email, session_scope); the session_lifecycle_events_owner_order
+	// index supports the (=, =, range) predicate shape.
 	queryLimit := limit + 1
 	const baseQ = `
 		SELECT order_key, email, session_scope, session_id, event_type,
 		       event_id, payload, occurred_at
 		FROM session_lifecycle_events
-		WHERE email = $1
+		WHERE email = $1 AND session_scope = $2
 	`
 	q := baseQ
-	args := []any{owner}
+	args := []any{owner, scope}
 	if cursor.AfterOrderKey != "" {
 		after, err := parseOrderKey(cursor.AfterOrderKey)
 		if err != nil {
 			return Page{}, err
 		}
-		q += " AND order_key > $2 ORDER BY order_key ASC LIMIT $3"
+		q += " AND order_key > $3 ORDER BY order_key ASC LIMIT $4"
 		args = append(args, after, queryLimit)
 	} else {
-		q += " ORDER BY order_key ASC LIMIT $2"
+		q += " ORDER BY order_key ASC LIMIT $3"
 		args = append(args, queryLimit)
 	}
 
@@ -226,7 +237,7 @@ func (s *postgresStore) ListByOwner(ctx context.Context, owner string, cursor Cu
 	return Page{Events: out, NextOrderKey: next, HasMore: hasMore}, nil
 }
 
-func (s *postgresStore) HasOrderKey(ctx context.Context, owner, orderKey string) (bool, error) {
+func (s *postgresStore) HasOrderKey(ctx context.Context, owner, scope, orderKey string) (bool, error) {
 	if strings.TrimSpace(orderKey) == "" {
 		return true, nil
 	}
@@ -234,14 +245,19 @@ func (s *postgresStore) HasOrderKey(ctx context.Context, owner, orderKey string)
 	if err != nil {
 		return false, nil
 	}
+	owner = normalizeOwner(owner)
+	scope = strings.TrimSpace(scope)
+	if owner == "" || scope == "" {
+		return false, nil
+	}
 	const q = `
 		SELECT 1
 		FROM session_lifecycle_events
-		WHERE email = $1 AND order_key = $2
+		WHERE email = $1 AND session_scope = $2 AND order_key = $3
 		LIMIT 1
 	`
 	var one int
-	err = s.pool.QueryRow(ctx, q, normalizeOwner(owner), parsed).Scan(&one)
+	err = s.pool.QueryRow(ctx, q, owner, scope, parsed).Scan(&one)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false, nil
 	}
@@ -411,11 +427,11 @@ func (StubStore) Append(_ context.Context, event Event) (Event, bool, error) {
 	return event, false, nil
 }
 
-func (StubStore) ListByOwner(_ context.Context, _ string, _ Cursor, _ int) (Page, error) {
+func (StubStore) ListByOwner(_ context.Context, _, _ string, _ Cursor, _ int) (Page, error) {
 	return Page{}, nil
 }
 
-func (StubStore) HasOrderKey(_ context.Context, _, orderKey string) (bool, error) {
+func (StubStore) HasOrderKey(_ context.Context, _, _, orderKey string) (bool, error) {
 	return strings.TrimSpace(orderKey) == "", nil
 }
 

--- a/backend-go/internal/podinformer/podinformer.go
+++ b/backend-go/internal/podinformer/podinformer.go
@@ -54,11 +54,14 @@ func (noopMetrics) RecordLag(_ float64)       {}
 func (noopMetrics) RecordLeaderStatus(_ bool) {}
 
 // EventPublisher publishes one already-marshaled lifecycle-event payload
-// onto the per-owner NATS session-list events subject. Implemented by
-// *sessionbus.Bus. Kept as a narrow interface so the informer can be
-// tested without spinning up NATS.
+// onto the per-(owner, scope) NATS session-list events subject.
+// Implemented by *sessionbus.Bus. Kept as a narrow interface so the
+// informer can be tested without spinning up NATS. Scope mirrors the
+// row's session_scope so the wire shape matches the durable partition;
+// publishing with a different scope than the row carries is the bug
+// class the (owner, scope) subject prevents at the wire layer.
 type EventPublisher interface {
-	PublishSessionListEvent(ctx context.Context, email string, payload []byte) error
+	PublishSessionListEvent(ctx context.Context, email, scope string, payload []byte) error
 }
 
 // Config wires the informer with everything it needs to produce durable
@@ -395,9 +398,10 @@ func (t *transitionTracker) emit(ctx context.Context, event lifecycleevents.Even
 		)
 		return
 	}
-	if err := t.publisher.PublishSessionListEvent(ctx, assigned.Email, payload); err != nil {
+	if err := t.publisher.PublishSessionListEvent(ctx, assigned.Email, assigned.SessionScope, payload); err != nil {
 		slog.Warn("podinformer: publish failed",
 			"session_id", event.SessionID,
+			"scope", assigned.SessionScope,
 			"type", event.Type,
 			"error", err,
 		)

--- a/backend-go/internal/podinformer/podinformer_test.go
+++ b/backend-go/internal/podinformer/podinformer_test.go
@@ -44,11 +44,11 @@ func (s *fakeStore) Append(_ context.Context, event lifecycleevents.Event) (life
 	return event, false, nil
 }
 
-func (s *fakeStore) ListByOwner(_ context.Context, _ string, _ lifecycleevents.Cursor, _ int) (lifecycleevents.Page, error) {
+func (s *fakeStore) ListByOwner(_ context.Context, _, _ string, _ lifecycleevents.Cursor, _ int) (lifecycleevents.Page, error) {
 	return lifecycleevents.Page{}, nil
 }
 
-func (s *fakeStore) HasOrderKey(_ context.Context, _, _ string) (bool, error) { return true, nil }
+func (s *fakeStore) HasOrderKey(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
 
 func (s *fakeStore) LatestActivity(_ context.Context, _, _ string) (*lifecycleevents.ActivitySummary, error) {
 	return nil, nil
@@ -62,10 +62,12 @@ func nextOrderKey(i int) string {
 	return time.Now().Format("150405.000") + "-" + string(rune('a'+i%26))
 }
 
-// fakePublisher records each (owner, payload) it sees. Used to assert
-// that the informer only publishes on a fresh append (the "already
-// exists" path must not re-publish, or stale rows would render on
-// connected clients).
+// fakePublisher records each (owner, scope, payload) it sees. Used to
+// assert that the informer only publishes on a fresh append (the
+// "already exists" path must not re-publish, or stale rows would render
+// on connected clients) and that the scope passed to the publisher
+// matches the row's session_scope (the wire shape is keyed on (email,
+// scope), so a stale scope here breaks delivery).
 type fakePublisher struct {
 	mu       sync.Mutex
 	payloads []publishedEvent
@@ -73,15 +75,16 @@ type fakePublisher struct {
 
 type publishedEvent struct {
 	owner string
+	scope string
 	raw   []byte
 }
 
-func (p *fakePublisher) PublishSessionListEvent(_ context.Context, owner string, payload []byte) error {
+func (p *fakePublisher) PublishSessionListEvent(_ context.Context, owner, scope string, payload []byte) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	cp := make([]byte, len(payload))
 	copy(cp, payload)
-	p.payloads = append(p.payloads, publishedEvent{owner: owner, raw: cp})
+	p.payloads = append(p.payloads, publishedEvent{owner: owner, scope: scope, raw: cp})
 	return nil
 }
 

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -264,44 +264,57 @@ func (b *Bus) PublishSessionEventWake(_ context.Context, sessionStorageKey strin
 }
 
 // PublishSessionListEvent publishes one typed lifecycle-event payload on
-// the per-owner session-list events subject. The SSE handler on
+// the per-(owner, scope) session-list events subject. The SSE handler on
 // /api/sessions/events forwards the payload verbatim to subscribed
 // clients — there is no separate wake-and-refetch step. Replaces the
 // prior opaque resync-trigger publish per tank-operator#83. Steady-state
 // expectation: zero publish failures; a failure here means NATS is down,
 // in which case SSE clients fall back to the durable Postgres replay on
 // reconnect.
-func (b *Bus) PublishSessionListEvent(_ context.Context, email string, payload []byte) error {
+//
+// Scope must match the lifecycleevents row's session_scope field. Passing
+// the wrong scope here is the failure mode the (email, scope) subject
+// shape is designed to make impossible — events publish to a subject no
+// other-scope subscriber is listening on, so cross-scope leakage is a
+// wire-shape impossibility instead of a delivery-time filter.
+func (b *Bus) PublishSessionListEvent(_ context.Context, email, scope string, payload []byte) error {
 	if b == nil {
 		return fmt.Errorf("session bus unavailable")
 	}
 	if strings.TrimSpace(email) == "" {
 		return nil
 	}
+	if strings.TrimSpace(scope) == "" {
+		return fmt.Errorf("session list event scope is required")
+	}
 	if len(payload) == 0 {
 		return fmt.Errorf("session list event payload is empty")
 	}
-	if err := b.nc.Publish(SessionListEventSubject(email), payload); err != nil {
+	if err := b.nc.Publish(SessionListEventSubject(email, scope), payload); err != nil {
 		b.wakeMetrics.RecordSessionListEventPublishFailed()
 		slog.Warn("session list event publish failed",
-			"email", email, "error", err)
+			"email", email, "scope", scope, "error", err)
 		return err
 	}
 	return nil
 }
 
 // SubscribeSessionListEvents returns a channel that receives each typed
-// lifecycle-event payload published for the owner. Channel cap is 64 to
-// absorb short bursts (pod-informer can emit several transitions in
-// quick succession during pod startup); if the consumer falls further
-// behind, payloads are dropped at the NATS-subscription callback and the
-// consumer's next reconnect cursor-resume catches up from Postgres.
-func (b *Bus) SubscribeSessionListEvents(ctx context.Context, email string) (<-chan []byte, func(), error) {
+// lifecycle-event payload published for the (owner, scope) pair. Channel
+// cap is 64 to absorb short bursts (pod-informer can emit several
+// transitions in quick succession during pod startup); if the consumer
+// falls further behind, payloads are dropped at the NATS-subscription
+// callback and the consumer's next reconnect cursor-resume catches up
+// from Postgres.
+func (b *Bus) SubscribeSessionListEvents(ctx context.Context, email, scope string) (<-chan []byte, func(), error) {
 	if b == nil {
 		return nil, func() {}, fmt.Errorf("session bus unavailable")
 	}
+	if strings.TrimSpace(scope) == "" {
+		return nil, func() {}, fmt.Errorf("session list event scope is required")
+	}
 	ch := make(chan []byte, 64)
-	sub, err := b.nc.Subscribe(SessionListEventSubject(email), func(msg *nats.Msg) {
+	sub, err := b.nc.Subscribe(SessionListEventSubject(email, scope), func(msg *nats.Msg) {
 		// Copy the data slice — the NATS client reuses the underlying
 		// buffer across deliveries.
 		payload := make([]byte, len(msg.Data))

--- a/backend-go/internal/sessionbus/subjects.go
+++ b/backend-go/internal/sessionbus/subjects.go
@@ -61,8 +61,8 @@ func WakeSubject(sessionStorageKey string) string {
 	return fmt.Sprintf("%s.%s.wake", liveRoot, StorageToken(sessionStorageKey))
 }
 
-// SessionListEventSubject names the per-owner typed-event subject that
-// carries session_lifecycle_events Append payloads to the sidebar SSE
+// SessionListEventSubject names the per-(owner, scope) typed-event subject
+// that carries session_lifecycle_events Append payloads to the sidebar SSE
 // handlers. Replaces the prior opaque wake subject (an empty-payload
 // resync trigger) per tank-operator#83 — see
 // docs/product-inspirations.md "Work delivery should use a real
@@ -70,9 +70,25 @@ func WakeSubject(sessionStorageKey string) string {
 // database polling are not the normal live path for app-managed GUI
 // chat." The wire payload is one lifecycleevents.Event JSON document;
 // SSE handlers forward it to clients verbatim.
-func SessionListEventSubject(email string) string {
-	normalized := strings.TrimSpace(strings.ToLower(email))
-	return fmt.Sprintf("%s.sessions.%s.events", liveRoot, base64.RawURLEncoding.EncodeToString([]byte(normalized)))
+//
+// Scope is part of the subject because every other partition of the
+// durable system uses (email, session_scope) as the natural key — the
+// session_lifecycle_events row PK, the registry PK, the per-scope
+// session_id allocator. An email-only subject conflated prod and slot
+// environments that share the same Postgres + NATS broker (one row in
+// prod's sidebar per slot session, deletes that came back when a slot
+// republished session.created on resync). The subject now matches the
+// durable partition so cross-scope events are unreachable on the wire,
+// not filtered after delivery.
+func SessionListEventSubject(email, scope string) string {
+	normalizedEmail := strings.TrimSpace(strings.ToLower(email))
+	normalizedScope := strings.TrimSpace(scope)
+	return fmt.Sprintf(
+		"%s.sessions.%s.%s.events",
+		liveRoot,
+		base64.RawURLEncoding.EncodeToString([]byte(normalizedEmail)),
+		base64.RawURLEncoding.EncodeToString([]byte(normalizedScope)),
+	)
 }
 
 func sanitizeSubjectToken(value string) string {

--- a/backend-go/internal/sessionbus/subjects_test.go
+++ b/backend-go/internal/sessionbus/subjects_test.go
@@ -1,0 +1,60 @@
+package sessionbus
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSessionListEventSubjectIncludesScope is the wire-shape lockdown
+// for the scope partition. Pre-#83-follow-up the subject was keyed on
+// email alone; prod and slot orchestrators sharing one NATS broker
+// received each other's events because they subscribed to the same
+// subject. Cross-environment delivery now has to be physically
+// unreachable on the broker, not filtered after the fact.
+func TestSessionListEventSubjectIncludesScope(t *testing.T) {
+	const email = "u@example.com"
+
+	prod := SessionListEventSubject(email, "default")
+	slot := SessionListEventSubject(email, "tank-operator-slot-0")
+
+	if prod == slot {
+		t.Fatalf("subjects must differ across scopes; got %q for both prod (default) and slot (tank-operator-slot-0)", prod)
+	}
+	if !strings.HasSuffix(prod, ".events") {
+		t.Fatalf("subject must end in .events; got %q", prod)
+	}
+	if !strings.HasSuffix(slot, ".events") {
+		t.Fatalf("subject must end in .events; got %q", slot)
+	}
+
+	// Same email and scope must hash to the same subject (idempotent +
+	// case-insensitive on the email half).
+	if got := SessionListEventSubject(strings.ToUpper(email), "default"); got != prod {
+		t.Fatalf("email casing must not change the subject; got %q, want %q", got, prod)
+	}
+}
+
+// TestSessionListEventSubjectFormat keeps the on-the-wire token shape
+// pinned. Both halves are base64-url-encoded so arbitrary scope names
+// (Helm release names containing `.`, etc.) survive NATS's reserved
+// `.`/`*`/`>` separators without ad-hoc sanitization.
+func TestSessionListEventSubjectFormat(t *testing.T) {
+	subject := SessionListEventSubject("u@example.com", "tank-operator-slot-0")
+	parts := strings.Split(subject, ".")
+	// Expected shape: tank.live.sessions.<email_token>.<scope_token>.events
+	if len(parts) != 6 {
+		t.Fatalf("subject tokens = %d, want 6: %q", len(parts), subject)
+	}
+	if parts[0] != "tank" || parts[1] != "live" || parts[2] != "sessions" || parts[5] != "events" {
+		t.Fatalf("subject scaffolding changed: %q", subject)
+	}
+	if parts[3] == "" || parts[4] == "" {
+		t.Fatalf("email and scope tokens must be non-empty: %q", subject)
+	}
+	// Scope tokens must not contain the raw "-" or "." from the source
+	// scope name — that's what base64-url-encoding buys us. (RawURLEncoding
+	// emits only [A-Za-z0-9_-], no `.` or `*`.)
+	if strings.Contains(parts[4], ".") {
+		t.Fatalf("scope token must not contain '.', the NATS separator; got %q", parts[4])
+	}
+}

--- a/backend-go/internal/sessions/manager.go
+++ b/backend-go/internal/sessions/manager.go
@@ -38,13 +38,14 @@ type SessionRegistry interface {
 }
 
 // SessionListEventPublisher is implemented by the session bus; it
-// publishes one typed lifecycle-event payload on the per-owner NATS
-// session-list events subject. Replaces the prior SessionListWaker
+// publishes one typed lifecycle-event payload on the per-(owner, scope)
+// NATS session-list events subject. Replaces the prior SessionListWaker
 // (opaque wake-and-refetch) per tank-operator#83 — the SSE handler now
 // forwards the payload verbatim to clients instead of just telling them
-// to re-fetch.
+// to re-fetch. Scope mirrors the row's session_scope so prod and slot
+// orchestrators sharing a NATS broker never see each other's payloads.
 type SessionListEventPublisher interface {
-	PublishSessionListEvent(ctx context.Context, email string, payload []byte) error
+	PublishSessionListEvent(ctx context.Context, email, scope string, payload []byte) error
 }
 
 // LifecycleAppender is the durable side of the producer pipeline.
@@ -671,11 +672,12 @@ func (m *Manager) emitLifecycle(ctx context.Context, event lifecycleevents.Event
 		)
 		return
 	}
-	if err := m.publisher.PublishSessionListEvent(ctx, assigned.Email, payload); err != nil {
+	if err := m.publisher.PublishSessionListEvent(ctx, assigned.Email, assigned.SessionScope, payload); err != nil {
 		slog.Warn("manager lifecycle publish failed",
 			"session_id", event.SessionID,
 			"type", event.Type,
 			"owner", assigned.Email,
+			"scope", assigned.SessionScope,
 			"error", err,
 		)
 	}

--- a/frontend/src/sessionListEvents.test.ts
+++ b/frontend/src/sessionListEvents.test.ts
@@ -37,16 +37,45 @@ test("normalizeSessionListEvent rejects unknown event types", () => {
   assert.equal(got, null);
 });
 
-test("normalizeSessionListEvent requires order_key / session_id / event_id", () => {
+test("normalizeSessionListEvent requires order_key / session_id / event_id / session_scope", () => {
+  // session_scope is required after tank-operator#83's follow-up: the
+  // backend SSE handler only forwards events from its own (email, scope)
+  // partition, so any payload without a scope on the wire is malformed.
+  // The reducer used to default-fill "default" here, which silently
+  // accepted cross-scope events from the email-only NATS subject and
+  // mutated state for the wrong environment.
+  const fullPayload = {
+    type: "session.created",
+    order_key: "1",
+    session_id: "21",
+    event_id: "x",
+    session_scope: "default",
+  } as const;
+
   assert.equal(
-    normalizeSessionListEvent({ type: "session.created", session_id: "21", event_id: "x" }),
+    normalizeSessionListEvent({ ...fullPayload, order_key: undefined as unknown as string }),
     null,
     "missing order_key must be rejected",
   );
   assert.equal(
-    normalizeSessionListEvent({ type: "session.created", order_key: "1", event_id: "x" }),
+    normalizeSessionListEvent({ ...fullPayload, session_id: undefined as unknown as string }),
     null,
     "missing session_id must be rejected",
+  );
+  assert.equal(
+    normalizeSessionListEvent({ ...fullPayload, event_id: undefined as unknown as string }),
+    null,
+    "missing event_id must be rejected",
+  );
+  assert.equal(
+    normalizeSessionListEvent({ ...fullPayload, session_scope: undefined as unknown as string }),
+    null,
+    "missing session_scope must be rejected (no default-fill)",
+  );
+  assert.equal(
+    normalizeSessionListEvent({ ...fullPayload, session_scope: "" }),
+    null,
+    "empty session_scope must be rejected (no default-fill)",
   );
 });
 

--- a/frontend/src/sessionListEvents.ts
+++ b/frontend/src/sessionListEvents.ts
@@ -49,6 +49,16 @@ export interface SessionListEvent {
 
 // ----- Wire parsing --------------------------------------------------------
 
+// normalizeSessionListEvent parses one wire payload from /api/sessions/events
+// or /api/sessions/timeline. session_scope is required: the backend SSE
+// handler only subscribes to its own (email, scope) NATS subject and only
+// catches up from that scope's slice of session_lifecycle_events, so a
+// well-formed payload always carries the scope it was produced under.
+// Rejecting payloads without a scope makes the wire shape an explicit
+// contract rather than letting a malformed payload silently land in
+// reducer state with a defaulted scope — which was the bug class behind
+// the "deletes come back" + "test-slot sessions in prod sidebar" symptoms
+// that pre-#83 cross-scope reads produced.
 export function normalizeSessionListEvent(value: unknown): SessionListEvent | null {
   if (!isRecord(value)) return null;
   const type = value.type;
@@ -56,11 +66,12 @@ export function normalizeSessionListEvent(value: unknown): SessionListEvent | nu
   const sessionId = stringField(value, "session_id");
   const orderKey = stringField(value, "order_key");
   const eventId = stringField(value, "event_id");
-  if (!sessionId || !orderKey || !eventId) return null;
+  const sessionScope = stringField(value, "session_scope");
+  if (!sessionId || !orderKey || !eventId || !sessionScope) return null;
   return {
     order_key: orderKey,
     email: stringField(value, "email") ?? "",
-    session_scope: stringField(value, "session_scope") ?? "default",
+    session_scope: sessionScope,
     session_id: sessionId,
     type,
     event_id: eventId,

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -202,6 +202,32 @@ spec:
               unread-count indicators will lag actual chat state. Inspect
               orchestrator logs for `lifecycle emitter:` lines.
 
+        # Cross-scope event leak guard. The per-(owner, scope) NATS
+        # subject prevents cross-scope delivery in steady state; if a
+        # publisher ever lands a wrong-scope payload (regression of the
+        # tank-operator#83 follow-up that scoped the wire shape), this
+        # counter increments and the SSE handler drops the payload before
+        # mutating client state. Any non-zero rate means cross-environment
+        # leakage came back — page on first sighting, not over a long
+        # window.
+        - alert: TankSessionListCrossScopeLeak
+          expr: rate(tank_session_list_cross_scope_events_dropped_total[10m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "session-list NATS payload arrived with the wrong session_scope"
+            runbook: |
+              A publisher emitted a session_lifecycle_events payload whose
+              embedded session_scope does not match the receiving
+              orchestrator's scope. The (email, scope) subject shape makes
+              this physically unreachable in steady state, so this is a
+              producer-side regression — usually one of
+              `sessions.Manager.emitLifecycle`,
+              `podinformer.emit`, or `lifecycleEmitter` passing a stale
+              scope to `PublishSessionListEvent`. Inspect orchestrator
+              logs for `session list payload dropped: scope mismatch`.
+
     - name: tank-operator.nats
       rules:
         - alert: TankNATSReconnectStorm

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -304,6 +304,46 @@ const blocked = [
   // 24px threshold was the smoking-gun signature of the prior listener —
   // ban the literal so a future refactor can't reintroduce it.
   { name: "removed 24px scroll hysteresis listener", pattern: /distanceFromBottom\s*>\s*24/ },
+  // tank-operator#83 follow-up — the session-list typed-event surface
+  // shipped with session_scope in the row + index but the read path,
+  // NATS subject, and frontend reducer all keyed on email alone. Prod
+  // and slot orchestrators share one Postgres + NATS broker, so
+  // cross-scope events leaked into each other's sidebars (deletes that
+  // came back, slot sessions showing up in prod). The fix made scope a
+  // first-class read dimension: (email, scope, order_key) is the
+  // partition everywhere. Block the specific call shapes that would
+  // resurrect the email-only path so a future PR can't quietly rebuild
+  // the leak the type signatures otherwise enforce against.
+  //
+  // The Go signature change is its own compile-time guard for
+  // ListByOwner/HasOrderKey/PublishSessionListEvent/SubscribeSessionList
+  // Events. The patterns below cover the wire-shape and reducer-shape
+  // regressions the compiler doesn't catch.
+  {
+    name: "retired email-only SessionListEventSubject call",
+    // Pattern matches a single-argument call like
+    // SessionListEventSubject(email). The new shape is two args
+    // (email, scope); a one-arg call is the pre-#83-follow-up signature
+    // that conflated scopes on the wire.
+    pattern: /\bSessionListEventSubject\(\s*[A-Za-z_][\w.]*\s*\)/,
+  },
+  {
+    name: "retired email-only session-list NATS subject literal",
+    // Old subject: tank.live.sessions.<email_token>.events
+    // New subject: tank.live.sessions.<email_token>.<scope_token>.events
+    // A literal matching the old 4-segment shape (no scope token
+    // between email and `.events`) is the old wire shape coming back.
+    pattern: /tank\.live\.sessions\.[A-Za-z0-9_\-]+\.events\b/,
+  },
+  {
+    name: "retired frontend session_scope default fallback",
+    // The reducer used to default-fill "default" when session_scope was
+    // missing on the wire; that turned malformed payloads into silent
+    // state mutations. The wire shape now requires scope to be present;
+    // any code that re-adds a ?? "default" fallback near session_scope
+    // is the regression.
+    pattern: /session_scope[\s\S]{0,40}\?\?\s*["']default["']/,
+  },
   // Interrupt-on-data-plane (the retired single-consumer architecture).
   // Until this PR, both runners dispatched isInterruptCommand →
   // acceptInterrupt from inside the data-plane command consumer. That's


### PR DESCRIPTION
## Summary
- Deletes came back after refresh, slot sessions appeared in prod's sidebar, and removed rows flashed for ~1s on cold open. Single root cause: tank-operator#83 added `session_scope` to `session_lifecycle_events` but the read SQL, NATS subject, and frontend reducer all keyed on email alone. Prod and slot orchestrators share one Postgres + NATS broker, so cross-scope events leaked through three surfaces at once.
- Makes `session_scope` a first-class read dimension everywhere: `lifecycleevents.Store.{ListByOwner,HasOrderKey}` take scope and add `AND session_scope = $N`; NATS subject re-keyed to `tank.live.sessions.<email>.<scope>.events`; SSE drops payloads whose embedded scope doesn't match the local orchestrator; frontend reducer rejects wire payloads missing `session_scope` (no more silent `"default"` fallback).
- Doctrine-aligned per `docs/quality-timeframes.md` + `docs/product-inspirations.md`: observability (`tank_session_list_cross_scope_events_dropped_total` + `TankSessionListCrossScopeLeak` alert), migration guards, and contract tests at three layers all land in the same PR — no follow-ups. Cursor invalidation for in-flight clients is free via the existing `resync_required` path.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/{sessionbus,lifecycleevents,podinformer,sessions} ./cmd/tank-operator` — all packages pass, including 5 new scope-isolation tests (`TestSessionListTimelineDoesNotCrossScopes`, `TestSessionListTimelineRejectsCursorFromOtherScope`, `TestSessionListPayloadDropsCrossScope`, `TestSessionListEventSubjectIncludesScope`, `TestSessionListEventSubjectFormat`)
- [x] `npm test` — 46/46 pass with strengthened `normalizeSessionListEvent` rejection test
- [x] `node scripts/check-removed-chat-runtime.mjs` — clean (guards block the email-only subject literal, single-arg `SessionListEventSubject` calls, and the `?? "default"` reducer fallback)
- [x] `helm template` renders the new `TankSessionListCrossScopeLeak` PrometheusRule
- [ ] Post-merge: verify `tank_session_list_cross_scope_events_dropped_total` stays at zero on the prod dashboard after rollout completes
- [ ] Post-merge: confirm a sidebar refresh in prod no longer shows slot sessions or flashes deleted rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)