### PR TITLE
agent-runner: log unhandled SDK messages for Monitor-stuck observability

### DIFF
--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -10,6 +10,7 @@ import {
   inputReplyAnswers,
   inputReplyTargetProviderItemID,
   joinAnswersForSDK,
+  logUnhandledSdkMessage,
   Runner,
 } from "./runner.js";
 import {
@@ -178,6 +179,93 @@ test("inputReplyAnnotations trims preview and notes, drops empty entries", () =>
   assert.deepEqual(inputReplyAnnotations(record as never), {
     Q1: { preview: "<div/>", notes: "hi" },
   });
+});
+
+// logUnhandledSdkMessage is the cheapest possible surface for "what is the
+// SDK telling us that the adapter throws away?" — task lifecycle events
+// (Monitor's status=completed/failed/stopped notification, the immediate
+// task_started ack, periodic task_progress) all arrive as `type:"system"`
+// with a `subtype` and never reach Tank conversation events. The test
+// pins two contracts at once:
+//   - canonical types the adapter already converts ("assistant", "user",
+//     "result", and the partial-typing "stream_event") MUST stay silent
+//     so we don't double-log them and don't flood kubectl logs with the
+//     per-token partial stream.
+//   - every other type MUST log one JSON line carrying the small set of
+//     identifying fields a debugger needs (subtype, task_id, tool_use_id,
+//     status, summary) without bringing the full payload along.
+// If a future patch promotes any of these types to first-class Tank
+// events, the adapter handler lands first and this test's expected
+// silent-type set gets the new entry — otherwise we'd double-emit.
+function captureConsoleLog<T>(fn: () => T): { result: T; lines: string[] } {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (msg: unknown) => {
+    lines.push(String(msg));
+  };
+  try {
+    const result = fn();
+    return { result, lines };
+  } finally {
+    console.log = original;
+  }
+}
+
+test("logUnhandledSdkMessage emits a structured JSON line for task_notification", () => {
+  const { lines } = captureConsoleLog(() =>
+    logUnhandledSdkMessage({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "task-abc",
+      tool_use_id: "toolu_xyz",
+      status: "failed",
+      summary: "Monitor stream ended without condition match",
+      uuid: "u-1",
+      session_id: "s-1",
+    } as never),
+  );
+  assert.equal(lines.length, 1);
+  const parsed = JSON.parse(lines[0]);
+  assert.equal(parsed.msg, "sdk_message_unhandled");
+  assert.equal(parsed.type, "system");
+  assert.equal(parsed.subtype, "task_notification");
+  assert.equal(parsed.task_id, "task-abc");
+  assert.equal(parsed.tool_use_id, "toolu_xyz");
+  assert.equal(parsed.status, "failed");
+  assert.equal(parsed.summary, "Monitor stream ended without condition match");
+  assert.equal(parsed.uuid, "u-1");
+  // session_id is intentionally not in UNHANDLED_LOG_FIELDS — the runner
+  // only ever serves one session_id so the surrounding pod context covers
+  // it. If a future change broadens scope (multi-session pod), revisit.
+  assert.equal(parsed.session_id, undefined);
+});
+
+test("logUnhandledSdkMessage is silent for types the adapter already handles", () => {
+  const { lines } = captureConsoleLog(() => {
+    for (const type of ["assistant", "user", "result", "stream_event"]) {
+      logUnhandledSdkMessage({ type } as never);
+    }
+  });
+  assert.equal(
+    lines.length,
+    0,
+    "adapter-handled types must not produce a duplicate diagnostic log",
+  );
+});
+
+test("logUnhandledSdkMessage logs unknown types even with no identifying fields", () => {
+  // A future SDK version may add types we haven't enumerated. The contract
+  // is "anything our adapter ignores becomes a single log line so it is
+  // discoverable" — not "log only the types we already know about." This
+  // pins the open-ended behavior so a forward-incompatible SDK message
+  // doesn't go silent.
+  const { lines } = captureConsoleLog(() =>
+    logUnhandledSdkMessage({ type: "future_unknown_kind" } as never),
+  );
+  assert.equal(lines.length, 1);
+  const parsed = JSON.parse(lines[0]);
+  assert.equal(parsed.msg, "sdk_message_unhandled");
+  assert.equal(parsed.type, "future_unknown_kind");
 });
 
 test("joinAnswersForSDK joins multi-select arrays with the SDK preprocess separator", () => {

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -94,6 +94,56 @@ export async function dispatch(
   return true;
 }
 
+// logUnhandledSdkMessage emits a structured JSON log line for SDK messages
+// whose `type` is not one the adapter converts into Tank conversation
+// events. canonicalEventsForClaudeMessage handles only "assistant", "user",
+// and "result"; "stream_event" is the partial-typing surface and is
+// intentionally noisy, so we skip it too. Everything else — task lifecycle
+// (system/task_started, system/task_progress, system/task_notification,
+// system/task_updated), hooks, status changes, plugin installs — currently
+// has no observable surface in tank's session_events or the UI. This log
+// is the cheapest path to learning what the SDK is reporting that we drop:
+// once a Monitor-stuck session reproduces, `kubectl logs -c agent-runner
+// | jq 'select(.msg=="sdk_message_unhandled")'` shows the SDK's verdict
+// (e.g. subtype=task_notification, status=failed) without a schema change.
+// Fields included are the small set of identifying ones that show up
+// across SDK message variants; the full payload is still in the on-disk
+// JSONL transcript for deeper digs.
+const UNHANDLED_LOG_FIELDS = [
+  "subtype",
+  "task_id",
+  "tool_use_id",
+  "status",
+  "summary",
+  "description",
+  "last_tool_name",
+  "error",
+  "patch",
+  "uuid",
+] as const;
+
+export function logUnhandledSdkMessage(message: SDKMessage): void {
+  const m = message as Record<string, unknown> & { type?: unknown };
+  const type = typeof m.type === "string" ? m.type : "";
+  if (
+    type === "assistant" ||
+    type === "user" ||
+    type === "result" ||
+    type === "stream_event"
+  ) {
+    return;
+  }
+  const fields: Record<string, unknown> = {
+    msg: "sdk_message_unhandled",
+    type,
+  };
+  for (const key of UNHANDLED_LOG_FIELDS) {
+    const v = m[key];
+    if (v !== undefined) fields[key] = v;
+  }
+  console.log(JSON.stringify(fields));
+}
+
 export interface PendingTurn {
   turnID: string;
   clientNonce: string;
@@ -454,7 +504,11 @@ export class Runner {
   private async handleEvent(message: SDKMessage): Promise<void> {
     // Claude SDK events are adapter inputs, not bus content. The adapter
     // converts them into Tank conversation events; only those reach the
-    // durable session bus.
+    // durable session bus. Anything the adapter does not understand
+    // (task lifecycle, hooks, status, etc.) is logged via
+    // logUnhandledSdkMessage so the diagnostic surface exists in kubectl
+    // logs without growing the durable event schema.
+    logUnhandledSdkMessage(message);
     const providerEvent = message as ClaudeProviderEvent;
     const activeTurn = await this.ensureActiveTurn(providerEvent);
 


### PR DESCRIPTION
## Summary

- The adapter only converts `assistant`/`user`/`result` SDK messages into Tank conversation events. Task lifecycle messages (`system/task_started`, `system/task_progress`, `system/task_notification`, `system/task_updated`), hooks, status changes, and similar SDK signals are silently dropped in [`handleEvent`](agent-runner/src/runner.ts) — which is why "agent set a Monitor and never returns" has no operator-visible surface.
- New `logUnhandledSdkMessage` emits one structured JSON line per non-canonical SDK message, carrying `subtype`, `task_id`, `tool_use_id`, `status`, `summary`, `description`, `last_tool_name`, `error`, `patch`, `uuid`. `stream_event` partials are intentionally excluded — they're per-token noise.
- No schema change, no metrics, no UI work, no behavior change. Pure discovery surface.

## Why

User reports Monitor (Claude Code's background polling tool) sometimes "consistently never returns." Session 60 analysis confirmed: the SDK ships a `SDKTaskNotificationMessage` with `status: completed | failed | stopped` when each Monitor's bash loop ends, but our adapter routes only `assistant`/`user`/`result` into Tank events, so that verdict is invisible. The 12-61ms "Monitor started" tool_result the UI sees today is just the synchronous task-spawned ack, not the actual outcome.

## How to use

Reproduce a Monitor-stuck session, then:
```sh
kubectl logs -n tank-operator-sessions session-NN -c agent-runner | jq 'select(.msg=="sdk_message_unhandled")'
```
The `subtype` + `status` fields reveal whether the SDK reported `task_notification status=failed/stopped` (= real failure surface) or whether the task is still in flight (= different problem).

## Test plan

- [x] `npm test` in `agent-runner/` — 32 pass, 0 fail; 3 new tests cover task_notification, silent-on-canonical-types, and forward-compat unknown types.
- [ ] After merge, image rebuild, fresh session reproduces the Monitor-stuck behavior; verify the structured log line appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)