### PR TITLE
Phase 2: snapshot reads from sessions row; drop pod-fallback; invert Manager.Create order

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -45,6 +45,12 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 // correctness with a small race window (events landing during the
 // snapshot query). Extracted from handleListSessions so the contract
 // is unit-testable without standing up the full Manager stub.
+//
+// Phase 3 of docs/session-list-redesign.md retires this header in
+// favor of stampSnapshotCursorHeader (the per-row-UPDATE wire reads
+// row_version, not order_key). Both headers are stamped during Phase
+// 2 so the SPA can be cut over in Phase 3's PR without a wire-shape
+// rollout race.
 func (s *appServer) stampLifecycleTipHeader(ctx context.Context, w http.ResponseWriter, owner string) {
 	if s.lifecycleEvents == nil {
 		return
@@ -59,6 +65,34 @@ func (s *appServer) stampLifecycleTipHeader(ctx context.Context, w http.Response
 		return
 	}
 	w.Header().Set("Tank-Lifecycle-Tip-Order-Key", tip)
+}
+
+// stampSnapshotCursorHeader writes Tank-Sessions-Snapshot-Cursor —
+// the per-row-UPDATE wire's cursor, MAX(row_version) for (owner,
+// scope) at snapshot time. Phase 3 of docs/session-list-redesign.md
+// wires the SPA to read this header and seed its SSE cursor from it,
+// replacing the lifecycle-ledger-based cursor entirely. Emitted now
+// (Phase 2) so the wire-shape rollout in Phase 3 doesn't depend on a
+// coordinated client+server cutover.
+func (s *appServer) stampSnapshotCursorHeader(ctx context.Context, w http.ResponseWriter, owner string) {
+	if s.pgPool == nil {
+		return
+	}
+	const q = `
+		SELECT COALESCE(MAX(row_version), 0)
+		FROM sessions
+		WHERE email = $1 AND session_scope = $2
+	`
+	var cursor int64
+	if err := s.pgPool.QueryRow(ctx, q, owner, s.sessionScope).Scan(&cursor); err != nil {
+		slog.Warn("list sessions: snapshot cursor lookup failed",
+			"owner", owner, "scope", s.sessionScope, "error", err)
+		return
+	}
+	if cursor == 0 {
+		return
+	}
+	w.Header().Set("Tank-Sessions-Snapshot-Cursor", fmt.Sprintf("%d", cursor))
 }
 
 // handleListSessions lists sessions for the authenticated user, or for
@@ -93,6 +127,7 @@ func (s *appServer) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	// catch-up replay covers anything that landed during the snapshot
 	// query itself.
 	s.stampLifecycleTipHeader(r.Context(), w, owner)
+	s.stampSnapshotCursorHeader(r.Context(), w, owner)
 
 	infos, err := s.mgr.ListSessions(r.Context(), owner)
 	if err != nil {

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -248,6 +248,7 @@ func main() {
 		profiles:                 profileStore,
 		sessionEvents:            sessionEventsStore,
 		lifecycleEvents:          lifecycleStore,
+		pgPool:                   pgPool,
 		sessionBus:               sessionBus,
 		readStates:               readStateStore,
 		verifier:                 verifier,
@@ -481,7 +482,13 @@ func (r *stubSessionRegistry) Upsert(_ context.Context, _ sessionmodel.SessionRe
 	return nil
 }
 func (r *stubSessionRegistry) SetName(_ context.Context, _, _ string, _ *string) error { return nil }
-func (r *stubSessionRegistry) MarkDeleted(_ context.Context, _, _ string) error        { return nil }
+func (r *stubSessionRegistry) SetTestState(_ context.Context, _, _ string, _ map[string]any) error {
+	return nil
+}
+func (r *stubSessionRegistry) SetRolloutState(_ context.Context, _, _ string, _ map[string]any) error {
+	return nil
+}
+func (r *stubSessionRegistry) MarkDeleted(_ context.Context, _, _ string) error { return nil }
 
 func envDefault(name, fallback string) string {
 	v := strings.TrimSpace(os.Getenv(name))

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +35,7 @@ type appServer struct {
 	profiles                 profilesStore
 	sessionEvents            store.SessionEventStore
 	lifecycleEvents          lifecycleevents.Store
+	pgPool                   *pgxpool.Pool
 	sessionBus               sessionCommandBus
 	readStates               store.ConversationReadStateStore
 	verifier                 *auth.Verifier

--- a/backend-go/internal/pgstore/migrations.go
+++ b/backend-go/internal/pgstore/migrations.go
@@ -75,6 +75,17 @@ var schemaMigrations = []string{
 	`CREATE INDEX IF NOT EXISTS sessions_email_scope_row_version
 		ON sessions (email, session_scope, row_version)`,
 
+	// Phase 2 (docs/session-list-redesign.md) — test_state and
+	// rollout_state move onto the row so Reader.List can build the
+	// snapshot Info without a K8s pod read. Pod annotations are still
+	// patched by Manager.SetTestState/SetRolloutState (the session-
+	// agent reads them at runtime via the projected downward-API
+	// volume); the column is the snapshot-facing replica.
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS test_state jsonb`,
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS rollout_state jsonb`,
+
 	// `session_events` — the durable transcript ledger. Partition key in
 	// Cosmos was `tank_session_id`; in Postgres the same field is the high
 	// cardinality column we always filter and order by, so it leads the index.

--- a/backend-go/internal/sessioncontroller/writer_test.go
+++ b/backend-go/internal/sessioncontroller/writer_test.go
@@ -12,7 +12,7 @@ import (
 // invariant: every lifecycle event type that the controller emits
 // produces the exact row-column mapping the Phase 2 snapshot cutover
 // will read against. The mapping must match what the existing
-// Reader.hydrateLifecycle / LatestPodStatus / LatestActivity path
+// pre-Phase-2 ledger-hydration / LatestPodStatus / LatestActivity path
 // computes today, so Phase 2 can switch the read source over without
 // changing what the SPA renders.
 func TestDeriveRowColumnChangesPerEventType(t *testing.T) {

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -80,6 +80,20 @@ type SessionRecord struct {
 	RequestedAt string
 	CreatedAt   string
 	UpdatedAt   string
+
+	// Sidebar-visible columns added in
+	// docs/session-list-redesign.md Phase 1 dual-write and consumed
+	// directly by Reader.List as of Phase 2's snapshot cutover. Status
+	// is non-empty in steady state ('Pending' / 'Active' / 'Failed');
+	// the other fields are pointers because they're optional (no
+	// ready_at until the pod first reached Ready, etc.).
+	Status         string
+	ReadyAt        string
+	TerminatingAt  string
+	ActivitySummary []byte         // JSON-marshaled; nil when no chat activity yet
+	TestState      map[string]any // jsonb column, materialized for the handler layer
+	RolloutState   map[string]any // jsonb column
+	RowVersion     int64
 }
 
 // sessionConfigMounts is the canonical list of files mounted into every

--- a/backend-go/internal/sessionregistry/registry.go
+++ b/backend-go/internal/sessionregistry/registry.go
@@ -2,6 +2,7 @@ package sessionregistry
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -45,9 +46,16 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 	}
 	const q = `
 		SELECT session_id, mode, pod_name, name, visible,
-			COALESCE(to_char(requested_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS requested_at,
-			COALESCE(to_char(created_at   AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS created_at,
-			COALESCE(to_char(updated_at   AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS updated_at
+			COALESCE(to_char(requested_at   AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS requested_at,
+			COALESCE(to_char(created_at     AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS created_at,
+			COALESCE(to_char(updated_at     AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS updated_at,
+			status,
+			COALESCE(to_char(ready_at       AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS ready_at,
+			COALESCE(to_char(terminating_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS terminating_at,
+			activity_summary,
+			test_state,
+			rollout_state,
+			row_version
 		FROM sessions
 		WHERE email = $1 AND session_scope = $2
 		ORDER BY created_at ASC
@@ -62,27 +70,57 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 	for rows.Next() {
 		var (
 			sessionID, mode, podName, requestedAt, createdAt, updatedAt string
+			status, readyAt, terminatingAt                              string
 			name                                                        *string
 			visible                                                     bool
+			activitySummary, testState, rolloutState                    []byte
+			rowVersion                                                  int64
 		)
-		if err := rows.Scan(&sessionID, &mode, &podName, &name, &visible, &requestedAt, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(
+			&sessionID, &mode, &podName, &name, &visible,
+			&requestedAt, &createdAt, &updatedAt,
+			&status, &readyAt, &terminatingAt,
+			&activitySummary, &testState, &rolloutState,
+			&rowVersion,
+		); err != nil {
 			return nil, err
 		}
 		if mode == "" {
 			mode = sessionmodel.DefaultSessionMode
 		}
 		records = append(records, sessionmodel.SessionRecord{
-			ID:          sessionID,
-			Email:       normalized,
-			Mode:        mode,
-			Scope:       s.scope,
-			PodName:     podName,
-			Name:        name,
-			Visible:     visible,
-			RequestedAt: requestedAt,
-			CreatedAt:   createdAt,
-			UpdatedAt:   updatedAt,
+			ID:              sessionID,
+			Email:           normalized,
+			Mode:            mode,
+			Scope:           s.scope,
+			PodName:         podName,
+			Name:            name,
+			Visible:         visible,
+			RequestedAt:     requestedAt,
+			CreatedAt:       createdAt,
+			UpdatedAt:       updatedAt,
+			Status:          status,
+			ReadyAt:         readyAt,
+			TerminatingAt:   terminatingAt,
+			ActivitySummary: activitySummary,
+			TestState:       unmarshalJSONB(testState),
+			RolloutState:    unmarshalJSONB(rolloutState),
+			RowVersion:      rowVersion,
 		})
 	}
 	return records, rows.Err()
+}
+
+// unmarshalJSONB turns a jsonb column's raw bytes into the
+// map[string]any the snapshot handler expects to render. Empty/NULL
+// columns return nil, which the SPA renders as "no state set."
+func unmarshalJSONB(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
 }

--- a/backend-go/internal/sessionregistry/write.go
+++ b/backend-go/internal/sessionregistry/write.go
@@ -2,6 +2,7 @@ package sessionregistry
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -36,9 +37,13 @@ func (s *Store) NextSessionID(ctx context.Context) (string, error) {
 	return fmt.Sprintf("%d", allocated), nil
 }
 
-// Upsert writes or overwrites a session record. created_at/updated_at default
-// to now() on insert; on conflict (same primary key) we keep the existing
-// created_at and only advance updated_at.
+// Upsert writes or overwrites a session record. created_at/updated_at
+// default to now() on insert; on conflict (same primary key) we keep
+// the existing created_at, advance updated_at, and bump row_version so
+// downstream cursor readers see the change. The row_version bump on
+// UPDATE is what makes Manager-driven mutations (create-with-existing-
+// id, name set, mark-deleted) visible to the Phase 3 per-row UPDATE
+// wire alongside the SessionController-driven writes.
 func (s *Store) Upsert(ctx context.Context, record sessionmodel.SessionRecord) error {
 	normalized := strings.ToLower(record.Email)
 	scope := record.Scope
@@ -74,7 +79,8 @@ func (s *Store) Upsert(ctx context.Context, record sessionmodel.SessionRecord) e
 			name         = EXCLUDED.name,
 			visible      = EXCLUDED.visible,
 			requested_at = COALESCE(EXCLUDED.requested_at, sessions.requested_at),
-			updated_at   = EXCLUDED.updated_at
+			updated_at   = EXCLUDED.updated_at,
+			row_version  = nextval('sessions_row_version_seq')
 	`
 	_, err := s.pool.Exec(ctx, q,
 		normalized,
@@ -91,8 +97,9 @@ func (s *Store) Upsert(ctx context.Context, record sessionmodel.SessionRecord) e
 	return err
 }
 
-// SetName updates the display name. Missing-session is a no-op (matches the
-// previous Cosmos impl, which swallowed not-found there).
+// SetName updates the display name. Missing-session is a no-op
+// (matches the previous Cosmos impl, which swallowed not-found there).
+// Bumps row_version so the per-row update cursor advances.
 func (s *Store) SetName(ctx context.Context, email, sessionID string, name *string) error {
 	normalized := strings.ToLower(strings.TrimSpace(email))
 	if normalized == "" || strings.TrimSpace(sessionID) == "" {
@@ -100,10 +107,54 @@ func (s *Store) SetName(ctx context.Context, email, sessionID string, name *stri
 	}
 	const q = `
 		UPDATE sessions
-		SET name = $4, updated_at = now()
+		SET name        = $4,
+			updated_at  = now(),
+			row_version = nextval('sessions_row_version_seq')
 		WHERE email = $1 AND session_scope = $2 AND session_id = $3
 	`
 	_, err := s.pool.Exec(ctx, q, normalized, s.scope, sessionID, name)
+	return err
+}
+
+// SetTestState replaces the row's test_state jsonb. nil clears the
+// column. Pod annotations are patched separately by Manager — the
+// session-agent reads the annotation at runtime via the projected
+// downward-API volume; this column is the snapshot-facing replica so
+// Reader.List doesn't need a pod read. Bumps row_version.
+func (s *Store) SetTestState(ctx context.Context, email, sessionID string, state map[string]any) error {
+	return s.setJSONBColumn(ctx, "test_state", email, sessionID, state)
+}
+
+// SetRolloutState replaces the row's rollout_state jsonb. Same shape
+// and rationale as SetTestState.
+func (s *Store) SetRolloutState(ctx context.Context, email, sessionID string, state map[string]any) error {
+	return s.setJSONBColumn(ctx, "rollout_state", email, sessionID, state)
+}
+
+func (s *Store) setJSONBColumn(ctx context.Context, column, email, sessionID string, state map[string]any) error {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" || strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	var payload any
+	if state != nil {
+		raw, err := json.Marshal(state)
+		if err != nil {
+			return fmt.Errorf("sessionregistry: marshal %s: %w", column, err)
+		}
+		payload = raw
+	}
+	// Column is parameterized via constant strings only; no SQL
+	// injection risk because the caller supplies a literal column
+	// name from two known values.
+	q := fmt.Sprintf(`
+		UPDATE sessions
+		SET %s        = $4,
+			updated_at  = now(),
+			row_version = nextval('sessions_row_version_seq')
+		WHERE email = $1 AND session_scope = $2 AND session_id = $3
+	`, column)
+	_, err := s.pool.Exec(ctx, q, normalized, s.scope, sessionID, payload)
 	return err
 }
 
@@ -139,7 +190,11 @@ func (s *Store) OwnerForSession(ctx context.Context, scope, sessionID string) (s
 	}
 }
 
-// MarkDeleted sets visible=false. Missing-session is a no-op.
+// MarkDeleted sets visible=false. Missing-session is a no-op. Bumps
+// row_version so the per-row update cursor surfaces the deletion to
+// the Phase 3 wire — that's how the SPA's SessionStore learns to
+// tombstone the id on the live transport (alongside the existing
+// session.deleted lifecycle event during the dual-write window).
 func (s *Store) MarkDeleted(ctx context.Context, email, sessionID string) error {
 	normalized := strings.ToLower(strings.TrimSpace(email))
 	if normalized == "" || strings.TrimSpace(sessionID) == "" {
@@ -147,7 +202,9 @@ func (s *Store) MarkDeleted(ctx context.Context, email, sessionID string) error 
 	}
 	const q = `
 		UPDATE sessions
-		SET visible = false, updated_at = now()
+		SET visible     = false,
+			updated_at  = now(),
+			row_version = nextval('sessions_row_version_seq')
 		WHERE email = $1 AND session_scope = $2 AND session_id = $3
 	`
 	_, err := s.pool.Exec(ctx, q, normalized, s.scope, sessionID)

--- a/backend-go/internal/sessions/manager.go
+++ b/backend-go/internal/sessions/manager.go
@@ -34,6 +34,8 @@ type SessionRegistry interface {
 	NextSessionID(ctx context.Context) (string, error)
 	Upsert(ctx context.Context, record sessionmodel.SessionRecord) error
 	SetName(ctx context.Context, email, sessionID string, name *string) error
+	SetTestState(ctx context.Context, email, sessionID string, state map[string]any) error
+	SetRolloutState(ctx context.Context, email, sessionID string, state map[string]any) error
 	MarkDeleted(ctx context.Context, email, sessionID string) error
 }
 
@@ -301,8 +303,44 @@ func (m *Manager) Create(ctx context.Context, owner, mode string, glimmungContex
 		return Info{}, fmt.Errorf("manifest unmarshal: %w", err)
 	}
 
+	// Phase 2 write-order inversion (docs/session-list-redesign.md):
+	// registry row goes in BEFORE the K8s pod create. The pre-Phase-2
+	// order was pod-create-first, registry-second, which left a brief
+	// race window where Reader.List would see a pod without a registry
+	// row and fall through to the pod-fallback path — the path that
+	// resurrected just-deleted sessions during the ~75s pod-termination
+	// window. Reader.List no longer reads pods at all, so this window
+	// becomes "session created but not yet visible to the snapshot,"
+	// which is fine: the POST response carries the Info directly to
+	// the SPA which adds it optimistically; the next snapshot finds it.
+	//
+	// On pod-create failure after the registry write succeeds, we mark
+	// the row visible=false so the snapshot stops returning it.
+	podName := "session-" + sessionID
+	if m.registry != nil {
+		if regErr := m.registry.Upsert(ctx, sessionmodel.SessionRecord{
+			ID:          sessionID,
+			Email:       owner,
+			Mode:        mode,
+			Scope:       m.manifestOpts.SessionScope,
+			PodName:     podName,
+			Visible:     true,
+			RequestedAt: requestedAt,
+			UpdatedAt:   requestedAt,
+		}); regErr != nil {
+			slog.Warn("create registry upsert failed",
+				"session_id", sessionID, "owner", owner, "error", regErr)
+		}
+	}
+
 	created, err := m.client.CoreV1().Pods(m.namespace).Create(ctx, &pod, metav1.CreateOptions{})
 	if err != nil {
+		if m.registry != nil {
+			if delErr := m.registry.MarkDeleted(ctx, owner, sessionID); delErr != nil {
+				slog.Warn("create rollback: registry mark-deleted failed",
+					"session_id", sessionID, "owner", owner, "error", delErr)
+			}
+		}
 		return Info{}, fmt.Errorf("create pod: %w", err)
 	}
 
@@ -316,7 +354,6 @@ func (m *Manager) Create(ctx context.Context, owner, mode string, glimmungContex
 		s := created.CreationTimestamp.UTC().Format("2006-01-02T15:04:05+00:00")
 		createdAt = &s
 	}
-	podName := created.Name
 
 	info := Info{
 		ID:          sessionID,
@@ -328,7 +365,9 @@ func (m *Manager) Create(ctx context.Context, owner, mode string, glimmungContex
 		CreatedAt:   createdAt,
 	}
 
-	if m.registry != nil {
+	// Refresh the registry row with the K8s-assigned created_at so the
+	// snapshot's CreatedAt matches the pod object's creation timestamp.
+	if m.registry != nil && createdAt != nil {
 		if regErr := m.registry.Upsert(ctx, sessionmodel.SessionRecord{
 			ID:          sessionID,
 			Email:       owner,
@@ -337,10 +376,10 @@ func (m *Manager) Create(ctx context.Context, owner, mode string, glimmungContex
 			PodName:     podName,
 			Visible:     true,
 			RequestedAt: requestedAt,
-			CreatedAt:   orEmpty(createdAt),
+			CreatedAt:   *createdAt,
 			UpdatedAt:   requestedAt,
 		}); regErr != nil {
-			slog.Warn("create registry upsert failed",
+			slog.Warn("create registry created_at refresh failed",
 				"session_id", sessionID, "owner", owner, "error", regErr)
 		}
 	}
@@ -444,7 +483,11 @@ func (m *Manager) SetName(ctx context.Context, owner, sessionID string, name *st
 	return m.GetByOwner(ctx, owner, sessionID)
 }
 
-// SetTestState updates the test-state annotation on the pod.
+// SetTestState updates the row's test_state column AND patches the
+// matching pod annotation (the session-agent reads the annotation via
+// the projected downward-API volume). Both writes are load-bearing in
+// steady state: the column is the snapshot-facing replica;
+// the annotation is what the agent code path consults.
 func (m *Manager) SetTestState(ctx context.Context, owner, sessionID string, active bool, slotIndex *int, url *string) (Info, error) {
 	state := map[string]any{"active": active}
 	if slotIndex != nil {
@@ -454,25 +497,39 @@ func (m *Manager) SetTestState(ctx context.Context, owner, sessionID string, act
 		state["url"] = *url
 	}
 	raw, _ := json.Marshal(state)
-	return m.patchAnnotation(ctx, owner, sessionID,
+	return m.patchStateAnnotation(ctx, owner, sessionID,
 		"tank-operator/test-state", string(raw),
-		lifecycleevents.EventTypeTestStateChanged, "test_state_changed", state)
+		lifecycleevents.EventTypeTestStateChanged, "test_state_changed", state,
+		func(c context.Context) error {
+			if m.registry == nil {
+				return nil
+			}
+			return m.registry.SetTestState(c, owner, sessionID, state)
+		})
 }
 
-// SetRolloutState updates the rollout-state annotation on the pod.
+// SetRolloutState updates the row's rollout_state column AND patches
+// the matching pod annotation. Same shape as SetTestState.
 func (m *Manager) SetRolloutState(ctx context.Context, owner, sessionID string, active bool) (Info, error) {
 	state := map[string]any{"active": active}
 	raw, _ := json.Marshal(state)
-	return m.patchAnnotation(ctx, owner, sessionID,
+	return m.patchStateAnnotation(ctx, owner, sessionID,
 		"tank-operator/rollout-state", string(raw),
-		lifecycleevents.EventTypeRolloutStateChanged, "rollout_state_changed", state)
+		lifecycleevents.EventTypeRolloutStateChanged, "rollout_state_changed", state,
+		func(c context.Context) error {
+			if m.registry == nil {
+				return nil
+			}
+			return m.registry.SetRolloutState(c, owner, sessionID, state)
+		})
 }
 
-func (m *Manager) patchAnnotation(
+func (m *Manager) patchStateAnnotation(
 	ctx context.Context,
 	owner, sessionID, annotation, value string,
 	eventType, eventIDPrefix string,
 	payload map[string]any,
+	writeColumn func(context.Context) error,
 ) (Info, error) {
 	patch := map[string]any{
 		"metadata": map[string]any{
@@ -486,6 +543,13 @@ func (m *Manager) patchAnnotation(
 	}
 	if _, patchErr := m.client.CoreV1().Pods(m.namespace).Patch(ctx, pod.Name, types.MergePatchType, raw, metav1.PatchOptions{}); patchErr != nil && !k8serrors.IsNotFound(patchErr) {
 		return Info{}, fmt.Errorf("patch annotation %s: %w", annotation, patchErr)
+	}
+	if writeColumn != nil {
+		if err := writeColumn(ctx); err != nil {
+			slog.Warn("session-state column write failed",
+				"session_id", sessionID, "owner", owner,
+				"annotation", annotation, "error", err)
+		}
 	}
 	m.emitLifecycle(ctx, lifecycleevents.Event{
 		Email:        owner,
@@ -623,11 +687,7 @@ func (m *Manager) reader() *Reader {
 	if m.registry != nil {
 		reg = &registryAdapter{m.registry}
 	}
-	var lifecycleSrc LifecycleStatusSource
-	if statusSrc, ok := m.lifecycle.(LifecycleStatusSource); ok {
-		lifecycleSrc = statusSrc
-	}
-	return NewReaderFull(m.client, m.namespace, reg, lifecycleSrc, m.scope)
+	return NewReaderFull(m.client, m.namespace, reg, m.scope)
 }
 
 // registryAdapter wraps the write-capable SessionRegistry into a read-only Registry.

--- a/backend-go/internal/sessions/sessions.go
+++ b/backend-go/internal/sessions/sessions.go
@@ -48,21 +48,10 @@ type Info struct {
 	Activity *lifecycleevents.ActivitySummary `json:"activity,omitempty"`
 }
 
-// LifecycleStatusSource lets the Reader pull each session's durable
-// pod-status snapshot from the lifecycle ledger so the `status` field on
-// Info reflects the latest pod-state event instead of being recomputed
-// from the live pod object on every List() call. Satisfied by
-// lifecycleevents.Store.
-type LifecycleStatusSource interface {
-	LatestPodStatus(ctx context.Context, scope, sessionID string) (*lifecycleevents.PodStatusSummary, error)
-	LatestActivity(ctx context.Context, scope, sessionID string) (*lifecycleevents.ActivitySummary, error)
-}
-
 type Reader struct {
 	client    kubernetes.Interface
 	namespace string
 	registry  Registry
-	lifecycle LifecycleStatusSource
 	scope     string
 }
 
@@ -75,113 +64,56 @@ func NewReader(client kubernetes.Interface, namespace string) *Reader {
 }
 
 func NewReaderWithRegistry(client kubernetes.Interface, namespace string, registry Registry) *Reader {
-	return NewReaderFull(client, namespace, registry, nil, "")
+	return NewReaderFull(client, namespace, registry, "")
 }
 
-// NewReaderFull is the full-fledged constructor that wires the lifecycle
-// store so List/Get can hydrate Activity and the durable Status field
-// from the ledger. The legacy two-arg / three-arg constructors are kept
-// for the manager's reaperLoop call sites that don't need the lifecycle
-// data.
-func NewReaderFull(client kubernetes.Interface, namespace string, registry Registry, lifecycle LifecycleStatusSource, scope string) *Reader {
+// NewReaderFull is the full-fledged constructor. The pre-Phase-2
+// lifecycle hydration parameter is gone — the snapshot reads Status
+// / ReadyAt / Activity directly from the sessions row columns now,
+// no ledger pull on the read path.
+func NewReaderFull(client kubernetes.Interface, namespace string, registry Registry, scope string) *Reader {
 	if namespace == "" {
 		namespace = defaultNamespace
 	}
 	if scope == "" {
 		scope = "default"
 	}
-	return &Reader{client: client, namespace: namespace, registry: registry, lifecycle: lifecycle, scope: scope}
+	return &Reader{client: client, namespace: namespace, registry: registry, scope: scope}
 }
 
+// List returns the sidebar snapshot for one owner. Phase 2 of
+// docs/session-list-redesign.md cut this from a three-source merge
+// (K8s pods + registry + lifecycle store hydration) down to a single
+// registry read — the row carries every column the SPA renders.
+//
+// The K8s pod list is no longer read here: every field the snapshot
+// needs (status, ready_at, terminating_at, activity_summary,
+// test_state, rollout_state) lives on the sessions row, populated by
+// sessioncontroller.RowWriter and the registry write methods.
+// Dropping the pod read also eliminates the pod-fallback loop, which
+// was the bug that let Terminating pods for just-deleted sessions
+// reappear in the sidebar for the full ~75s graceful-shutdown window
+// (tank-operator#525 Bug A — the surface symptom that drove the
+// redesign).
+//
+// Registry-only mode (no registry wired): returns empty. Local-dev
+// shape; production always has a registry.
 func (r *Reader) List(ctx context.Context, owner string) ([]Info, error) {
-	ownerLabel := sessionmodel.OwnerLabel(owner)
-	pods, err := r.client.CoreV1().Pods(r.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "tank-operator/owner=" + ownerLabel,
-	})
+	if r.registry == nil {
+		return nil, nil
+	}
+	records, err := r.registry.List(ctx, owner)
 	if err != nil {
 		return nil, err
 	}
-
-	podsByID := make(map[string]*corev1.Pod, len(pods.Items))
-	podOrder := make([]*corev1.Pod, 0, len(pods.Items))
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		podsByID[sessionIDFromPod(pod)] = pod
-		podOrder = append(podOrder, pod)
-	}
-
-	if r.registry != nil {
-		// registry.List returns visible AND invisible rows (see
-		// sessionregistry.Store.List). `seen` is built from every
-		// registered session id so the pod-fallback loop below can tell
-		// "no registry row" (legitimate Manager.Create race window —
-		// Reader returns the pod-derived Info) apart from "registry
-		// row marked deleted" (the post-delete pod is Terminating
-		// during its grace window — Reader must NOT re-append it).
-		// Pre-tank-operator#525 the seen set only contained visible
-		// ids, so Terminating pods for just-deleted sessions reappeared
-		// in the sidebar for the full ~75s graceful-shutdown window.
-		records, err := r.registry.List(ctx, owner)
-		if err != nil {
-			return nil, err
-		}
-		seen := make(map[string]struct{}, len(records))
-		out := make([]Info, 0, len(records)+len(pods.Items))
-		for _, record := range records {
-			seen[record.ID] = struct{}{}
-			if !record.Visible {
-				continue
-			}
-			info := infoFromRecord(owner, record, podsByID[record.ID])
-			r.hydrateLifecycle(ctx, &info)
-			out = append(out, info)
-		}
-		for _, pod := range podOrder {
-			id := sessionIDFromPod(pod)
-			if _, ok := seen[id]; ok || !podHasSandboxAgent(pod) {
-				continue
-			}
-			info := infoFromPod(owner, pod)
-			r.hydrateLifecycle(ctx, &info)
-			out = append(out, info)
-		}
-		return out, nil
-	}
-
-	out := make([]Info, 0, len(pods.Items))
-	for _, pod := range podOrder {
-		if !podHasSandboxAgent(pod) {
+	out := make([]Info, 0, len(records))
+	for _, record := range records {
+		if !record.Visible {
 			continue
 		}
-		info := infoFromPod(owner, pod)
-		r.hydrateLifecycle(ctx, &info)
-		out = append(out, info)
+		out = append(out, infoFromRecord(owner, record))
 	}
 	return out, nil
-}
-
-// hydrateLifecycle replaces the live-pod status computation with the
-// durable equivalent: the latest session.pod_* event drives Status (and
-// ReadyAt where applicable), and the latest session.activity_changed
-// fills the Activity block. Falls back to whatever Status the
-// infoFromRecord/infoFromPod path already set if the lifecycle store is
-// unwired (local dev with stub store) or hasn't seen the session yet.
-func (r *Reader) hydrateLifecycle(ctx context.Context, info *Info) {
-	if r.lifecycle == nil || info == nil || info.ID == "" {
-		return
-	}
-	if status, err := r.lifecycle.LatestPodStatus(ctx, r.scope, info.ID); err == nil && status != nil {
-		if status.Status != "" {
-			info.Status = status.Status
-		}
-		if status.ReadyAt != nil {
-			info.ReadyAt = status.ReadyAt
-		}
-	}
-	if activity, err := r.lifecycle.LatestActivity(ctx, r.scope, info.ID); err == nil && activity != nil {
-		copy := *activity
-		info.Activity = &copy
-	}
 }
 
 func (r *Reader) Get(ctx context.Context, owner, sessionID string) (Info, error) {
@@ -249,36 +181,61 @@ func (r *Reader) GetByID(ctx context.Context, sessionID string) (Info, error) {
 	return infoFromPod(owner, pod), nil
 }
 
-func infoFromRecord(owner string, record sessionmodel.SessionRecord, pod *corev1.Pod) Info {
-	if pod != nil {
-		info := infoFromPod(owner, pod)
-		info.ID = record.ID
-		info.Mode = sessionmodel.NormalizeSessionMode(record.Mode)
-		info.RequestedAt = firstString(record.RequestedAt, record.CreatedAt, valueString(info.RequestedAt))
-		info.CreatedAt = firstString(record.CreatedAt, valueString(info.CreatedAt))
-		info.Name = record.Name
-		return info
+// infoFromRecord builds the snapshot Info entirely from a sessions
+// row. All sidebar-visible fields live on the row as of Phase 2; the
+// K8s pod is no longer consulted on the snapshot path. Activity is
+// parsed from the activity_summary jsonb column written by the
+// chat-activity emitter on each indicator-affecting chat event.
+func infoFromRecord(owner string, record sessionmodel.SessionRecord) Info {
+	status := record.Status
+	if status == "" {
+		// Brand-new rows whose status hasn't been written yet: render
+		// as Pending. The Phase 1 schema default also stamps 'Pending'
+		// at INSERT time, so this branch only fires for synthetic
+		// records (tests with empty fixtures).
+		status = "Pending"
 	}
-	return Info{
-		ID:          record.ID,
-		PodName:     optionalString(record.PodName),
-		Owner:       owner,
-		Status:      "Failed",
-		Mode:        sessionmodel.NormalizeSessionMode(record.Mode),
-		RequestedAt: firstString(record.RequestedAt, record.CreatedAt),
-		CreatedAt:   optionalString(record.CreatedAt),
-		ReadyAt:     nil,
-		Name:        record.Name,
+	info := Info{
+		ID:           record.ID,
+		PodName:      optionalString(record.PodName),
+		Owner:        owner,
+		Status:       status,
+		Mode:         sessionmodel.NormalizeSessionMode(record.Mode),
+		RequestedAt:  firstString(record.RequestedAt, record.CreatedAt),
+		CreatedAt:    optionalString(record.CreatedAt),
+		ReadyAt:      optionalString(record.ReadyAt),
+		Name:         record.Name,
+		TestState:    record.TestState,
+		RolloutState: record.RolloutState,
 	}
+	if activity := parseActivitySummary(record.ActivitySummary); activity != nil {
+		info.Activity = activity
+	}
+	return info
 }
 
-// infoFromPod builds an Info from a live pod for callers that haven't
-// wired the lifecycle store yet (legacy NewReader / NewReaderWithRegistry).
-// The Status field defaults to "Pending" — the real Status comes from
-// hydrateLifecycle's pull against the latest session.pod_* lifecycle
-// event. Live pod-state computation is intentionally NOT done here per
-// tank-operator#83: status is derived from the durable ledger, not the
-// pod object.
+// parseActivitySummary decodes the row's activity_summary jsonb into
+// the lifecycleevents.ActivitySummary the Info field expects. Empty
+// columns return nil so the sidebar renders "no activity yet" for
+// fresh sessions.
+func parseActivitySummary(raw []byte) *lifecycleevents.ActivitySummary {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out lifecycleevents.ActivitySummary
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return &out
+}
+
+// infoFromPod builds an Info from a live pod. After Phase 2 of
+// docs/session-list-redesign.md this is only called by Reader.Get
+// (per-session detail page); Reader.List goes straight to the row.
+// Status defaults to "Pending" here because the row's value already
+// reflects the latest lifecycle transition by the time the per-
+// session GET handler runs and the SPA snapshot view always wins on
+// the sidebar.
 func infoFromPod(owner string, pod *corev1.Pod) Info {
 	podName := pod.Name
 	createdAt := timeString(pod.CreationTimestamp.Time)
@@ -344,10 +301,11 @@ func podHasSandboxAgent(pod *corev1.Pod) bool {
 	return false
 }
 
-// podStatus was deleted in tank-operator#83. Status is derived from the
-// session_lifecycle_events ledger via LatestPodStatus, not computed live
-// from the pod object. See Reader.hydrateLifecycle and the
-// scripts/check-removed-chat-runtime.mjs guard.
+// podStatus was deleted in tank-operator#83. Status is sourced from
+// the sessions.status row column (docs/session-list-redesign.md
+// Phase 2), populated by sessioncontroller.RowWriter. The
+// scripts/check-removed-chat-runtime.mjs guard blocks
+// reintroduction of any live pod-status computation here.
 
 func podReady(pod *corev1.Pod) bool {
 	if pod.Status.Phase != corev1.PodRunning || len(pod.Status.ContainerStatuses) == 0 {

--- a/backend-go/internal/sessions/sessions_test.go
+++ b/backend-go/internal/sessions/sessions_test.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"slices"
 	"testing"
@@ -11,45 +12,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/nelsong6/tank-operator/backend-go/internal/lifecycleevents"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 )
 
-// fakeLifecycleSource is the test stand-in for the production
-// lifecycleevents.Store that drives the Reader's Status + Activity
-// hydration. Maps session_id → canned values; missing entries return
-// nil/nil so the Reader leaves the default Status alone (the legacy
-// behavior).
-type fakeLifecycleSource struct {
-	pod      map[string]*lifecycleevents.PodStatusSummary
-	activity map[string]*lifecycleevents.ActivitySummary
-}
-
-func (f fakeLifecycleSource) LatestPodStatus(_ context.Context, _, sessionID string) (*lifecycleevents.PodStatusSummary, error) {
-	return f.pod[sessionID], nil
-}
-
-func (f fakeLifecycleSource) LatestActivity(_ context.Context, _, sessionID string) (*lifecycleevents.ActivitySummary, error) {
-	return f.activity[sessionID], nil
-}
-
-// readyAtPtr / activeSummary build the fixtures the merge test expects.
-func readyAtPtr(t string) *string { v := t; return &v }
-
-func TestListReturnsOwnedSandboxAgentPods(t *testing.T) {
-	client := fake.NewSimpleClientset(
-		sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true),
-		sessionPod("13", "nelson@romaine.life", corev1.PodRunning, false),
-		sessionPod("14", "other@example.com", corev1.PodRunning, true),
-	)
-	// Status comes from the lifecycle ledger now (tank-operator#83); seed
-	// the test source with a "ready" entry for session 12.
-	lifecycle := fakeLifecycleSource{
-		pod: map[string]*lifecycleevents.PodStatusSummary{
-			"12": {Status: "Active", ReadyAt: readyAtPtr("2026-05-11T00:00:03+00:00")},
+// TestListReadsEverythingFromTheRegistryRow is the Phase 2 cutover
+// contract: Reader.List returns the sidebar snapshot purely from the
+// sessions row. K8s is not consulted (a fake client with zero pods
+// still produces the full Info); no lifecycle-store hydration is
+// involved; status / ready_at / test_state / rollout_state /
+// activity_summary all come straight off the row columns Phase 1
+// populated.
+func TestListReadsEverythingFromTheRegistryRow(t *testing.T) {
+	activity, _ := json.Marshal(map[string]any{
+		"status":       "running",
+		"unread_count": 3,
+	})
+	registry := registryRecords{
+		{
+			ID:            "12",
+			Email:         "nelson@romaine.life",
+			Mode:          sessionmodel.CodexGUIMode,
+			PodName:       "session-12",
+			Name:          stringPtr("Workbench"),
+			Visible:       true,
+			RequestedAt:   "2026-05-11T00:00:00+00:00",
+			CreatedAt:     "2026-05-11T00:00:01+00:00",
+			Status:        "Active",
+			ReadyAt:       "2026-05-11T00:00:03+00:00",
+			ActivitySummary: activity,
+			TestState:     map[string]any{"active": true},
+			RolloutState:  map[string]any{"active": true},
 		},
 	}
-	reader := NewReaderFull(client, sessionmodel.SessionsNamespace, nil, lifecycle, "default")
+	// Empty K8s client — proves the snapshot doesn't touch K8s.
+	client := fake.NewSimpleClientset()
+	reader := NewReaderFull(client, sessionmodel.SessionsNamespace, registry, "default")
 
 	got, err := reader.List(context.Background(), "nelson@romaine.life")
 	if err != nil {
@@ -59,20 +56,17 @@ func TestListReturnsOwnedSandboxAgentPods(t *testing.T) {
 		t.Fatalf("session count = %d, want 1: %#v", len(got), got)
 	}
 	session := got[0]
-	if session.ID != "12" {
-		t.Fatalf("session id = %q, want 12", session.ID)
+	if session.ID != "12" || session.Status != "Active" || session.Mode != sessionmodel.CodexGUIMode {
+		t.Fatalf("session = %#v", session)
 	}
-	if session.Status != "Active" {
-		t.Fatalf("session status = %q, want Active", session.Status)
-	}
-	if session.Mode != sessionmodel.CodexGUIMode {
-		t.Fatalf("session mode = %q, want %q", session.Mode, sessionmodel.CodexGUIMode)
+	if session.Name == nil || *session.Name != "Workbench" {
+		t.Fatalf("name = %#v, want Workbench", session.Name)
 	}
 	if session.PodName == nil || *session.PodName != "session-12" {
 		t.Fatalf("pod name = %#v, want session-12", session.PodName)
 	}
-	if session.Name == nil || *session.Name != "Workbench" {
-		t.Fatalf("name = %#v, want Workbench", session.Name)
+	if session.ReadyAt == nil || *session.ReadyAt != "2026-05-11T00:00:03+00:00" {
+		t.Fatalf("ready_at = %#v", session.ReadyAt)
 	}
 	if session.TestState["active"] != true {
 		t.Fatalf("test state = %#v, want active true", session.TestState)
@@ -80,11 +74,71 @@ func TestListReturnsOwnedSandboxAgentPods(t *testing.T) {
 	if session.RolloutState["active"] != true {
 		t.Fatalf("rollout state = %#v, want active true", session.RolloutState)
 	}
-	if session.CreatedAt == nil || *session.CreatedAt != "2026-05-11T00:00:01+00:00" {
-		t.Fatalf("created_at = %#v", session.CreatedAt)
+	if session.Activity == nil || session.Activity.UnreadCount != 3 {
+		t.Fatalf("activity = %#v, want unread_count=3", session.Activity)
 	}
-	if session.ReadyAt == nil || *session.ReadyAt != "2026-05-11T00:00:03+00:00" {
-		t.Fatalf("ready_at = %#v", session.ReadyAt)
+	// Verify no K8s API calls were made.
+	if actions := client.Actions(); len(actions) > 0 {
+		t.Fatalf("Reader.List made %d K8s calls; the Phase 2 snapshot must not touch K8s: %#v", len(actions), actions)
+	}
+}
+
+// TestListSkipsInvisibleRows confirms visible=false rows are excluded
+// from the snapshot. Together with TestListReadsEverythingFromTheRegistryRow,
+// this nails down the row-only read shape that retired the pod-
+// fallback loop responsible for tank-operator#525's 75s resurrection
+// window.
+func TestListSkipsInvisibleRows(t *testing.T) {
+	registry := registryRecords{
+		{
+			ID:      "12",
+			Email:   "nelson@romaine.life",
+			Mode:    sessionmodel.CodexGUIMode,
+			Visible: true,
+			Status:  "Active",
+		},
+		{
+			ID:      "13",
+			Email:   "nelson@romaine.life",
+			Mode:    sessionmodel.CodexGUIMode,
+			Visible: false, // Manager.Delete just ran; pod may still be Terminating
+			Status:  "Failed",
+		},
+	}
+	reader := NewReaderFull(fake.NewSimpleClientset(), sessionmodel.SessionsNamespace, registry, "default")
+	got, err := reader.List(context.Background(), "nelson@romaine.life")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("count = %d, want 1 (only visible row): %#v", len(got), got)
+	}
+	if got[0].ID != "12" {
+		t.Fatalf("id = %q, want 12", got[0].ID)
+	}
+}
+
+// TestListSortsByRegistryOrder pins that the snapshot preserves the
+// row order returned by registry.List (oldest-first by created_at).
+// The SPA does its own ordering on top, but the snapshot's stable
+// order is what makes the SSE reducer's "find row by id" predictable.
+func TestListSortsByRegistryOrder(t *testing.T) {
+	registry := registryRecords{
+		{ID: "11", Email: "u@example.com", Visible: true, Status: "Active"},
+		{ID: "21", Email: "u@example.com", Visible: true, Status: "Active"},
+		{ID: "31", Email: "u@example.com", Visible: true, Status: "Active"},
+	}
+	reader := NewReaderFull(fake.NewSimpleClientset(), sessionmodel.SessionsNamespace, registry, "default")
+	got, err := reader.List(context.Background(), "u@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, info := range got {
+		ids = append(ids, info.ID)
+	}
+	if !slices.Equal(ids, []string{"11", "21", "31"}) {
+		t.Fatalf("ids = %v, want [11 21 31] in registry order", ids)
 	}
 }
 
@@ -113,136 +167,7 @@ func TestGetRejectsWrongOwner(t *testing.T) {
 	}
 }
 
-func TestListMergesRegistryRecordsWithPods(t *testing.T) {
-	recordedName := "Saved name"
-	client := fake.NewSimpleClientset(
-		sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true),
-		sessionPod("16", "nelson@romaine.life", corev1.PodRunning, true),
-	)
-	registry := registryRecords{
-		{
-			ID:          "12",
-			Email:       "nelson@romaine.life",
-			Mode:        sessionmodel.CodexGUIMode,
-			PodName:     "session-12",
-			Name:        &recordedName,
-			RequestedAt: "2026-05-11T00:00:00+00:00",
-			CreatedAt:   "2026-05-11T00:00:01+00:00",
-			Visible:     true,
-		},
-		{
-			ID:          "15",
-			Email:       "nelson@romaine.life",
-			Mode:        sessionmodel.ClaudeCLIMode,
-			PodName:     "session-15",
-			RequestedAt: "2026-05-10T00:00:00+00:00",
-			CreatedAt:   "2026-05-10T00:00:01+00:00",
-			Visible:     true,
-		},
-	}
-	lifecycle := fakeLifecycleSource{
-		pod: map[string]*lifecycleevents.PodStatusSummary{
-			"12": {Status: "Active", ReadyAt: readyAtPtr("2026-05-11T00:00:03+00:00")},
-			"16": {Status: "Active", ReadyAt: readyAtPtr("2026-05-11T00:00:03+00:00")},
-			// 15 has no pod and no lifecycle row — the infoFromRecord
-			// fallback path stamps "Failed", which is what the test
-			// expects.
-		},
-	}
-	reader := NewReaderFull(client, sessionmodel.SessionsNamespace, registry, lifecycle, "default")
-
-	got, err := reader.List(context.Background(), "nelson@romaine.life")
-	if err != nil {
-		t.Fatal(err)
-	}
-	slices.SortFunc(got, func(a, b Info) int {
-		if a.ID < b.ID {
-			return -1
-		}
-		if a.ID > b.ID {
-			return 1
-		}
-		return 0
-	})
-	if len(got) != 3 {
-		t.Fatalf("session count = %d, want 3: %#v", len(got), got)
-	}
-	if got[0].ID != "12" || got[0].Status != "Active" || got[0].Name == nil || *got[0].Name != recordedName {
-		t.Fatalf("merged session = %#v", got[0])
-	}
-	if got[0].RequestedAt == nil || *got[0].RequestedAt != "2026-05-11T00:00:00+00:00" {
-		t.Fatalf("merged requested_at = %#v", got[0].RequestedAt)
-	}
-	if got[1].ID != "15" || got[1].Status != "Failed" || got[1].Mode != sessionmodel.ClaudeCLIMode {
-		t.Fatalf("registry-only session = %#v", got[1])
-	}
-	if got[2].ID != "16" || got[2].Status != "Active" {
-		t.Fatalf("pod-only session = %#v", got[2])
-	}
-}
-
-// TestListExcludesInvisibleRegistryRowsEvenWhenPodAlive is the
-// regression gate for the symptom that drove tank-operator#525: pod
-// delete is asynchronous (~75s graceful shutdown), so the pod stays in
-// etcd as Terminating while the registry row already says
-// visible=false. Pre-#525 Reader.List built `seen` from visible-only
-// registry rows, so its pod-fallback loop re-appended the
-// just-deleted session for the full grace window. The user saw the
-// row "come back" on every refresh until the pod finished
-// terminating.
-//
-// The fix: registry.List returns visible+invisible rows; Reader.List
-// uses every registered id for `seen` but only emits visible records.
-// Invisible rows whose pod is still alive must NOT be re-added by the
-// pod-fallback loop.
-func TestListExcludesInvisibleRegistryRowsEvenWhenPodAlive(t *testing.T) {
-	client := fake.NewSimpleClientset(
-		sessionPod("12", "nelson@romaine.life", corev1.PodRunning, true),
-		sessionPod("13", "nelson@romaine.life", corev1.PodRunning, true),
-	)
-	registry := registryRecords{
-		{
-			ID:          "12",
-			Email:       "nelson@romaine.life",
-			Mode:        sessionmodel.CodexGUIMode,
-			PodName:     "session-12",
-			RequestedAt: "2026-05-11T00:00:00+00:00",
-			CreatedAt:   "2026-05-11T00:00:01+00:00",
-			Visible:     true,
-		},
-		{
-			ID:          "13",
-			Email:       "nelson@romaine.life",
-			Mode:        sessionmodel.CodexGUIMode,
-			PodName:     "session-13",
-			RequestedAt: "2026-05-11T00:01:00+00:00",
-			CreatedAt:   "2026-05-11T00:01:01+00:00",
-			// Marked deleted by Manager.Delete; pod is still
-			// Terminating in K8s for another ~75s.
-			Visible: false,
-		},
-	}
-	reader := NewReaderFull(client, sessionmodel.SessionsNamespace, registry, nil, "default")
-
-	got, err := reader.List(context.Background(), "nelson@romaine.life")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 {
-		t.Fatalf("session count = %d, want 1 (only the visible row): %#v", len(got), got)
-	}
-	if got[0].ID != "12" {
-		t.Fatalf("visible session id = %q, want 12 (session 13's registry row is visible=false; its still-alive pod must not be re-added via the pod-fallback loop)", got[0].ID)
-	}
-}
-
-// TestPodStatusCompatibility was deleted in tank-operator#83 along with
-// the podStatus() helper it pinned. Status is now derived from the
-// session_lifecycle_events ledger via Reader.hydrateLifecycle and tested
-// end-to-end through TestListReturnsOwnedSandboxAgentPods (which wires a
-// fakeLifecycleSource). Re-introducing this test would resurrect the
-// retired path the migration-guard forbids; the equivalent pod-state
-// derivation is now tested in internal/sessioncontroller.
+func stringPtr(s string) *string { return &s }
 
 type registryRecords []sessionmodel.SessionRecord
 

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -422,6 +422,20 @@ const blocked = [
     // new exported type with a parallel implementation.
     pattern: /\blifecycleEmitter\b/,
   },
+  // docs/session-list-redesign.md Phase 2 — Reader.List cut over to
+  // reading every sidebar-visible field from the sessions row, dropping
+  // the K8s pod list and the lifecycle-store hydration entirely. The
+  // hydrate path was the read-side of the multi-pipe architecture the
+  // redesign retires; reintroducing it would resurrect the merge-
+  // boundary bug class.
+  {
+    name: "removed LifecycleStatusSource interface",
+    pattern: /\bLifecycleStatusSource\b/,
+  },
+  {
+    name: "removed Reader.hydrateLifecycle method",
+    pattern: /\bhydrateLifecycle\b/,
+  },
   // Interrupt-on-data-plane (the retired single-consumer architecture).
   // Until this PR, both runners dispatched isInterruptCommand →
   // acceptInterrupt from inside the data-plane command consumer. That's


### PR DESCRIPTION
## Summary
docs/session-list-redesign.md Phase 2. The sidebar snapshot path becomes a single registry SELECT — no K8s pod read, no lifecycle-store hydration.

- `Reader.List` now reads `status` / `ready_at` / `terminating_at` / `activity_summary` / `test_state` / `rollout_state` directly off the sessions row. The K8s pod list call is gone, the pod-fallback loop is gone, the `hydrateLifecycle` / `LifecycleStatusSource` surface is deleted. The pod-fallback was the path that let Terminating pods for just-deleted sessions reappear in the sidebar for the full ~75s graceful-shutdown window — tank-operator#525 Bug A, the surface symptom that drove this redesign.
- `Manager.Create` write order inverted: `registry.Upsert(visible=true)` BEFORE `pod.Create`. On pod-create failure the row gets `MarkDeleted`. The pre-Phase-2 order (pod-first, registry-second) was the race window the pod-fallback was meant to cover; the new order plus the row-only read makes that window irrelevant.
- Schema adds `test_state jsonb` and `rollout_state jsonb` so the snapshot doesn't need K8s annotations. The pod annotations are still patched (the session-agent reads them via the projected downward-API volume); the columns are the snapshot-facing replicas.
- Registry write methods (`Upsert UPDATE`, `SetName`, `MarkDeleted`, new `SetTestState`, new `SetRolloutState`) all now bump `row_version` via `nextval('sessions_row_version_seq')`. Together with Phase 1's controller writes, every mutation advances the per-(owner, scope) cursor — Phase 3's per-row UPDATE wire reads against this.
- `handleListSessions` emits the new `Tank-Sessions-Snapshot-Cursor` header (= `MAX(row_version)`) alongside the existing `Tank-Lifecycle-Tip-Order-Key`. Phase 3 will wire the SPA to read the new header and retire the old one.

## Test plan
- [x] `go build ./...` clean
- [x] `go test` across `sessions`, `sessioncontroller`, `cmd/tank-operator` — all pass. Sessions tests rewritten for the row-only shape: `TestListReadsEverythingFromTheRegistryRow` asserts the snapshot builds Info entirely from the row AND that zero K8s API calls are made (verified via fake.Clientset.Actions()); `TestListSkipsInvisibleRows` covers the visible=false exclusion that replaces the #525 pod-fallback regression test.
- [x] `node scripts/check-removed-chat-runtime.mjs` — clean. Migration guards block `LifecycleStatusSource` and `hydrateLifecycle` reintroduction.
- [x] `helm template` renders.
- [ ] Post-merge: the user's repro (delete session, refresh, deleted session reappears) should not reproduce in any window. The pod-fallback resurrection is structurally impossible now.

## Next phases
- Phase 3: per-row UPDATE wire; frontend SessionStore; `/_debug/session-list` page; old event-type reducer deleted; `Tank-Lifecycle-Tip-Order-Key` retired.
- Phase 4: `session_lifecycle_events` table dropped end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)