### PR TITLE
Trim session pod CPU requests; widen spawn alerts to slot namespaces

### DIFF
--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -755,9 +755,9 @@ func withManifestDefaults(opts ManifestOptions) ManifestOptions {
 // it; limits cap a runaway runner at the agreed budget so one
 // misbehaving session can't blast its noisy neighbors.
 //
-// Budgets are calibrated against observed steady-state usage from the
-// 7-day sample around the eviction (agent-runner at ~150-300 MiB
-// steady, ~795 MiB at the failure point; claude/sandbox-agent at
+// Memory budgets are calibrated against observed steady-state usage
+// from the 7-day sample around the eviction (agent-runner at ~150-300
+// MiB steady, ~795 MiB at the failure point; claude/sandbox-agent at
 // ~14 MiB; mcp-auth-proxy at ~27 MiB). Limits leave 4-5x headroom on
 // every container so normal-but-bursty sessions don't OOMKill.
 //
@@ -765,10 +765,24 @@ func withManifestDefaults(opts ManifestOptions) ManifestOptions {
 // throttling that creates the appearance of latency bugs in agent
 // streaming, and the node-level CPU budget is enforced by the
 // scheduler's request packing.
+//
+// CPU requests were retuned 2026-05 after FailedScheduling pressure on
+// the 3-node Standard_B2s_v2 cluster (prod sessions + 10 test slots
+// sharing one node pool). Per-pod sample across the live namespaces:
+// idle session pods drew ~10m total (agent-runner ~9m, sandbox-agent
+// ~0m, mcp-auth-proxy ~1m); active turns peaked ~120m on agent-runner.
+// The prior 100m/50m/25m=175m budget packed every pod as if it were
+// active, blocking new sessions from scheduling even though actual node
+// CPU sat under 35%. Lowered to 50m/25m/10m=85m: ~5x headroom over
+// idle, peaks still allowed via burstability (no CPU limit). The
+// `tank:session_pod_spawn_seconds:*` recording rules in
+// k8s/templates/observability.yaml are the regression detector — if
+// scheduling pressure returns, p50/p95 spawn time rises and the
+// existing TankSessionSpawnSlow* alerts fire.
 func agentRunnerResources() map[string]any {
 	return map[string]any{
 		"requests": map[string]any{
-			"cpu":    "100m",
+			"cpu":    "50m",
 			"memory": "512Mi",
 		},
 		"limits": map[string]any{
@@ -780,7 +794,7 @@ func agentRunnerResources() map[string]any {
 func sandboxAgentResources() map[string]any {
 	return map[string]any{
 		"requests": map[string]any{
-			"cpu":    "50m",
+			"cpu":    "25m",
 			"memory": "64Mi",
 		},
 		"limits": map[string]any{
@@ -792,7 +806,7 @@ func sandboxAgentResources() map[string]any {
 func mcpAuthProxyResources() map[string]any {
 	return map[string]any{
 		"requests": map[string]any{
-			"cpu":    "25m",
+			"cpu":    "10m",
 			"memory": "64Mi",
 		},
 		"limits": map[string]any{

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -131,10 +131,19 @@ declares one rule group per subsystem:
   `tank:session_pod_spawn_seconds:p50_24h`,
   `tank:session_pod_spawn_seconds:p95_24h`, and
   `tank:session_pod_spawn_seconds:max_1h`, derived from
-  `kube_pod_status_container_ready_time - kube_pod_created` on session-namespace pods.
-  Recording rules collapse the per-pod series to single scalars so the
-  forbidden-labels rule above is respected for stored series; the
-  per-pod dashboard panel renders the same primitive on-demand.
+  `kube_pod_status_container_ready_time - kube_pod_created` on every
+  session-pod namespace — the production namespace
+  (`tank-operator-sessions`) plus every test-slot sessions namespace
+  (`tank-operator-slot-<N>-sessions`). Recording rules collapse the
+  per-pod series to single scalars so the forbidden-labels rule above
+  is respected for stored series; the per-pod dashboard panel renders
+  the same primitive on-demand, labeled by `namespace/pod` so slot vs
+  production pods are distinguishable. The two failure modes worth
+  separating: image distribution (cold pulls cluster around 27-33s)
+  and cluster CPU/memory request packing (FailedScheduling, pods sit
+  Pending for minutes). The latter typically only shows up in the
+  outlier alert (`max_1h > 60s`) since one stuck pod doesn't move the
+  median.
 
 Severity is `info` for "diagnostic-only, page nobody", `warning` for
 "a user feature is degraded", `critical` for "user-trust is on the line"

--- a/k8s/templates/grafana-dashboard.yaml
+++ b/k8s/templates/grafana-dashboard.yaml
@@ -234,7 +234,7 @@ data:
         {
           "id": 14,
           "title": "Session pod spawn p50 / p95 (24h trailing)",
-          "description": "Time from pod creation to ContainersReady across session pods created in the trailing 24h. Backed by recording rules tank:session_pod_spawn_seconds:p50_24h and :p95_24h. The alert TankSessionSpawnSlowMedian fires when p50 > 5s for 1h — that signature means every spawn is paying cold-pull cost (image distribution is broken).",
+          "description": "Time from pod creation to ContainersReady across session pods (production + every test slot) created in the trailing 24h. Backed by recording rules tank:session_pod_spawn_seconds:p50_24h and :p95_24h. The alert TankSessionSpawnSlowMedian fires when p50 > 5s for 1h — typical causes are cold-pull image distribution OR cluster CPU/memory request packing forcing FailedScheduling.",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
           "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -253,15 +253,15 @@ data:
         {
           "id": 15,
           "title": "Per-pod spawn duration (recent)",
-          "description": "Per-session-pod time from creation to ContainersReady. One series per session pod observed by kube-state-metrics; series age out when the pod is deleted. Bimodal distribution is expected — fast spawns (~3s) hit the node's image cache, slow spawns (~30s) are cold pulls of the ~712MB claude-container image. Anything materially above the cold-pull baseline is the diagnostic signal to chase.",
+          "description": "Per-session-pod time from creation to ContainersReady, across the production sessions namespace and every test-slot sessions namespace. One series per session pod observed by kube-state-metrics; series age out when the pod is deleted. Bimodal distribution is expected — fast spawns (~3s) hit the node's image cache, slow spawns (~30s) are cold pulls of the ~712MB claude-container image. Anything materially above the cold-pull baseline is the diagnostic signal to chase. Spawn times in the minutes-range typically indicate FailedScheduling (cluster CPU/memory request packing) rather than image pull cost.",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "fieldConfig": { "defaults": { "unit": "s" } },
           "targets": [
             {
-              "expr": "kube_pod_status_container_ready_time{namespace=\"tank-operator-sessions\"} - on(pod, namespace) kube_pod_created{namespace=\"tank-operator-sessions\"}",
-              "legendFormat": "{{`{{ pod }}`}}"
+              "expr": "kube_pod_status_container_ready_time{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"} - on(pod, namespace) kube_pod_created{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"}",
+              "legendFormat": "{{`{{ namespace }}/{{ pod }}`}}"
             }
           ]
         },
@@ -282,7 +282,7 @@ data:
         {
           "id": 17,
           "title": "Inferred warm-spawn ratio (24h)",
-          "description": "Fraction of session pods spawned in the last 24h that completed in under 10s. Bimodal-distribution proxy for cache hits: warm pulls cluster at 2-3s, cold pulls at 27-33s, the 10s threshold sits in the empty middle. Drift downward suggests nodes are losing the image cache more often. Drift upward suggests cache distribution is improving (e.g. after a pre-pull DaemonSet ships).",
+          "description": "Fraction of session pods spawned in the last 24h (across the production sessions namespace and every test-slot sessions namespace) that completed in under 10s. Bimodal-distribution proxy for cache hits: warm pulls cluster at 2-3s, cold pulls at 27-33s, the 10s threshold sits in the empty middle. Drift downward suggests nodes are losing the image cache more often OR FailedScheduling is delaying spawns beyond 10s. Drift upward suggests cache distribution is improving (e.g. after a pre-pull DaemonSet ships).",
           "type": "stat",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 64 },
           "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -303,7 +303,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(((kube_pod_status_container_ready_time{namespace=\"tank-operator-sessions\"} - on(pod, namespace) kube_pod_created{namespace=\"tank-operator-sessions\"}) < bool 10) and on(pod, namespace) (time() - kube_pod_created{namespace=\"tank-operator-sessions\"} < 86400)) / count((kube_pod_status_container_ready_time{namespace=\"tank-operator-sessions\"} - on(pod, namespace) kube_pod_created{namespace=\"tank-operator-sessions\"}) and on(pod, namespace) (time() - kube_pod_created{namespace=\"tank-operator-sessions\"} < 86400))",
+              "expr": "sum(((kube_pod_status_container_ready_time{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"} - on(pod, namespace) kube_pod_created{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"}) < bool 10) and on(pod, namespace) (time() - kube_pod_created{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"} < 86400)) / count((kube_pod_status_container_ready_time{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"} - on(pod, namespace) kube_pod_created{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"}) and on(pod, namespace) (time() - kube_pod_created{namespace=~\"tank-operator(-slot-[0-9]+)?-sessions\"} < 86400))",
               "legendFormat": "warm-spawn ratio"
             }
           ]

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -351,6 +351,15 @@ spec:
     # tank_* series). The dashboard's per-pod panels render the same
     # primitives on-demand, where cardinality is bounded by browser session.
     #
+    # Namespace selector matches both the production sessions namespace
+    # (`tank-operator-sessions`) and every test-slot sessions namespace
+    # (`tank-operator-slot-<N>-sessions`). Without the slot coverage,
+    # FailedScheduling pressure in the slots — where the orchestrator
+    # is exercised end-to-end during change validation — would never
+    # surface to TankSessionSpawnSlow* even though kube-state-metrics
+    # has the data. Cardinality stays at three recording series total
+    # because the aggregations collapse across pods AND namespaces.
+    #
     # Thresholds are calibrated against the 7-day baseline observed at
     # introduction: warm-cache spawns cluster at 2-3s, cold pulls at
     # 27-33s, with a few partial-cache spawns in between. The 5s/60s
@@ -362,25 +371,25 @@ spec:
         - record: tank:session_pod_spawn_seconds:p50_24h
           expr: |
             quantile(0.5,
-              (kube_pod_status_container_ready_time{namespace="tank-operator-sessions"}
-                - on(pod, namespace) kube_pod_created{namespace="tank-operator-sessions"})
-              and on(pod, namespace) (time() - kube_pod_created{namespace="tank-operator-sessions"} < 86400)
+              (kube_pod_status_container_ready_time{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"}
+                - on(pod, namespace) kube_pod_created{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"})
+              and on(pod, namespace) (time() - kube_pod_created{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"} < 86400)
             )
 
         - record: tank:session_pod_spawn_seconds:p95_24h
           expr: |
             quantile(0.95,
-              (kube_pod_status_container_ready_time{namespace="tank-operator-sessions"}
-                - on(pod, namespace) kube_pod_created{namespace="tank-operator-sessions"})
-              and on(pod, namespace) (time() - kube_pod_created{namespace="tank-operator-sessions"} < 86400)
+              (kube_pod_status_container_ready_time{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"}
+                - on(pod, namespace) kube_pod_created{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"})
+              and on(pod, namespace) (time() - kube_pod_created{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"} < 86400)
             )
 
         - record: tank:session_pod_spawn_seconds:max_1h
           expr: |
             max(
-              (kube_pod_status_container_ready_time{namespace="tank-operator-sessions"}
-                - on(pod, namespace) kube_pod_created{namespace="tank-operator-sessions"})
-              and on(pod, namespace) (time() - kube_pod_created{namespace="tank-operator-sessions"} < 3600)
+              (kube_pod_status_container_ready_time{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"}
+                - on(pod, namespace) kube_pod_created{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"})
+              and on(pod, namespace) (time() - kube_pod_created{namespace=~"tank-operator(-slot-[0-9]+)?-sessions"} < 3600)
             )
 
         - alert: TankSessionSpawnSlowMedian
@@ -413,8 +422,13 @@ spec:
               A single user waited more than 60s for their session, which is roughly
               double the worst observed cold-pull baseline. Diagnostic only — does
               not page. Use the "Per-pod spawn duration (recent)" panel to identify
-              the pod, then `kubectl describe pod <name> -n tank-operator-sessions`
-              for the event timeline (Pulling/Pulled events with their durations).
-              Common causes: registry throttling, network egress congestion from the
-              AKS node to ACR, or an oversized image bump.
+              the pod and its namespace (prod is `tank-operator-sessions`; test
+              slots are `tank-operator-slot-<N>-sessions`), then
+              `kubectl describe pod <name> -n <namespace>` for the event timeline
+              (FailedScheduling, Pulling/Pulled events with their durations).
+              Common causes: FailedScheduling from cluster CPU/memory pressure
+              (`kubectl top nodes` to confirm — typically pinned by aggregate
+              request packing, not actual usage), registry throttling, network
+              egress congestion from the AKS node to ACR, or an oversized image
+              bump.
 {{- end }}


### PR DESCRIPTION
## Summary

- Session pod CPU requests trimmed from 175m -> 85m per `claude_gui` pod (agent-runner 100m -> 50m, sandbox-agent 50m -> 25m, mcp-auth-proxy 25m -> 10m). Memory and limits unchanged — the [tank-operator#83](https://github.com/nelsong6/tank-operator/pull/83) eviction calibration still binds, and CPU has no limit (CFS throttling causes spurious latency bugs in agent streaming). The prior values were packing every pod as if it were mid-turn even though idle session pods draw ~10m total and active peaks land around 120m on agent-runner. On the 3-node `Standard_B2s_v2` cluster this caused `FailedScheduling` while actual node CPU sat under 35%.

- Recording-rule namespace selector on `tank:session_pod_spawn_seconds:{p50_24h, p95_24h, max_1h}` widened from `="tank-operator-sessions"` to `=~"tank-operator(-slot-[0-9]+)?-sessions"` so the existing `TankSessionSpawnSlowMedian` / `TankSessionSpawnSlowOutlier` alerts also fire on test-slot pods. Recording-series cardinality stays at three total because the aggregations collapse across both pods and namespaces. Today's slot-5 Pending-3min incident wouldn't have triggered the outlier alert because slots were outside the selector — that gap is the reason the spawn-alert change is paired here with the request trim.

- Outlier-alert runbook, Grafana panel descriptions, and `docs/observability.md` updated to acknowledge multi-namespace coverage and call out FailedScheduling (cluster scheduling pressure) as a distinct failure mode from cold-pull image distribution. The per-pod Grafana legend changed to `{{namespace}}/{{pod}}` so slot vs production pods with overlapping `session-N` names are distinguishable.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all 12 packages pass (sessionmodel, sessions, podinformer, sessionbus, pgstore, etc.)
- [x] `helm lint k8s` — 1 chart, 0 failed
- [x] `helm template` renders 2621 lines; `session_pod_spawn_seconds` rule + alert + dashboard panel expressions all show the regex-widened selector
- [ ] After merge: watch Grafana "Per-pod spawn duration (recent)" panel for slot-namespace series appearing alongside production
- [ ] After merge: next `FailedScheduling` event in any slot should trigger `TankSessionSpawnSlowOutlier` (severity `info`, max_1h > 60s)
- [ ] After deploy of the orchestrator image carrying the trim: per-node session-pod packing capacity ~doubles (10 -> ~22 by request math), so the cluster should sit through normal slot churn without FailedScheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)