### PR TITLE
agent-runner: log claude CLI version at startup

### DIFF
--- a/agent-runner/src/cliVersion.test.ts
+++ b/agent-runner/src/cliVersion.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { readClaudeCliVersion } from "./cliVersion.js";
+
+test("readClaudeCliVersion extracts the semver token from `claude --version` output", () => {
+  // Format observed on session pods today: "2.1.143 (Claude Code)\n".
+  // The product-name suffix is stripped because the log line only needs
+  // the version for "is this in the affected range?" lookups.
+  const got = readClaudeCliVersion(() => "2.1.143 (Claude Code)\n");
+  assert.equal(got, "2.1.143");
+});
+
+test("readClaudeCliVersion returns null when `claude` is not on PATH", () => {
+  // Defensive fallback: a malformed session image, a bash sandbox that
+  // hides the binary, or an environment where `claude --version` exits
+  // non-zero must not crash the runner. Logging `claude_cli_version:null`
+  // is the right signal — it tells the operator "the binary was reachable
+  // by SDK but not introspectable" without taking the pod down.
+  const got = readClaudeCliVersion(() => {
+    throw new Error("ENOENT");
+  });
+  assert.equal(got, null);
+});
+
+test("readClaudeCliVersion returns null when the subprocess prints nothing", () => {
+  // A future CLI release that changes --version output (or a Windows path
+  // where the command silently returns empty) shouldn't write the empty
+  // string into the log line; null is more honest.
+  const got = readClaudeCliVersion(() => "");
+  assert.equal(got, null);
+});
+
+test("readClaudeCliVersion tolerates leading/trailing whitespace", () => {
+  const got = readClaudeCliVersion(() => "   2.1.143 (Claude Code)   \n");
+  assert.equal(got, "2.1.143");
+});

--- a/agent-runner/src/cliVersion.ts
+++ b/agent-runner/src/cliVersion.ts
@@ -1,0 +1,32 @@
+// readClaudeCliVersion captures the Claude Code CLI version at runner boot
+// for inclusion in the agent-runner startup log line. The session image
+// installs @anthropic-ai/claude-code from npm without a version pin (see
+// claude-container/Dockerfile's `npm install -g @anthropic-ai/claude-code`),
+// so the binary version floats with whatever is latest at image-build time.
+// Recording it per-session means future debugging — "which CC version was
+// running when Monitor hung?", "did the streaming-receive regression
+// (anthropics/claude-code#53328) ship before or after this stuck session?" —
+// doesn't require cross-referencing the session pod's image fingerprint
+// back through a chart-bump commit to a build-log artifact.
+//
+// `run` is injected so the unit test can substitute a fake without
+// spawning a real `claude` subprocess. In production the call is one
+// blocking exec at runner boot; the CLI's --version path is fast and
+// the cost is paid once per pod.
+
+import { execSync } from "node:child_process";
+
+export function readClaudeCliVersion(
+  run: (cmd: string) => string = (cmd) => execSync(cmd, { encoding: "utf8" }),
+): string | null {
+  try {
+    const raw = run("claude --version").trim();
+    // `claude --version` emits e.g. "2.1.143 (Claude Code)". The first
+    // whitespace-separated token is the semver we want; everything after
+    // is the human-readable product name and adds nothing to the log.
+    const token = raw.split(/\s+/)[0] ?? "";
+    return token || null;
+  } catch {
+    return null;
+  }
+}

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -2,6 +2,7 @@
 // @anthropic-ai/claude-agent-sdk for one session pod's lifetime and publishes
 // canonical transcript events to the session bus.
 
+import { readClaudeCliVersion } from "./cliVersion.js";
 import { loadConfig } from "./config.js";
 import { startMetricsServer } from "./metrics.js";
 import { Runner } from "./runner.js";
@@ -22,6 +23,11 @@ async function main(): Promise<void> {
       nats_url: cfg.natsURL,
       nats_stream: cfg.natsStream,
       workspace: cfg.workspace,
+      // CC version floats with npm-latest at image-build time (no pin in
+      // claude-container/Dockerfile). Captured here so a future "which
+      // version was running when X broke?" lookup is a one-liner against
+      // kubectl logs instead of a chart-bump-to-build-log archaeology.
+      claude_cli_version: readClaudeCliVersion(),
     }),
   );
 

--- a/agent-runner/src/runner.test.ts
+++ b/agent-runner/src/runner.test.ts
@@ -10,6 +10,7 @@ import {
   inputReplyAnswers,
   inputReplyTargetProviderItemID,
   joinAnswersForSDK,
+  logUnhandledSdkMessage,
   Runner,
 } from "./runner.js";
 import {
@@ -178,6 +179,93 @@ test("inputReplyAnnotations trims preview and notes, drops empty entries", () =>
   assert.deepEqual(inputReplyAnnotations(record as never), {
     Q1: { preview: "<div/>", notes: "hi" },
   });
+});
+
+// logUnhandledSdkMessage is the cheapest possible surface for "what is the
+// SDK telling us that the adapter throws away?" — task lifecycle events
+// (Monitor's status=completed/failed/stopped notification, the immediate
+// task_started ack, periodic task_progress) all arrive as `type:"system"`
+// with a `subtype` and never reach Tank conversation events. The test
+// pins two contracts at once:
+//   - canonical types the adapter already converts ("assistant", "user",
+//     "result", and the partial-typing "stream_event") MUST stay silent
+//     so we don't double-log them and don't flood kubectl logs with the
+//     per-token partial stream.
+//   - every other type MUST log one JSON line carrying the small set of
+//     identifying fields a debugger needs (subtype, task_id, tool_use_id,
+//     status, summary) without bringing the full payload along.
+// If a future patch promotes any of these types to first-class Tank
+// events, the adapter handler lands first and this test's expected
+// silent-type set gets the new entry — otherwise we'd double-emit.
+function captureConsoleLog<T>(fn: () => T): { result: T; lines: string[] } {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (msg: unknown) => {
+    lines.push(String(msg));
+  };
+  try {
+    const result = fn();
+    return { result, lines };
+  } finally {
+    console.log = original;
+  }
+}
+
+test("logUnhandledSdkMessage emits a structured JSON line for task_notification", () => {
+  const { lines } = captureConsoleLog(() =>
+    logUnhandledSdkMessage({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "task-abc",
+      tool_use_id: "toolu_xyz",
+      status: "failed",
+      summary: "Monitor stream ended without condition match",
+      uuid: "u-1",
+      session_id: "s-1",
+    } as never),
+  );
+  assert.equal(lines.length, 1);
+  const parsed = JSON.parse(lines[0]);
+  assert.equal(parsed.msg, "sdk_message_unhandled");
+  assert.equal(parsed.type, "system");
+  assert.equal(parsed.subtype, "task_notification");
+  assert.equal(parsed.task_id, "task-abc");
+  assert.equal(parsed.tool_use_id, "toolu_xyz");
+  assert.equal(parsed.status, "failed");
+  assert.equal(parsed.summary, "Monitor stream ended without condition match");
+  assert.equal(parsed.uuid, "u-1");
+  // session_id is intentionally not in UNHANDLED_LOG_FIELDS — the runner
+  // only ever serves one session_id so the surrounding pod context covers
+  // it. If a future change broadens scope (multi-session pod), revisit.
+  assert.equal(parsed.session_id, undefined);
+});
+
+test("logUnhandledSdkMessage is silent for types the adapter already handles", () => {
+  const { lines } = captureConsoleLog(() => {
+    for (const type of ["assistant", "user", "result", "stream_event"]) {
+      logUnhandledSdkMessage({ type } as never);
+    }
+  });
+  assert.equal(
+    lines.length,
+    0,
+    "adapter-handled types must not produce a duplicate diagnostic log",
+  );
+});
+
+test("logUnhandledSdkMessage logs unknown types even with no identifying fields", () => {
+  // A future SDK version may add types we haven't enumerated. The contract
+  // is "anything our adapter ignores becomes a single log line so it is
+  // discoverable" — not "log only the types we already know about." This
+  // pins the open-ended behavior so a forward-incompatible SDK message
+  // doesn't go silent.
+  const { lines } = captureConsoleLog(() =>
+    logUnhandledSdkMessage({ type: "future_unknown_kind" } as never),
+  );
+  assert.equal(lines.length, 1);
+  const parsed = JSON.parse(lines[0]);
+  assert.equal(parsed.msg, "sdk_message_unhandled");
+  assert.equal(parsed.type, "future_unknown_kind");
 });
 
 test("joinAnswersForSDK joins multi-select arrays with the SDK preprocess separator", () => {

--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -94,6 +94,56 @@ export async function dispatch(
   return true;
 }
 
+// logUnhandledSdkMessage emits a structured JSON log line for SDK messages
+// whose `type` is not one the adapter converts into Tank conversation
+// events. canonicalEventsForClaudeMessage handles only "assistant", "user",
+// and "result"; "stream_event" is the partial-typing surface and is
+// intentionally noisy, so we skip it too. Everything else — task lifecycle
+// (system/task_started, system/task_progress, system/task_notification,
+// system/task_updated), hooks, status changes, plugin installs — currently
+// has no observable surface in tank's session_events or the UI. This log
+// is the cheapest path to learning what the SDK is reporting that we drop:
+// once a Monitor-stuck session reproduces, `kubectl logs -c agent-runner
+// | jq 'select(.msg=="sdk_message_unhandled")'` shows the SDK's verdict
+// (e.g. subtype=task_notification, status=failed) without a schema change.
+// Fields included are the small set of identifying ones that show up
+// across SDK message variants; the full payload is still in the on-disk
+// JSONL transcript for deeper digs.
+const UNHANDLED_LOG_FIELDS = [
+  "subtype",
+  "task_id",
+  "tool_use_id",
+  "status",
+  "summary",
+  "description",
+  "last_tool_name",
+  "error",
+  "patch",
+  "uuid",
+] as const;
+
+export function logUnhandledSdkMessage(message: SDKMessage): void {
+  const m = message as Record<string, unknown> & { type?: unknown };
+  const type = typeof m.type === "string" ? m.type : "";
+  if (
+    type === "assistant" ||
+    type === "user" ||
+    type === "result" ||
+    type === "stream_event"
+  ) {
+    return;
+  }
+  const fields: Record<string, unknown> = {
+    msg: "sdk_message_unhandled",
+    type,
+  };
+  for (const key of UNHANDLED_LOG_FIELDS) {
+    const v = m[key];
+    if (v !== undefined) fields[key] = v;
+  }
+  console.log(JSON.stringify(fields));
+}
+
 export interface PendingTurn {
   turnID: string;
   clientNonce: string;
@@ -454,7 +504,11 @@ export class Runner {
   private async handleEvent(message: SDKMessage): Promise<void> {
     // Claude SDK events are adapter inputs, not bus content. The adapter
     // converts them into Tank conversation events; only those reach the
-    // durable session bus.
+    // durable session bus. Anything the adapter does not understand
+    // (task lifecycle, hooks, status, etc.) is logged via
+    // logUnhandledSdkMessage so the diagnostic surface exists in kubectl
+    // logs without growing the durable event schema.
+    logUnhandledSdkMessage(message);
     const providerEvent = message as ClaudeProviderEvent;
     const activeTurn = await this.ensureActiveTurn(providerEvent);
 


### PR DESCRIPTION
## Summary

- [claude-container/Dockerfile:123](claude-container/Dockerfile:123) does `npm install -g @anthropic-ai/claude-code` with no version pin, so the CLI version baked into a session image floats with whatever was latest at image-build time. Today every session pod runs 2.1.143, which is inside the regression window for [anthropics/claude-code#53328](https://github.com/anthropics/claude-code/issues/53328) (streaming-receive lost on tool_use); tomorrow's rebuild could be 2.1.144 with no signal.
- Captures the version once at runner boot via `claude --version` and stamps it onto the existing `agent-runner starting` JSON log line.
- New `readClaudeCliVersion` takes an injectable command runner so the unit test does not need a real `claude` binary on PATH.

## Why

Companion to #533. With auto-update on the CLI being the chosen trade-off, this is the cheapest way to make "which CC version was running when X broke?" a one-liner against `kubectl logs` instead of chart-bump-to-build-log archaeology.

## How to use

```sh
kubectl logs -n tank-operator-sessions session-NN -c agent-runner | jq 'select(.msg=="agent-runner starting") | .claude_cli_version'
# => "2.1.143"
```

## Test plan

- [x] `npm test` in `agent-runner/` — 36/36 pass; 4 new tests cover happy path, subprocess failure, empty output, and whitespace.
- [ ] After merge + image rebuild, fresh session shows `claude_cli_version` in the startup log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)