### PR TITLE
Add chat scroll diagnostics lab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,7 +116,10 @@ import {
   logSessionListSseOpen,
   logSessionListStreamSignal,
 } from "./sessionListTelemetry";
-import { isChatScrollDebugEnabled, logChatScrollEvent } from "./chatScrollTelemetry";
+import {
+  chatScrollElementSnapshot,
+  logChatScrollEvent,
+} from "./chatScrollTelemetry";
 import {
   isDurableTankConversationEvent,
   isTankConversationEvent,
@@ -170,7 +173,7 @@ type AskUserQuestionAnswer = {
   notes?: string;
   preview?: string;
 };
-type TranscriptEntry = Omit<SandboxTranscriptEntry, "role" | "kind"> & {
+export type TranscriptEntry = Omit<SandboxTranscriptEntry, "role" | "kind"> & {
   kind: SandboxTranscriptEntry["kind"] | "background_task";
   role?: "user" | "assistant" | "system";
   toolKind?: ToolKind;
@@ -3049,7 +3052,6 @@ function logChatScrollGroups(
   entryCount: number,
   detail: Record<string, unknown> = {},
 ): void {
-  if (!isChatScrollDebugEnabled()) return;
   logChatScrollEvent(event, {
     ...detail,
     ...chatScrollGroupSnapshot(groups, entryCount),
@@ -3061,7 +3063,6 @@ function logChatScrollEntries(
   entries: TranscriptEntry[],
   detail: Record<string, unknown> = {},
 ): void {
-  if (!isChatScrollDebugEnabled()) return;
   logChatScrollEvent(event, {
     ...detail,
     ...chatScrollEntrySnapshot(entries),
@@ -4626,7 +4627,7 @@ function toolGroupDefaultOpen(
 // inline render. The `followOutput` + `startReached` +
 // `atBottomStateChange` props replace the hand-rolled scroll-detect /
 // auto-scroll effects deleted from ChatPane in this stage.
-function RunMessages({
+export function RunMessages({
   entries,
   avatar,
   sessionId,
@@ -4727,19 +4728,21 @@ function RunMessages({
       sessionId,
       previousFirst,
       nextIndex,
+      ...chatScrollElementSnapshot(scrollParent),
     });
     virtuosoRef.current?.scrollToIndex({
       index: nextIndex,
       align: "start",
       behavior: "auto",
     });
-  }, [entries.length, groups, sessionId]);
+  }, [entries.length, groups, scrollParent, sessionId]);
   useEffect(() => {
     logChatScrollGroups("virtuoso-window", groups, entries.length, {
       sessionId,
       initialTopMostItemIndex: Math.max(groups.length - 1, 0),
+      ...chatScrollElementSnapshot(scrollParent),
     });
-  }, [entries.length, groups, sessionId]);
+  }, [entries.length, groups, scrollParent, sessionId]);
   useLayoutEffect(() => {
     if (!scrollToLatestSignal || groups.length === 0) return;
     if (consumedScrollToLatestSignalRef.current === scrollToLatestSignal) return;
@@ -4749,6 +4752,7 @@ function RunMessages({
       signal: scrollToLatestSignal,
       behavior: scrollToLatestBehavior,
       reason: scrollToLatestReason,
+      ...chatScrollElementSnapshot(scrollParent),
     });
     virtuosoRef.current?.scrollToIndex({
       index: groups.length - 1,
@@ -4760,6 +4764,7 @@ function RunMessages({
     entries.length,
     groups,
     onScrollToLatestConsumed,
+    scrollParent,
     scrollToLatestBehavior,
     scrollToLatestReason,
     scrollToLatestSignal,
@@ -4770,13 +4775,14 @@ function RunMessages({
     logChatScrollGroups("scroll-to-oldest", groups, entries.length, {
       sessionId,
       signal: scrollToOldestSignal,
+      ...chatScrollElementSnapshot(scrollParent),
     });
     virtuosoRef.current?.scrollToIndex({
       index: 0,
       align: "start",
       behavior: "smooth",
     });
-  }, [entries.length, groups, scrollToOldestSignal, sessionId]);
+  }, [entries.length, groups, scrollParent, scrollToOldestSignal, sessionId]);
   // computeItemKey stabilizes Virtuoso's per-item identity across renders.
   // Tool groups have no single id, so the first child id identifies the
   // group while later tool entries append during a streaming turn.
@@ -4861,18 +4867,20 @@ function RunMessages({
   const handleStartReached = useCallback(() => {
     logChatScrollGroups("start-reached", groups, entries.length, {
       sessionId,
+      ...chatScrollElementSnapshot(scrollParent),
     });
     onStartReached?.();
-  }, [entries.length, groups, onStartReached, sessionId]);
+  }, [entries.length, groups, onStartReached, scrollParent, sessionId]);
   const handleAtBottomChange = useCallback(
     (atBottom: boolean) => {
       logChatScrollGroups("at-bottom-change", groups, entries.length, {
         sessionId,
         atBottom,
+        ...chatScrollElementSnapshot(scrollParent),
       });
       onAtBottomChange?.(atBottom);
     },
-    [entries.length, groups, onAtBottomChange, sessionId],
+    [entries.length, groups, onAtBottomChange, scrollParent, sessionId],
   );
   // followOutput="smooth" keeps the user stuck to the live tail when they
   // ARE at the bottom; releases when they scroll up. Returning false from
@@ -5293,7 +5301,11 @@ function ChatPane({
   const [transcriptScrollEl, setTranscriptScrollEl] = useState<HTMLElement | null>(null);
   const transcriptScrollCallbackRef = useCallback((node: HTMLElement | null) => {
     setTranscriptScrollEl(node);
-  }, []);
+    logChatScrollEvent(node ? "scroll-parent-mounted" : "scroll-parent-unmounted", {
+      sessionId: session.id,
+      ...chatScrollElementSnapshot(node),
+    });
+  }, [session.id]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const sdkEventSourceRef = useRef<EventSource | null>(null);
   const historyRefreshRef = useRef<Promise<unknown> | null>(null);
@@ -5959,26 +5971,24 @@ function ChatPane({
       const terminal = clientNonce
         ? sdkHistoryTerminalForRun(body.events, clientNonce)
         : undefined;
-      if (isChatScrollDebugEnabled()) {
-        const projection = projectConversationState(
-          reduceConversationEvents(orderedConversationEvents(canonicalEvents)),
-        );
-        const projectedEntries = conversationEntriesToTranscript(projection.entries);
-        logChatScrollEntries("timeline-loaded", projectedEntries, {
-          sessionId: refreshSessionId,
-          source,
-          anchor,
-          eventCount: Array.isArray(body.events) ? body.events.length : 0,
-          canonicalEventCount: canonicalEvents.length,
-          foundOldest,
-          foundNewest,
-          hasPrevCursor: Boolean(prevAfter),
-          hasNextCursor: Boolean(nextAfter),
-          clearRealtime,
-          terminalStatus: terminal?.status ?? "",
-          durationMs: Math.round(performance.now() - startedAt),
-        });
-      }
+      const projection = projectConversationState(
+        reduceConversationEvents(orderedConversationEvents(canonicalEvents)),
+      );
+      const projectedEntries = conversationEntriesToTranscript(projection.entries);
+      logChatScrollEntries("timeline-loaded", projectedEntries, {
+        sessionId: refreshSessionId,
+        source,
+        anchor,
+        eventCount: Array.isArray(body.events) ? body.events.length : 0,
+        canonicalEventCount: canonicalEvents.length,
+        foundOldest,
+        foundNewest,
+        hasPrevCursor: Boolean(prevAfter),
+        hasNextCursor: Boolean(nextAfter),
+        clearRealtime,
+        terminalStatus: terminal?.status ?? "",
+        durationMs: Math.round(performance.now() - startedAt),
+      });
       if (canonicalEvents.length === 0) {
         if (scrollToLatestOnReady) timelineBootstrapScrollToLatestRef.current = false;
         return { replayed: false, terminal };
@@ -6068,20 +6078,18 @@ function ChatPane({
           ...sdkServerEventsRef.current,
         ]);
         syncSdkRenderedEntries();
-        if (isChatScrollDebugEnabled()) {
-          const projection = projectConversationState(
-            reduceConversationEvents(sdkServerEventsRef.current),
-          );
-          logChatScrollEntries(
-            "older-loaded",
-            conversationEntriesToTranscript(projection.entries),
-            {
-              sessionId: refreshSessionId,
-              eventCount: olderEvents.length,
-              beforeOrderKey: oldest,
-            },
-          );
-        }
+        const projection = projectConversationState(
+          reduceConversationEvents(sdkServerEventsRef.current),
+        );
+        logChatScrollEntries(
+          "older-loaded",
+          conversationEntriesToTranscript(projection.entries),
+          {
+            sessionId: refreshSessionId,
+            eventCount: olderEvents.length,
+            beforeOrderKey: oldest,
+          },
+        );
       }
       const prevAfter =
         typeof body.prev_order_key === "string" ? body.prev_order_key : "";

--- a/frontend/src/LongChatDebugPage.tsx
+++ b/frontend/src/LongChatDebugPage.tsx
@@ -1,0 +1,514 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  BugIcon,
+  ClipboardListIcon,
+  Loader2Icon,
+  Trash2Icon,
+} from "lucide-react";
+import { ChatComposer, type RunComposerMode } from "./ChatComposer";
+import { WorkspaceShell } from "./WorkspaceShell";
+import { getSessionAvatar } from "./sessionAvatars";
+import {
+  chatScrollElementSnapshot,
+  clearChatScrollEvents,
+  isChatScrollDebugEnabled,
+  logChatScrollEvent,
+  readChatScrollEvents,
+  setChatScrollDebugEnabled,
+  type ChatScrollTelemetryRecord,
+} from "./chatScrollTelemetry";
+import { RunMessages, type TranscriptEntry } from "./App";
+
+const DEBUG_SESSION_ID = "debug-long-chat";
+const INITIAL_TURN_COUNT = 240;
+const PREPEND_TURN_COUNT = 80;
+const TURN_TIME_BASE = Date.UTC(2026, 4, 21, 9, 0, 0);
+const TURN_ORDER_OFFSET = 10_000;
+
+const debugChatFontScaleStyle = {
+  "--run-chat-font-scale": 1,
+  "--run-chat-font-xs": "0.75rem",
+  "--run-chat-font-sm": "0.875rem",
+  "--run-chat-font-meta": "0.72rem",
+  "--run-chat-font-code-xs": "0.7rem",
+  "--run-chat-font-code-sm": "0.78rem",
+  "--run-chat-font-star": "0.95rem",
+} as CSSProperties;
+
+export function LongChatDebugPage() {
+  const [entries, setEntries] = useState<TranscriptEntry[]>(() =>
+    makeMockTranscript(0, INITIAL_TURN_COUNT),
+  );
+  const [records, setRecords] = useState<ChatScrollTelemetryRecord[]>(() =>
+    readChatScrollEvents(),
+  );
+  const [consoleDebug, setConsoleDebug] = useState(() => isChatScrollDebugEnabled());
+  const [permissionMode, setPermissionMode] = useState<RunComposerMode>("default");
+  const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
+  const [atBottom, setAtBottom] = useState(true);
+  const [bottomDistance, setBottomDistance] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [scrollToLatestSignal, setScrollToLatestSignal] = useState(0);
+  const [scrollToOldestSignal, setScrollToOldestSignal] = useState(0);
+  const oldestTurnRef = useRef(0);
+  const newestTurnRef = useRef(INITIAL_TURN_COUNT - 1);
+  const mockTimerRef = useRef<number | null>(null);
+  const mockReplyIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const refreshRecords = () => setRecords(readChatScrollEvents());
+    refreshRecords();
+    window.addEventListener("tank:chat-scroll-telemetry", refreshRecords);
+    return () => {
+      window.removeEventListener("tank:chat-scroll-telemetry", refreshRecords);
+      if (mockTimerRef.current !== null) {
+        window.clearInterval(mockTimerRef.current);
+        mockTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!scrollParent) return;
+    const update = () => {
+      const distance = Math.max(
+        0,
+        scrollParent.scrollHeight - scrollParent.scrollTop - scrollParent.clientHeight,
+      );
+      setBottomDistance(Math.round(distance));
+      setAtBottom(distance <= 4);
+    };
+    update();
+    scrollParent.addEventListener("scroll", update, { passive: true });
+    return () => scrollParent.removeEventListener("scroll", update);
+  }, [scrollParent]);
+
+  const bodyRef = useCallback((node: HTMLElement | null) => {
+    setScrollParent(node);
+    logChatScrollEvent(node ? "debug-scroll-parent-mounted" : "debug-scroll-parent-unmounted", {
+      sessionId: DEBUG_SESSION_ID,
+      ...chatScrollElementSnapshot(node),
+    });
+  }, []);
+
+  const resetTranscript = useCallback((turnCount: number) => {
+    oldestTurnRef.current = 0;
+    newestTurnRef.current = turnCount - 1;
+    setEntries(makeMockTranscript(0, turnCount));
+    setAtBottom(true);
+    setScrollToLatestSignal((value) => value + 1);
+    logChatScrollEvent("debug-reset-transcript", {
+      sessionId: DEBUG_SESSION_ID,
+      turnCount,
+      ...chatScrollElementSnapshot(scrollParent),
+    });
+  }, [scrollParent]);
+
+  const prependOlder = useCallback(() => {
+    if (loadingOlder) return;
+    setLoadingOlder(true);
+    const nextOldest = oldestTurnRef.current - PREPEND_TURN_COUNT;
+    const older = makeMockTranscript(nextOldest, PREPEND_TURN_COUNT);
+    window.setTimeout(() => {
+      oldestTurnRef.current = nextOldest;
+      setEntries((current) => [...older, ...current]);
+      setLoadingOlder(false);
+      logChatScrollEvent("debug-prepend-older", {
+        sessionId: DEBUG_SESSION_ID,
+        addedTurns: PREPEND_TURN_COUNT,
+        oldestTurn: nextOldest,
+        ...chatScrollElementSnapshot(scrollParent),
+      });
+    }, 250);
+  }, [loadingOlder, scrollParent]);
+
+  const appendBurst = useCallback((count = 12) => {
+    const start = newestTurnRef.current + 1;
+    newestTurnRef.current += count;
+    const next = makeMockTranscript(start, count);
+    setEntries((current) => [...current, ...next]);
+    logChatScrollEvent("debug-append-burst", {
+      sessionId: DEBUG_SESSION_ID,
+      addedTurns: count,
+      atBottom,
+      ...chatScrollElementSnapshot(scrollParent),
+    });
+  }, [atBottom, scrollParent]);
+
+  const stopMockReply = useCallback(() => {
+    if (mockTimerRef.current !== null) {
+      window.clearInterval(mockTimerRef.current);
+      mockTimerRef.current = null;
+    }
+    const stoppedId = mockReplyIdRef.current;
+    mockReplyIdRef.current = null;
+    setRunning(false);
+    if (stoppedId) {
+      setEntries((current) =>
+        current.map((entry) =>
+          entry.id === stoppedId && entry.kind === "message"
+            ? { ...entry, text: `${entry.text}\n\n[Mock reply stopped]` }
+            : entry,
+        ),
+      );
+    }
+    logChatScrollEvent("debug-mock-reply-stopped", {
+      sessionId: DEBUG_SESSION_ID,
+      replyId: stoppedId ?? "",
+      ...chatScrollElementSnapshot(scrollParent),
+    });
+  }, [scrollParent]);
+
+  const submitMockMessage = useCallback(({ text }: { text: string }) => {
+    const trimmed = text.trim();
+    if (!trimmed || running) return;
+    const turn = newestTurnRef.current + 1;
+    newestTurnRef.current = turn;
+    const userEntry = mockMessageEntry(turn, 0, "user", trimmed, "posted");
+    const replyId = mockId("assistant", turn, "posted");
+    const replyChunks = mockReplyFor(trimmed, turn).split(" ");
+    mockReplyIdRef.current = replyId;
+    setRunning(true);
+    setEntries((current) => [
+      ...current,
+      userEntry,
+      mockMessageEntry(turn, 3, "assistant", "Thinking...", "posted", replyId),
+    ]);
+    logChatScrollEvent("debug-submit-message", {
+      sessionId: DEBUG_SESSION_ID,
+      turn,
+      atBottom,
+      ...chatScrollElementSnapshot(scrollParent),
+    });
+    let chunkIndex = 0;
+    mockTimerRef.current = window.setInterval(() => {
+      chunkIndex += 4;
+      const nextText = replyChunks.slice(0, chunkIndex).join(" ");
+      setEntries((current) =>
+        current.map((entry) =>
+          entry.id === replyId && entry.kind === "message"
+            ? { ...entry, text: nextText || "Thinking..." }
+            : entry,
+        ),
+      );
+      if (chunkIndex >= replyChunks.length) {
+        if (mockTimerRef.current !== null) {
+          window.clearInterval(mockTimerRef.current);
+          mockTimerRef.current = null;
+        }
+        mockReplyIdRef.current = null;
+        setRunning(false);
+        logChatScrollEvent("debug-mock-reply-complete", {
+          sessionId: DEBUG_SESSION_ID,
+          turn,
+          ...chatScrollElementSnapshot(scrollParent),
+        });
+      }
+    }, 120);
+  }, [atBottom, running, scrollParent]);
+
+  const recentRecords = records.slice(-160).reverse();
+  const avatar = getSessionAvatar(DEBUG_SESSION_ID);
+
+  return (
+    <div className="debug-scroll-lab">
+      <WorkspaceShell
+        className="debug-long-chat"
+        style={debugChatFontScaleStyle}
+        bodyRef={bodyRef}
+        bodyClassName={running ? "run-main-running" : "run-main-idle"}
+        title={(
+          <div className="debug-long-chat-title">
+            <span>Long chat scroll lab</span>
+            <small>
+              {entries.length} entries - {bottomDistance <= 4 ? "at tail" : `${bottomDistance}px above tail`}
+            </small>
+          </div>
+        )}
+        tabs={(
+          <>
+            <button type="button" className="run-tab" onClick={() => resetTranscript(240)}>
+              240 turns
+            </button>
+            <button type="button" className="run-tab" onClick={() => resetTranscript(900)}>
+              900 turns
+            </button>
+            <button type="button" className="run-tab" onClick={prependOlder}>
+              {loadingOlder ? <Loader2Icon className="run-spin" size={14} /> : "Prepend"}
+            </button>
+            <button type="button" className="run-tab" onClick={() => appendBurst(12)}>
+              Burst
+            </button>
+          </>
+        )}
+        body={(
+          <>
+            {loadingOlder ? (
+              <div className="run-transcript-load-older run-transcript-load-older-passive">
+                Loading earlier messages...
+              </div>
+            ) : (
+              <button type="button" className="run-transcript-load-older" onClick={prependOlder}>
+                Load earlier messages
+              </button>
+            )}
+            <RunMessages
+              entries={entries}
+              avatar={avatar}
+              sessionId={DEBUG_SESSION_ID}
+              showThinking
+              autoExpandTools={false}
+              showTimestamps
+              showDuration={false}
+              onQuote={() => undefined}
+              scrollParent={scrollParent}
+              onStartReached={prependOlder}
+              onAtBottomChange={setAtBottom}
+              scrollToLatestSignal={scrollToLatestSignal}
+              scrollToOldestSignal={scrollToOldestSignal}
+            />
+          </>
+        )}
+        floatingBetweenBodyAndComposer={(
+          <>
+            {!atBottom && (
+              <button
+                type="button"
+                className="run-scroll-to-top"
+                onClick={() => setScrollToOldestSignal((value) => value + 1)}
+                aria-label="Scroll to beginning of mock conversation"
+              >
+                <ArrowUpIcon size={16} strokeWidth={2.2} aria-hidden="true" />
+              </button>
+            )}
+            <button
+              type="button"
+              className={`run-scroll-to-bottom${atBottom ? " run-scroll-to-bottom-hidden" : ""}`}
+              onClick={() => setScrollToLatestSignal((value) => value + 1)}
+              aria-label="Scroll to latest mock message"
+            >
+              <ArrowDownIcon size={16} strokeWidth={2.2} aria-hidden="true" />
+            </button>
+          </>
+        )}
+        composer={(
+          <ChatComposer
+            placeholder="Send a mock message"
+            onSubmit={submitMockMessage}
+            permissionMode={permissionMode}
+            onPermissionModeChange={setPermissionMode}
+            sendByCtrlEnter={false}
+            submitStatus={running ? "streaming" : undefined}
+            onStop={stopMockReply}
+            isStopping={false}
+          />
+        )}
+      />
+      <aside className="debug-scroll-ledger" aria-label="Chat scroll telemetry">
+        <div className="debug-scroll-ledger-header">
+          <div>
+            <span className="debug-scroll-ledger-title">
+              <ClipboardListIcon size={15} aria-hidden="true" />
+              Scroll ledger
+            </span>
+            <span className="debug-scroll-ledger-subtitle">{records.length} captured</span>
+          </div>
+          <div className="debug-scroll-ledger-actions">
+            <button
+              type="button"
+              className={`debug-scroll-ledger-btn${consoleDebug ? " active" : ""}`}
+              onClick={() => {
+                const next = !consoleDebug;
+                setConsoleDebug(next);
+                setChatScrollDebugEnabled(next);
+              }}
+              title="Toggle console mirror"
+              aria-pressed={consoleDebug}
+            >
+              <BugIcon size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="debug-scroll-ledger-btn"
+              onClick={() => {
+                clearChatScrollEvents();
+                setRecords([]);
+              }}
+              title="Clear scroll ledger"
+            >
+              <Trash2Icon size={14} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+        <div className="debug-scroll-records">
+          {recentRecords.length === 0 ? (
+            <div className="debug-scroll-empty">No scroll events captured yet.</div>
+          ) : (
+            recentRecords.map((record) => (
+              <article key={record.id} className="debug-scroll-record">
+                <header>
+                  <span>{record.event}</span>
+                  <time dateTime={record.at}>{formatDebugTime(record.at)}</time>
+                </header>
+                <pre>{formatDebugDetail(record.detail)}</pre>
+              </article>
+            ))
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function makeMockTranscript(startTurn: number, count: number): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = [];
+  for (let turn = startTurn; turn < startTurn + count; turn += 1) {
+    entries.push(...makeMockTurn(turn));
+  }
+  return entries;
+}
+
+function makeMockTurn(turn: number): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = [
+    mockMessageEntry(
+      turn,
+      0,
+      "user",
+      `Mock prompt ${turn}: check scroll behavior around ${turn % 2 === 0 ? "streaming output" : "older history"}.`,
+    ),
+  ];
+  if (turn % 9 === 0) {
+    entries.push({
+      id: mockId("reasoning", turn),
+      kind: "reasoning",
+      reasoning: {
+        text: `Reasoning trace for turn ${turn}. The block is intentionally short but present so virtual row heights vary.`,
+      },
+      time: mockTime(turn, 1),
+      orderKey: mockOrderKey(turn, 1),
+    } as TranscriptEntry);
+  }
+  if (turn % 6 === 0) {
+    entries.push(mockToolEntry(turn, 2));
+    if (turn % 12 === 0) entries.push(mockToolEntry(turn, 3, "Read", "completed"));
+  }
+  entries.push(
+    mockMessageEntry(turn, 4, "assistant", mockAssistantText(turn)),
+  );
+  return entries;
+}
+
+function mockMessageEntry(
+  turn: number,
+  sequence: number,
+  role: "user" | "assistant" | "system",
+  text: string,
+  prefix = "seed",
+  id = mockId(role, turn, prefix),
+): TranscriptEntry {
+  return {
+    id,
+    kind: "message",
+    role,
+    text,
+    time: mockTime(turn, sequence),
+    orderKey: mockOrderKey(turn, sequence),
+  } as TranscriptEntry;
+}
+
+function mockToolEntry(
+  turn: number,
+  sequence: number,
+  toolName = "Bash",
+  status = turn % 18 === 0 ? "failed" : "completed",
+): TranscriptEntry {
+  return {
+    id: mockId(`tool-${sequence}`, turn),
+    kind: "tool",
+    toolName,
+    toolKind: toolName === "Bash" ? "shell" : "mcp",
+    toolInput: toolName === "Bash"
+      ? `printf "turn ${turn}\\n"`
+      : JSON.stringify({ file_path: `/workspace/mock-${turn}.ts` }, null, 2),
+    toolOutput: status === "failed"
+      ? "exit status 1: mock failure used to test expanded tool heights"
+      : `mock output for turn ${turn}`,
+    toolStatus: status,
+    time: mockTime(turn, sequence),
+    startedAt: mockTime(turn, sequence),
+    completedAt: mockTime(turn, sequence + 0.5),
+    orderKey: mockOrderKey(turn, sequence),
+  } as TranscriptEntry;
+}
+
+function mockAssistantText(turn: number): string {
+  const paragraphCount = 1 + Math.abs(turn % 4);
+  const paragraphs = Array.from({ length: paragraphCount }, (_, index) =>
+    `Assistant reply ${turn}.${index + 1}: ${mockSentence(turn, index)} The varying length is deliberate so row measurement changes while scrolling.`,
+  );
+  if (turn % 8 === 0) {
+    paragraphs.push(
+      [
+        "```ts",
+        `const turn = ${turn};`,
+        "const stable = turn % 2 === 0;",
+        "console.log({ turn, stable });",
+        "```",
+      ].join("\n"),
+    );
+  }
+  if (turn % 10 === 0) {
+    paragraphs.push("- first mock checklist item\n- second mock checklist item\n- third mock checklist item");
+  }
+  return paragraphs.join("\n\n");
+}
+
+function mockSentence(turn: number, index: number): string {
+  const bank = [
+    "This branch adds enough content to force a tall markdown bubble.",
+    "The next event should not pull the viewport unless the tail is pinned.",
+    "Back-pagination should preserve the first visible item after prepend.",
+    "The bottom affordance should show up only after the tail is no longer visible.",
+  ];
+  return bank[Math.abs(turn + index) % bank.length]!;
+}
+
+function mockReplyFor(prompt: string, turn: number): string {
+  return [
+    `Mock response for turn ${turn}.`,
+    `You posted: "${prompt.slice(0, 120)}".`,
+    "This reply streams in chunks so follow-output, tail pinning, and the scroll ledger can be inspected without a live runner.",
+    "If you scroll upward before it finishes, the viewport should stay where you left it and the latest button should become reachable.",
+  ].join(" ");
+}
+
+function mockId(kind: string, turn: number, prefix = "seed"): string {
+  return `debug-${prefix}-${kind}-${turn < 0 ? `neg${Math.abs(turn)}` : turn}`;
+}
+
+function mockTime(turn: number, sequence: number): string {
+  return new Date(TURN_TIME_BASE + (turn + TURN_ORDER_OFFSET) * 60_000 + sequence * 1000).toISOString();
+}
+
+function mockOrderKey(turn: number, sequence: number): string {
+  const millis = TURN_TIME_BASE + (turn + TURN_ORDER_OFFSET) * 60_000 + sequence * 1000;
+  return `${String(millis).padStart(13, "0")}-${String(Math.round(sequence * 1000)).padStart(8, "0")}-debug`;
+}
+
+function formatDebugTime(value: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatDebugDetail(detail: Record<string, unknown>): string {
+  return JSON.stringify(detail, null, 2);
+}

--- a/frontend/src/chatScrollTelemetry.test.ts
+++ b/frontend/src/chatScrollTelemetry.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  clearChatScrollEvents,
   isChatScrollDebugEnabled,
   logChatScrollEvent,
+  readChatScrollEvents,
 } from "./chatScrollTelemetry";
 
 let fakeStorage: Record<string, string>;
@@ -39,6 +41,7 @@ beforeEach(() => {
   console.log = (message: string, ...args: unknown[]) => {
     consoleLogs.push([message, args]);
   };
+  clearChatScrollEvents();
 });
 
 afterEach(() => {
@@ -50,6 +53,8 @@ test("chat scroll debug logs are off by default", () => {
   assert.equal(isChatScrollDebugEnabled(), false);
   logChatScrollEvent("timeline-loaded", { sessionId: "101" });
   assert.equal(consoleLogs.length, 0);
+  assert.equal(readChatScrollEvents().length, 1);
+  assert.equal(readChatScrollEvents()[0]?.event, "timeline-loaded");
 });
 
 test("chat scroll debug logs fire when tankDebug includes chat-scroll", () => {
@@ -58,4 +63,11 @@ test("chat scroll debug logs fire when tankDebug includes chat-scroll", () => {
   logChatScrollEvent("timeline-loaded", { sessionId: "101" });
   assert.equal(consoleLogs.length, 1);
   assert.equal(consoleLogs[0]?.[0], "[tank/chat-scroll] timeline-loaded");
+});
+
+test("chat scroll ledger can be cleared without console debug", () => {
+  logChatScrollEvent("at-bottom-change", { sessionId: "101", atBottom: false });
+  assert.equal(readChatScrollEvents().length, 1);
+  clearChatScrollEvents();
+  assert.deepEqual(readChatScrollEvents(), []);
 });

--- a/frontend/src/chatScrollTelemetry.ts
+++ b/frontend/src/chatScrollTelemetry.ts
@@ -1,14 +1,30 @@
-// Chat transcript scroll telemetry. Enable per browser with
+// Chat transcript scroll telemetry. Console logging is opt-in per browser with
 // `localStorage.tankDebug = "chat-scroll"` or a comma-separated list that
 // includes `chat-scroll`.
 //
-// This intentionally mirrors sessionListTelemetry's zero-cost-by-default
-// console surface. It is for diagnosing user-visible scroll trust failures
-// without making browser-local position a product source of truth.
+// The bounded local ledger is always written. It gives the app an after-the-
+// fact diagnostic surface for user-visible scroll trust failures without
+// making browser-local position a product source of truth.
 
 const DEBUG_STORAGE_KEY = "tankDebug";
 const DEBUG_TOKEN = "chat-scroll";
 const CONSOLE_PREFIX = "[tank/chat-scroll]";
+const LEDGER_STORAGE_KEY = "tank.chatScrollEvents";
+const LEDGER_EVENT_NAME = "tank:chat-scroll-telemetry";
+const MAX_LEDGER_RECORDS = 500;
+const MAX_DETAIL_KEYS = 60;
+const MAX_STRING_LENGTH = 260;
+
+export interface ChatScrollTelemetryRecord {
+  id: string;
+  at: string;
+  event: string;
+  detail: Record<string, unknown>;
+  path?: string;
+}
+
+let volatileLedger: ChatScrollTelemetryRecord[] = [];
+let sequence = 0;
 
 export function isChatScrollDebugEnabled(): boolean {
   try {
@@ -22,10 +38,151 @@ export function isChatScrollDebugEnabled(): boolean {
   }
 }
 
+export function setChatScrollDebugEnabled(enabled: boolean): void {
+  try {
+    const tokens = new Set(
+      (localStorage.getItem(DEBUG_STORAGE_KEY) ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+    if (enabled) tokens.add(DEBUG_TOKEN);
+    else tokens.delete(DEBUG_TOKEN);
+    if (tokens.size === 0) {
+      localStorage.removeItem(DEBUG_STORAGE_KEY);
+    } else {
+      localStorage.setItem(DEBUG_STORAGE_KEY, [...tokens].join(","));
+    }
+  } catch {
+    // localStorage can be unavailable in hardened/private contexts.
+  }
+}
+
 export function logChatScrollEvent(
   event: string,
   detail: Record<string, unknown> = {},
 ): void {
+  const record = appendChatScrollRecord(event, detail);
   if (!isChatScrollDebugEnabled()) return;
-  console.log(`${CONSOLE_PREFIX} ${event}`, detail);
+  console.log(`${CONSOLE_PREFIX} ${event}`, record.detail);
+}
+
+export function readChatScrollEvents(): ChatScrollTelemetryRecord[] {
+  const persisted = readPersistedLedger();
+  return persisted.length > 0 ? persisted : volatileLedger;
+}
+
+export function clearChatScrollEvents(): void {
+  volatileLedger = [];
+  try {
+    localStorage.removeItem(LEDGER_STORAGE_KEY);
+  } catch {
+    // localStorage can be unavailable in hardened/private contexts.
+  }
+  emitChatScrollRecordEvent(null);
+}
+
+export function chatScrollElementSnapshot(
+  element: HTMLElement | null,
+): Record<string, unknown> {
+  if (!element) return { hasScrollParent: false };
+  const scrollTop = Math.round(element.scrollTop);
+  const scrollHeight = Math.round(element.scrollHeight);
+  const clientHeight = Math.round(element.clientHeight);
+  return {
+    hasScrollParent: true,
+    scrollTop,
+    scrollHeight,
+    clientHeight,
+    bottomDistance: Math.max(0, scrollHeight - scrollTop - clientHeight),
+  };
+}
+
+function appendChatScrollRecord(
+  event: string,
+  detail: Record<string, unknown>,
+): ChatScrollTelemetryRecord {
+  sequence += 1;
+  const record: ChatScrollTelemetryRecord = {
+    id: `${Date.now()}-${sequence}`,
+    at: new Date().toISOString(),
+    event,
+    detail: sanitizeDetail(detail),
+    path: typeof window !== "undefined" ? window.location.pathname : undefined,
+  };
+  const nextLedger = [...readChatScrollEvents(), record].slice(-MAX_LEDGER_RECORDS);
+  volatileLedger = nextLedger;
+  try {
+    localStorage.setItem(LEDGER_STORAGE_KEY, JSON.stringify(nextLedger));
+  } catch {
+    // Keep the in-memory ledger when localStorage quota/access fails.
+  }
+  emitChatScrollRecordEvent(record);
+  return record;
+}
+
+function readPersistedLedger(): ChatScrollTelemetryRecord[] {
+  try {
+    const raw = localStorage.getItem(LEDGER_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isChatScrollTelemetryRecord).slice(-MAX_LEDGER_RECORDS);
+  } catch {
+    return [];
+  }
+}
+
+function isChatScrollTelemetryRecord(value: unknown): value is ChatScrollTelemetryRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.at === "string" &&
+    typeof candidate.event === "string" &&
+    Boolean(candidate.detail) &&
+    typeof candidate.detail === "object" &&
+    !Array.isArray(candidate.detail)
+  );
+}
+
+function sanitizeDetail(detail: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(detail).slice(0, MAX_DETAIL_KEYS)) {
+    out[key] = sanitizeValue(value, 0);
+  }
+  return out;
+}
+
+function sanitizeValue(value: unknown, depth: number): unknown {
+  if (value == null) return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : String(value);
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    return value.length <= MAX_STRING_LENGTH
+      ? value
+      : `${value.slice(0, MAX_STRING_LENGTH)}...`;
+  }
+  if (Array.isArray(value)) {
+    if (depth >= 2) return `[array:${value.length}]`;
+    return value.slice(0, 20).map((item) => sanitizeValue(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    if (depth >= 2) return "[object]";
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>).slice(0, 20)) {
+      out[key] = sanitizeValue(child, depth + 1);
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function emitChatScrollRecordEvent(record: ChatScrollTelemetryRecord | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new CustomEvent(LEDGER_EVENT_NAME, { detail: record }));
+  } catch {
+    // CustomEvent can be blocked in unusual embedded contexts.
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6293,3 +6293,161 @@ textarea.run-files-viewer-editor:focus {
     @apply font-sans;
   }
 }
+
+.debug-scroll-lab {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(20rem, 28rem);
+  overflow: hidden;
+  background: var(--bg-base, #0a0a0a);
+}
+
+.debug-long-chat {
+  border-right: 1px solid var(--border-soft, rgba(255, 255, 255, 0.08));
+}
+
+.debug-long-chat-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.debug-long-chat-title > span {
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: 650;
+}
+
+.debug-long-chat-title > small {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.debug-scroll-ledger {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: #101010;
+  font-family: var(--font-primary);
+}
+
+.debug-scroll-ledger-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-soft, rgba(255, 255, 255, 0.08));
+}
+
+.debug-scroll-ledger-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 650;
+}
+
+.debug-scroll-ledger-subtitle {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.debug-scroll-ledger-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.debug-scroll-ledger-btn {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.debug-scroll-ledger-btn:hover,
+.debug-scroll-ledger-btn.active {
+  border-color: rgba(103, 232, 249, 0.35);
+  background: rgba(103, 232, 249, 0.1);
+  color: var(--cyan-bright);
+}
+
+.debug-scroll-records {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.debug-scroll-empty {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  padding: var(--space-3);
+}
+
+.debug-scroll-record {
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.025);
+  overflow: hidden;
+}
+
+.debug-scroll-record header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 0.45rem 0.55rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: 650;
+}
+
+.debug-scroll-record time {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.debug-scroll-record pre {
+  margin: 0;
+  max-height: 12rem;
+  overflow: auto;
+  padding: 0.55rem;
+  color: var(--text-body);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 980px) {
+  .debug-scroll-lab {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(12rem, 34vh);
+  }
+
+  .debug-long-chat {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-soft, rgba(255, 255, 255, 0.08));
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { LongChatDebugPage } from "./LongChatDebugPage";
 import { StyleguideAvatars } from "./styleguide/avatars";
 import { StyleguideBootState } from "./styleguide/boot-state";
 import { StyleguideButtons } from "./styleguide/buttons";
@@ -48,6 +49,7 @@ const TANK_KEY_ALLOWLIST = [
   "tank.defaultInteraction",
   "tank.homeSelectedRepos",
   "tank.sessionInteraction:",
+  "tank.chatScrollEvents",
 ];
 function isAllowedTankKey(key: string): boolean {
   for (const allowed of TANK_KEY_ALLOWLIST) {
@@ -96,8 +98,14 @@ const STYLEGUIDE_ROUTES: Record<string, () => JSX.Element> = {
   "/_styleguide/avatars": () => <StyleguideAvatars />,
 };
 
+const DEBUG_ROUTES: Record<string, () => JSX.Element> = {
+  "/_debug/long-chat": () => <LongChatDebugPage />,
+};
+
 function Root() {
   if (typeof window !== "undefined") {
+    const debugRender = DEBUG_ROUTES[window.location.pathname];
+    if (debugRender) return debugRender();
     const render = STYLEGUIDE_ROUTES[window.location.pathname];
     if (render) return render();
   }

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -2,44 +2,25 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-const appSource = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
-const conversationReducerSource = readFileSync(
-  new URL("./conversationReducer.ts", import.meta.url),
-  "utf8",
+function readSource(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8").replace(/\r\n/g, "\n");
+}
+
+const appSource = readSource("./App.tsx");
+const conversationReducerSource = readSource("./conversationReducer.ts");
+const chatScrollTelemetrySource = readSource("./chatScrollTelemetry.ts");
+const mainSource = readSource("./main.tsx");
+const indexCssSource = readSource("./index.css");
+const sessionConfigMapSource = readSource("../../k8s/templates/session-configmap.yaml");
+const installTankDocsSource = readSource("../../k8s/session-config/install-tank-docs.sh");
+const agentRunnerLaunchSource = readSource("../../k8s/session-config/agent-runner-launch.sh");
+const codexRunnerLaunchSource = readSource("../../k8s/session-config/codex-runner-launch.sh");
+const defaultClaudeSource = readSource("../../k8s/session-config/default-claude.md");
+const bundledQualityTimeframesSource = readSource(
+  "../../k8s/session-config/docs/quality-timeframes.md",
 );
-const chatScrollTelemetrySource = readFileSync(
-  new URL("./chatScrollTelemetry.ts", import.meta.url),
-  "utf8",
-);
-const mainSource = readFileSync(new URL("./main.tsx", import.meta.url), "utf8");
-const indexCssSource = readFileSync(new URL("./index.css", import.meta.url), "utf8");
-const sessionConfigMapSource = readFileSync(
-  new URL("../../k8s/templates/session-configmap.yaml", import.meta.url),
-  "utf8",
-);
-const installTankDocsSource = readFileSync(
-  new URL("../../k8s/session-config/install-tank-docs.sh", import.meta.url),
-  "utf8",
-);
-const agentRunnerLaunchSource = readFileSync(
-  new URL("../../k8s/session-config/agent-runner-launch.sh", import.meta.url),
-  "utf8",
-);
-const codexRunnerLaunchSource = readFileSync(
-  new URL("../../k8s/session-config/codex-runner-launch.sh", import.meta.url),
-  "utf8",
-);
-const defaultClaudeSource = readFileSync(
-  new URL("../../k8s/session-config/default-claude.md", import.meta.url),
-  "utf8",
-);
-const bundledQualityTimeframesSource = readFileSync(
-  new URL("../../k8s/session-config/docs/quality-timeframes.md", import.meta.url),
-  "utf8",
-);
-const bundledMigrationPolicySource = readFileSync(
-  new URL("../../k8s/session-config/docs/migration-policy.md", import.meta.url),
-  "utf8",
+const bundledMigrationPolicySource = readSource(
+  "../../k8s/session-config/docs/migration-policy.md",
 );
 
 test("session activity is not refreshed by a steady interval", () => {
@@ -250,6 +231,14 @@ test("chat back-pagination keeps the focused load button mounted while loading",
 test("chat scroll diagnostics are debug gated", () => {
   assert.equal(chatScrollTelemetrySource.includes('DEBUG_TOKEN = "chat-scroll"'), true);
   assert.equal(chatScrollTelemetrySource.includes("isChatScrollDebugEnabled"), true);
+  assert.equal(chatScrollTelemetrySource.includes("readChatScrollEvents"), true);
+  assert.equal(chatScrollTelemetrySource.includes("tank.chatScrollEvents"), true);
   assert.equal(appSource.includes("logChatScrollGroups"), true);
   assert.equal(appSource.includes("logChatScrollEntries"), true);
+});
+
+test("long-chat scroll lab route is available without the authenticated app", () => {
+  assert.equal(mainSource.includes('"/_debug/long-chat"'), true);
+  assert.equal(mainSource.includes("LongChatDebugPage"), true);
+  assert.equal(mainSource.includes("tank.chatScrollEvents"), true);
 });


### PR DESCRIPTION
## Summary
- Persist a bounded chat-scroll telemetry ledger in localStorage so scroll events can be inspected after the fact without browser devtools.
- Add `/_debug/long-chat`, a standalone long-session scroll lab with mock history, prepend, burst append, mock message submission, and live ledger controls.
- Add policy/test coverage for the debug route and make source-policy tests newline-normalized on Windows worktrees.

## Verification
- `npm test`
- `npm run build`
- Headless Chrome smoke test against `/_debug/long-chat`: rendered desktop layout, scrolled to top, prepended older mock entries, and confirmed ledger records were captured.