### PR TITLE
Fix sidebar resurrection of deleted sessions; add client-side telemetry

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_debug_client_metric.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_client_metric.go
@@ -1,0 +1,61 @@
+// Client-side telemetry beacon. The SPA POSTs here when its
+// session-list reducer hits a code path that should be cold in
+// production (currently: placeholder synthesis on an unknown session
+// id). The endpoint translates the allowlisted name into a Prometheus
+// counter increment so an operator can spot a regression of the
+// resurrection paths without needing the user to share devtools
+// captures.
+//
+// Design choices:
+//   - Auth required (existing JWT/cookie path). No anonymous push.
+//   - Strict name allowlist: every accepted value maps to a fixed
+//     pre-registered counter. Unknown names get 400 — never a dynamic
+//     counter, since unbounded names would explode Prometheus cardinality.
+//   - 256-byte body cap. The wire shape is intentionally tiny.
+//   - No per-caller label on the counter. The slog line below carries
+//     the email for forensic correlation if the rate ever goes
+//     non-zero; the metric itself stays low-cardinality.
+//   - Response is 204; the SPA does not consume the body and the
+//     beacon is best-effort.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+const clientMetricMaxBody = 256
+
+func (s *appServer) handleClientMetric(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, clientMetricMaxBody)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid client metric payload")
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	switch name {
+	case "session_list.placeholder_synthesized":
+		sessionListClientPlaceholderSynthesizedTotal.Inc()
+		slog.Info("client metric",
+			"name", name,
+			"caller", user.Email,
+		)
+	default:
+		// Strict allowlist — unknown names would let the SPA register
+		// arbitrary metric families and is the cardinality risk this
+		// endpoint exists to prevent. The 400 surfaces the typo to the
+		// client developer.
+		writeError(w, http.StatusBadRequest, "unknown client metric name")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend-go/cmd/tank-operator/handlers_debug_client_metric_test.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_client_metric_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+)
+
+// TestClientMetricAcceptsAllowlistedName confirms the beacon endpoint
+// translates the SPA's allowlisted metric name into a 204 and (by
+// proxy) a counter increment. The exact counter assertion lives in
+// the package-level promauto registration; the handler-side test is
+// the wire-contract gate.
+func TestClientMetricAcceptsAllowlistedName(t *testing.T) {
+	srv := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/debug/client-metric",
+		strings.NewReader(`{"name":"session_list.placeholder_synthesized"}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "u@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	srv.handleClientMetric(resp, req)
+
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestClientMetricRejectsUnknownName is the cardinality gate. The
+// endpoint must never accept an arbitrary metric name — that would let
+// the SPA register unbounded Prometheus counters. New SPA-side
+// counters require an explicit server-side allowlist entry in
+// handlers_debug_client_metric.go.
+func TestClientMetricRejectsUnknownName(t *testing.T) {
+	srv := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/debug/client-metric",
+		strings.NewReader(`{"name":"arbitrary_unregistered_name"}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "u@example.com"))
+	resp := httptest.NewRecorder()
+
+	srv.handleClientMetric(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (unknown metric names must be rejected to keep cardinality bounded)", resp.Code)
+	}
+}
+
+// TestClientMetricRequiresAuth confirms the beacon is not anonymous.
+// An unauthenticated push would let any visitor inflate the counter
+// and mask the real regression signal.
+func TestClientMetricRequiresAuth(t *testing.T) {
+	srv := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/debug/client-metric",
+		strings.NewReader(`{"name":"session_list.placeholder_synthesized"}`))
+	resp := httptest.NewRecorder()
+
+	srv.handleClientMetric(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (anonymous push must be rejected)", resp.Code)
+	}
+}

--- a/backend-go/cmd/tank-operator/handlers_session_list_events_test.go
+++ b/backend-go/cmd/tank-operator/handlers_session_list_events_test.go
@@ -97,6 +97,26 @@ func (f *fakeLifecycleStore) HasOrderKey(_ context.Context, owner, scope, orderK
 	return ok, nil
 }
 
+func (f *fakeLifecycleStore) LatestOrderKey(_ context.Context, owner, scope string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	src := f.rows[owner+"|"+scope]
+	if len(src) == 0 {
+		return "", nil
+	}
+	// Tests seed in ascending order_key; return the highest by simple
+	// lexicographic max since the seeded values are short integer
+	// strings ("1", "2", ...). Postgres returns the BIGSERIAL max for
+	// the real implementation.
+	max := src[0].OrderKey
+	for _, e := range src[1:] {
+		if e.OrderKey > max {
+			max = e.OrderKey
+		}
+	}
+	return max, nil
+}
+
 func (f *fakeLifecycleStore) LatestActivity(_ context.Context, _, _ string) (*lifecycleevents.ActivitySummary, error) {
 	return nil, nil
 }
@@ -273,6 +293,98 @@ func TestSessionListPayloadDropsCrossScope(t *testing.T) {
 	}
 	if cursor.AfterOrderKey != "" {
 		t.Fatalf("cursor advanced to %q, want \"\" (dropped payload must not move the cursor)", cursor.AfterOrderKey)
+	}
+}
+
+// TestStampLifecycleTipHeaderEmitsSnapshotTip pins the cold-open
+// contract: handleListSessions stamps Tank-Lifecycle-Tip-Order-Key so
+// the SPA can seed its SSE cursor at the snapshot's tip. Without this
+// header, events that land between the snapshot query and the SSE
+// open are missed (the SSE handler's fallback fast-forward jumps to
+// current tip, not the snapshot tip). The header value comes from the
+// lifecycle store's LatestOrderKey for (owner, scope) at snapshot
+// time.
+func TestStampLifecycleTipHeaderEmitsSnapshotTip(t *testing.T) {
+	store := newFakeLifecycleStore()
+	store.seed("u@example.com",
+		lifecycleevents.Event{
+			OrderKey: "1", Email: "u@example.com", SessionScope: "default",
+			SessionID: "8", Type: lifecycleevents.EventTypeCreated, EventID: "created",
+		},
+		lifecycleevents.Event{
+			OrderKey: "42", Email: "u@example.com", SessionScope: "default",
+			SessionID: "8", Type: lifecycleevents.EventTypeDeleted, EventID: "deleted",
+		},
+	)
+	srv := newTestAppServer(t, store)
+
+	w := httptest.NewRecorder()
+	srv.stampLifecycleTipHeader(context.Background(), w, "u@example.com")
+	if got := w.Header().Get("Tank-Lifecycle-Tip-Order-Key"); got != "42" {
+		t.Fatalf("header = %q, want %q (max of seeded order_keys)", got, "42")
+	}
+}
+
+// TestStampLifecycleTipHeaderOmitsHeaderWhenLedgerEmpty confirms the
+// header is absent for fresh owners. The SPA treats a missing header
+// the same as "cursor empty", which lets the SSE handler fall back to
+// its own current-tip fast-forward — correct shape for a brand-new
+// owner with no lifecycle history yet.
+func TestStampLifecycleTipHeaderOmitsHeaderWhenLedgerEmpty(t *testing.T) {
+	srv := newTestAppServer(t, newFakeLifecycleStore())
+	w := httptest.NewRecorder()
+	srv.stampLifecycleTipHeader(context.Background(), w, "u@example.com")
+	if got := w.Header().Get("Tank-Lifecycle-Tip-Order-Key"); got != "" {
+		t.Fatalf("header = %q, want empty (no lifecycle rows for owner)", got)
+	}
+}
+
+// TestSessionListSSEColdOpenFastForwardsCursor verifies the SSE
+// handler does not replay history from order_key=0 when the client
+// opens with no cursor. Pre-#525 the handler looped writeSessionListStreamPage
+// from cursor="" and emitted every historical event for (owner, scope),
+// which let the reducer's placeholder-synthesis branch resurrect
+// deleted sessions via post-delete pod-status events still in the
+// ledger. The fix: server jumps an empty cursor to LatestOrderKey
+// before the catch-up loop runs, so the loop emits zero events.
+func TestSessionListSSEColdOpenFastForwardsCursor(t *testing.T) {
+	// Reuse the existing exercise: writeSessionListStreamPage with
+	// cursor=tip should emit no events past tip (page is empty). This
+	// is what the fast-forward path produces: cursor jumps to tip,
+	// then the catch-up loop sees nothing past it.
+	store := newFakeLifecycleStore()
+	store.seed("u@example.com",
+		lifecycleevents.Event{
+			OrderKey: "1", Email: "u@example.com", SessionScope: "default",
+			SessionID: "8", Type: lifecycleevents.EventTypeCreated, EventID: "created",
+		},
+		lifecycleevents.Event{
+			OrderKey: "5", Email: "u@example.com", SessionScope: "default",
+			SessionID: "8", Type: lifecycleevents.EventTypeDeleted, EventID: "deleted",
+		},
+	)
+	srv := newTestAppServer(t, store)
+
+	tip, err := store.LatestOrderKey(context.Background(), "u@example.com", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tip == "" {
+		t.Fatal("LatestOrderKey returned empty; cannot verify fast-forward behavior")
+	}
+
+	// Simulate the fast-forwarded state: cursor positioned at the tip.
+	cursor := lifecycleevents.Cursor{AfterOrderKey: tip}
+	resp := httptest.NewRecorder()
+	hasMore, written, err := srv.writeSessionListStreamPage(context.Background(), resp, "u@example.com", &cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasMore {
+		t.Fatalf("hasMore = true, want false (cursor at tip leaves nothing to replay)")
+	}
+	if written != 0 {
+		t.Fatalf("written = %d, want 0 (the cold-open fast-forward must not emit historical events): body = %q", written, resp.Body.String())
 	}
 }
 

--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -35,18 +35,65 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusCreated, info)
 }
 
+// stampLifecycleTipHeader writes Tank-Lifecycle-Tip-Order-Key on the
+// response if the lifecycle ledger has any rows for (owner, scope) at
+// call time. Absent header is the correct signal for fresh owners
+// with no history yet; the SPA falls back to letting the SSE handler
+// fast-forward an empty cursor on its own. Errors are logged but
+// non-fatal — the SPA's worst-case behavior on a missing header is a
+// fallback to the server-side fast-forward, which gives the same
+// correctness with a small race window (events landing during the
+// snapshot query). Extracted from handleListSessions so the contract
+// is unit-testable without standing up the full Manager stub.
+func (s *appServer) stampLifecycleTipHeader(ctx context.Context, w http.ResponseWriter, owner string) {
+	if s.lifecycleEvents == nil {
+		return
+	}
+	tip, err := s.lifecycleEvents.LatestOrderKey(ctx, owner, s.sessionScope)
+	if err != nil {
+		slog.Warn("list sessions: lifecycle tip lookup failed",
+			"owner", owner, "scope", s.sessionScope, "error", err)
+		return
+	}
+	if tip == "" {
+		return
+	}
+	w.Header().Set("Tank-Lifecycle-Tip-Order-Key", tip)
+}
+
 // handleListSessions lists sessions for the authenticated user, or for
 // a different owner when an admin passes `?owner=<email>`. The query
 // param is the explicit signal that unlocks the admin cross-user path
 // (intentional opt-in so the default response stays own-only and an
 // admin token isn't a footgun for tools that didn't expect cross-user
 // reads).
+//
+// The Tank-Lifecycle-Tip-Order-Key response header carries the latest
+// session_lifecycle_events order_key for this (owner, scope) at
+// snapshot time. The SPA passes that value as the SSE cursor when it
+// opens /api/sessions/events, so the cursor-resumable catch-up only
+// emits events that landed *after* the snapshot — closing the race
+// between the snapshot query and the SSE open. Without this header,
+// the SSE handler fast-forwards an empty cursor to the current tip;
+// either way, cold opens never replay history. See
+// docs/product-inspirations.md: "Live transport should wake clients
+// and runners; it should not be the only place product state exists" —
+// the snapshot is the source of cold-open state, lifecycle events are
+// deltas on top.
 func (s *appServer) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAuth(w, r)
 	if !ok {
 		return
 	}
 	owner := listSessionsOwner(user, r)
+
+	// Query the snapshot tip BEFORE listing sessions so the cursor is
+	// conservative (older than every event included in the snapshot).
+	// That way, when the SPA hands the tip to the SSE handler, the
+	// catch-up replay covers anything that landed during the snapshot
+	// query itself.
+	s.stampLifecycleTipHeader(r.Context(), w, owner)
+
 	infos, err := s.mgr.ListSessions(r.Context(), owner)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -85,7 +132,36 @@ func (s *appServer) handleSessionsEvents(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	cursor := sessionListCursorFromRequest(r)
-	if s.lifecycleEvents != nil {
+
+	// Cursor-empty cold-open fast-forward: when the client opens with no
+	// Last-Event-ID and no after_order_key query (legacy clients, freshly
+	// cleared state, or a snapshot taken before the lifecycle ledger had
+	// any rows), the server jumps the cursor to the current tip. Cold
+	// opens get their state from GET /api/sessions; replaying historical
+	// session_lifecycle_events past cursor="" is the bug that let
+	// previously-deleted sessions resurrect via the reducer's
+	// placeholder-synthesis branch (pod-status events landing in the
+	// ledger after session.deleted re-added the row in client state).
+	// New clients pass the Tank-Lifecycle-Tip-Order-Key value they
+	// received from the snapshot response, so the catch-up still covers
+	// any events that landed between the snapshot query and the SSE
+	// open.
+	if cursor.AfterOrderKey == "" && s.lifecycleEvents != nil {
+		if tip, err := s.lifecycleEvents.LatestOrderKey(r.Context(), owner, s.sessionScope); err != nil {
+			recordSessionListStreamError()
+			writeSSEJSONEvent(w, "stream-error", "", map[string]any{
+				"reason": "tip_lookup_failed",
+				"detail": err.Error(),
+			})
+			flusher.Flush()
+			return
+		} else if tip != "" {
+			cursor.AfterOrderKey = tip
+			sessionListStreamColdOpenFastForwardTotal.Inc()
+		}
+	}
+
+	if s.lifecycleEvents != nil && cursor.AfterOrderKey != "" {
 		if ok, err := s.lifecycleEvents.HasOrderKey(r.Context(), owner, s.sessionScope, cursor.AfterOrderKey); err != nil {
 			recordSessionListStreamError()
 			writeSSEJSONEvent(w, "stream-error", "", map[string]any{

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -243,6 +243,33 @@ var (
 		Name: "tank_session_list_stream_heartbeat_total",
 		Help: "Heartbeat frames written on idle sidebar SSE streams.",
 	})
+	// sessionListStreamColdOpenFastForwardTotal fires when an SSE
+	// connection opens with no cursor and the server jumps the cursor
+	// to the current lifecycle-ledger tip instead of replaying from
+	// order_key=0. New clients pass the snapshot tip via
+	// Tank-Lifecycle-Tip-Order-Key, so a high rate here indicates
+	// legacy clients (or a client whose snapshot pre-dated the
+	// lifecycle ledger having any rows) — informational, not an alert
+	// signal.
+	sessionListStreamColdOpenFastForwardTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_list_stream_cold_open_fast_forward_total",
+		Help: "Sidebar SSE opens that jumped an empty cursor to the current tip instead of replaying history.",
+	})
+	// sessionListClientPlaceholderSynthesizedTotal is pushed by the
+	// SPA via POST /api/debug/client-metric whenever the reducer's
+	// applyPodStatusEvent branch synthesizes a Session row for an
+	// unknown session id. Pre-tank-operator#525 that branch fired on
+	// every cold-open replay for deleted sessions because the SSE
+	// catch-up walked history from order_key=0; post-fix the cold-
+	// open fast-forward + the Reader.List visible-filter mean the
+	// branch should only fire in the narrow live-event race window
+	// (pod_ready arriving before session.created in NATS delivery).
+	// A non-zero rate in steady state is the regression-detection
+	// signal that a resurrection path snuck back in.
+	sessionListClientPlaceholderSynthesizedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_list_client_placeholder_synthesized_total",
+		Help: "SPA-reported placeholder synthesis in the session-list reducer; expected ~0 in steady state post-#525.",
+	})
 	// sessionListCrossScopeEventsDroppedTotal fires when a payload arrives
 	// on the per-(owner, scope) NATS subject whose embedded session_scope
 	// does not match this orchestrator's configured scope. The subject

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -126,6 +126,11 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/sessions/{session_id}/cli-process", s.handleCLIProcess)
 	mux.HandleFunc("GET /api/sessions/{session_id}/sandbox-agent/v1/processes/{process_id}/terminal/ws", s.handleSandboxTerminalProxy)
 
+	// Client-side telemetry beacon (allowlisted Prometheus counters
+	// the SPA pushes when its reducer hits a code path that should be
+	// cold post-tank-operator#525 — see handlers_debug_client_metric.go).
+	mux.HandleFunc("POST /api/debug/client-metric", s.handleClientMetric)
+
 	// Internal API.
 	mux.HandleFunc("GET /api/internal/jwks", s.handleInternalJWKS)
 	mux.HandleFunc("GET /api/internal/github/installation", s.handleInternalGitHubInstallation)

--- a/backend-go/internal/lifecycleevents/store.go
+++ b/backend-go/internal/lifecycleevents/store.go
@@ -50,6 +50,19 @@ type Store interface {
 	// cross-scope read window naturally miss here and trigger resync.
 	HasOrderKey(ctx context.Context, owner, scope, orderKey string) (bool, error)
 
+	// LatestOrderKey returns the highest order_key in
+	// session_lifecycle_events for one (owner, scope), or "" if the
+	// owner has no rows. Used by handleListSessions to stamp the
+	// Tank-Lifecycle-Tip-Order-Key response header at snapshot time,
+	// and by the SSE handler to fast-forward an empty cursor to the
+	// current tip (so cold opens don't replay history from
+	// order_key=0). Replaces the pre-tank-operator#525 cold-open behavior
+	// where the SSE handler emitted every historical event past
+	// cursor="", which let pod-status events that landed after a
+	// session.deleted in the ledger resurrect the row via the
+	// reducer's placeholder-synthesis branch.
+	LatestOrderKey(ctx context.Context, owner, scope string) (string, error)
+
 	// LatestActivity returns the most recent session.activity_changed
 	// payload for one session, or nil if none exists yet. Used by both
 	// GET /api/sessions (initial-state hydration) and the persister
@@ -235,6 +248,30 @@ func (s *postgresStore) ListByOwner(ctx context.Context, owner, scope string, cu
 		next = out[len(out)-1].OrderKey
 	}
 	return Page{Events: out, NextOrderKey: next, HasMore: hasMore}, nil
+}
+
+func (s *postgresStore) LatestOrderKey(ctx context.Context, owner, scope string) (string, error) {
+	owner = normalizeOwner(owner)
+	scope = strings.TrimSpace(scope)
+	if owner == "" || scope == "" {
+		return "", nil
+	}
+	const q = `
+		SELECT order_key
+		FROM session_lifecycle_events
+		WHERE email = $1 AND session_scope = $2
+		ORDER BY order_key DESC
+		LIMIT 1
+	`
+	var orderKey int64
+	err := s.pool.QueryRow(ctx, q, owner, scope).Scan(&orderKey)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return formatOrderKey(orderKey), nil
 }
 
 func (s *postgresStore) HasOrderKey(ctx context.Context, owner, scope, orderKey string) (bool, error) {
@@ -433,6 +470,10 @@ func (StubStore) ListByOwner(_ context.Context, _, _ string, _ Cursor, _ int) (P
 
 func (StubStore) HasOrderKey(_ context.Context, _, _, orderKey string) (bool, error) {
 	return strings.TrimSpace(orderKey) == "", nil
+}
+
+func (StubStore) LatestOrderKey(_ context.Context, _, _ string) (string, error) {
+	return "", nil
 }
 
 func (StubStore) LatestActivity(_ context.Context, _, _ string) (*ActivitySummary, error) {

--- a/backend-go/internal/podinformer/podinformer_test.go
+++ b/backend-go/internal/podinformer/podinformer_test.go
@@ -50,6 +50,8 @@ func (s *fakeStore) ListByOwner(_ context.Context, _, _ string, _ lifecycleevent
 
 func (s *fakeStore) HasOrderKey(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
 
+func (s *fakeStore) LatestOrderKey(_ context.Context, _, _ string) (string, error) { return "", nil }
+
 func (s *fakeStore) LatestActivity(_ context.Context, _, _ string) (*lifecycleevents.ActivitySummary, error) {
 	return nil, nil
 }

--- a/backend-go/internal/sessionregistry/registry.go
+++ b/backend-go/internal/sessionregistry/registry.go
@@ -26,8 +26,18 @@ func NewPostgresStore(pool *pgxpool.Pool, scope string) *Store {
 	return &Store{pool: pool, scope: scope}
 }
 
-// List returns the visible session records for an owner in this scope,
-// ordered oldest-first by created_at to match the Cosmos impl.
+// List returns every session record for an owner in this scope (visible
+// and invisible), ordered oldest-first by created_at. Callers that only
+// want visible rows must filter on SessionRecord.Visible.
+//
+// Returning invisible rows is load-bearing for Reader.List: it needs to
+// know which session IDs have a registry row at all (regardless of
+// visibility) so its pod-fallback loop doesn't append phantom rows for
+// pods whose registry row is visible=false. Pre-tank-operator#525 this
+// query filtered `AND visible = true` and the Reader could not
+// distinguish "no registry row" from "registry row marked deleted",
+// which let Terminating pods (and any pod whose K8s delete failed)
+// reappear in the sidebar via the pod-fallback path.
 func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionRecord, error) {
 	normalized := strings.ToLower(strings.TrimSpace(owner))
 	if normalized == "" {
@@ -39,7 +49,7 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 			COALESCE(to_char(created_at   AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS created_at,
 			COALESCE(to_char(updated_at   AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS updated_at
 		FROM sessions
-		WHERE email = $1 AND session_scope = $2 AND visible = true
+		WHERE email = $1 AND session_scope = $2
 		ORDER BY created_at ASC
 	`
 	rows, err := s.pool.Query(ctx, q, normalized, s.scope)

--- a/backend-go/internal/sessions/sessions.go
+++ b/backend-go/internal/sessions/sessions.go
@@ -111,6 +111,16 @@ func (r *Reader) List(ctx context.Context, owner string) ([]Info, error) {
 	}
 
 	if r.registry != nil {
+		// registry.List returns visible AND invisible rows (see
+		// sessionregistry.Store.List). `seen` is built from every
+		// registered session id so the pod-fallback loop below can tell
+		// "no registry row" (legitimate Manager.Create race window —
+		// Reader returns the pod-derived Info) apart from "registry
+		// row marked deleted" (the post-delete pod is Terminating
+		// during its grace window — Reader must NOT re-append it).
+		// Pre-tank-operator#525 the seen set only contained visible
+		// ids, so Terminating pods for just-deleted sessions reappeared
+		// in the sidebar for the full ~75s graceful-shutdown window.
 		records, err := r.registry.List(ctx, owner)
 		if err != nil {
 			return nil, err
@@ -119,6 +129,9 @@ func (r *Reader) List(ctx context.Context, owner string) ([]Info, error) {
 		out := make([]Info, 0, len(records)+len(pods.Items))
 		for _, record := range records {
 			seen[record.ID] = struct{}{}
+			if !record.Visible {
+				continue
+			}
 			info := infoFromRecord(owner, record, podsByID[record.ID])
 			r.hydrateLifecycle(ctx, &info)
 			out = append(out, info)

--- a/backend-go/internal/sessions/sessions_test.go
+++ b/backend-go/internal/sessions/sessions_test.go
@@ -181,6 +181,61 @@ func TestListMergesRegistryRecordsWithPods(t *testing.T) {
 	}
 }
 
+// TestListExcludesInvisibleRegistryRowsEvenWhenPodAlive is the
+// regression gate for the symptom that drove tank-operator#525: pod
+// delete is asynchronous (~75s graceful shutdown), so the pod stays in
+// etcd as Terminating while the registry row already says
+// visible=false. Pre-#525 Reader.List built `seen` from visible-only
+// registry rows, so its pod-fallback loop re-appended the
+// just-deleted session for the full grace window. The user saw the
+// row "come back" on every refresh until the pod finished
+// terminating.
+//
+// The fix: registry.List returns visible+invisible rows; Reader.List
+// uses every registered id for `seen` but only emits visible records.
+// Invisible rows whose pod is still alive must NOT be re-added by the
+// pod-fallback loop.
+func TestListExcludesInvisibleRegistryRowsEvenWhenPodAlive(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true),
+		sessionPod("13", "nelson@romaine.life", corev1.PodRunning, true),
+	)
+	registry := registryRecords{
+		{
+			ID:          "12",
+			Email:       "nelson@romaine.life",
+			Mode:        sessionmodel.CodexGUIMode,
+			PodName:     "session-12",
+			RequestedAt: "2026-05-11T00:00:00+00:00",
+			CreatedAt:   "2026-05-11T00:00:01+00:00",
+			Visible:     true,
+		},
+		{
+			ID:          "13",
+			Email:       "nelson@romaine.life",
+			Mode:        sessionmodel.CodexGUIMode,
+			PodName:     "session-13",
+			RequestedAt: "2026-05-11T00:01:00+00:00",
+			CreatedAt:   "2026-05-11T00:01:01+00:00",
+			// Marked deleted by Manager.Delete; pod is still
+			// Terminating in K8s for another ~75s.
+			Visible: false,
+		},
+	}
+	reader := NewReaderFull(client, sessionmodel.SessionsNamespace, registry, nil, "default")
+
+	got, err := reader.List(context.Background(), "nelson@romaine.life")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("session count = %d, want 1 (only the visible row): %#v", len(got), got)
+	}
+	if got[0].ID != "12" {
+		t.Fatalf("visible session id = %q, want 12 (session 13's registry row is visible=false; its still-alive pod must not be re-added via the pod-fallback loop)", got[0].ID)
+	}
+}
+
 // TestPodStatusCompatibility was deleted in tank-operator#83 along with
 // the podStatus() helper it pinned. Status is now derived from the
 // session_lifecycle_events ledger via Reader.hydrateLifecycle and tested

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,6 +107,13 @@ import {
   type SessionListReducerState,
 } from "./sessionListEvents";
 import {
+  logSessionListEvent,
+  logSessionListSnapshot,
+  logSessionListSseOpen,
+  logSessionListStreamSignal,
+  notePlaceholderSynthesized,
+} from "./sessionListTelemetry";
+import {
   isDurableTankConversationEvent,
   isTankConversationEvent,
   type TankConversationEvent,
@@ -7231,6 +7238,14 @@ export function App() {
   // updated by the effects below.
   const sessionsRef = useRef<Session[]>([]);
   const sessionActivitiesRef = useRef<Record<string, SessionActivitySummary>>({});
+  // lifecycleTipRef holds the Tank-Lifecycle-Tip-Order-Key header value
+  // from the most recent /api/sessions snapshot. The SSE useEffect seeds
+  // its cursor from this on cold open so the server's catch-up replay
+  // only emits events that landed AFTER the snapshot — without it, the
+  // SSE handler fast-forwards an empty cursor to current tip but loses
+  // any events that landed during the snapshot query itself. Updated by
+  // refresh() after each successful snapshot fetch.
+  const lifecycleTipRef = useRef<string | null>(null);
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [interactionMenuOpen, setInteractionMenuOpen] = useState(false);
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
@@ -7306,7 +7321,22 @@ export function App() {
     try {
       const res = await authedFetch("/api/sessions");
       if (!res.ok) throw new Error(`list failed: ${res.status}`);
+      // The server stamps the latest session_lifecycle_events order_key
+      // for this (owner, scope) at snapshot time. Threading it into the
+      // SSE cursor before /api/sessions/events opens means catch-up only
+      // emits events strictly after the snapshot — closes the race
+      // window without replaying history. See
+      // docs/product-inspirations.md: "Reconnect resumes from a cursor
+      // over persisted events" — that cursor must start at the snapshot
+      // tip on cold open, not at order_key=0.
+      const tip = res.headers.get("Tank-Lifecycle-Tip-Order-Key");
+      lifecycleTipRef.current = tip && tip.trim() !== "" ? tip : null;
       const listed: Session[] = (await res.json()).map(normalizeSession);
+      logSessionListSnapshot({
+        tip: lifecycleTipRef.current,
+        sessionCount: listed.length,
+        source: "initial",
+      });
       setSessions((prev) => {
         const previousById = new Map(prev.map((session) => [session.id, session]));
         const merged = listed.map((session) =>
@@ -7411,8 +7441,20 @@ export function App() {
 
     const open = () => {
       if (cancelled) return;
+      // Cold open: seed the cursor from the snapshot's
+      // Tank-Lifecycle-Tip-Order-Key. The server's catch-up will then
+      // emit only events strictly after that cursor — no
+      // replay-from-zero, no resurrection of deleted sessions via the
+      // reducer's placeholder-synthesis branch on stale pod events. If
+      // the snapshot didn't carry a tip (e.g. first request after
+      // backend roll, or the lifecycle ledger is empty), the server
+      // fast-forwards an empty cursor itself.
+      if (!cursorRef.current && lifecycleTipRef.current) {
+        cursorRef.current = lifecycleTipRef.current;
+      }
       const params = new URLSearchParams();
       if (cursorRef.current) params.set("last_order_key", cursorRef.current);
+      logSessionListSseOpen(cursorRef.current);
       const query = params.toString();
       source = new EventSource(`/api/sessions/events${query ? `?${query}` : ""}`, {
         withCredentials: true,
@@ -7427,15 +7469,21 @@ export function App() {
         }
         const normalized = normalizeSessionListEvent(parsed);
         if (!normalized) return;
+        logSessionListEvent(normalized);
         cursorRef.current = normalized.order_key;
         // Reducer mutates both the sessions list and the activities
         // map in one pass; React batches the two setState calls into a
-        // single render.
+        // single render. The onPlaceholderSynthesized callback fires
+        // the bug-detection beacon (see sessionListTelemetry); the
+        // reducer itself stays pure for unit tests, which don't pass
+        // the callback.
         const state: SessionListReducerState<Session> = {
           sessions: sessionsRef.current,
           activities: sessionActivitiesRef.current,
         };
-        const next = applySessionListEvent(state, normalized);
+        const next = applySessionListEvent(state, normalized, {
+          onPlaceholderSynthesized: notePlaceholderSynthesized,
+        });
         if (next.sessions !== state.sessions) {
           setSessions(
             user
@@ -7447,7 +7495,25 @@ export function App() {
           setSessionActivities(next.activities);
         }
       });
-      source.addEventListener("resync_required", () => {
+      source.addEventListener("ready", (event) => {
+        const message = event as MessageEvent;
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = JSON.parse(String(message.data));
+        } catch {
+          parsed = undefined;
+        }
+        logSessionListStreamSignal({ signal: "ready", detail: parsed });
+      });
+      source.addEventListener("resync_required", (event) => {
+        const message = event as MessageEvent;
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = JSON.parse(String(message.data));
+        } catch {
+          parsed = undefined;
+        }
+        logSessionListStreamSignal({ signal: "resync_required", detail: parsed });
         cursorRef.current = null;
         source?.close();
         source = null;
@@ -7456,7 +7522,15 @@ export function App() {
         // from a fresh cursor on the next tick.
         reopenTimer = window.setTimeout(open, 250);
       });
-      source.addEventListener("stream-error", () => {
+      source.addEventListener("stream-error", (event) => {
+        const message = event as MessageEvent;
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = JSON.parse(String(message.data));
+        } catch {
+          parsed = undefined;
+        }
+        logSessionListStreamSignal({ signal: "stream-error", detail: parsed });
         // Server-acknowledged error; close and let onerror restart.
         source?.close();
         source = null;

--- a/frontend/src/sessionListEvents.ts
+++ b/frontend/src/sessionListEvents.ts
@@ -128,7 +128,18 @@ export interface SessionListReducerState<S extends SessionListShape = SessionLis
 export function applySessionListEvent<S extends SessionListShape>(
   state: SessionListReducerState<S>,
   event: SessionListEvent,
-  options: { sessionFactory?: (id: string) => S } = {},
+  options: {
+    sessionFactory?: (id: string) => S;
+    // onPlaceholderSynthesized fires when applyPodStatusEvent has to
+    // synthesize a Session row for an unknown id (legitimate-but-rare
+    // live-event race window — pre-#525 this also fired on every
+    // cold-open replay for sessions that had been deleted). Threaded
+    // as a callback so the reducer stays a pure function for tests;
+    // production wiring in App.tsx posts the
+    // tank_session_list_client_placeholder_synthesized_total beacon so
+    // any regression of the resurrection paths surfaces in metrics.
+    onPlaceholderSynthesized?: (event: SessionListEvent) => void;
+  } = {},
 ): SessionListReducerState<S> {
   const factory = options.sessionFactory ?? defaultSessionFactory<S>();
 
@@ -157,7 +168,7 @@ export function applySessionListEvent<S extends SessionListShape>(
     case "session.pod_not_ready":
     case "session.pod_failed":
     case "session.pod_terminating":
-      return applyPodStatusEvent(state, event, factory);
+      return applyPodStatusEvent(state, event, factory, options.onPlaceholderSynthesized);
     case "session.activity_changed":
       return applyActivityEvent(state, event);
     default:
@@ -232,6 +243,7 @@ function applyPodStatusEvent<S extends SessionListShape>(
   state: SessionListReducerState<S>,
   event: SessionListEvent,
   factory: (id: string) => S,
+  onPlaceholderSynthesized?: (event: SessionListEvent) => void,
 ): SessionListReducerState<S> {
   const status = stringField(event.payload, "status");
   if (!status) return state;
@@ -243,9 +255,17 @@ function applyPodStatusEvent<S extends SessionListShape>(
   });
   const idx = state.sessions.findIndex((s) => s.id === event.session_id);
   if (idx === -1) {
-    // Pod transitioned before the matching /api/sessions row landed.
-    // Synthesize a placeholder so the status renders correctly; the
-    // next snapshot will fill in the missing fields (mode, name, etc).
+    // Pod transitioned before the matching /api/sessions row landed
+    // (legitimate live-event race) — synthesize a placeholder so the
+    // status renders correctly; the next snapshot will fill in the
+    // missing fields. Post-tank-operator#525 this branch should fire
+    // only in that narrow race window; cold-open replay no longer
+    // walks history from order_key=0 and Reader.List excludes pods
+    // whose registry row is visible=false. Telemetry callback lets
+    // App.tsx beacon to the server-side counter so any regression of
+    // the resurrection paths is observable instead of silently
+    // mutating sidebar state.
+    onPlaceholderSynthesized?.(event);
     const placeholder = updateSession(factory(event.session_id));
     placeholder.owner = event.email || placeholder.owner;
     placeholder.pod_name = stringOrNull(event.payload.pod_name) ?? placeholder.pod_name;

--- a/frontend/src/sessionListTelemetry.test.ts
+++ b/frontend/src/sessionListTelemetry.test.ts
@@ -1,0 +1,134 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  logSessionListEvent,
+  logSessionListSnapshot,
+  notePlaceholderSynthesized,
+} from "./sessionListTelemetry";
+import type { SessionListEvent } from "./sessionListEvents";
+
+// node:test runs without jsdom; the telemetry module needs
+// `localStorage` and `fetch`. Stub them per-test so the no-op vs.
+// enabled paths are deterministic regardless of node version.
+let fakeStorage: Record<string, string>;
+let fetchCalls: Array<{ url: string; body: unknown }>;
+let consoleLogs: Array<[string, unknown[]]>;
+let consoleWarns: Array<[string, unknown[]]>;
+let origConsoleLog: typeof console.log;
+let origConsoleWarn: typeof console.warn;
+
+beforeEach(() => {
+  fakeStorage = {};
+  fetchCalls = [];
+  consoleLogs = [];
+  consoleWarns = [];
+
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(fakeStorage, key)
+        ? fakeStorage[key]
+        : null;
+    },
+    setItem(key: string, value: string) {
+      fakeStorage[key] = value;
+    },
+    removeItem(key: string) {
+      delete fakeStorage[key];
+    },
+    clear() {
+      fakeStorage = {};
+    },
+    length: 0,
+    key() {
+      return null;
+    },
+  };
+
+  (globalThis as { fetch?: unknown }).fetch = async (
+    input: unknown,
+    init?: { body?: unknown },
+  ) => {
+    fetchCalls.push({
+      url: typeof input === "string" ? input : String(input),
+      body: init?.body,
+    });
+    return new Response(null, { status: 204 });
+  };
+
+  origConsoleLog = console.log;
+  origConsoleWarn = console.warn;
+  console.log = (message: string, ...args: unknown[]) => {
+    consoleLogs.push([message, args]);
+  };
+  console.warn = (message: string, ...args: unknown[]) => {
+    consoleWarns.push([message, args]);
+  };
+});
+
+afterEach(() => {
+  console.log = origConsoleLog;
+  console.warn = origConsoleWarn;
+  delete (globalThis as { fetch?: unknown }).fetch;
+  delete (globalThis as { localStorage?: unknown }).localStorage;
+});
+
+function makeEvent(): SessionListEvent {
+  return {
+    order_key: "42",
+    email: "u@example.com",
+    session_scope: "default",
+    session_id: "8",
+    type: "session.pod_terminating",
+    event_id: "pod_terminating:uid:0",
+    occurred_at: "2026-05-18T00:00:00Z",
+    payload: { status: "Failed" },
+  };
+}
+
+test("debug logs are no-ops when tankDebug is unset", () => {
+  logSessionListEvent(makeEvent());
+  logSessionListSnapshot({ tip: "42", sessionCount: 3, source: "initial" });
+  assert.equal(consoleLogs.length, 0, "debug-gated logs must not fire without the flag");
+});
+
+test("debug logs fire when tankDebug includes session-list", () => {
+  fakeStorage["tankDebug"] = "other-tag,session-list,more";
+  logSessionListEvent(makeEvent());
+  logSessionListSnapshot({ tip: "42", sessionCount: 3, source: "initial" });
+  assert.ok(
+    consoleLogs.some(([msg]) => msg.includes("event")),
+    "event log must fire when flag is enabled",
+  );
+  assert.ok(
+    consoleLogs.some(([msg]) => msg.includes("snapshot")),
+    "snapshot log must fire when flag is enabled",
+  );
+});
+
+test("notePlaceholderSynthesized always beacons regardless of debug flag", async () => {
+  // No tankDebug flag set — beacon must still fire.
+  notePlaceholderSynthesized(makeEvent());
+  // Console warn always fires.
+  assert.equal(consoleWarns.length, 1, "placeholder synthesis must always warn");
+  // Best-effort fetch; resolve microtasks before assertion.
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(fetchCalls.length, 1, "placeholder beacon must POST to /api/debug/client-metric");
+  assert.equal(fetchCalls[0].url, "/api/debug/client-metric");
+  const body = JSON.parse(String(fetchCalls[0].body));
+  assert.equal(
+    body.name,
+    "session_list.placeholder_synthesized",
+    "beacon name must match the server-side allowlist entry",
+  );
+});
+
+test("notePlaceholderSynthesized swallows fetch errors silently", async () => {
+  (globalThis as { fetch?: unknown }).fetch = async () => {
+    throw new Error("network down");
+  };
+  // Must not throw.
+  notePlaceholderSynthesized(makeEvent());
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(consoleWarns.length, 1, "warn fires before the fetch attempt");
+});

--- a/frontend/src/sessionListTelemetry.ts
+++ b/frontend/src/sessionListTelemetry.ts
@@ -1,0 +1,104 @@
+// Sidebar session-list client-side telemetry. Two surfaces:
+//
+//  1. Debug-gated console transcript. Enable per browser by setting
+//     `localStorage.tankDebug = "session-list"` (comma-separated tokens
+//     are accepted; this checks for "session-list" specifically). Once
+//     enabled, every snapshot fetch, every applied SSE event, and every
+//     cursor advance prints to the console under `[tank/session-list]`.
+//     Off by default — zero perf cost when not enabled.
+//
+//  2. Always-on placeholder-synthesis beacon. The reducer's
+//     applyPodStatusEvent branch that synthesizes a Session row for an
+//     unknown id is supposed to fire only in a narrow live-event race
+//     window. Post-tank-operator#525 the cold-open replay-from-zero is
+//     gone and the Reader.List pod-fallback excludes invisible rows, so
+//     the synthesis branch should be effectively cold in production.
+//     Any fire posts to /api/debug/client-metric which increments
+//     `tank_session_list_client_placeholder_synthesized_total` — a
+//     non-zero rate in steady state is the smoking-gun signal that a
+//     resurrection path snuck back in.
+//
+// Both helpers are best-effort: they swallow localStorage/fetch errors
+// so a misconfigured browser or transient network glitch can never
+// affect the reducer's correctness path.
+
+import type { SessionListEvent } from "./sessionListEvents";
+
+const DEBUG_STORAGE_KEY = "tankDebug";
+const DEBUG_TOKEN = "session-list";
+const CONSOLE_PREFIX = "[tank/session-list]";
+
+function isDebugEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(DEBUG_STORAGE_KEY) ?? "";
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .includes(DEBUG_TOKEN);
+  } catch {
+    // Private mode or storage-disabled browsers — treat as off.
+    return false;
+  }
+}
+
+export function logSessionListSnapshot(args: {
+  tip: string | null;
+  sessionCount: number;
+  source: "initial" | "resync";
+}): void {
+  if (!isDebugEnabled()) return;
+  console.log(`${CONSOLE_PREFIX} snapshot`, args);
+}
+
+export function logSessionListSseOpen(cursor: string | null): void {
+  if (!isDebugEnabled()) return;
+  console.log(`${CONSOLE_PREFIX} sse open`, { cursor });
+}
+
+export function logSessionListEvent(event: SessionListEvent): void {
+  if (!isDebugEnabled()) return;
+  console.log(`${CONSOLE_PREFIX} event`, {
+    type: event.type,
+    session_id: event.session_id,
+    scope: event.session_scope,
+    order_key: event.order_key,
+  });
+}
+
+export function logSessionListStreamSignal(args: {
+  signal: "resync_required" | "stream-error" | "ready";
+  detail?: Record<string, unknown>;
+}): void {
+  if (!isDebugEnabled()) return;
+  console.log(`${CONSOLE_PREFIX} stream`, args);
+}
+
+// notePlaceholderSynthesized fires unconditionally — this is the
+// regression-detection signal for the post-#525 invariant that
+// placeholder synthesis should be cold in production. Both the console
+// warning AND the server-side counter beacon fire regardless of the
+// debug flag. The fetch is fire-and-forget; failures (auth, network,
+// abort) are swallowed so the reducer is never blocked by telemetry.
+export function notePlaceholderSynthesized(event: SessionListEvent): void {
+  console.warn(`${CONSOLE_PREFIX} placeholder synthesized`, {
+    type: event.type,
+    session_id: event.session_id,
+    scope: event.session_scope,
+    order_key: event.order_key,
+  });
+  try {
+    void fetch("/api/debug/client-metric", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      // Allowlisted name; the server rejects any other value with 400
+      // so we don't leak arbitrary client strings into Prometheus.
+      body: JSON.stringify({ name: "session_list.placeholder_synthesized" }),
+      keepalive: true,
+    }).catch(() => {
+      // swallow — telemetry must not affect rendering
+    });
+  } catch {
+    // swallow
+  }
+}

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -344,6 +344,37 @@ const blocked = [
     // is the regression.
     pattern: /session_scope[\s\S]{0,40}\?\?\s*["']default["']/,
   },
+  // tank-operator#525 — the session-list cold-open replay path was
+  // resurrecting deleted sessions because (a) Reader.List's pod-fallback
+  // re-appended pods whose registry row was visible=false during the
+  // ~75s pod-termination window, and (b) the SSE handler replayed
+  // session_lifecycle_events from order_key=0 when the client opened
+  // with an empty cursor, letting pod-status events landing after
+  // session.deleted in the ledger re-add the row via the reducer's
+  // placeholder-synthesis branch. The fix made registry.List return
+  // visible+invisible rows (the Reader filters output by Visible but
+  // uses every id for `seen`), and made the SSE handler fast-forward
+  // an empty cursor to current tip. Block reintroduction of the
+  // visible-only registry SQL shape and the cursor="" loop-from-zero.
+  {
+    name: "retired registry visible-only SQL filter",
+    // The sessions-table read query used to filter `AND visible = true`
+    // at SQL time, which hid invisible rows from Reader.List's seen
+    // set and let the pod-fallback re-append Terminating pods.
+    // Reader is now responsible for filtering by SessionRecord.Visible
+    // at output time; the SQL must return all rows for the partition.
+    pattern: /FROM sessions[\s\S]{0,200}?AND\s+visible\s*=\s*true/,
+  },
+  {
+    name: "retired SSE replay-from-zero on empty cursor",
+    // Pre-#525 handleSessionsEvents looped writeSessionListStreamPage
+    // when cursor.AfterOrderKey was empty; the loop emitted every
+    // historical event for (email, scope) on cold open. Cold opens now
+    // fast-forward the cursor to LatestOrderKey before any catch-up
+    // emission. Block reintroduction of an explicit empty-cursor
+    // catch-up entry point.
+    pattern: /writeSessionListStreamPage\([\s\S]{0,200}?AfterOrderKey:\s*""/,
+  },
   // Interrupt-on-data-plane (the retired single-consumer architecture).
   // Until this PR, both runners dispatched isInterruptCommand →
   // acceptInterrupt from inside the data-plane command consumer. That's


### PR DESCRIPTION
## Summary
- Follow-up to [#524](https://github.com/nelsong6/tank-operator/pull/524). That PR scoped session-list reads correctly but left two **within-scope** resurrection paths the user reproduced with `hard refresh → see deleted → click delete → fine → refresh → back`. Both fixed here:
  - **Bug A** — `Reader.List`'s pod-fallback re-appended pods whose registry row was `visible=false`. K8s pod deletion is async (~75s graceful shutdown); during that window the Terminating pod was still re-added to `GET /api/sessions`. Fix: `registry.List` returns visible+invisible rows; `Reader.List` uses every registered id for `seen` but only emits `Visible=true` records.
  - **Bug B** — SSE catch-up replayed from `order_key=0` on cold open. The reducer's `applyPodStatusEvent` synthesizes a placeholder when no matching session exists; `session.pod_terminating` lands in the ledger after the user's `session.deleted`, so cold-open replay resurrected the row via synthesis. Fix: `handleListSessions` stamps `Tank-Lifecycle-Tip-Order-Key`; the SPA threads it into the SSE cursor so catch-up only emits events past the snapshot. When cursor is still empty (legacy clients), the handler fast-forwards to `LatestOrderKey` instead of looping from zero.
- **Client-side telemetry** for forensic visibility (per `docs/quality-timeframes.md`: \"Observability exists for the bugs a user would otherwise have to guess about\"):
  - `frontend/src/sessionListTelemetry.ts` — debug-gated console transcript (`localStorage.tankDebug = \"session-list\"`) of every snapshot, SSE open, applied event, and stream signal. Off by default.
  - `notePlaceholderSynthesized` — always-on beacon to `POST /api/debug/client-metric` → `tank_session_list_client_placeholder_synthesized_total`. Reducer's synthesis branch should be cold post-fix; any non-zero rate flags a resurrection regression.
  - `applySessionListEvent` stays a pure function; beacon wired via an opt-in callback the production caller passes from `App.tsx`. Tests don't pass the callback.
  - `/api/debug/client-metric` is auth-gated with a strict name allowlist; unknown names get 400 to keep Prometheus cardinality bounded.

## Test plan
- [x] `go build ./...` clean
- [x] `go test` across `sessionbus`, `lifecycleevents`, `podinformer`, `sessions`, `sessionregistry`, `cmd/tank-operator` — all pass, including new tests for visible-only filtering, cold-open fast-forward, snapshot tip header, beacon allowlist, beacon auth requirement
- [x] `npm test` — 52/52 pass, including 4 new tests for `sessionListTelemetry` (debug no-op vs. flag-enabled, always-on beacon, swallow-on-fetch-failure)
- [x] `node scripts/check-removed-chat-runtime.mjs` — clean (migration guards block the visible-only registry SQL shape and the empty-cursor replay-from-zero shape)
- [x] Rebased onto current `origin/main` (picked up #482, #520, #525 intervening); post-rebase build + tests still pass
- [ ] **Post-merge: user repro check.** Hard refresh after rollout completes; deleted sessions should not appear. If they do, devtools network capture of `GET /api/sessions` (response body + `Tank-Lifecycle-Tip-Order-Key` header) and the first few SSE `session-event` frames will pinpoint which path is still firing.
- [ ] Post-merge: verify `tank_session_list_client_placeholder_synthesized_total` stays at ~0 on the prod dashboard. A non-zero rate means the reducer is still resurrecting and we missed a path.

## Process note
[#524](https://github.com/nelsong6/tank-operator/pull/524) shipped after I committed to a unified theory (\"cross-scope unscoped reads explains all three named symptoms\") and stopped tracing. The user's literal reproduction was deterministic in a single env; cross-scope is probabilistic. Saved the lesson as a memory: trace the simplest single-env case through the code end-to-end before locking in a root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)