### PR TITLE
Use Prometheus for chat scroll telemetry

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_client_metrics.go
+++ b/backend-go/cmd/tank-operator/handlers_client_metrics.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+)
+
+const (
+	chatScrollMetricsMaxBodyBytes = 64 * 1024
+	chatScrollMetricsMaxEvents    = 50
+)
+
+type chatScrollMetricsRequest struct {
+	Events []chatScrollMetricEvent `json:"events"`
+}
+
+type chatScrollMetricEvent struct {
+	Event           string   `json:"event"`
+	Surface         string   `json:"surface"`
+	SessionMode     string   `json:"sessionMode"`
+	AtBottom        *bool    `json:"atBottom,omitempty"`
+	HasScrollParent *bool    `json:"hasScrollParent,omitempty"`
+	ScrollTop       *float64 `json:"scrollTop,omitempty"`
+	ScrollHeight    *float64 `json:"scrollHeight,omitempty"`
+	ClientHeight    *float64 `json:"clientHeight,omitempty"`
+	BottomDistance  *float64 `json:"bottomDistance,omitempty"`
+	Entries         *float64 `json:"entries,omitempty"`
+	Groups          *float64 `json:"groups,omitempty"`
+	Messages        *float64 `json:"messages,omitempty"`
+	ToolGroups      *float64 `json:"toolGroups,omitempty"`
+}
+
+func (s *appServer) handleChatScrollMetrics(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	if !user.IsHuman() {
+		recordChatScrollClientReport("denied_role")
+		writeError(w, http.StatusForbidden, "human user required")
+		return
+	}
+
+	var body chatScrollMetricsRequest
+	limited := http.MaxBytesReader(w, r.Body, chatScrollMetricsMaxBodyBytes)
+	decoder := json.NewDecoder(limited)
+	if err := decoder.Decode(&body); err != nil {
+		recordChatScrollClientReport("invalid_json")
+		writeError(w, http.StatusBadRequest, "invalid chat scroll metrics payload")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		recordChatScrollClientReport("invalid_json")
+		writeError(w, http.StatusBadRequest, "invalid chat scroll metrics payload")
+		return
+	}
+	if len(body.Events) > chatScrollMetricsMaxEvents {
+		recordChatScrollClientReport("too_many_events")
+		writeError(w, http.StatusBadRequest, "too many chat scroll metric events")
+		return
+	}
+	for _, event := range body.Events {
+		if !validChatScrollMetricNumbers(event) {
+			recordChatScrollClientReport("invalid_value")
+			writeError(w, http.StatusBadRequest, "invalid chat scroll metric value")
+			return
+		}
+	}
+	for _, event := range body.Events {
+		recordChatScrollClientEvent(event)
+	}
+	recordChatScrollClientReport("ok")
+	writeJSON(w, http.StatusAccepted, map[string]any{"accepted": len(body.Events)})
+}
+
+func validChatScrollMetricNumbers(event chatScrollMetricEvent) bool {
+	for _, value := range []*float64{
+		event.ScrollTop,
+		event.ScrollHeight,
+		event.ClientHeight,
+		event.BottomDistance,
+		event.Entries,
+		event.Groups,
+		event.Messages,
+		event.ToolGroups,
+	} {
+		if value == nil {
+			continue
+		}
+		if math.IsNaN(*value) || math.IsInf(*value, 0) {
+			return false
+		}
+	}
+	return true
+}
+
+var chatScrollMetricEventLabels = map[string]struct{}{
+	"tail-bootstrap-reset":          {},
+	"timeline-request":              {},
+	"timeline-error":                {},
+	"timeline-stale":                {},
+	"timeline-loaded":               {},
+	"older-missing-cursor":          {},
+	"older-request":                 {},
+	"older-loaded":                  {},
+	"prepend-preserve-scroll":       {},
+	"virtuoso-window":               {},
+	"scroll-to-latest":              {},
+	"scroll-to-oldest":              {},
+	"start-reached":                 {},
+	"at-bottom-change":              {},
+	"scroll-parent-mounted":         {},
+	"scroll-parent-unmounted":       {},
+	"debug-scroll-parent-mounted":   {},
+	"debug-scroll-parent-unmounted": {},
+	"debug-reset-transcript":        {},
+	"debug-prepend-older":           {},
+	"debug-append-burst":            {},
+	"debug-mock-reply-stopped":      {},
+	"debug-submit-message":          {},
+	"debug-mock-reply-complete":     {},
+}
+
+func chatScrollEventLabel(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if _, ok := chatScrollMetricEventLabels[raw]; ok {
+		return raw
+	}
+	return "other"
+}
+
+func chatScrollSurfaceLabel(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "session", "debug_lab":
+		return raw
+	default:
+		return "unknown"
+	}
+}
+
+var chatScrollSessionModeLabels = map[string]struct{}{
+	"api_key":          {},
+	"claude_cli":       {},
+	"claude_gui":       {},
+	"config":           {},
+	"codex_cli":        {},
+	"codex_gui":        {},
+	"codex_exec_gui":   {},
+	"codex_app_server": {},
+	"codex_config":     {},
+	"debug":            {},
+	"hermes_gui":       {},
+	"pi_cli":           {},
+	"pi_config":        {},
+}
+
+func chatScrollSessionModeLabel(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if _, ok := chatScrollSessionModeLabels[raw]; ok {
+		return raw
+	}
+	return "unknown"
+}

--- a/backend-go/cmd/tank-operator/handlers_client_metrics_test.go
+++ b/backend-go/cmd/tank-operator/handlers_client_metrics_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+)
+
+func TestHandleChatScrollMetricsRecordsPrometheus(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/chat-scroll", strings.NewReader(`{
+		"events": [{
+			"event": "at-bottom-change",
+			"surface": "session",
+			"sessionMode": "codex_gui",
+			"atBottom": false,
+			"hasScrollParent": true,
+			"bottomDistance": 240,
+			"entries": 180
+		}]
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	res := httptest.NewRecorder()
+
+	app.handleChatScrollMetrics(res, req)
+
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("metrics status = %d body=%s, want 202", res.Code, res.Body.String())
+	}
+	metrics := scrapePrometheus(t)
+	for _, want := range []string{
+		`tank_chat_scroll_client_reports_total{result="ok"}`,
+		`tank_chat_scroll_client_events_total{at_bottom="false",event="at-bottom-change",has_scroll_parent="true",session_mode="codex_gui",surface="session"}`,
+		`tank_chat_scroll_client_bottom_distance_pixels_bucket{event="at-bottom-change",session_mode="codex_gui",surface="session",le="500"}`,
+		`tank_chat_scroll_client_entries_bucket{event="at-bottom-change",session_mode="codex_gui",surface="session",le="200"}`,
+	} {
+		if !strings.Contains(metrics, want) {
+			t.Fatalf("scrape missing %s\n%s", want, metrics)
+		}
+	}
+}
+
+func TestHandleChatScrollMetricsRejectsUnboundedBatch(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	var body bytes.Buffer
+	body.WriteString(`{"events":[`)
+	for i := 0; i < chatScrollMetricsMaxEvents+1; i++ {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteString(`{"event":"at-bottom-change","surface":"session","sessionMode":"codex_gui"}`)
+	}
+	body.WriteString(`]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/chat-scroll", &body)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	res := httptest.NewRecorder()
+
+	app.handleChatScrollMetrics(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("metrics status = %d body=%s, want 400", res.Code, res.Body.String())
+	}
+}
+
+func TestChatScrollMetricLabelsAreBounded(t *testing.T) {
+	trueValue := true
+	event := chatScrollMetricEvent{
+		Event:           "random-user-controlled-value",
+		Surface:         "/raw/path/123",
+		SessionMode:     "mode-for-user-123",
+		AtBottom:        nil,
+		HasScrollParent: &trueValue,
+	}
+	recordChatScrollClientEvent(event)
+
+	metrics := scrapePrometheus(t)
+	for _, want := range []string{
+		`tank_chat_scroll_client_events_total{at_bottom="unknown",event="other",has_scroll_parent="true",session_mode="unknown",surface="unknown"}`,
+	} {
+		if !strings.Contains(metrics, want) {
+			t.Fatalf("scrape missing %s\n%s", want, metrics)
+		}
+	}
+	if strings.Contains(metrics, "random-user-controlled-value") || strings.Contains(metrics, "/raw/path/123") {
+		t.Fatalf("scrape leaked unbounded labels:\n%s", metrics)
+	}
+}
+
+func scrapePrometheus(t *testing.T) string {
+	t.Helper()
+	res := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body, _ := io.ReadAll(res.Body)
+	return string(body)
+}

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -236,6 +236,90 @@ var sessionReposSelectedTotal = promauto.NewCounterVec(
 	[]string{"count_bucket"},
 )
 
+// --- Browser chat-scroll metrics ---
+//
+// The SPA reports semantic scroll decisions here; the orchestrator owns
+// label bucketing so browser details never become high-cardinality series.
+// No user, session_id, URL, or raw path labels are exposed.
+
+var (
+	chatScrollClientReportsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_chat_scroll_client_reports_total",
+			Help: "Browser chat-scroll metric report requests, labeled by bounded result.",
+		},
+		[]string{"result"},
+	)
+	chatScrollClientEventsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_chat_scroll_client_events_total",
+			Help: "Semantic chat transcript scroll events reported by browsers.",
+		},
+		[]string{"event", "surface", "session_mode", "at_bottom", "has_scroll_parent"},
+	)
+	chatScrollClientBottomDistancePixels = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "tank_chat_scroll_client_bottom_distance_pixels",
+			Help: "Distance in pixels from the transcript viewport bottom when browser scroll events were reported.",
+			Buckets: []float64{
+				0, 1, 4, 24, 100, 500, 1000, 5000, 10000, 50000,
+			},
+		},
+		[]string{"event", "surface", "session_mode"},
+	)
+	chatScrollClientEntries = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "tank_chat_scroll_client_entries",
+			Help:    "Transcript entry counts attached to browser scroll events.",
+			Buckets: []float64{0, 10, 50, 100, 200, 500, 1000, 2000, 5000},
+		},
+		[]string{"event", "surface", "session_mode"},
+	)
+)
+
+func recordChatScrollClientReport(result string) {
+	chatScrollClientReportsTotal.WithLabelValues(result).Inc()
+}
+
+func recordChatScrollClientEvent(event chatScrollMetricEvent) {
+	eventLabel := chatScrollEventLabel(event.Event)
+	surface := chatScrollSurfaceLabel(event.Surface)
+	mode := chatScrollSessionModeLabel(event.SessionMode)
+	atBottom := boolMetricLabel(event.AtBottom)
+	hasScrollParent := boolMetricLabel(event.HasScrollParent)
+	chatScrollClientEventsTotal.WithLabelValues(
+		eventLabel,
+		surface,
+		mode,
+		atBottom,
+		hasScrollParent,
+	).Inc()
+	if event.BottomDistance != nil && *event.BottomDistance >= 0 {
+		chatScrollClientBottomDistancePixels.WithLabelValues(
+			eventLabel,
+			surface,
+			mode,
+		).Observe(*event.BottomDistance)
+	}
+	if event.Entries != nil && *event.Entries >= 0 {
+		chatScrollClientEntries.WithLabelValues(
+			eventLabel,
+			surface,
+			mode,
+		).Observe(*event.Entries)
+	}
+}
+
+func boolMetricLabel(value *bool) string {
+	if value == nil {
+		return "unknown"
+	}
+	if *value {
+		return "true"
+	}
+	return "false"
+}
+
 // GET /api/github/repos counters. The endpoint proxies through to
 // mcp-github via an on-behalf-of token mint; both legs can fail
 // independently, so we surface a simple ok|error outcome label plus

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -86,6 +86,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/config", s.handleConfig)
 	mux.HandleFunc("GET /api/design/selection/latest", s.handleGetLatestDesignSelection)
 	mux.HandleFunc("POST /api/design/selection", s.handlePostDesignSelection)
+	mux.HandleFunc("POST /api/client-metrics/chat-scroll", s.handleChatScrollMetrics)
 
 	// Auth.
 	mux.HandleFunc("GET /api/auth/me", s.handleMe)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,6 +40,12 @@ All metric names are prefixed `tank_`. The full namespace:
   `tank_session_event_stream_lag_seconds` histogram. Same names as the
   prior expvar counters (`_total` suffix added where missing per Prom
   convention).
+- `tank_chat_scroll_client_*` - browser-reported transcript scroll
+  diagnostics ingested through `POST /api/client-metrics/chat-scroll`.
+  Labels are server-bucketed only: `event`, `surface`, `session_mode`,
+  `at_bottom`, and `has_scroll_parent`. The endpoint never exposes
+  `session_id`, email, raw route paths, or user-supplied event names as
+  labels; unknown values collapse to `other` / `unknown`.
 - `tank_turn_interrupt_request_total` — counter of stop requests posted
   to `/interrupt`. Single label `outcome` with three bounded values:
   `persisted`, `persist_failed`, `publish_failed`. Steady-state

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4914,6 +4914,8 @@ export function RunMessages({
   entries,
   avatar,
   sessionId,
+  sessionMode = "unknown",
+  telemetrySurface = "session",
   pendingScrollMessageId,
   onScrollConsumed,
   showThinking,
@@ -4936,6 +4938,8 @@ export function RunMessages({
   entries: TranscriptEntry[];
   avatar: AgentAvatar;
   sessionId: string;
+  sessionMode?: string;
+  telemetrySurface?: string;
   // Set when the SPA cold-started with ?message=<entry.id>. RunMessages
   // searches the loaded groups for that id and, when found, scrolls
   // Virtuoso to it and lights up a highlight pulse on the bubble. If
@@ -5067,7 +5071,9 @@ export function RunMessages({
     const nextIndex = currentKeys.indexOf(previousFirst);
     if (nextIndex <= 0) return;
     logChatScrollGroups("prepend-preserve-scroll", groups, entries.length, {
+      surface: telemetrySurface,
       sessionId,
+      sessionMode,
       previousFirst,
       nextIndex,
       ...chatScrollElementSnapshot(scrollParent),
@@ -5077,20 +5083,24 @@ export function RunMessages({
       align: "start",
       behavior: "auto",
     });
-  }, [entries.length, groups, scrollParent, sessionId]);
+  }, [entries.length, groups, scrollParent, sessionId, sessionMode, telemetrySurface]);
   useEffect(() => {
     logChatScrollGroups("virtuoso-window", groups, entries.length, {
+      surface: telemetrySurface,
       sessionId,
+      sessionMode,
       initialTopMostItemIndex: Math.max(groups.length - 1, 0),
       ...chatScrollElementSnapshot(scrollParent),
     });
-  }, [entries.length, groups, scrollParent, sessionId]);
+  }, [entries.length, groups, scrollParent, sessionId, sessionMode, telemetrySurface]);
   useLayoutEffect(() => {
     if (!scrollToLatestSignal || groups.length === 0) return;
     if (consumedScrollToLatestSignalRef.current === scrollToLatestSignal) return;
     consumedScrollToLatestSignalRef.current = scrollToLatestSignal;
     logChatScrollGroups("scroll-to-latest", groups, entries.length, {
+      surface: telemetrySurface,
       sessionId,
+      sessionMode,
       signal: scrollToLatestSignal,
       behavior: scrollToLatestBehavior,
       reason: scrollToLatestReason,
@@ -5111,11 +5121,15 @@ export function RunMessages({
     scrollToLatestReason,
     scrollToLatestSignal,
     sessionId,
+    sessionMode,
+    telemetrySurface,
   ]);
   useEffect(() => {
     if (!scrollToOldestSignal || groups.length === 0) return;
     logChatScrollGroups("scroll-to-oldest", groups, entries.length, {
+      surface: telemetrySurface,
       sessionId,
+      sessionMode,
       signal: scrollToOldestSignal,
       ...chatScrollElementSnapshot(scrollParent),
     });
@@ -5124,7 +5138,7 @@ export function RunMessages({
       align: "start",
       behavior: "smooth",
     });
-  }, [entries.length, groups, scrollParent, scrollToOldestSignal, sessionId]);
+  }, [entries.length, groups, scrollParent, scrollToOldestSignal, sessionId, sessionMode, telemetrySurface]);
   // computeItemKey stabilizes Virtuoso's per-item identity across renders.
   // Tool groups have no single id, so the first child id identifies the
   // group while later tool entries append during a streaming turn.
@@ -5224,21 +5238,25 @@ export function RunMessages({
   );
   const handleStartReached = useCallback(() => {
     logChatScrollGroups("start-reached", groups, entries.length, {
+      surface: telemetrySurface,
       sessionId,
+      sessionMode,
       ...chatScrollElementSnapshot(scrollParent),
     });
     onStartReached?.();
-  }, [entries.length, groups, onStartReached, scrollParent, sessionId]);
+  }, [entries.length, groups, onStartReached, scrollParent, sessionId, sessionMode, telemetrySurface]);
   const handleAtBottomChange = useCallback(
     (atBottom: boolean) => {
       logChatScrollGroups("at-bottom-change", groups, entries.length, {
+        surface: telemetrySurface,
         sessionId,
+        sessionMode,
         atBottom,
         ...chatScrollElementSnapshot(scrollParent),
       });
       onAtBottomChange?.(atBottom);
     },
-    [entries.length, groups, onAtBottomChange, scrollParent, sessionId],
+    [entries.length, groups, onAtBottomChange, scrollParent, sessionId, sessionMode, telemetrySurface],
   );
   // followOutput="smooth" keeps the user stuck to the live tail when they
   // ARE at the bottom; releases when they scroll up. Returning false from
@@ -5661,10 +5679,12 @@ function ChatPane({
   const transcriptScrollCallbackRef = useCallback((node: HTMLElement | null) => {
     setTranscriptScrollEl(node);
     logChatScrollEvent(node ? "scroll-parent-mounted" : "scroll-parent-unmounted", {
+      surface: "session",
       sessionId: session.id,
+      sessionMode: session.mode,
       ...chatScrollElementSnapshot(node),
     });
-  }, [session.id]);
+  }, [session.id, session.mode]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const sdkEventSourceRef = useRef<EventSource | null>(null);
   const historyRefreshRef = useRef<Promise<unknown> | null>(null);
@@ -5915,7 +5935,9 @@ function ChatPane({
       epoch,
     });
     logChatScrollEvent("tail-bootstrap-reset", {
+      surface: "session",
       sessionId: session.id,
+      sessionMode: session.mode,
       reason,
       epoch,
       source: timelineBootstrapSourceRef.current,
@@ -6245,7 +6267,9 @@ function ChatPane({
         timelineBootstrapScrollToLatestRef.current = false;
       }
       logChatScrollEvent("timeline-request", {
+        surface: "session",
         sessionId: refreshSessionId,
+        sessionMode: session.mode,
         source,
         anchor,
         clearRealtime,
@@ -6257,7 +6281,9 @@ function ChatPane({
       );
       if (!res.ok) {
         logChatScrollEvent("timeline-error", {
+          surface: "session",
           sessionId: refreshSessionId,
+          sessionMode: session.mode,
           source,
           anchor,
           status: res.status,
@@ -6281,7 +6307,9 @@ function ChatPane({
       if (sessionIdRef.current !== refreshSessionId) return { replayed: false };
       if (sdkWindowEpochRef.current !== refreshEpoch) {
         logChatScrollEvent("timeline-stale", {
+          surface: "session",
           sessionId: refreshSessionId,
+          sessionMode: session.mode,
           source,
           anchor,
           epoch: refreshEpoch,
@@ -6335,7 +6363,9 @@ function ChatPane({
       );
       const projectedEntries = conversationEntriesToTranscript(projection.entries);
       logChatScrollEntries("timeline-loaded", projectedEntries, {
+        surface: "session",
         sessionId: refreshSessionId,
+        sessionMode: session.mode,
         source,
         anchor,
         eventCount: Array.isArray(body.events) ? body.events.length : 0,
@@ -6386,7 +6416,9 @@ function ChatPane({
     setSdkLoadingOlder(true);
     if (!oldest) {
       logChatScrollEvent("older-missing-cursor", {
+        surface: "session",
         sessionId: refreshSessionId,
+        sessionMode: session.mode,
       });
       try {
         await jumpSdkToOldest();
@@ -6401,7 +6433,9 @@ function ChatPane({
       return;
     }
     logChatScrollEvent("older-request", {
+      surface: "session",
       sessionId: refreshSessionId,
+      sessionMode: session.mode,
       beforeOrderKey: oldest,
     });
     try {
@@ -6444,7 +6478,9 @@ function ChatPane({
           "older-loaded",
           conversationEntriesToTranscript(projection.entries),
           {
+            surface: "session",
             sessionId: refreshSessionId,
+            sessionMode: session.mode,
             eventCount: olderEvents.length,
             beforeOrderKey: oldest,
           },
@@ -8330,6 +8366,7 @@ function ChatPane({
               entries={renderedEntries}
               avatar={sessionAvatar}
               sessionId={session.id}
+              sessionMode={session.mode}
               pendingScrollMessageId={pendingScrollMessageId}
               onScrollConsumed={onScrollConsumed}
               showThinking={runPrefs.showThinking}

--- a/frontend/src/LongChatDebugPage.tsx
+++ b/frontend/src/LongChatDebugPage.tsx
@@ -3,24 +3,17 @@ import type { CSSProperties } from "react";
 import {
   ArrowDownIcon,
   ArrowUpIcon,
-  BugIcon,
-  ClipboardListIcon,
   Loader2Icon,
-  Trash2Icon,
 } from "lucide-react";
 import { ChatComposer, type RunComposerMode } from "./ChatComposer";
 import { WorkspaceShell } from "./WorkspaceShell";
 import { getSessionAvatar } from "./sessionAvatars";
 import {
   chatScrollElementSnapshot,
-  clearChatScrollEvents,
-  isChatScrollDebugEnabled,
   logChatScrollEvent,
-  readChatScrollEvents,
-  setChatScrollDebugEnabled,
-  type ChatScrollTelemetryRecord,
 } from "./chatScrollTelemetry";
 import { RunMessages, type TranscriptEntry } from "./App";
+import { bootstrapAuth, startLogin } from "./auth";
 
 const DEBUG_SESSION_ID = "debug-long-chat";
 const INITIAL_TURN_COUNT = 240;
@@ -39,13 +32,10 @@ const debugChatFontScaleStyle = {
 } as CSSProperties;
 
 export function LongChatDebugPage() {
+  const [access, setAccess] = useState<"loading" | "admin" | "signed-out" | "denied">("loading");
   const [entries, setEntries] = useState<TranscriptEntry[]>(() =>
     makeMockTranscript(0, INITIAL_TURN_COUNT),
   );
-  const [records, setRecords] = useState<ChatScrollTelemetryRecord[]>(() =>
-    readChatScrollEvents(),
-  );
-  const [consoleDebug, setConsoleDebug] = useState(() => isChatScrollDebugEnabled());
   const [permissionMode, setPermissionMode] = useState<RunComposerMode>("default");
   const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
   const [atBottom, setAtBottom] = useState(true);
@@ -60,11 +50,18 @@ export function LongChatDebugPage() {
   const mockReplyIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const refreshRecords = () => setRecords(readChatScrollEvents());
-    refreshRecords();
-    window.addEventListener("tank:chat-scroll-telemetry", refreshRecords);
+    let cancelled = false;
+    bootstrapAuth()
+      .then((user) => {
+        if (cancelled) return;
+        if (!user) setAccess("signed-out");
+        else setAccess(user.role === "admin" ? "admin" : "denied");
+      })
+      .catch(() => {
+        if (!cancelled) setAccess("signed-out");
+      });
     return () => {
-      window.removeEventListener("tank:chat-scroll-telemetry", refreshRecords);
+      cancelled = true;
       if (mockTimerRef.current !== null) {
         window.clearInterval(mockTimerRef.current);
         mockTimerRef.current = null;
@@ -90,6 +87,8 @@ export function LongChatDebugPage() {
   const bodyRef = useCallback((node: HTMLElement | null) => {
     setScrollParent(node);
     logChatScrollEvent(node ? "debug-scroll-parent-mounted" : "debug-scroll-parent-unmounted", {
+      surface: "debug_lab",
+      sessionMode: "debug",
       sessionId: DEBUG_SESSION_ID,
       ...chatScrollElementSnapshot(node),
     });
@@ -102,6 +101,8 @@ export function LongChatDebugPage() {
     setAtBottom(true);
     setScrollToLatestSignal((value) => value + 1);
     logChatScrollEvent("debug-reset-transcript", {
+      surface: "debug_lab",
+      sessionMode: "debug",
       sessionId: DEBUG_SESSION_ID,
       turnCount,
       ...chatScrollElementSnapshot(scrollParent),
@@ -118,6 +119,8 @@ export function LongChatDebugPage() {
       setEntries((current) => [...older, ...current]);
       setLoadingOlder(false);
       logChatScrollEvent("debug-prepend-older", {
+        surface: "debug_lab",
+        sessionMode: "debug",
         sessionId: DEBUG_SESSION_ID,
         addedTurns: PREPEND_TURN_COUNT,
         oldestTurn: nextOldest,
@@ -132,6 +135,8 @@ export function LongChatDebugPage() {
     const next = makeMockTranscript(start, count);
     setEntries((current) => [...current, ...next]);
     logChatScrollEvent("debug-append-burst", {
+      surface: "debug_lab",
+      sessionMode: "debug",
       sessionId: DEBUG_SESSION_ID,
       addedTurns: count,
       atBottom,
@@ -157,6 +162,8 @@ export function LongChatDebugPage() {
       );
     }
     logChatScrollEvent("debug-mock-reply-stopped", {
+      surface: "debug_lab",
+      sessionMode: "debug",
       sessionId: DEBUG_SESSION_ID,
       replyId: stoppedId ?? "",
       ...chatScrollElementSnapshot(scrollParent),
@@ -179,6 +186,8 @@ export function LongChatDebugPage() {
       mockMessageEntry(turn, 3, "assistant", "Thinking...", "posted", replyId),
     ]);
     logChatScrollEvent("debug-submit-message", {
+      surface: "debug_lab",
+      sessionMode: "debug",
       sessionId: DEBUG_SESSION_ID,
       turn,
       atBottom,
@@ -203,6 +212,8 @@ export function LongChatDebugPage() {
         mockReplyIdRef.current = null;
         setRunning(false);
         logChatScrollEvent("debug-mock-reply-complete", {
+          surface: "debug_lab",
+          sessionMode: "debug",
           sessionId: DEBUG_SESSION_ID,
           turn,
           ...chatScrollElementSnapshot(scrollParent),
@@ -211,8 +222,23 @@ export function LongChatDebugPage() {
     }, 120);
   }, [atBottom, running, scrollParent]);
 
-  const recentRecords = records.slice(-160).reverse();
   const avatar = getSessionAvatar(DEBUG_SESSION_ID);
+
+  if (access === "loading") {
+    return <DebugAccessScreen title="Loading debug session..." />;
+  }
+  if (access === "signed-out") {
+    return (
+      <DebugAccessScreen
+        title="Sign in required"
+        actionLabel="Sign in"
+        onAction={() => void startLogin()}
+      />
+    );
+  }
+  if (access !== "admin") {
+    return <DebugAccessScreen title="Admin access required" />;
+  }
 
   return (
     <div className="debug-scroll-lab">
@@ -260,6 +286,8 @@ export function LongChatDebugPage() {
               entries={entries}
               avatar={avatar}
               sessionId={DEBUG_SESSION_ID}
+              sessionMode="debug"
+              telemetrySurface="debug_lab"
               showThinking
               autoExpandTools={false}
               showTimestamps
@@ -308,58 +336,29 @@ export function LongChatDebugPage() {
           />
         )}
       />
-      <aside className="debug-scroll-ledger" aria-label="Chat scroll telemetry">
-        <div className="debug-scroll-ledger-header">
-          <div>
-            <span className="debug-scroll-ledger-title">
-              <ClipboardListIcon size={15} aria-hidden="true" />
-              Scroll ledger
-            </span>
-            <span className="debug-scroll-ledger-subtitle">{records.length} captured</span>
-          </div>
-          <div className="debug-scroll-ledger-actions">
-            <button
-              type="button"
-              className={`debug-scroll-ledger-btn${consoleDebug ? " active" : ""}`}
-              onClick={() => {
-                const next = !consoleDebug;
-                setConsoleDebug(next);
-                setChatScrollDebugEnabled(next);
-              }}
-              title="Toggle console mirror"
-              aria-pressed={consoleDebug}
-            >
-              <BugIcon size={14} aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              className="debug-scroll-ledger-btn"
-              onClick={() => {
-                clearChatScrollEvents();
-                setRecords([]);
-              }}
-              title="Clear scroll ledger"
-            >
-              <Trash2Icon size={14} aria-hidden="true" />
-            </button>
-          </div>
-        </div>
-        <div className="debug-scroll-records">
-          {recentRecords.length === 0 ? (
-            <div className="debug-scroll-empty">No scroll events captured yet.</div>
-          ) : (
-            recentRecords.map((record) => (
-              <article key={record.id} className="debug-scroll-record">
-                <header>
-                  <span>{record.event}</span>
-                  <time dateTime={record.at}>{formatDebugTime(record.at)}</time>
-                </header>
-                <pre>{formatDebugDetail(record.detail)}</pre>
-              </article>
-            ))
-          )}
-        </div>
-      </aside>
+    </div>
+  );
+}
+
+function DebugAccessScreen({
+  title,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <div className="debug-scroll-access">
+      <div>
+        <h1>{title}</h1>
+        {actionLabel && onAction && (
+          <button type="button" className="btn-primary" onClick={onAction}>
+            {actionLabel}
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -481,7 +480,7 @@ function mockReplyFor(prompt: string, turn: number): string {
   return [
     `Mock response for turn ${turn}.`,
     `You posted: "${prompt.slice(0, 120)}".`,
-    "This reply streams in chunks so follow-output, tail pinning, and the scroll ledger can be inspected without a live runner.",
+    "This reply streams in chunks so follow-output, tail pinning, and Prometheus scroll metrics can be inspected without a live runner.",
     "If you scroll upward before it finishes, the viewport should stay where you left it and the latest button should become reachable.",
   ].join(" ");
 }
@@ -497,18 +496,4 @@ function mockTime(turn: number, sequence: number): string {
 function mockOrderKey(turn: number, sequence: number): string {
   const millis = TURN_TIME_BASE + (turn + TURN_ORDER_OFFSET) * 60_000 + sequence * 1000;
   return `${String(millis).padStart(13, "0")}-${String(Math.round(sequence * 1000)).padStart(8, "0")}-debug`;
-}
-
-function formatDebugTime(value: string): string {
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return value;
-  return new Date(parsed).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-}
-
-function formatDebugDetail(detail: Record<string, unknown>): string {
-  return JSON.stringify(detail, null, 2);
 }

--- a/frontend/src/chatScrollTelemetry.test.ts
+++ b/frontend/src/chatScrollTelemetry.test.ts
@@ -2,19 +2,21 @@ import { afterEach, beforeEach, test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  clearChatScrollEvents,
+  flushChatScrollMetricsForTest,
   isChatScrollDebugEnabled,
   logChatScrollEvent,
-  readChatScrollEvents,
 } from "./chatScrollTelemetry";
 
 let fakeStorage: Record<string, string>;
 let consoleLogs: Array<[string, unknown[]]>;
 let origConsoleLog: typeof console.log;
+let fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }>;
+let origFetch: typeof fetch;
 
 beforeEach(() => {
   fakeStorage = {};
   consoleLogs = [];
+  fetchCalls = [];
 
   (globalThis as { localStorage?: unknown }).localStorage = {
     getItem(key: string) {
@@ -41,20 +43,25 @@ beforeEach(() => {
   console.log = (message: string, ...args: unknown[]) => {
     consoleLogs.push([message, args]);
   };
-  clearChatScrollEvents();
+  origFetch = fetch;
+  (globalThis as { fetch: typeof fetch }).fetch = (async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response("{}", { status: 202 });
+  }) as typeof fetch;
 });
 
 afterEach(() => {
   console.log = origConsoleLog;
+  (globalThis as { fetch: typeof fetch }).fetch = origFetch;
   delete (globalThis as { localStorage?: unknown }).localStorage;
+  delete (globalThis as { window?: unknown }).window;
 });
 
 test("chat scroll debug logs are off by default", () => {
   assert.equal(isChatScrollDebugEnabled(), false);
   logChatScrollEvent("timeline-loaded", { sessionId: "101" });
   assert.equal(consoleLogs.length, 0);
-  assert.equal(readChatScrollEvents().length, 1);
-  assert.equal(readChatScrollEvents()[0]?.event, "timeline-loaded");
+  assert.equal(fakeStorage["tank.chatScrollEvents"], undefined);
 });
 
 test("chat scroll debug logs fire when tankDebug includes chat-scroll", () => {
@@ -65,9 +72,27 @@ test("chat scroll debug logs fire when tankDebug includes chat-scroll", () => {
   assert.equal(consoleLogs[0]?.[0], "[tank/chat-scroll] timeline-loaded");
 });
 
-test("chat scroll ledger can be cleared without console debug", () => {
-  logChatScrollEvent("at-bottom-change", { sessionId: "101", atBottom: false });
-  assert.equal(readChatScrollEvents().length, 1);
-  clearChatScrollEvents();
-  assert.deepEqual(readChatScrollEvents(), []);
+test("chat scroll metrics flush to the prometheus ingestion endpoint", () => {
+  fakeStorage["auth-romaine-jwt"] = "token-123";
+  const listeners: Record<string, EventListener> = {};
+  (globalThis as { window?: unknown }).window = {
+    location: { pathname: "/sessions/101" },
+    setTimeout: () => 1,
+    addEventListener: (event: string, listener: EventListener) => {
+      listeners[event] = listener;
+    },
+  };
+  logChatScrollEvent("at-bottom-change", {
+    sessionMode: "codex_gui",
+    atBottom: false,
+    bottomDistance: 240,
+  });
+  flushChatScrollMetricsForTest();
+
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0]?.input, "/api/client-metrics/chat-scroll");
+  assert.equal(fetchCalls[0]?.init?.method, "POST");
+  assert.equal(new Headers(fetchCalls[0]?.init?.headers).get("Authorization"), "Bearer token-123");
+  assert.match(String(fetchCalls[0]?.init?.body), /"event":"at-bottom-change"/);
+  assert.match(String(fetchCalls[0]?.init?.body), /"sessionMode":"codex_gui"/);
 });

--- a/frontend/src/chatScrollTelemetry.ts
+++ b/frontend/src/chatScrollTelemetry.ts
@@ -1,30 +1,39 @@
+import { getStoredToken } from "./auth";
+
 // Chat transcript scroll telemetry. Console logging is opt-in per browser with
 // `localStorage.tankDebug = "chat-scroll"` or a comma-separated list that
 // includes `chat-scroll`.
 //
-// The bounded local ledger is always written. It gives the app an after-the-
-// fact diagnostic surface for user-visible scroll trust failures without
-// making browser-local position a product source of truth.
+// Production observability is Prometheus-backed: semantic browser events are
+// batched to the orchestrator, which owns the bounded metric labels.
 
 const DEBUG_STORAGE_KEY = "tankDebug";
 const DEBUG_TOKEN = "chat-scroll";
 const CONSOLE_PREFIX = "[tank/chat-scroll]";
-const LEDGER_STORAGE_KEY = "tank.chatScrollEvents";
-const LEDGER_EVENT_NAME = "tank:chat-scroll-telemetry";
-const MAX_LEDGER_RECORDS = 500;
+const METRICS_ENDPOINT = "/api/client-metrics/chat-scroll";
+const MAX_BATCH_EVENTS = 40;
+const FLUSH_DELAY_MS = 1_000;
 const MAX_DETAIL_KEYS = 60;
 const MAX_STRING_LENGTH = 260;
 
-export interface ChatScrollTelemetryRecord {
-  id: string;
-  at: string;
+interface ChatScrollMetricPayload {
   event: string;
-  detail: Record<string, unknown>;
-  path?: string;
+  surface: string;
+  sessionMode: string;
+  atBottom?: boolean;
+  hasScrollParent?: boolean;
+  scrollTop?: number;
+  scrollHeight?: number;
+  clientHeight?: number;
+  bottomDistance?: number;
+  entries?: number;
+  groups?: number;
+  messages?: number;
+  toolGroups?: number;
 }
 
-let volatileLedger: ChatScrollTelemetryRecord[] = [];
-let sequence = 0;
+let pendingMetrics: ChatScrollMetricPayload[] = [];
+let flushTimer: number | null = null;
 
 export function isChatScrollDebugEnabled(): boolean {
   try {
@@ -38,48 +47,14 @@ export function isChatScrollDebugEnabled(): boolean {
   }
 }
 
-export function setChatScrollDebugEnabled(enabled: boolean): void {
-  try {
-    const tokens = new Set(
-      (localStorage.getItem(DEBUG_STORAGE_KEY) ?? "")
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean),
-    );
-    if (enabled) tokens.add(DEBUG_TOKEN);
-    else tokens.delete(DEBUG_TOKEN);
-    if (tokens.size === 0) {
-      localStorage.removeItem(DEBUG_STORAGE_KEY);
-    } else {
-      localStorage.setItem(DEBUG_STORAGE_KEY, [...tokens].join(","));
-    }
-  } catch {
-    // localStorage can be unavailable in hardened/private contexts.
-  }
-}
-
 export function logChatScrollEvent(
   event: string,
   detail: Record<string, unknown> = {},
 ): void {
-  const record = appendChatScrollRecord(event, detail);
+  const sanitized = sanitizeDetail(detail);
+  enqueueChatScrollMetric(event, sanitized);
   if (!isChatScrollDebugEnabled()) return;
-  console.log(`${CONSOLE_PREFIX} ${event}`, record.detail);
-}
-
-export function readChatScrollEvents(): ChatScrollTelemetryRecord[] {
-  const persisted = readPersistedLedger();
-  return persisted.length > 0 ? persisted : volatileLedger;
-}
-
-export function clearChatScrollEvents(): void {
-  volatileLedger = [];
-  try {
-    localStorage.removeItem(LEDGER_STORAGE_KEY);
-  } catch {
-    // localStorage can be unavailable in hardened/private contexts.
-  }
-  emitChatScrollRecordEvent(null);
+  console.log(`${CONSOLE_PREFIX} ${event}`, sanitized);
 }
 
 export function chatScrollElementSnapshot(
@@ -98,52 +73,87 @@ export function chatScrollElementSnapshot(
   };
 }
 
-function appendChatScrollRecord(
+export function flushChatScrollMetricsForTest(): void {
+  if (flushTimer !== null && typeof window !== "undefined") {
+    if (typeof window.clearTimeout === "function") {
+      window.clearTimeout(flushTimer);
+    }
+    flushTimer = null;
+  }
+  flushChatScrollMetrics();
+}
+
+function enqueueChatScrollMetric(
   event: string,
   detail: Record<string, unknown>,
-): ChatScrollTelemetryRecord {
-  sequence += 1;
-  const record: ChatScrollTelemetryRecord = {
-    id: `${Date.now()}-${sequence}`,
-    at: new Date().toISOString(),
+): void {
+  if (typeof window === "undefined") return;
+  pendingMetrics.push({
     event,
-    detail: sanitizeDetail(detail),
-    path: typeof window !== "undefined" ? window.location.pathname : undefined,
-  };
-  const nextLedger = [...readChatScrollEvents(), record].slice(-MAX_LEDGER_RECORDS);
-  volatileLedger = nextLedger;
-  try {
-    localStorage.setItem(LEDGER_STORAGE_KEY, JSON.stringify(nextLedger));
-  } catch {
-    // Keep the in-memory ledger when localStorage quota/access fails.
+    surface: metricString(detail.surface) || inferMetricSurface(),
+    sessionMode: metricString(detail.sessionMode) || "unknown",
+    atBottom: typeof detail.atBottom === "boolean" ? detail.atBottom : undefined,
+    hasScrollParent:
+      typeof detail.hasScrollParent === "boolean" ? detail.hasScrollParent : undefined,
+    scrollTop: metricNumber(detail.scrollTop),
+    scrollHeight: metricNumber(detail.scrollHeight),
+    clientHeight: metricNumber(detail.clientHeight),
+    bottomDistance: metricNumber(detail.bottomDistance),
+    entries: metricNumber(detail.entries),
+    groups: metricNumber(detail.groups),
+    messages: metricNumber(detail.messages),
+    toolGroups: metricNumber(detail.toolGroups),
+  });
+  if (pendingMetrics.length >= MAX_BATCH_EVENTS) {
+    flushChatScrollMetrics();
+    return;
   }
-  emitChatScrollRecordEvent(record);
-  return record;
+  scheduleFlush();
 }
 
-function readPersistedLedger(): ChatScrollTelemetryRecord[] {
-  try {
-    const raw = localStorage.getItem(LEDGER_STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isChatScrollTelemetryRecord).slice(-MAX_LEDGER_RECORDS);
-  } catch {
-    return [];
-  }
+function scheduleFlush(): void {
+  if (typeof window === "undefined" || flushTimer !== null) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    flushChatScrollMetrics();
+  }, FLUSH_DELAY_MS);
 }
 
-function isChatScrollTelemetryRecord(value: unknown): value is ChatScrollTelemetryRecord {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const candidate = value as Record<string, unknown>;
-  return (
-    typeof candidate.id === "string" &&
-    typeof candidate.at === "string" &&
-    typeof candidate.event === "string" &&
-    Boolean(candidate.detail) &&
-    typeof candidate.detail === "object" &&
-    !Array.isArray(candidate.detail)
-  );
+function flushChatScrollMetrics(): void {
+  if (typeof window === "undefined" || pendingMetrics.length === 0) return;
+  const events = pendingMetrics.splice(0, MAX_BATCH_EVENTS);
+  let token: string | null = null;
+  try {
+    token = getStoredToken();
+  } catch {
+    return;
+  }
+  if (!token) return;
+  if (typeof fetch !== "function") return;
+  fetch(METRICS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ events }),
+    keepalive: true,
+  }).catch(() => undefined);
+  if (pendingMetrics.length > 0) scheduleFlush();
+}
+
+function inferMetricSurface(): string {
+  if (typeof window === "undefined") return "unknown";
+  return window.location.pathname.startsWith("/_debug/") ? "debug_lab" : "session";
+}
+
+function metricString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, 80);
+}
+
+function metricNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function sanitizeDetail(detail: Record<string, unknown>): Record<string, unknown> {
@@ -170,7 +180,10 @@ function sanitizeValue(value: unknown, depth: number): unknown {
   if (typeof value === "object") {
     if (depth >= 2) return "[object]";
     const out: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(value as Record<string, unknown>).slice(0, 20)) {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>).slice(
+      0,
+      20,
+    )) {
       out[key] = sanitizeValue(child, depth + 1);
     }
     return out;
@@ -178,11 +191,6 @@ function sanitizeValue(value: unknown, depth: number): unknown {
   return String(value);
 }
 
-function emitChatScrollRecordEvent(record: ChatScrollTelemetryRecord | null): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.dispatchEvent(new CustomEvent(LEDGER_EVENT_NAME, { detail: record }));
-  } catch {
-    // CustomEvent can be blocked in unusual embedded contexts.
-  }
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", flushChatScrollMetrics);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6382,14 +6382,14 @@ textarea.run-files-viewer-editor:focus {
 .debug-scroll-lab {
   width: 100%;
   height: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(20rem, 28rem);
+  display: block;
   overflow: hidden;
   background: var(--bg-base, #0a0a0a);
 }
 
 .debug-long-chat {
-  border-right: 1px solid var(--border-soft, rgba(255, 255, 255, 0.08));
+  width: 100%;
+  height: 100%;
 }
 
 .debug-long-chat-title {
@@ -6410,129 +6410,25 @@ textarea.run-files-viewer-editor:focus {
   font-size: var(--text-xs);
 }
 
-.debug-scroll-ledger {
-  min-width: 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  background: #101010;
+.debug-scroll-access {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  background: var(--bg-base, #0a0a0a);
+  color: var(--text-primary);
   font-family: var(--font-primary);
 }
 
-.debug-scroll-ledger-header {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3);
-  border-bottom: 1px solid var(--border-soft, rgba(255, 255, 255, 0.08));
-}
-
-.debug-scroll-ledger-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: var(--text-primary);
-  font-size: var(--text-sm);
-  font-weight: 650;
-}
-
-.debug-scroll-ledger-subtitle {
-  display: block;
-  margin-top: 0.15rem;
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-}
-
-.debug-scroll-ledger-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.debug-scroll-ledger-btn {
-  width: 2rem;
-  height: 2rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.45rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.035);
-  color: var(--text-muted);
-  cursor: pointer;
-}
-
-.debug-scroll-ledger-btn:hover,
-.debug-scroll-ledger-btn.active {
-  border-color: rgba(103, 232, 249, 0.35);
-  background: rgba(103, 232, 249, 0.1);
-  color: var(--cyan-bright);
-}
-
-.debug-scroll-records {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow: auto;
-  padding: var(--space-3);
+.debug-scroll-access > div {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-}
-
-.debug-scroll-empty {
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-  padding: var(--space-3);
-}
-
-.debug-scroll-record {
-  border: 1px solid rgba(255, 255, 255, 0.075);
-  border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.025);
-  overflow: hidden;
-}
-
-.debug-scroll-record header {
-  display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  padding: 0.45rem 0.55rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
-  color: var(--text-primary);
-  font-size: var(--text-xs);
-  font-weight: 650;
+  gap: var(--space-4);
 }
 
-.debug-scroll-record time {
-  flex: 0 0 auto;
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
-.debug-scroll-record pre {
+.debug-scroll-access h1 {
   margin: 0;
-  max-height: 12rem;
-  overflow: auto;
-  padding: 0.55rem;
-  color: var(--text-body);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  line-height: 1.45;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-@media (max-width: 980px) {
-  .debug-scroll-lab {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(0, 1fr) minmax(12rem, 34vh);
-  }
-
-  .debug-long-chat {
-    border-right: 0;
-    border-bottom: 1px solid var(--border-soft, rgba(255, 255, 255, 0.08));
-  }
+  font-size: var(--text-lg);
+  font-weight: 650;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -48,7 +48,6 @@ const TANK_KEY_ALLOWLIST = [
   "tank.defaultInteraction",
   "tank.homeSelectedRepos",
   "tank.sessionInteraction:",
-  "tank.chatScrollEvents",
 ];
 function isAllowedTankKey(key: string): boolean {
   for (const allowed of TANK_KEY_ALLOWLIST) {

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -9,6 +9,7 @@ function readSource(path: string): string {
 const appSource = readSource("./App.tsx");
 const conversationReducerSource = readSource("./conversationReducer.ts");
 const chatScrollTelemetrySource = readSource("./chatScrollTelemetry.ts");
+const longChatDebugSource = readSource("./LongChatDebugPage.tsx");
 const mainSource = readSource("./main.tsx");
 const indexCssSource = readSource("./index.css");
 const sessionConfigMapSource = readSource("../../k8s/templates/session-configmap.yaml");
@@ -228,17 +229,20 @@ test("chat back-pagination keeps the focused load button mounted while loading",
   assert.equal(appSource.includes("run-transcript-load-older-passive"), false);
 });
 
-test("chat scroll diagnostics are debug gated", () => {
+test("chat scroll diagnostics are prometheus backed", () => {
   assert.equal(chatScrollTelemetrySource.includes('DEBUG_TOKEN = "chat-scroll"'), true);
   assert.equal(chatScrollTelemetrySource.includes("isChatScrollDebugEnabled"), true);
-  assert.equal(chatScrollTelemetrySource.includes("readChatScrollEvents"), true);
-  assert.equal(chatScrollTelemetrySource.includes("tank.chatScrollEvents"), true);
+  assert.equal(chatScrollTelemetrySource.includes("/api/client-metrics/chat-scroll"), true);
+  assert.equal(chatScrollTelemetrySource.includes("tank.chatScrollEvents"), false);
   assert.equal(appSource.includes("logChatScrollGroups"), true);
   assert.equal(appSource.includes("logChatScrollEntries"), true);
 });
 
-test("long-chat scroll lab route is available without the authenticated app", () => {
+test("long-chat scroll lab route is admin gated and uses prometheus metrics", () => {
   assert.equal(mainSource.includes('"/_debug/long-chat"'), true);
   assert.equal(mainSource.includes("LongChatDebugPage"), true);
-  assert.equal(mainSource.includes("tank.chatScrollEvents"), true);
+  assert.equal(mainSource.includes("tank.chatScrollEvents"), false);
+  assert.equal(longChatDebugSource.includes("bootstrapAuth"), true);
+  assert.equal(longChatDebugSource.includes('user.role === "admin"'), true);
+  assert.equal(longChatDebugSource.includes("readChatScrollEvents"), false);
 });


### PR DESCRIPTION
## Summary
- replace the browser-local chat scroll ledger with authenticated Prometheus-backed client metrics ingestion
- add bounded server-side Prometheus labels and histograms for chat transcript scroll diagnostics
- keep the long-chat debug lab admin-gated while sending mock-lab scroll events to the same metrics path

## Validation
- npm test
- npm run build
- go test ./...
- git diff --check