### PR TITLE
Keep splash composer controls visible

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1067,6 +1067,61 @@ function currentSessionSkillState(
   return null;
 }
 
+interface ComposerUsageRingProps {
+  tokensUsed: number;
+  contextWindow: number;
+  placeholder?: boolean;
+  ariaLabel?: string;
+  title?: string;
+}
+
+function ComposerUsageRing({
+  tokensUsed,
+  contextWindow,
+  placeholder = false,
+  ariaLabel = "Context usage",
+  title,
+}: ComposerUsageRingProps) {
+  const safeContextWindow = Math.max(contextWindow, 1);
+  const usagePct = Math.min(100, (tokensUsed / safeContextWindow) * 100);
+  const usageLevel = usagePct >= 75 ? "high" : usagePct >= 50 ? "mid" : "low";
+  const displayPct = usagePct.toFixed(usagePct < 10 ? 1 : 0);
+
+  return (
+    <span
+      className={`run-usage-ring${placeholder ? " is-placeholder" : ""}`}
+      aria-label={ariaLabel}
+      aria-disabled={placeholder || undefined}
+      title={title ?? `${tokensUsed.toLocaleString()} / ${contextWindow.toLocaleString()} tokens`}
+      data-level={placeholder ? undefined : usageLevel}
+    >
+      <svg className="run-usage-ring-svg" viewBox="0 0 32 32" aria-hidden="true">
+        <circle
+          cx="16"
+          cy="16"
+          r="13"
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity="0.18"
+          strokeWidth="2.5"
+        />
+        <circle
+          cx="16"
+          cy="16"
+          r="13"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeDasharray={`${(usagePct / 100) * (2 * Math.PI * 13)} ${2 * Math.PI * 13}`}
+          transform="rotate(-90 16 16)"
+        />
+      </svg>
+      <span className="run-usage-ring-text">{displayPct}%</span>
+    </span>
+  );
+}
+
 function sessionSkillStateClass(session: Session): string {
   const currentSkill = currentSessionSkillState(session.test_state, session.rollout_state);
   if (currentSkill === "test") return " is-skill-test";
@@ -1844,7 +1899,7 @@ function DemoLanding() {
                   session. The icon row mirrors the authenticated home so
                   the demo accurately previews the chat surface. */}
               <ChatComposer
-                className="run-composer-home"
+                className="run-composer-home run-composer-interactive"
                 placeholder="Sign in to start a session…"
                 onSubmit={() => {
                   startLogin();
@@ -1863,6 +1918,24 @@ function DemoLanding() {
                     >
                       <ImageIcon className="run-composer-icon" aria-hidden="true" />
                     </button>
+                    <ComposerUsageRing
+                      tokensUsed={0}
+                      contextWindow={getContextWindow(selectedDemoModelId)}
+                      placeholder
+                      ariaLabel="Context usage preview"
+                      title="Context usage appears after sign in"
+                    />
+                    {GUI_ROLLOUT_MODES.has(selectedMode) && (
+                      <button
+                        type="button"
+                        className="run-composer-icon-btn run-composer-action-btn run-rollout-action-btn"
+                        disabled
+                        aria-label="Start rollout"
+                        title="Sign in to use /rollout"
+                      >
+                        <TankIcon className="run-composer-icon" aria-hidden="true" />
+                      </button>
+                    )}
                     <button
                       type="button"
                       className="run-composer-icon-btn run-composer-action-btn run-test-action-btn"
@@ -7698,8 +7771,6 @@ function ChatPane({
   const testActionActive = currentSkillState === "test";
   const rolloutActionActive = currentSkillState === "rollout";
   const contextWindow = getContextWindow(selectedModelId);
-  const usagePct = Math.min(100, (tokensUsed / contextWindow) * 100);
-  const usageLevel = usagePct >= 75 ? "high" : usagePct >= 50 ? "mid" : "low";
 
   const focusComposerTextarea = useCallback((): boolean => {
     const textarea = composerWrapRef.current?.querySelector("textarea") as HTMLTextAreaElement | null;
@@ -8712,145 +8783,119 @@ function ChatPane({
       </>)}
       composer={(
         <ChatComposer
-            placeholder={RUN_COMPOSER_PLACEHOLDER}
-            onSubmit={(args) => handleSubmit({ text: args.text, files: [] })}
-            permissionMode={composerMode}
-            onPermissionModeChange={setComposerMode}
-            sendByCtrlEnter={runPrefs.sendByCtrlEnter}
-            hintSuffix={RUN_COMPOSER_HINT_SUFFIX}
-            disabled={!ready}
-            submitStatus={submitStatus}
-            onStop={cancelRun}
-            isStopping={runStatus === "stopping"}
-            onTextChange={setComposerText}
-            toolButtons={
-              <>
-                {/* Image-attach — opens the hidden file input. Drag-and-drop
+          className="run-composer-runpane run-composer-interactive"
+          placeholder={RUN_COMPOSER_PLACEHOLDER}
+          onSubmit={(args) => handleSubmit({ text: args.text, files: [] })}
+          permissionMode={composerMode}
+          onPermissionModeChange={setComposerMode}
+          sendByCtrlEnter={runPrefs.sendByCtrlEnter}
+          hintSuffix={RUN_COMPOSER_HINT_SUFFIX}
+          canSubmit={ready}
+          controlsDisabled={!ready}
+          submitStatus={submitStatus}
+          onStop={cancelRun}
+          isStopping={runStatus === "stopping"}
+          onTextChange={setComposerText}
+          toolButtons={
+            <>
+              {/* Image-attach — opens the hidden file input. Drag-and-drop
                     and clipboard paste are wired on the composer wrap. */}
+              <button
+                type="button"
+                className="run-composer-icon-btn"
+                aria-label="Attach files"
+                title={
+                  supportsFileAttachments
+                    ? "Attach files"
+                    : "File attachments require a session workspace"
+                }
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!supportsFileAttachments}
+              >
+                <ImageIcon className="run-composer-icon" aria-hidden="true" />
+              </button>
+              <ComposerUsageRing
+                tokensUsed={tokensUsed}
+                contextWindow={contextWindow}
+              />
+              {GUI_ROLLOUT_MODES.has(session.mode) && (
                 <button
                   type="button"
-                  className="run-composer-icon-btn"
-                  aria-label="Attach files"
-                  title={
-                    supportsFileAttachments
-                      ? "Attach files"
-                      : "File attachments require a session workspace"
-                  }
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={!supportsFileAttachments}
+                  className={`run-composer-icon-btn run-composer-action-btn run-rollout-action-btn${rolloutActionActive ? " is-active" : ""}`}
+                  onClick={startGuiRollout}
+                  disabled={!ready}
+                  aria-label="Start rollout"
+                  title={isClaude ? "Use /rollout in this run" : "Use $rollout in this run"}
                 >
-                  <ImageIcon className="run-composer-icon" aria-hidden="true" />
+                  <TankIcon className="run-composer-icon" />
                 </button>
-                <span
-                  className="run-usage-ring"
-                  aria-label={`Context usage: ${usagePct.toFixed(1)}%`}
-                  title={`${tokensUsed.toLocaleString()} / ${contextWindow.toLocaleString()} tokens`}
-                  data-level={usageLevel}
+              )}
+              {testState?.active && testState.url ? (
+                <a
+                  className={`run-composer-icon-btn run-composer-action-btn run-test-action-btn is-ready${testActionActive ? " is-active" : ""}`}
+                  href={testState.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => {
+                    void markTestState({ ...testState, active: true });
+                  }}
+                  aria-label="Open test environment in new tab"
+                  title="Open test environment in new tab"
                 >
-                  <svg className="run-usage-ring-svg" viewBox="0 0 32 32" aria-hidden="true">
-                    <circle
-                      cx="16"
-                      cy="16"
-                      r="13"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeOpacity="0.18"
-                      strokeWidth="2.5"
-                    />
-                    <circle
-                      cx="16"
-                      cy="16"
-                      r="13"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2.5"
-                      strokeLinecap="round"
-                      strokeDasharray={`${(usagePct / 100) * (2 * Math.PI * 13)} ${2 * Math.PI * 13}`}
-                      transform="rotate(-90 16 16)"
-                    />
-                  </svg>
-                  <span className="run-usage-ring-text">
-                    {usagePct.toFixed(usagePct < 10 ? 1 : 0)}%
+                  <FlaskConicalIcon className="run-composer-icon" aria-hidden="true" />
+                  <ExternalLinkIcon className="run-test-ready-icon" aria-hidden="true" />
+                </a>
+              ) : (
+                <button
+                  type="button"
+                  className={`run-composer-icon-btn run-composer-action-btn run-test-action-btn${testActionActive ? " is-active" : ""}`}
+                  onClick={startTestSkill}
+                  disabled={!ready}
+                  aria-label="Start test skill"
+                  title={testState?.active ? "Test skill is active" : "Use the test skill"}
+                >
+                  <FlaskConicalIcon className="run-composer-icon" aria-hidden="true" />
+                </button>
+              )}
+              <button
+                type="button"
+                className="run-composer-icon-btn run-command-menu-btn"
+                aria-label="Show slash commands"
+                title="Show slash commands"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  openSlashCommandMenu();
+                }}
+              >
+                <MessageSquareIcon className="run-composer-icon" aria-hidden="true" />
+                {slashCommands.length > 0 && (
+                  <span className="run-command-menu-count">
+                    {slashCommands.length}
                   </span>
-                </span>
-                {GUI_ROLLOUT_MODES.has(session.mode) && (
-                  <button
-                    type="button"
-                    className={`run-composer-icon-btn run-composer-action-btn run-rollout-action-btn${rolloutActionActive ? " is-active" : ""}`}
-                    onClick={startGuiRollout}
-                    disabled={!ready}
-                    aria-label="Start rollout"
-                    title={isClaude ? "Use /rollout in this run" : "Use $rollout in this run"}
-                  >
-                    <TankIcon className="run-composer-icon" />
-                  </button>
                 )}
-                {testState?.active && testState.url ? (
-                  <a
-                    className={`run-composer-icon-btn run-composer-action-btn run-test-action-btn is-ready${testActionActive ? " is-active" : ""}`}
-                    href={testState.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    onClick={() => {
-                      void markTestState({ ...testState, active: true });
-                    }}
-                    aria-label="Open test environment in new tab"
-                    title="Open test environment in new tab"
-                  >
-                    <FlaskConicalIcon className="run-composer-icon" aria-hidden="true" />
-                    <ExternalLinkIcon className="run-test-ready-icon" aria-hidden="true" />
-                  </a>
-                ) : (
-                  <button
-                    type="button"
-                    className={`run-composer-icon-btn run-composer-action-btn run-test-action-btn${testActionActive ? " is-active" : ""}`}
-                    onClick={startTestSkill}
-                    disabled={!ready}
-                    aria-label="Start test skill"
-                    title={testState?.active ? "Test skill is active" : "Use the test skill"}
-                  >
-                    <FlaskConicalIcon className="run-composer-icon" aria-hidden="true" />
-                  </button>
+              </button>
+              <button
+                type="button"
+                className="run-composer-icon-btn run-command-menu-btn"
+                aria-label="Show MCP servers"
+                title="Show MCP servers"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  setSlashOpen(false);
+                  setMentionOpen(false);
+                  setMcpOpen((open) => !open);
+                }}
+              >
+                <McpIcon className="run-composer-icon" aria-hidden="true" />
+                {mcpServers && mcpServers.length > 0 && (
+                  <span className="run-command-menu-count">
+                    {mcpServers.length}
+                  </span>
                 )}
-                <button
-                  type="button"
-                  className="run-composer-icon-btn run-command-menu-btn"
-                  aria-label="Show slash commands"
-                  title="Show slash commands"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    openSlashCommandMenu();
-                  }}
-                >
-                  <MessageSquareIcon className="run-composer-icon" aria-hidden="true" />
-                  {slashCommands.length > 0 && (
-                    <span className="run-command-menu-count">
-                      {slashCommands.length}
-                    </span>
-                  )}
-                </button>
-                <button
-                  type="button"
-                  className="run-composer-icon-btn run-command-menu-btn"
-                  aria-label="Show MCP servers"
-                  title="Show MCP servers"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    setSlashOpen(false);
-                    setMentionOpen(false);
-                    setMcpOpen((open) => !open);
-                  }}
-                >
-                  <McpIcon className="run-composer-icon" aria-hidden="true" />
-                  {mcpServers && mcpServers.length > 0 && (
-                    <span className="run-command-menu-count">
-                      {mcpServers.length}
-                    </span>
-                  )}
-                </button>
-              </>
-            }
-          />
+              </button>
+            </>
+          }
+        />
       )}
     />
     </RunContext.Provider>
@@ -11008,6 +11053,7 @@ export function App() {
             </>)}
             composer={(
               <ChatComposer
+                className="run-composer-home run-composer-interactive"
                 placeholder={RUN_COMPOSER_PLACEHOLDER}
                 onSubmit={({ text, permissionMode }) => {
                   const trimmed = text.trim();
@@ -11031,71 +11077,72 @@ export function App() {
                 disabled={busy}
                 onTextChange={setHomeComposerText}
                 toolButtons={
-                    <>
+                  <>
+                    <button
+                      type="button"
+                      className="run-composer-icon-btn"
+                      aria-label="Attach files"
+                      title={
+                        sessionModeSupportsWorkspaceFiles(defaultSessionMode)
+                          ? "Attach files for the first turn"
+                          : "File attachments require a session workspace"
+                      }
+                      onClick={() => homeFileInputRef.current?.click()}
+                      disabled={busy || !sessionModeSupportsWorkspaceFiles(defaultSessionMode)}
+                    >
+                      <ImageIcon className="run-composer-icon" aria-hidden="true" />
+                    </button>
+                    <ComposerUsageRing
+                      tokensUsed={0}
+                      contextWindow={getContextWindow(selectedHomeModelId)}
+                      placeholder
+                      ariaLabel="Context usage preview"
+                      title="Context usage appears after the session starts"
+                    />
+                    {GUI_ROLLOUT_MODES.has(defaultSessionMode) && (
                       <button
                         type="button"
-                        className="run-composer-icon-btn"
-                        aria-label="Attach files"
-                        title={
-                          sessionModeSupportsWorkspaceFiles(defaultSessionMode)
-                            ? "Attach files for the first turn"
-                            : "File attachments require a session workspace"
-                        }
-                        onClick={() => homeFileInputRef.current?.click()}
-                        disabled={busy || !sessionModeSupportsWorkspaceFiles(defaultSessionMode)}
-                      >
-                        <ImageIcon className="run-composer-icon" aria-hidden="true" />
-                      </button>
-                      {GUI_ROLLOUT_MODES.has(defaultSessionMode) && (
-                        <button
-                          type="button"
-                          className="run-composer-icon-btn run-composer-action-btn run-rollout-action-btn"
-                          disabled
-                          aria-label="Start rollout"
-                          title="Use /rollout once your session starts"
-                        >
-                          <TankIcon className="run-composer-icon" />
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        className="run-composer-icon-btn run-composer-action-btn run-test-action-btn"
-                        onClick={() => {
-                          void createSession(
-                            defaultSessionMode,
-                            homeComposerText.trim() || undefined,
-                            homeComposerMode,
-                            "test",
-                          );
-                        }}
-                        disabled={busy || !CHAT_MODES.has(defaultSessionMode)}
-                        aria-label="Start test skill"
-                        title={
-                          CHAT_MODES.has(defaultSessionMode)
-                            ? selectedProvider === "anthropic"
-                              ? "Start with /test"
-                              : "Start with $test"
-                            : "Choose a GUI chat runtime to start with test"
-                        }
-                      >
-                        <FlaskConicalIcon className="run-composer-icon" aria-hidden="true" />
-                      </button>
-                      <button
-                        type="button"
-                        className="run-composer-icon-btn run-command-menu-btn"
+                        className="run-composer-icon-btn run-composer-action-btn run-rollout-action-btn"
                         disabled
-                        aria-label="Show slash commands"
-                        title="Slash commands appear once your session has skills"
+                        aria-label="Start rollout"
+                        title="Use /rollout once your session starts"
                       >
-                        <MessageSquareIcon className="run-composer-icon" aria-hidden="true" />
+                        <TankIcon className="run-composer-icon" />
                       </button>
-                      <button
-                        type="button"
-                        className="run-composer-icon-btn run-command-menu-btn"
-                        disabled
-                        aria-label="Show MCP servers"
-                        title="MCP servers appear once your session is connected"
-                      >
+                    )}
+                    <button
+                      type="button"
+                      className="run-composer-icon-btn run-composer-action-btn run-test-action-btn"
+                      onClick={() => {
+                        void createSession(
+                          defaultSessionMode,
+                          homeComposerText.trim() || undefined,
+                          homeComposerMode,
+                          "test",
+                        );
+                      }}
+                      disabled
+                      aria-label="Start test skill"
+                      title="Available in an active chat session"
+                    >
+                      <FlaskConicalIcon className="run-composer-icon" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      className="run-composer-icon-btn run-command-menu-btn"
+                      disabled
+                      aria-label="Show slash commands"
+                      title="Slash commands appear once your session has skills"
+                    >
+                      <MessageSquareIcon className="run-composer-icon" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      className="run-composer-icon-btn run-command-menu-btn"
+                      disabled
+                      aria-label="Show MCP servers"
+                      title="MCP servers appear once your session is connected"
+                    >
                       <McpIcon className="run-composer-icon" aria-hidden="true" />
                     </button>
                   </>

--- a/frontend/src/ChatComposer.tsx
+++ b/frontend/src/ChatComposer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { FormEventHandler, ReactNode } from "react";
 import {
   PromptInput,
   PromptInputFooter,
@@ -92,6 +92,13 @@ export interface ChatComposerProps {
   hintSuffix?: string;
   /** Disables the textarea and submit (and stop) interactions. */
   disabled?: boolean;
+  /**
+   * Keeps the composer interactive but ignores submit attempts.
+   * Used while a session is warming up so the text box still invites input.
+   */
+  canSubmit?: boolean;
+  /** Disables the permission-mode dropdown and any other internal controls. */
+  controlsDisabled?: boolean;
   /** PromptInputSubmit status — drives spinner/stop icon swaps while a turn streams. */
   submitStatus?: ChatStatus;
   onStop?: () => void;
@@ -121,6 +128,8 @@ export function ChatComposer({
   sendByCtrlEnter,
   hintSuffix,
   disabled,
+  canSubmit = true,
+  controlsDisabled,
   submitStatus,
   onStop,
   isStopping,
@@ -159,13 +168,26 @@ export function ChatComposer({
 
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
+      if (!canSubmit) return;
       onSubmit({ text: message.text, permissionMode });
       // PromptInput auto-clears after a sync onSubmit; reflect that in our
       // mirror so the hint un-fades and the clear-X disappears.
       setText("");
       onTextChange?.("");
     },
-    [onSubmit, onTextChange, permissionMode],
+    [canSubmit, onSubmit, onTextChange, permissionMode],
+  );
+
+  const handleSubmitCapture = useCallback<FormEventHandler<HTMLFormElement>>(
+    (event) => {
+      if (canSubmit) return;
+      // PromptInput resets the underlying form before its own submit handler
+      // runs. Stopping propagation in capture keeps the warm-up text in place
+      // until the session is ready to accept a real turn.
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [canSubmit],
   );
 
   const handleClear = useCallback(() => {
@@ -209,6 +231,7 @@ export function ChatComposer({
     >
       <PromptInput
         onSubmit={handleSubmit}
+        onSubmitCapture={handleSubmitCapture}
         className={["run-composer", className].filter(Boolean).join(" ")}
       >
         <PromptInputTextarea
@@ -223,6 +246,7 @@ export function ChatComposer({
                 <button
                   type="button"
                   className="run-mode-pill run-mode-pill-button"
+                  disabled={disabled || controlsDisabled}
                   aria-label="Permission mode"
                 >
                   <span

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3487,6 +3487,40 @@ button:disabled {
   box-shadow: none !important;
 }
 
+/* Interactive composer shells keep the text box + send button visually live
+   even while sibling tool buttons are disabled. */
+.run-composer.run-composer-interactive,
+.run-composer.run-composer-runpane {
+  transition:
+    border-color var(--motion-fast, 120ms) ease,
+    box-shadow var(--motion-fast, 120ms) ease,
+    background var(--motion-fast, 120ms) ease;
+}
+
+.run-composer.run-composer-interactive:focus-within,
+.run-composer.run-composer-runpane:focus-within {
+  border-color: rgba(110, 168, 255, 0.42);
+  background: rgba(255, 255, 255, 0.025);
+  box-shadow:
+    0 0 0 1px rgba(110, 168, 255, 0.12),
+    0 18px 36px rgba(0, 0, 0, 0.22);
+}
+
+.run-composer.run-composer-interactive > [data-slot="input-group"],
+.run-composer.run-composer-runpane > [data-slot="input-group"] {
+  opacity: 1 !important;
+}
+
+.run-composer.run-composer-interactive .run-composer-hint,
+.run-composer.run-composer-runpane .run-composer-hint {
+  color: var(--text-secondary);
+}
+
+.run-composer.run-composer-interactive .run-composer-textarea::placeholder,
+.run-composer.run-composer-runpane .run-composer-textarea::placeholder {
+  color: rgba(255, 255, 255, 0.42);
+}
+
 .run-mode-pill {
   display: inline-flex;
   align-items: center;
@@ -3525,7 +3559,7 @@ button:disabled {
 
 /* Fades out once the composer has any content. */
 .run-composer-hint-faded {
-  opacity: 0.32;
+  opacity: 0.44;
 }
 
 /* Clear-input X — sits between the hint and the send button. */
@@ -3835,6 +3869,11 @@ button:disabled {
 .run-usage-ring[data-level="mid"]  { color: #fbbf24; }
 .run-usage-ring[data-level="high"] { color: #f87171; }
 
+.run-usage-ring.is-placeholder {
+  color: var(--text-muted);
+  opacity: 0.72;
+}
+
 .run-usage-ring-svg {
   position: absolute;
   inset: 0;
@@ -3849,6 +3888,10 @@ button:disabled {
   color: var(--text-body);
   letter-spacing: 0.02em;
   z-index: 1;
+}
+
+.run-usage-ring.is-placeholder .run-usage-ring-text {
+  color: var(--text-muted);
 }
 
 /* Comment badge — placeholder slot for thread/notes count. */

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -158,6 +158,14 @@ test("home splash test action seeds the first turn as a skill invocation", () =>
   assert.equal(appSource.includes("Available once your session starts"), false);
 });
 
+test("home splash test action stays disabled on the splash page", () => {
+  assert.match(appSource, /disabled\s+aria-label="Start test skill"\s+title="Available in an active chat session"/);
+  assert.equal(
+    appSource.includes("disabled={busy || !CHAT_MODES.has(defaultSessionMode)}"),
+    false,
+  );
+});
+
 test("files tab is gated until the session container is available", () => {
   assert.equal(appSource.includes("sessionFilesAvailable(session)"), true);
   assert.match(appSource, /if \(tab === "files" && !filesAvailable\) return;/);


### PR DESCRIPTION
## Summary
- keep the splash/demo composer visually aligned with the active chat composer by rendering the same disabled control strip and context usage ring
- keep the run-pane composer text box and submit affordance interactive during warm-up while gating real submit/control actions on readiness
- disable the splash-page mid-chat test button and add a regression guard for that state

## Verification
- git diff --check
- npm test
- npm run build
- local smoke test at http://127.0.0.1:5182/ confirmed composer controls and no toolbar overlap