### PR TITLE
Fix chat timeline bootstrap and back-pagination

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from "react";
 import type {
   AnchorHTMLAttributes,
   ComponentProps,
@@ -18,6 +18,10 @@ import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { ChatComposer, type RunComposerMode } from "./ChatComposer";
 import { WorkspaceShell } from "./WorkspaceShell";
+import {
+  initialTimelineBootstrapState,
+  reduceTimelineBootstrap,
+} from "./chatTimelineBootstrap";
 import {
   AlertCircleIcon,
   ArrowDownIcon,
@@ -196,6 +200,8 @@ type SdkTerminalResult = {
 type SdkHistoryRefreshResult = {
   replayed: boolean;
   terminal?: SdkTerminalResult;
+  stale?: boolean;
+  error?: string;
 };
 type SdkHistoryRefreshSource =
   | "history"
@@ -5080,7 +5086,8 @@ function ChatPane({
   const historyRefreshRef = useRef<Promise<unknown> | null>(null);
   const sdkWindowEpochRef = useRef(0);
   const wasVisibleRef = useRef(visible);
-  const pendingVisibleTailBootstrapRef = useRef(false);
+  const timelineBootstrapSourceRef = useRef<SdkHistoryRefreshSource>("history");
+  const timelineBootstrapClearRealtimeRef = useRef(false);
   const sdkTimelineCursorRef = useRef<string | null>(null);
   const sdkLastReadSentRef = useRef<string | null>(null);
   // Windowed-transcript bookkeeping introduced when /timeline switched from
@@ -5097,6 +5104,7 @@ function ChatPane({
   const [sdkFoundOldest, setSdkFoundOldest] = useState(false);
   const [sdkFoundNewest, setSdkFoundNewest] = useState(false);
   const [sdkLoadingOlder, setSdkLoadingOlder] = useState(false);
+  const [sdkOlderError, setSdkOlderError] = useState<string | null>(null);
   const [scrollToLatestSignal, setScrollToLatestSignal] = useState(0);
   const [scrollToOldestSignal, setScrollToOldestSignal] = useState(0);
   // Streaming-while-back-reading bookkeeping. While the user is reading
@@ -5257,9 +5265,20 @@ function ChatPane({
     }
     syncSdkRenderedEntries();
   }
-  function resetSdkTimelineBootstrapState(reason: string): void {
+  function resetSdkTimelineBootstrapState(
+    reason: string,
+    options: {
+      source?: SdkHistoryRefreshSource;
+      clearRealtime?: boolean;
+    } = {},
+  ): void {
     sdkWindowEpochRef.current += 1;
+    const epoch = sdkWindowEpochRef.current;
+    timelineBootstrapSourceRef.current = options.source ?? "history";
+    timelineBootstrapClearRealtimeRef.current = options.clearRealtime ?? false;
     historyRefreshRef.current = null;
+    sdkEventSourceRef.current?.close();
+    sdkEventSourceRef.current = null;
     sdkServerEntriesRef.current = [];
     sdkRealtimeEntriesRef.current = [];
     sdkServerEventsRef.current = [];
@@ -5277,11 +5296,20 @@ function ChatPane({
     setScrollToOldestSignal(0);
     setUserScrolledUp(false);
     setSdkPendingTailCount(0);
+    setSdkOlderError(null);
     setEntries([]);
+    setSdkConnectionState("idle");
+    dispatchTimelineBootstrap({
+      type: "reset",
+      sessionId: session.id,
+      epoch,
+    });
     logChatScrollEvent("tail-bootstrap-reset", {
       sessionId: session.id,
       reason,
-      epoch: sdkWindowEpochRef.current,
+      epoch,
+      source: timelineBootstrapSourceRef.current,
+      clearRealtime: timelineBootstrapClearRealtimeRef.current,
     });
   }
   function canClearSdkRealtime(
@@ -5473,8 +5501,6 @@ function ChatPane({
     const wasVisible = wasVisibleRef.current;
     wasVisibleRef.current = visible;
     if (!visible) {
-      pendingVisibleTailBootstrapRef.current = false;
-      setHistoryBootstrapped(false);
       return;
     }
     if (wasVisible) return;
@@ -5482,45 +5508,12 @@ function ChatPane({
     const hasExplicitTarget = Boolean(pendingScrollMessageId?.trim());
     resetSdkTimelineBootstrapState(
       hasExplicitTarget ? "visible-message-target" : "visible-reactivation",
+      {
+        source: "visible-reactivation",
+        clearRealtime: true,
+      },
     );
-    pendingVisibleTailBootstrapRef.current = true;
-    setHistoryAttempted(true);
-    setHistoryBootstrapped(false);
   }, [pendingScrollMessageId, session.id, session.status, visible]);
-
-  useEffect(() => {
-    if (!visible || session.status !== "Active") return;
-    if (!pendingVisibleTailBootstrapRef.current) return;
-    if (historyRefreshRef.current) return;
-    pendingVisibleTailBootstrapRef.current = false;
-    const refreshSessionId = session.id;
-    const refreshEpoch = sdkWindowEpochRef.current;
-    const run = currentRunRef.current;
-    const refresh = refreshSdkRunHistoryResult(
-      false,
-      true,
-      run?.id,
-      "visible-reactivation",
-    )
-      .then((result) => {
-        if (run && result.terminal) {
-          finalizeSdkRun(run, result.terminal, { refreshHistory: false });
-        }
-        return result.replayed;
-      })
-      .finally(() => {
-        if (sessionIdRef.current !== refreshSessionId) return;
-        if (sdkWindowEpochRef.current !== refreshEpoch) return;
-        if (historyRefreshRef.current === refresh) {
-          historyRefreshRef.current = null;
-        }
-        setHistoryBootstrapped(true);
-      });
-    historyRefreshRef.current = refresh;
-  // refreshSdkRunHistoryResult/finalizeSdkRun close over current refs and
-  // intentionally should not resubscribe this activation fetch.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session.id, session.status, visible]);
 
   useEffect(() => {
     visibleRef.current = visible;
@@ -5573,27 +5566,16 @@ function ChatPane({
 
   // History replay is intentionally not limited to empty transcript state: a
   // run can finish while the tab is closed, leaving a stale partial transcript.
-  const [historyAttempted, setHistoryAttempted] = useState(false);
-  const [historyBootstrapped, setHistoryBootstrapped] = useState(false);
+  const [timelineBootstrap, dispatchTimelineBootstrap] = useReducer(
+    reduceTimelineBootstrap,
+    session.id,
+    (initialSessionId) =>
+      initialTimelineBootstrapState(initialSessionId, sdkWindowEpochRef.current),
+  );
+  const historyBootstrapped = timelineBootstrap.status === "ready";
   // Toggled briefly when entries are restored from backend history so we can
   // show a "Continuing previous conversation" hint.
   const [continueHintVisible, setContinueHintVisible] = useState(false);
-  function refreshRunHistory(showHint: boolean) {
-    if (session.status !== "Active") return;
-    if (historyRefreshRef.current) return;
-    const refreshSessionId = session.id;
-    const refreshEpoch = sdkWindowEpochRef.current;
-    const refresh = refreshSdkRunHistory(showHint)
-      .finally(() => {
-        if (sessionIdRef.current !== refreshSessionId) return;
-        if (sdkWindowEpochRef.current !== refreshEpoch) return;
-        if (historyRefreshRef.current === refresh) {
-          historyRefreshRef.current = null;
-        }
-        setHistoryBootstrapped(true);
-      });
-    historyRefreshRef.current = refresh;
-  }
 
   // History replay hits the canonical event log written by the pod-side
   // runner, then renders through the same reducer/projection path used for
@@ -5662,7 +5644,10 @@ function ChatPane({
           status: res.status,
           durationMs: Math.round(performance.now() - startedAt),
         });
-        return { replayed: false };
+        return {
+          replayed: false,
+          error: `timeline request failed: ${res.status}`,
+        };
       }
       const body = (await res.json()) as {
         session_id?: string;
@@ -5683,7 +5668,7 @@ function ChatPane({
           epoch: refreshEpoch,
           currentEpoch: sdkWindowEpochRef.current,
         });
-        return { replayed: false };
+        return { replayed: false, stale: true };
       }
       const lastReadOrderKey = body.read_state?.last_read_order_key;
       if (typeof lastReadOrderKey === "string" && lastReadOrderKey) {
@@ -5692,7 +5677,9 @@ function ChatPane({
           lastReadOrderKey,
         );
       }
-      if (!Array.isArray(body.events)) return { replayed: false };
+      if (!Array.isArray(body.events)) {
+        return { replayed: false, error: "timeline response did not include events" };
+      }
       const canonicalEvents: TankConversationEvent[] = [];
       for (const ev of body.events) {
         if (isTankConversationEvent(ev)) {
@@ -5755,7 +5742,10 @@ function ChatPane({
       }
       return { replayed: true, terminal };
     };
-    return load().catch(() => ({ replayed: false }));
+    return load().catch((err) => ({
+      replayed: false,
+      error: `timeline request failed: ${String((err as Error).message ?? err)}`,
+    }));
   }
 
   // loadSdkOlderEvents fetches one bounded page of events strictly older
@@ -5766,14 +5756,30 @@ function ChatPane({
   async function loadSdkOlderEvents(): Promise<void> {
     const refreshSessionId = session.id;
     const oldest = sdkOldestLoadedOrderKeyRef.current;
-    if (!oldest) return;
     if (sdkFoundOldestRef.current) return;
     if (sdkLoadingOlder) return;
+    setSdkOlderError(null);
+    setSdkLoadingOlder(true);
+    if (!oldest) {
+      logChatScrollEvent("older-missing-cursor", {
+        sessionId: refreshSessionId,
+      });
+      try {
+        await jumpSdkToOldest();
+        setScrollToOldestSignal((value) => value + 1);
+      } catch (err) {
+        setSdkOlderError(
+          `Could not load earlier messages: ${String((err as Error).message ?? err)}`,
+        );
+      } finally {
+        setSdkLoadingOlder(false);
+      }
+      return;
+    }
     logChatScrollEvent("older-request", {
       sessionId: refreshSessionId,
       beforeOrderKey: oldest,
     });
-    setSdkLoadingOlder(true);
     try {
       const params = new URLSearchParams({
         before_order_key: oldest,
@@ -5782,7 +5788,10 @@ function ChatPane({
       const res = await authedFetch(
         `/api/sessions/${encodeURIComponent(refreshSessionId)}/timeline?${params.toString()}`,
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        setSdkOlderError(`Could not load earlier messages: ${res.status}`);
+        return;
+      }
       const body = (await res.json()) as {
         events?: unknown[];
         prev_order_key?: string;
@@ -5829,6 +5838,7 @@ function ChatPane({
         sdkFoundOldestRef.current = true;
         setSdkFoundOldest(true);
       }
+      setSdkOlderError(null);
     } finally {
       setSdkLoadingOlder(false);
     }
@@ -5848,7 +5858,7 @@ function ChatPane({
     const res = await authedFetch(
       `/api/sessions/${encodeURIComponent(refreshSessionId)}/timeline?${params.toString()}`,
     );
-    if (!res.ok) return;
+    if (!res.ok) throw new Error(`timeline request failed: ${res.status}`);
     const body = (await res.json()) as {
       events?: unknown[];
       next_order_key?: string;
@@ -5857,7 +5867,9 @@ function ChatPane({
       found_newest?: boolean;
     };
     if (sessionIdRef.current !== refreshSessionId) return;
-    if (!Array.isArray(body.events)) return;
+    if (!Array.isArray(body.events)) {
+      throw new Error("timeline response did not include events");
+    }
     const canonicalEvents: TankConversationEvent[] = [];
     for (const ev of body.events) {
       if (isTankConversationEvent(ev)) {
@@ -5936,20 +5948,67 @@ function ChatPane({
   }
 
   useEffect(() => {
-    if (!visible) return;
-    if (historyAttempted) return;
-    if (entries.length > 0) {
-      setHistoryAttempted(true);
-      refreshRunHistory(false);
-      return;
-    }
-    if (session.status !== "Active") return;
-    setHistoryAttempted(true);
-    refreshRunHistory(true);
-  // refreshRunHistory is intentionally omitted; it closes over current
-  // session state and should only run for the gates above.
+    if (!visible || session.status !== "Active") return;
+    if (timelineBootstrap.status !== "idle") return;
+    if (historyRefreshRef.current) return;
+    const refreshSessionId = session.id;
+    const refreshEpoch = sdkWindowEpochRef.current;
+    const source = timelineBootstrapSourceRef.current;
+    const clearRealtime = timelineBootstrapClearRealtimeRef.current;
+    const showHint = source === "history" && entries.length === 0;
+    const run = currentRunRef.current;
+    dispatchTimelineBootstrap({
+      type: "loading",
+      sessionId: refreshSessionId,
+      epoch: refreshEpoch,
+    });
+    const refresh = refreshSdkRunHistoryResult(
+      showHint,
+      clearRealtime,
+      run?.id,
+      source,
+    )
+      .then((result) => {
+        if (sessionIdRef.current !== refreshSessionId) return;
+        if (sdkWindowEpochRef.current !== refreshEpoch) return;
+        if (result.stale) {
+          dispatchTimelineBootstrap({
+            type: "reset",
+            sessionId: refreshSessionId,
+            epoch: sdkWindowEpochRef.current,
+          });
+          return;
+        }
+        if (result.error) {
+          dispatchTimelineBootstrap({
+            type: "error",
+            sessionId: refreshSessionId,
+            epoch: refreshEpoch,
+            error: result.error,
+          });
+          return;
+        }
+        if (run && result.terminal) {
+          finalizeSdkRun(run, result.terminal, { refreshHistory: false });
+        }
+        dispatchTimelineBootstrap({
+          type: "ready",
+          sessionId: refreshSessionId,
+          epoch: refreshEpoch,
+        });
+      })
+      .finally(() => {
+        if (sessionIdRef.current !== refreshSessionId) return;
+        if (sdkWindowEpochRef.current !== refreshEpoch) return;
+        if (historyRefreshRef.current === refresh) {
+          historyRefreshRef.current = null;
+        }
+      });
+    historyRefreshRef.current = refresh;
+  // refreshSdkRunHistoryResult/finalizeSdkRun close over current refs and
+  // should not resubscribe an in-flight bootstrap.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session.id, session.status, historyAttempted, entries.length, visible]);
+  }, [session.id, session.status, timelineBootstrap.epoch, timelineBootstrap.status, visible]);
 
   // Files tab — fetch directory listing whenever the path changes or the
   // user opens the tab on a ready session.
@@ -6223,39 +6282,24 @@ function ChatPane({
 
   // When the session id changes, reset transcript state and allow the
   // history sync to run again. The replay paths repopulate from backend.
-  useEffect(() => {
+  useLayoutEffect(() => {
     sessionIdRef.current = session.id;
-    sdkWindowEpochRef.current += 1;
     wasVisibleRef.current = visible;
-    pendingVisibleTailBootstrapRef.current = false;
-    sdkServerEntriesRef.current = [];
-    sdkRealtimeEntriesRef.current = [];
-    sdkServerEventsRef.current = [];
-    sdkRealtimeEventsRef.current = [];
-    sdkConversationStateRef.current = initialConversationState;
+    resetSdkTimelineBootstrapState("session-change", {
+      source: "history",
+      clearRealtime: false,
+    });
     sdkAssistantDurationsRef.current = new Map();
-    sdkTimelineCursorRef.current = null;
-    sdkOldestLoadedOrderKeyRef.current = null;
-    sdkFoundOldestRef.current = false;
-    sdkFoundNewestRef.current = false;
-    setSdkFoundOldest(false);
-    setSdkFoundNewest(false);
-    setSdkLoadingOlder(false);
-    setScrollToLatestSignal(0);
-    setScrollToOldestSignal(0);
-    sdkAtBottomRef.current = true;
-    setSdkPendingTailCount(0);
     currentRunRef.current = null;
     activeInterruptTargetRef.current = null;
-    setEntries([]);
     setQueuedMessages([]);
-    historyRefreshRef.current = null;
-    setHistoryAttempted(false);
-    setHistoryBootstrapped(false);
     setContinueHintVisible(false);
-    setSdkConnectionState("idle");
     setRunStatus("idle");
     setRunning(false);
+  // resetSdkTimelineBootstrapState intentionally closes over current session
+  // state; this layout reset must run exactly once for each session id before
+  // passive timeline bootstrap effects can start.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.id]);
 
   // sendByCtrlEnter — when on, plain Enter inserts a newline and only
@@ -7092,6 +7136,16 @@ function ChatPane({
   const toggleRunTab = (tab: Exclude<RunTab, "chat">) => {
     setActiveTab((current) => (current === tab ? "chat" : tab));
   };
+  const retryTimelineBootstrap = () => {
+    historyRefreshRef.current = null;
+    timelineBootstrapSourceRef.current = "history";
+    timelineBootstrapClearRealtimeRef.current = false;
+    dispatchTimelineBootstrap({
+      type: "reset",
+      sessionId: session.id,
+      epoch: sdkWindowEpochRef.current,
+    });
+  };
 
   return (
     <RunContext.Provider value={{ openWorkspacePath, sendInputReply, user }}>
@@ -7501,25 +7555,44 @@ function ChatPane({
           />
         ) : activeTab === "help" ? (
           <RunHelpScreen />
+        ) : timelineBootstrap.status === "error" ? (
+          <div className="run-empty run-transcript-state" role="alert">
+            <strong>Conversation failed to load</strong>
+            <span>{timelineBootstrap.error ?? "Timeline bootstrap failed."}</span>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={retryTimelineBootstrap}
+            >
+              Retry
+            </button>
+          </div>
+        ) : renderedEntries.length === 0 && timelineBootstrap.status !== "ready" ? (
+          <div className="run-shell-loading" role="status" aria-live="polite">
+            <Loader2Icon size={18} className="run-spin" aria-hidden="true" />
+            <span>Loading conversation...</span>
+          </div>
         ) : renderedEntries.length === 0 ? (
-          null
+          <div className="run-empty run-transcript-state" role="status">
+            <span>No messages yet.</span>
+          </div>
         ) : (
           <>
-            {/* Passive top-of-transcript indicator. Replaces the prior
-                explicit "Load earlier messages" button: the auto-load on
-                Virtuoso's startReached (wired below) is the affordance now,
-                matching Slack and Discord. Three states:
+            {/* Top-of-transcript pagination surface. Auto-load still fires via
+                Virtuoso's startReached, and the explicit button keeps older
+                history reachable if the virtualized edge callback misses.
+                States:
                   - sdkLoadingOlder: spinner-ish "Loading earlier messages…"
                     surfaced while the back-paginate fetch is in flight so
                     the user has feedback that the silent scroll-up triggered
                     something.
+                  - sdkOlderError: visible retry instead of a silent stop.
+                  - !sdkFoundOldest: explicit load button for long sessions.
                   - sdkFoundOldest: a "Beginning of conversation" divider so
                     the user can tell they've hit the head of the ledger
                     instead of just a scroll-stop with no explanation.
-                  - otherwise: nothing — older content sits virtualized just
-                    above the viewport and reveals itself as the user scrolls.
-                Both states are status, not actions; the SDk loading marker
-                gets role="status" so screenreaders announce it. */}
+                Loading and terminal states use status/alert roles so
+                screenreaders announce them. */}
             {sdkLoadingOlder ? (
               <div
                 className="run-transcript-load-older run-transcript-load-older-passive"
@@ -7528,6 +7601,29 @@ function ChatPane({
               >
                 Loading earlier messages…
               </div>
+            ) : sdkOlderError ? (
+              <div className="run-transcript-load-error" role="alert">
+                <span>{sdkOlderError}</span>
+                <button
+                  type="button"
+                  className="run-transcript-load-older"
+                  onClick={() => {
+                    void loadSdkOlderEvents();
+                  }}
+                >
+                  Retry
+                </button>
+              </div>
+            ) : !sdkFoundOldest && renderedEntries.length > 0 ? (
+              <button
+                type="button"
+                className="run-transcript-load-older"
+                onClick={() => {
+                  void loadSdkOlderEvents();
+                }}
+              >
+                Load earlier messages
+              </button>
             ) : sdkFoundOldest && renderedEntries.length > 0 ? (
               <div
                 className="run-transcript-beginning"

--- a/frontend/src/chatTimelineBootstrap.test.ts
+++ b/frontend/src/chatTimelineBootstrap.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  initialTimelineBootstrapState,
+  reduceTimelineBootstrap,
+} from "./chatTimelineBootstrap";
+
+test("timeline bootstrap ignores stale async completions", () => {
+  let state = initialTimelineBootstrapState("121", 1);
+  state = reduceTimelineBootstrap(state, {
+    type: "loading",
+    sessionId: "121",
+    epoch: 1,
+  });
+  state = reduceTimelineBootstrap(state, {
+    type: "reset",
+    sessionId: "121",
+    epoch: 2,
+  });
+  state = reduceTimelineBootstrap(state, {
+    type: "ready",
+    sessionId: "121",
+    epoch: 1,
+  });
+
+  assert.deepEqual(state, {
+    sessionId: "121",
+    epoch: 2,
+    status: "idle",
+    error: null,
+  });
+});
+
+test("timeline bootstrap exposes current-generation failures for retry", () => {
+  let state = initialTimelineBootstrapState("121", 3);
+  state = reduceTimelineBootstrap(state, {
+    type: "loading",
+    sessionId: "121",
+    epoch: 3,
+  });
+  state = reduceTimelineBootstrap(state, {
+    type: "error",
+    sessionId: "121",
+    epoch: 3,
+    error: "timeline request failed: 500",
+  });
+
+  assert.equal(state.status, "error");
+  assert.equal(state.error, "timeline request failed: 500");
+
+  state = reduceTimelineBootstrap(state, {
+    type: "reset",
+    sessionId: "121",
+    epoch: 4,
+  });
+  assert.equal(state.status, "idle");
+  assert.equal(state.error, null);
+});

--- a/frontend/src/chatTimelineBootstrap.ts
+++ b/frontend/src/chatTimelineBootstrap.ts
@@ -1,0 +1,42 @@
+export type TimelineBootstrapStatus = "idle" | "loading" | "ready" | "error";
+
+export type TimelineBootstrapState = {
+  sessionId: string;
+  epoch: number;
+  status: TimelineBootstrapStatus;
+  error: string | null;
+};
+
+export type TimelineBootstrapAction =
+  | { type: "reset"; sessionId: string; epoch: number }
+  | { type: "loading"; sessionId: string; epoch: number }
+  | { type: "ready"; sessionId: string; epoch: number }
+  | { type: "error"; sessionId: string; epoch: number; error: string };
+
+export function initialTimelineBootstrapState(
+  sessionId: string,
+  epoch = 0,
+): TimelineBootstrapState {
+  return { sessionId, epoch, status: "idle", error: null };
+}
+
+export function reduceTimelineBootstrap(
+  state: TimelineBootstrapState,
+  action: TimelineBootstrapAction,
+): TimelineBootstrapState {
+  if (action.type === "reset") {
+    return initialTimelineBootstrapState(action.sessionId, action.epoch);
+  }
+
+  if (state.sessionId !== action.sessionId || state.epoch !== action.epoch) {
+    return state;
+  }
+
+  if (action.type === "loading") {
+    return { ...state, status: "loading", error: null };
+  }
+  if (action.type === "ready") {
+    return { ...state, status: "ready", error: null };
+  }
+  return { ...state, status: "error", error: action.error };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2879,6 +2879,17 @@ button:disabled {
   gap: var(--space-3);
 }
 
+.run-transcript-state {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  text-align: center;
+}
+
+.run-transcript-state strong {
+  color: var(--text-default);
+  font-size: var(--text-base);
+}
+
 /* Composer footer at the bottom of the chat pane. */
 .run-composer-wrap {
   flex: 0 0 auto;
@@ -4125,6 +4136,16 @@ textarea.run-files-viewer-editor:focus {
 .run-transcript-load-older:disabled {
   cursor: progress;
   color: var(--text-muted);
+}
+
+.run-transcript-load-error {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-3) auto var(--space-2);
+  color: var(--danger, #f87171);
+  font-size: var(--text-xs);
 }
 
 @keyframes run-status-pulse {

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -124,8 +124,15 @@ test("home splash test action seeds the first turn as a skill invocation", () =>
 test("mounted chat reactivation resets local timeline state before bootstrap", () => {
   assert.equal(appSource.includes("visible-reactivation"), true);
   assert.equal(appSource.includes("resetSdkTimelineBootstrapState"), true);
-  assert.match(appSource, /if \(!visible\) return;\s+if \(historyAttempted\) return;/);
-  assert.equal(appSource.includes("pendingVisibleTailBootstrapRef"), true);
+  assert.equal(appSource.includes("reduceTimelineBootstrap"), true);
+  assert.match(appSource, /useLayoutEffect\(\(\) => \{\s+sessionIdRef\.current = session\.id;/);
+  assert.match(appSource, /if \(timelineBootstrap\.status !== "idle"\) return;/);
+});
+
+test("chat back-pagination keeps an explicit access path", () => {
+  assert.equal(appSource.includes("before_order_key"), true);
+  assert.equal(appSource.includes("Load earlier messages"), true);
+  assert.equal(appSource.includes("older-missing-cursor"), true);
 });
 
 test("chat scroll diagnostics are debug gated", () => {


### PR DESCRIPTION
## Summary
- move chat timeline bootstrap onto an explicit reducer-backed lifecycle so stale timeline responses cannot leave a pane blank
- surface transcript loading, error, empty, and retry states instead of rendering null
- restore an explicit Load earlier messages path and retry UI for older-history pagination

## Verification
- npm test
- npm run build
- node scripts/check-removed-chat-runtime.mjs