### PR TITLE
Increase Codex runner memory limit

### DIFF
--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -779,7 +779,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			"ports": []any{
 				map[string]any{"name": "runner-metrics", "containerPort": CodexRunnerMetricsPort},
 			},
-			"resources": agentRunnerResources(),
+			"resources": codexRunnerResources(),
 		}
 		if len(envFrom) > 0 {
 			codexRunnerContainer["envFrom"] = envFrom
@@ -959,6 +959,17 @@ func agentRunnerResources() map[string]any {
 			"memory": "1536Mi",
 		},
 	}
+}
+
+func codexRunnerResources() map[string]any {
+	resources := agentRunnerResources()
+	limits := resources["limits"].(map[string]any)
+	// Codex app-server compaction runs in the runner container. Session
+	// 146 showed that the shared 1536Mi Claude-runner cap can OOMKill a
+	// live Codex thread during compaction, so Codex gets more burst
+	// headroom while keeping the same scheduling request.
+	limits["memory"] = "3072Mi"
+	return resources
 }
 
 func sandboxAgentResources() map[string]any {

--- a/backend-go/internal/sessionmodel/sessionmodel_test.go
+++ b/backend-go/internal/sessionmodel/sessionmodel_test.go
@@ -141,6 +141,10 @@ func TestPodManifestCompatibilityCore(t *testing.T) {
 	if got, want := codexRunner["image"], "codex-image"; got != want {
 		t.Fatalf("codex-runner image = %v, want %q (same image as the user container; the runner is a multi-stage build into the same image)", got, want)
 	}
+	codexRunnerResources := codexRunner["resources"].(map[string]any)
+	if got, want := codexRunnerResources["limits"].(map[string]any)["memory"], "3072Mi"; got != want {
+		t.Fatalf("codex-runner memory limit = %v, want %q", got, want)
+	}
 	assertVolumeMount(t, codexRunner, "tank-operator-sa-token")
 	assertVolumeMount(t, codexRunner, "auth-romaine-sa-token")
 	volumes := spec["volumes"].([]any)


### PR DESCRIPTION
## Summary
- give codex-runner its own resource helper
- raise codex-runner memory limit from 1536Mi to 3072Mi while keeping the existing 512Mi request
- pin the generated pod manifest shape in sessionmodel tests

## Tests
- go test ./internal/sessionmodel
- helm template tank-operator k8s