### PR TITLE
Fix durable initial session launch transcript

### DIFF
--- a/.github/workflows/go-backend.yml
+++ b/.github/workflows/go-backend.yml
@@ -19,6 +19,20 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: tank
+          POSTGRES_PASSWORD: tank
+          POSTGRES_DB: tank_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U tank -d tank_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     defaults:
       run:
         working-directory: backend-go
@@ -30,4 +44,6 @@ jobs:
           go-version-file: backend-go/go.mod
 
       - name: go test
+        env:
+          TANK_TEST_POSTGRES_DSN: postgres://tank:tank@localhost:5432/tank_test?sslmode=disable
         run: go test ./...

--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/nelsong6/tank-operator/backend-go/internal/conversation"
 	"github.com/nelsong6/tank-operator/backend-go/internal/kubeexec"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
@@ -36,6 +37,75 @@ func repoSelectionBucket(count int) string {
 	}
 }
 
+type createSessionInitialTurnRequest struct {
+	ClientNonce    string `json:"client_nonce"`
+	Prompt         string `json:"prompt"`
+	Model          string `json:"model,omitempty"`
+	Effort         string `json:"effort,omitempty"`
+	PermissionMode string `json:"permission_mode,omitempty"`
+	SkillName      string `json:"skill_name,omitempty"`
+	Deferred       bool   `json:"deferred,omitempty"`
+}
+
+func validateCreateSessionInitialTurn(mode string, turn *createSessionInitialTurnRequest) (createSessionInitialTurnRequest, int, string) {
+	if turn == nil {
+		return createSessionInitialTurnRequest{}, 0, ""
+	}
+	runtime, ok := turnRuntimeForSessionMode(mode)
+	if !ok {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn is only supported for durable chat sessions"
+	}
+	if turn.Deferred && sessionmodel.IsNoPodMode(mode) {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.deferred requires a session workspace"
+	}
+	clientNonce := strings.TrimSpace(turn.ClientNonce)
+	if clientNonce == "" || !turnIDPattern.MatchString(clientNonce) {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.client_nonce is required and must match turn id syntax"
+	}
+	prompt := strings.TrimSpace(turn.Prompt)
+	if prompt == "" {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.prompt is required"
+	}
+	if len([]byte(prompt)) > maxSDKTurnPromptBytes {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.prompt too large"
+	}
+	skillName := validateSkillName(turn.SkillName)
+	if strings.TrimSpace(turn.SkillName) != "" && skillName == "" {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.skill_name is invalid"
+	}
+	if skillName != "" && !promptMatchesSkillTrigger(runtime, skillName, prompt) {
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.skill_name does not match prompt trigger"
+	}
+	effort := validateEffort(runtime, strings.TrimSpace(turn.Effort))
+	if strings.TrimSpace(turn.Effort) != "" && effort == "" {
+		if runtime == "codex" {
+			return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.effort is invalid; want one of low|medium|high|xhigh"
+		}
+		return createSessionInitialTurnRequest{}, http.StatusBadRequest, "initial_turn.effort is invalid; want one of low|medium|high|xhigh|max"
+	}
+	return createSessionInitialTurnRequest{
+		ClientNonce:    clientNonce,
+		Prompt:         prompt,
+		Model:          strings.TrimSpace(turn.Model),
+		Effort:         effort,
+		PermissionMode: strings.TrimSpace(turn.PermissionMode),
+		SkillName:      skillName,
+		Deferred:       turn.Deferred,
+	}, 0, ""
+}
+
+func turnRuntimeForSessionMode(mode string) (string, bool) {
+	if sessionmodel.IsNoPodMode(mode) {
+		switch sessionmodel.NormalizeSessionMode(mode) {
+		case sessionmodel.HermesGUIMode:
+			return "hermes", true
+		default:
+			return "", false
+		}
+	}
+	return sdkProviderForMode(mode)
+}
+
 // handleCreateSession creates a new session pod. Accepts the optional
 // `repos[]` selection from the splash picker; the slugs are validated
 // at this boundary (validateRepoSlugs / sessionModeSupportsRepos),
@@ -48,12 +118,14 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var body struct {
-		Mode  string   `json:"mode"`
-		Repos []string `json:"repos"`
+		Mode        string                           `json:"mode"`
+		Repos       []string                         `json:"repos"`
+		InitialTurn *createSessionInitialTurnRequest `json:"initial_turn,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		body.Mode = ""
 		body.Repos = nil
+		body.InitialTurn = nil
 	}
 	repos, err := validateRepoSlugs(body.Repos)
 	if err != nil {
@@ -64,18 +136,118 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, errReposUnsupportedForMode.Error())
 		return
 	}
+	initialTurn, status, detail := validateCreateSessionInitialTurn(body.Mode, body.InitialTurn)
+	if status != 0 {
+		writeError(w, status, detail)
+		return
+	}
+	if body.InitialTurn != nil && s.sessionEvents == nil {
+		writeError(w, http.StatusServiceUnavailable, "initial_turn submit path unavailable")
+		return
+	}
+	if body.InitialTurn != nil && !initialTurn.Deferred && !sessionmodel.IsNoPodMode(body.Mode) && s.sessionBus == nil {
+		writeError(w, http.StatusServiceUnavailable, "initial_turn submit path unavailable")
+		return
+	}
 	owner := user.OwnerEmail()
+	launchTurnAt := time.Time{}
+	requestedAt := ""
+	if body.InitialTurn != nil {
+		launchTurnAt = time.Now().UTC()
+		requestedAt = launchTurnAt.Add(2 * time.Millisecond).Format(time.RFC3339Nano)
+	}
 	info, err := s.mgr.Create(r.Context(), sessions.CreateOptions{
-		Owner: owner,
-		Mode:  body.Mode,
-		Repos: repos,
+		Owner:       owner,
+		Mode:        body.Mode,
+		Repos:       repos,
+		RequestedAt: requestedAt,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if body.InitialTurn != nil {
+		if initialTurn.Deferred {
+			if status, detail := s.persistInitialTurnUserMessage(r.Context(), owner, info.ID, initialTurn, launchTurnAt); status != 0 {
+				s.rollbackCreatedSession(r.Context(), owner, info.ID, "persist deferred initial turn", detail)
+				writeError(w, status, detail)
+				return
+			}
+		} else {
+			if _, status, detail := s.enqueueSDKTurn(r.Context(), owner, info.ID, sdkTurnRequest{
+				ClientNonce:      initialTurn.ClientNonce,
+				RequireNonce:     true,
+				Prompt:           initialTurn.Prompt,
+				Model:            initialTurn.Model,
+				Effort:           initialTurn.Effort,
+				PermissionMode:   initialTurn.PermissionMode,
+				SkillName:        initialTurn.SkillName,
+				FollowUp:         false,
+				AllowBeforeReady: true,
+				SessionMode:      info.Mode,
+				CreatedAt:        launchTurnAt,
+				OrderBase:        launchTurnAt,
+			}); status != 0 {
+				s.rollbackCreatedSession(r.Context(), owner, info.ID, "submit initial turn", detail)
+				writeError(w, status, detail)
+				return
+			}
+		}
+	}
 	sessionReposSelectedTotal.WithLabelValues(repoSelectionBucket(len(repos))).Inc()
 	writeJSON(w, http.StatusCreated, info)
+}
+
+func (s *appServer) persistInitialTurnUserMessage(ctx context.Context, owner, sessionID string, turn createSessionInitialTurnRequest, createdAt time.Time) (int, string) {
+	info, err := s.mgr.GetByOwner(ctx, owner, sessionID)
+	if err != nil {
+		return http.StatusNotFound, "session not found"
+	}
+	runtime, ok := turnRuntimeForSessionMode(info.Mode)
+	if !ok {
+		return http.StatusBadRequest, "session mode does not support durable initial turns"
+	}
+	storageKey := sessionmodel.SessionStorageKey(s.sessionScope, sessionID)
+	_, events, err := conversation.UserSubmissionEventMaps(conversation.UserSubmissionArgs{
+		SessionID:         sessionID,
+		SessionStorageKey: storageKey,
+		Email:             owner,
+		ClientNonce:       turn.ClientNonce,
+		Text:              turn.Prompt,
+		Message:           map[string]any{"role": "user", "content": turn.Prompt},
+		Runtime:           runtime,
+		SkillName:         turn.SkillName,
+		Now:               createdAt.UTC(),
+	})
+	if err != nil {
+		return http.StatusBadRequest, err.Error()
+	}
+	retimeTurnBoundaryEvents(events, createdAt)
+	for _, event := range events {
+		if event["type"] != string(conversation.EventUserMessageCreated) {
+			continue
+		}
+		if writeErr := s.persistBackendEvent(ctx, storageKey, event); writeErr != nil {
+			return http.StatusInternalServerError, "persist initial user message: " + writeErr.Error()
+		}
+		return 0, ""
+	}
+	return http.StatusInternalServerError, "initial user message event missing"
+}
+
+func (s *appServer) rollbackCreatedSession(ctx context.Context, owner, sessionID, action, detail string) {
+	if s == nil || s.mgr == nil {
+		return
+	}
+	if err := s.mgr.Delete(ctx, owner, sessionID); err != nil {
+		slog.Warn("create session rollback failed",
+			"session_id", sessionID,
+			"owner", owner,
+			"action", action,
+			"detail", detail,
+			"error", err,
+		)
+	}
 }
 
 // stampSnapshotCursorHeader writes Tank-Sessions-Snapshot-Cursor on

--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -71,14 +72,15 @@ func (s *appServer) handleEnqueueSessionTurn(w http.ResponseWriter, r *http.Requ
 	}
 
 	var body struct {
-		ClientNonce     string `json:"client_nonce"`
-		Prompt          string `json:"prompt"`
-		Model           string `json:"model"`
-		Effort          string `json:"effort"`
-		PermissionMode  string `json:"permission_mode"`
-		SkillName       string `json:"skill_name"`
-		FollowUp        bool   `json:"follow_up"`
-		OriginSessionID string `json:"origin_session_id"`
+		ClientNonce         string `json:"client_nonce"`
+		Prompt              string `json:"prompt"`
+		Model               string `json:"model"`
+		Effort              string `json:"effort"`
+		PermissionMode      string `json:"permission_mode"`
+		SkillName           string `json:"skill_name"`
+		FollowUp            bool   `json:"follow_up"`
+		OriginSessionID     string `json:"origin_session_id"`
+		ExistingUserMessage bool   `json:"existing_user_message"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid body")
@@ -95,6 +97,7 @@ func (s *appServer) handleEnqueueSessionTurn(w http.ResponseWriter, r *http.Requ
 		PermissionMode:  body.PermissionMode,
 		SkillName:       body.SkillName,
 		FollowUp:        body.FollowUp,
+		OmitUserMessage: body.ExistingUserMessage,
 		OriginSessionID: body.OriginSessionID,
 	})
 	if detail != "" {
@@ -403,14 +406,19 @@ func inputReplyPayloadSize(answers map[string][]string, annotations map[string]s
 }
 
 type sdkTurnRequest struct {
-	ClientNonce    string
-	RequireNonce   bool
-	Prompt         string
-	Model          string
-	Effort         string
-	PermissionMode string
-	SkillName      string
-	FollowUp       bool
+	ClientNonce      string
+	RequireNonce     bool
+	Prompt           string
+	Model            string
+	Effort           string
+	PermissionMode   string
+	SkillName        string
+	FollowUp         bool
+	AllowBeforeReady bool
+	OmitUserMessage  bool
+	SessionMode      string
+	CreatedAt        time.Time
+	OrderBase        time.Time
 	// OriginSessionID identifies the sibling tank-operator session that
 	// authored this turn via an MCP handoff, or the source session for a
 	// browser-created fork. Human-typed browser turns leave it empty.
@@ -420,6 +428,12 @@ type sdkTurnRequest struct {
 }
 
 func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string, req sdkTurnRequest) (map[string]string, int, string) {
+	createdAt := req.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	} else {
+		createdAt = createdAt.UTC()
+	}
 	clientNonce := strings.TrimSpace(req.ClientNonce)
 	if clientNonce == "" {
 		if req.RequireNonce {
@@ -439,32 +453,44 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 		return nil, http.StatusBadRequest, "prompt too large"
 	}
 
-	info, err := s.mgr.GetByOwner(ctx, email, sessionID)
-	if err != nil {
-		return nil, http.StatusNotFound, "session not found"
+	sessionMode := strings.TrimSpace(req.SessionMode)
+	var podName *string
+	if sessionMode == "" {
+		info, err := s.mgr.GetByOwner(ctx, email, sessionID)
+		if err != nil {
+			return nil, http.StatusNotFound, "session not found"
+		}
+		sessionMode = info.Mode
+		podName = info.PodName
+	} else {
+		sessionMode = sessionmodel.NormalizeSessionMode(sessionMode)
 	}
 
 	// hermes_gui short-circuits the NATS / pod path entirely. The bridge
 	// owns the durable boundary events, the /v1/runs POST, and the
 	// SSE-tailing goroutine that writes translated events into
 	// session_events. See nelsong6/tank-operator#540.
-	if sessionmodel.IsNoPodMode(info.Mode) {
+	if sessionmodel.IsNoPodMode(sessionMode) {
 		if s.hermesBridge == nil {
 			return nil, http.StatusServiceUnavailable, "hermes bridge not configured (HERMES_API_URL / HERMES_API_BEARER missing on the orchestrator)"
 		}
 		result, err := s.hermesBridge.SubmitTurn(ctx, hermes.SubmitArgs{
-			SessionID:   sessionID,
-			Email:       email,
-			ClientNonce: clientNonce,
-			Text:        prompt,
+			SessionID:       sessionID,
+			Email:           email,
+			ClientNonce:     clientNonce,
+			Text:            prompt,
+			SkillName:       validateSkillName(req.SkillName),
+			OmitUserMessage: req.OmitUserMessage,
+			Now:             createdAt,
+			OrderBase:       req.OrderBase,
 		})
 		if err != nil {
 			return nil, http.StatusBadGateway, "hermes submit: " + err.Error()
 		}
-		return map[string]string{"turn_id": result.TurnID, "run_id": result.RunID}, http.StatusAccepted, ""
+		return map[string]string{"turn_id": result.TurnID, "run_id": result.RunID}, 0, ""
 	}
 
-	provider, ok := sdkProviderForMode(info.Mode)
+	provider, ok := sdkProviderForMode(sessionMode)
 	if !ok {
 		return nil, http.StatusBadRequest, "session mode does not support app chat turns"
 	}
@@ -487,15 +513,17 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 		}
 		return nil, http.StatusBadRequest, "effort is invalid; want one of low|medium|high|xhigh|max"
 	}
-	if info.PodName == nil {
-		return nil, http.StatusServiceUnavailable, "session pod not ready"
-	}
-	pod, err := s.k8s.CoreV1().Pods(s.namespace).Get(ctx, *info.PodName, metav1.GetOptions{})
-	if err != nil {
-		return nil, http.StatusServiceUnavailable, "pod fetch failed: " + err.Error()
-	}
-	if !podHasSDKRunner(pod) {
-		return nil, http.StatusBadRequest, "session pod has no SDK runner container"
+	if !req.AllowBeforeReady {
+		if podName == nil {
+			return nil, http.StatusServiceUnavailable, "session pod not ready"
+		}
+		pod, err := s.k8s.CoreV1().Pods(s.namespace).Get(ctx, *podName, metav1.GetOptions{})
+		if err != nil {
+			return nil, http.StatusServiceUnavailable, "pod fetch failed: " + err.Error()
+		}
+		if !podHasSDKRunner(pod) {
+			return nil, http.StatusBadRequest, "session pod has no SDK runner container"
+		}
 	}
 
 	if s.sessionBus == nil {
@@ -512,10 +540,19 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 		Runtime:           provider,
 		SkillName:         skillName,
 		OriginSessionID:   strings.TrimSpace(req.OriginSessionID),
-		Now:               time.Now().UTC(),
+		Now:               createdAt,
 	})
 	if err != nil {
 		return nil, http.StatusBadRequest, err.Error()
+	}
+	if req.OmitUserMessage {
+		if status, detail := s.requireExistingUserMessage(ctx, sessionID, turnID); status != 0 {
+			return nil, status, detail
+		}
+	}
+	retimeTurnBoundaryEvents(events, req.OrderBase)
+	if req.OmitUserMessage {
+		events = omitUserMessageEvents(events)
 	}
 	command := sessionbus.Command{
 		CommandID:         "turn:" + clientNonce,
@@ -533,7 +570,7 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 		PermissionMode:    validateTurnArg(req.PermissionMode),
 		SkillName:         skillName,
 		FollowUp:          req.FollowUp,
-		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		CreatedAt:         createdAt.Format(time.RFC3339Nano),
 	}
 	// Boundary events are backend-owned: the orchestrator accepted the turn,
 	// the orchestrator persists user_message.created + turn.submitted to
@@ -578,13 +615,64 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 	}, 0, ""
 }
 
+func (s *appServer) requireExistingUserMessage(ctx context.Context, sessionID, turnID string) (int, string) {
+	if s.sessionEvents == nil {
+		return http.StatusServiceUnavailable, "session event store unavailable"
+	}
+	orderKey, err := s.sessionEvents.OrderKeyForTimelineID(ctx, sessionID, turnID+":user")
+	if err != nil {
+		return http.StatusInternalServerError, "lookup existing user message: " + err.Error()
+	}
+	if strings.TrimSpace(orderKey) == "" {
+		return http.StatusBadRequest, "existing_user_message requires a durable launch user message"
+	}
+	return 0, ""
+}
+
+func omitUserMessageEvents(events []map[string]any) []map[string]any {
+	out := events[:0]
+	for _, event := range events {
+		if event["type"] == string(conversation.EventUserMessageCreated) {
+			continue
+		}
+		out = append(out, event)
+	}
+	return out
+}
+
+func retimeTurnBoundaryEvents(events []map[string]any, base time.Time) {
+	if base.IsZero() {
+		return
+	}
+	base = base.UTC()
+	for i, event := range events {
+		eventTime := base.Add(time.Duration(i) * time.Millisecond)
+		event["created_at"] = eventTime.Format(time.RFC3339Nano)
+		event["written_at"] = eventTime.Format(time.RFC3339Nano)
+		event["order_key"] = orderKeyForEventTime(eventTime, i, eventIDForOrderKey(event))
+	}
+}
+
+func orderKeyForEventTime(eventTime time.Time, sequence int, eventID string) string {
+	return fmt.Sprintf("%013d-%08d-%s", eventTime.UTC().UnixMilli(), sequence, eventID)
+}
+
+func eventIDForOrderKey(event map[string]any) string {
+	for _, key := range []string{"event_id", "id", "uuid"} {
+		if value, ok := event[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return auth.RandomHex(12)
+}
+
 func promptMatchesSkillTrigger(provider, skillName, prompt string) bool {
 	trigger := skillPromptTrigger(provider, skillName)
 	return prompt == trigger || strings.HasPrefix(prompt, trigger+" ") || strings.HasPrefix(prompt, trigger+"\n")
 }
 
 func skillPromptTrigger(provider, skillName string) string {
-	if provider == "codex" {
+	if provider == "codex" || provider == "hermes" {
 		return "$" + skillName
 	}
 	return "/" + skillName

--- a/backend-go/cmd/tank-operator/handlers_turns_test.go
+++ b/backend-go/cmd/tank-operator/handlers_turns_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/hermes"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
@@ -35,12 +38,28 @@ type recordingSessionEventStore struct {
 	err     error
 }
 
+type staticHermesTokenSource struct{}
+
+func (staticHermesTokenSource) Token(context.Context) (string, error) {
+	return "test-token", nil
+}
+
 func (r *recordingSessionEventStore) Upsert(_ context.Context, event map[string]any) error {
 	if r.err != nil {
 		return r.err
 	}
 	r.upserts = append(r.upserts, event)
 	return nil
+}
+
+func (r *recordingSessionEventStore) OrderKeyForTimelineID(_ context.Context, _, timelineID string) (string, error) {
+	for i := len(r.upserts) - 1; i >= 0; i-- {
+		if got, _ := r.upserts[i]["timeline_id"].(string); got == timelineID {
+			orderKey, _ := r.upserts[i]["order_key"].(string)
+			return orderKey, nil
+		}
+	}
+	return "", nil
 }
 
 func (b *recordingSessionBus) PublishCommand(_ context.Context, command sessionbus.Command) error {
@@ -121,6 +140,242 @@ func TestEnqueueSessionTurnPublishesSDKCommand(t *testing.T) {
 	// command. Mirror of the model/permission_mode assertion above.
 	if got.Effort != "xhigh" {
 		t.Fatalf("effort = %q, want xhigh", got.Effort)
+	}
+}
+
+func TestCreateSessionInitialTurnPersistsBeforeStartupStatus(t *testing.T) {
+	bus := &recordingSessionBus{}
+	app := testTurnsApp(t, bus)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(`{
+		"mode":"claude_gui",
+		"initial_turn":{
+			"client_nonce":"turn-launch_123",
+			"prompt":"  /test\n\nlaunch prompt  ",
+			"model":"claude-sonnet-4-6",
+			"effort":"xhigh",
+			"permission_mode":"bypassPermissions",
+			"skill_name":"test"
+		}
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	app.handleCreateSession(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	var created sessions.Info
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.RequestedAt == nil || *created.RequestedAt == "" {
+		t.Fatalf("created session missing requested_at: %#v", created)
+	}
+	requestedAt, err := time.Parse(time.RFC3339Nano, *created.RequestedAt)
+	if err != nil {
+		t.Fatalf("parse requested_at %q: %v", *created.RequestedAt, err)
+	}
+	es := app.sessionEvents.(*recordingSessionEventStore)
+	if len(es.upserts) != 2 {
+		t.Fatalf("session-event upserts = %d, want 2 (user_message.created + turn.submitted)", len(es.upserts))
+	}
+	for i, want := range []string{"user_message.created", "turn.submitted"} {
+		if got, _ := es.upserts[i]["type"].(string); got != want {
+			t.Fatalf("upsert[%d].type = %q, want %q", i, got, want)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, es.upserts[i]["created_at"].(string))
+		if err != nil {
+			t.Fatalf("parse upsert[%d].created_at: %v", i, err)
+		}
+		if !createdAt.Before(requestedAt) {
+			t.Fatalf("upsert[%d].created_at = %s, want before session requested_at %s", i, createdAt, requestedAt)
+		}
+	}
+	if len(bus.commands) != 1 {
+		t.Fatalf("published commands = %d, want 1", len(bus.commands))
+	}
+	got := bus.commands[0]
+	if got.Type != sessionbus.CommandSubmitTurn || got.ClientNonce != "turn-launch_123" {
+		t.Fatalf("command type/client nonce = %q/%q", got.Type, got.ClientNonce)
+	}
+	if got.SessionID != created.ID || got.Provider != "claude" || got.Prompt != "/test\n\nlaunch prompt" {
+		t.Fatalf("command routing/prompt = %#v", got)
+	}
+	if got.Model != "claude-sonnet-4-6" || got.Effort != "xhigh" || got.PermissionMode != "bypassPermissions" || got.SkillName != "test" {
+		t.Fatalf("command payload fields = %#v", got)
+	}
+}
+
+func TestCreateSessionInitialTurnDeferredReusesUserMessage(t *testing.T) {
+	bus := &recordingSessionBus{}
+	app := testTurnsApp(t, bus)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(`{
+		"mode":"claude_gui",
+		"initial_turn":{
+			"client_nonce":"turn-launch_attach",
+			"prompt":"launch prompt\n\nAttachments:\n- notes.txt",
+			"deferred":true
+		}
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	app.handleCreateSession(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	var created sessions.Info
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	es := app.sessionEvents.(*recordingSessionEventStore)
+	if len(es.upserts) != 1 {
+		t.Fatalf("session-event upserts after create = %d, want 1 deferred user message", len(es.upserts))
+	}
+	if got, _ := es.upserts[0]["type"].(string); got != "user_message.created" {
+		t.Fatalf("create upsert type = %q, want user_message.created", got)
+	}
+	if len(bus.commands) != 0 {
+		t.Fatalf("commands after deferred create = %d, want 0", len(bus.commands))
+	}
+
+	turnReq := authedTurnRequest(t, created.ID, `{
+		"client_nonce":"turn-launch_attach",
+		"prompt":"launch prompt\n\nAttachments (use the Read tool to load):\n- /workspace/.attachments/123-notes.txt",
+		"existing_user_message":true
+	}`)
+	turnResp := httptest.NewRecorder()
+
+	app.handleEnqueueSessionTurn(turnResp, turnReq)
+
+	if turnResp.Code != http.StatusAccepted {
+		t.Fatalf("turn status = %d body = %s", turnResp.Code, turnResp.Body.String())
+	}
+	if len(es.upserts) != 2 {
+		t.Fatalf("session-event upserts after turn = %d, want 2 total", len(es.upserts))
+	}
+	if got, _ := es.upserts[1]["type"].(string); got != "turn.submitted" {
+		t.Fatalf("second upsert type = %q, want turn.submitted", got)
+	}
+	if len(bus.commands) != 1 {
+		t.Fatalf("commands after deferred submit = %d, want 1", len(bus.commands))
+	}
+	if got := bus.commands[0].Prompt; got != "launch prompt\n\nAttachments (use the Read tool to load):\n- /workspace/.attachments/123-notes.txt" {
+		t.Fatalf("command prompt = %q", got)
+	}
+}
+
+func TestEnqueueSessionTurnRejectsExistingUserMessageWithoutLaunchRow(t *testing.T) {
+	bus := &recordingSessionBus{}
+	app := testTurnsApp(t, bus, sdkSessionPod("session-63", "63", "user@example.com", sessionmodel.ClaudeGUIMode, "agent-runner"))
+	req := authedTurnRequest(t, "63", `{
+		"client_nonce":"turn-missing-user",
+		"prompt":"hello",
+		"existing_user_message":true
+	}`)
+	resp := httptest.NewRecorder()
+
+	app.handleEnqueueSessionTurn(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if len(bus.commands) != 0 {
+		t.Fatalf("commands = %d, want 0", len(bus.commands))
+	}
+}
+
+func TestCreateSessionInitialTurnFailureRollsBackCreatedPod(t *testing.T) {
+	bus := &recordingSessionBus{}
+	app := testTurnsApp(t, bus)
+	app.sessionEvents = &recordingSessionEventStore{err: errors.New("postgres unavailable")}
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(`{
+		"mode":"claude_gui",
+		"initial_turn":{"client_nonce":"turn-launch_fail","prompt":"hello"}
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	app.handleCreateSession(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	pods, err := app.k8s.CoreV1().Pods(sessionmodel.SessionsNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("pods after rollback = %d, want 0", len(pods.Items))
+	}
+}
+
+func TestCreateHermesSessionInitialTurnSubmitsAtCreate(t *testing.T) {
+	bus := &recordingSessionBus{}
+	app := testTurnsApp(t, bus)
+	var createRun hermes.CreateRunRequest
+	hermesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			if err := json.NewDecoder(r.Body).Decode(&createRun); err != nil {
+				t.Errorf("decode create run: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeJSON(w, http.StatusOK, hermes.CreateRunResponse{RunID: "run-1", Status: "started"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run-1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer hermesServer.Close()
+	app.hermesBridge = hermes.NewBridge(hermes.BridgeOptions{
+		Client: hermes.NewClient(hermes.Options{
+			BaseURL: hermesServer.URL,
+			Tokens:  staticHermesTokenSource{},
+			Timeout: time.Second,
+		}),
+		Store: app.sessionEvents.(*recordingSessionEventStore),
+		Scope: "default",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(`{
+		"mode":"hermes_gui",
+		"initial_turn":{"client_nonce":"turn-hermes_launch","prompt":"hello hermes"}
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	app.handleCreateSession(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	var created sessions.Info
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Mode != sessionmodel.HermesGUIMode || created.Status != "Active" {
+		t.Fatalf("created hermes session = %#v", created)
+	}
+	if createRun.Input != "hello hermes" || createRun.SessionID != created.ID {
+		t.Fatalf("hermes create run request = %#v", createRun)
+	}
+	es := app.sessionEvents.(*recordingSessionEventStore)
+	if len(es.upserts) != 2 {
+		t.Fatalf("hermes upserts = %d, want 2", len(es.upserts))
+	}
+	for i, want := range []string{"user_message.created", "turn.submitted"} {
+		if got, _ := es.upserts[i]["type"].(string); got != want {
+			t.Fatalf("upsert[%d].type = %q, want %q", i, got, want)
+		}
 	}
 }
 

--- a/backend-go/internal/hermes/bridge.go
+++ b/backend-go/internal/hermes/bridge.go
@@ -26,7 +26,7 @@ type EventStore interface {
 type Recorder interface {
 	RunCreated()
 	RunCreateFailed()
-	RunTerminal(terminal string) // "completed" | "failed" | "interrupted" | "command_failed" | "lost"
+	RunTerminal(terminal string)   // "completed" | "failed" | "interrupted" | "command_failed" | "lost"
 	TranslatorError(reason string) // "decode" | "unhandled_type"
 }
 
@@ -102,11 +102,15 @@ func (b *Bridge) record(fn func(Recorder)) {
 // turn id and the run id; the run id is opaque to callers but recorded on
 // the activeTurns map for Stop.
 type SubmitArgs struct {
-	SessionID    string
-	Email        string
-	ClientNonce  string
-	Text         string
-	Instructions string // optional; layered on top of Hermes' core prompt
+	SessionID       string
+	Email           string
+	ClientNonce     string
+	Text            string
+	Instructions    string // optional; layered on top of Hermes' core prompt
+	SkillName       string
+	OmitUserMessage bool
+	Now             time.Time
+	OrderBase       time.Time
 }
 
 type SubmitResult struct {
@@ -127,6 +131,12 @@ func (b *Bridge) SubmitTurn(ctx context.Context, args SubmitArgs) (SubmitResult,
 	if args.Text == "" {
 		return SubmitResult{}, errors.New("text is required")
 	}
+	now := args.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
 	storageKey := sessionmodel.SessionStorageKey(b.scope, args.SessionID)
 
 	// 1. Land the user_message + turn.submitted pair. These are Tank-origin
@@ -139,9 +149,15 @@ func (b *Bridge) SubmitTurn(ctx context.Context, args SubmitArgs) (SubmitResult,
 		Text:              args.Text,
 		ClientNonce:       args.ClientNonce,
 		Runtime:           "hermes",
+		SkillName:         args.SkillName,
+		Now:               now,
 	})
 	if err != nil {
 		return SubmitResult{}, fmt.Errorf("user submission events: %w", err)
+	}
+	retimeTurnBoundaryEvents(userEvents, args.OrderBase)
+	if args.OmitUserMessage {
+		userEvents = omitUserMessageEvents(userEvents)
 	}
 	for _, evt := range userEvents {
 		if upErr := b.store.Upsert(ctx, evt); upErr != nil {
@@ -188,6 +204,43 @@ func (b *Bridge) SubmitTurn(ctx context.Context, args SubmitArgs) (SubmitResult,
 	}, at)
 
 	return SubmitResult{TurnID: turnID, RunID: runResp.RunID}, nil
+}
+
+func omitUserMessageEvents(events []map[string]any) []map[string]any {
+	out := events[:0]
+	for _, event := range events {
+		if event["type"] == string(conversation.EventUserMessageCreated) {
+			continue
+		}
+		out = append(out, event)
+	}
+	return out
+}
+
+func retimeTurnBoundaryEvents(events []map[string]any, base time.Time) {
+	if base.IsZero() {
+		return
+	}
+	base = base.UTC()
+	for i, event := range events {
+		eventTime := base.Add(time.Duration(i) * time.Millisecond)
+		event["created_at"] = eventTime.Format(time.RFC3339Nano)
+		event["written_at"] = eventTime.Format(time.RFC3339Nano)
+		event["order_key"] = orderKeyForEventTime(eventTime, i, eventIDForOrderKey(event))
+	}
+}
+
+func orderKeyForEventTime(eventTime time.Time, sequence int, eventID string) string {
+	return fmt.Sprintf("%013d-%08d-%s", eventTime.UTC().UnixMilli(), sequence, eventID)
+}
+
+func eventIDForOrderKey(event map[string]any) string {
+	for _, key := range []string{"event_id", "id", "uuid"} {
+		if value, ok := event[key].(string); ok && value != "" {
+			return value
+		}
+	}
+	return "missing-event-id"
 }
 
 type runStreamArgs struct {
@@ -338,4 +391,3 @@ func (b *Bridge) statsSnapshot() map[string]int {
 		"active_turns": len(b.activeTurns),
 	}
 }
-

--- a/backend-go/internal/pgstore/launch_transcript_integration_test.go
+++ b/backend-go/internal/pgstore/launch_transcript_integration_test.go
@@ -1,0 +1,131 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/conversation"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+func TestPostgresLaunchTranscriptOrdering(t *testing.T) {
+	dsn := os.Getenv("TANK_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TANK_TEST_POSTGRES_DSN is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	adminPool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect admin pool: %v", err)
+	}
+	schema := fmt.Sprintf("tank_launch_%d", time.Now().UnixNano())
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schemaIdent); err != nil {
+		adminPool.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(context.Background(), "DROP SCHEMA IF EXISTS "+schemaIdent+" CASCADE")
+		adminPool.Close()
+	})
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse test dsn: %v", err)
+	}
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect schema pool: %v", err)
+	}
+	defer pool.Close()
+
+	if err := RunMigrations(ctx, pool); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	sessionID := "launch-order"
+	owner := "user@example.com"
+	scope := "default"
+	launchAt := time.Now().UTC().Truncate(time.Millisecond)
+	requestedAt := launchAt.Add(2 * time.Millisecond)
+	readyAt := launchAt.Add(10 * time.Millisecond)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sessions (
+			email, session_scope, session_id, mode, pod_name, visible,
+			requested_at, created_at, updated_at, status
+		) VALUES ($1, $2, $3, $4, $5, true, $6, $6, $6, 'Pending')
+	`, owner, scope, sessionID, sessionmodel.ClaudeGUIMode, "session-"+sessionID, requestedAt); err != nil {
+		t.Fatalf("insert session row: %v", err)
+	}
+
+	eventStore := store.NewPostgresSessionEventStore(pool, scope)
+	storageKey := sessionmodel.SessionStorageKey(scope, sessionID)
+	_, events, err := conversation.UserSubmissionEventMaps(conversation.UserSubmissionArgs{
+		SessionID:         sessionID,
+		SessionStorageKey: storageKey,
+		Email:             owner,
+		ClientNonce:       "turn-launch-order",
+		Text:              "hello from launch",
+		Message:           map[string]any{"role": "user", "content": "hello from launch"},
+		Runtime:           "claude",
+		Now:               launchAt,
+	})
+	if err != nil {
+		t.Fatalf("build launch events: %v", err)
+	}
+	for i, event := range events {
+		eventTime := launchAt.Add(time.Duration(i) * time.Millisecond)
+		event["created_at"] = eventTime.Format(time.RFC3339Nano)
+		event["written_at"] = eventTime.Format(time.RFC3339Nano)
+		eventID, _ := event["event_id"].(string)
+		event["order_key"] = fmt.Sprintf("%013d-%08d-%s", eventTime.UnixMilli(), i, eventID)
+		if err := eventStore.Upsert(ctx, event); err != nil {
+			t.Fatalf("upsert launch event %d: %v", i, err)
+		}
+	}
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE sessions
+		SET status = 'Active', ready_at = $4, updated_at = $4
+		WHERE email = $1 AND session_scope = $2 AND session_id = $3
+	`, owner, scope, sessionID, readyAt); err != nil {
+		t.Fatalf("mark session active: %v", err)
+	}
+
+	page, err := eventStore.ListBySession(ctx, sessionID, store.SessionEventCursor{}, 10)
+	if err != nil {
+		t.Fatalf("list session events: %v", err)
+	}
+	if len(page.Events) != 4 {
+		t.Fatalf("events = %d, want 4; events=%#v", len(page.Events), page.Events)
+	}
+	wantTypes := []string{"user_message.created", "turn.submitted", "session.status", "session.status"}
+	for i, want := range wantTypes {
+		if got, _ := page.Events[i]["type"].(string); got != want {
+			t.Fatalf("event[%d].type = %q, want %q; events=%#v", i, got, want, page.Events)
+		}
+	}
+	for i, want := range map[int]string{2: "loading", 3: "ready"} {
+		payload, ok := page.Events[i]["payload"].(map[string]any)
+		if !ok {
+			t.Fatalf("event[%d].payload = %#v", i, page.Events[i]["payload"])
+		}
+		if got, _ := payload["status"].(string); got != want {
+			t.Fatalf("event[%d].payload.status = %q, want %q", i, got, want)
+		}
+	}
+}

--- a/backend-go/internal/pgstore/migrations_test.go
+++ b/backend-go/internal/pgstore/migrations_test.go
@@ -36,6 +36,8 @@ func TestMigrationsPersistSessionStatusEvents(t *testing.T) {
 		"WHEN 'ready' THEN '00000001'",
 		"WHEN 'failed' THEN '00000002'",
 		"se.event_id = v_event_id",
+		"coalesce(NEW.requested_at, NEW.created_at)",
+		"coalesce(NEW.ready_at, NEW.created_at, NEW.requested_at)",
 		"FROM sessions",
 	} {
 		if !strings.Contains(migrations, want) {

--- a/backend-go/internal/sessioncontroller/row_publisher.go
+++ b/backend-go/internal/sessioncontroller/row_publisher.go
@@ -37,6 +37,14 @@ type RowUpdatePublisher interface {
 	PublishSessionRowUpdate(ctx context.Context, email, scope string, payload []byte) error
 }
 
+// SessionEventWakePublisher is the optional per-session transcript
+// wake surface. sessions status DB triggers write durable
+// session.status rows as part of registry updates; this wake lets an
+// already-open transcript SSE read those rows immediately.
+type SessionEventWakePublisher interface {
+	PublishSessionEventWake(ctx context.Context, storageKey string) error
+}
+
 // RowPublisher fans a single row's post-write state out on NATS.
 // Stateless beyond its dependencies; safe for concurrent use.
 type RowPublisher struct {
@@ -68,6 +76,7 @@ func (p *RowPublisher) PublishCurrentRow(ctx context.Context, owner, sessionID s
 	if !ok {
 		return
 	}
+	defer p.publishSessionEventWake(ctx, sessionID)
 	payload, err := MarshalRowUpdate(record)
 	if err != nil {
 		slog.Warn("sessioncontroller: row marshal for publish failed",
@@ -77,6 +86,18 @@ func (p *RowPublisher) PublishCurrentRow(ctx context.Context, owner, sessionID s
 	if err := p.Publisher.PublishSessionRowUpdate(ctx, owner, p.Scope, payload); err != nil {
 		slog.Warn("sessioncontroller: row update publish failed",
 			"owner", owner, "scope", p.Scope, "session_id", sessionID, "error", err)
+	}
+}
+
+func (p *RowPublisher) publishSessionEventWake(ctx context.Context, sessionID string) {
+	waker, ok := p.Publisher.(SessionEventWakePublisher)
+	if !ok {
+		return
+	}
+	storageKey := sessionmodel.SessionStorageKey(p.Scope, sessionID)
+	if err := waker.PublishSessionEventWake(ctx, storageKey); err != nil {
+		slog.Warn("sessioncontroller: session event wake publish failed",
+			"scope", p.Scope, "session_id", sessionID, "storage_key", storageKey, "error", err)
 	}
 }
 

--- a/backend-go/internal/sessioncontroller/row_publisher_test.go
+++ b/backend-go/internal/sessioncontroller/row_publisher_test.go
@@ -1,0 +1,79 @@
+package sessioncontroller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
+)
+
+type fakeRowFetcher struct {
+	record sessionmodel.SessionRecord
+	ok     bool
+	err    error
+}
+
+func (f fakeRowFetcher) Get(context.Context, string, string) (sessionmodel.SessionRecord, bool, error) {
+	return f.record, f.ok, f.err
+}
+
+type recordedRowPublish struct {
+	email   string
+	scope   string
+	payload []byte
+}
+
+type recordingRowPublisher struct {
+	rows  []recordedRowPublish
+	wakes []string
+}
+
+func (p *recordingRowPublisher) PublishSessionRowUpdate(_ context.Context, email, scope string, payload []byte) error {
+	p.rows = append(p.rows, recordedRowPublish{
+		email:   email,
+		scope:   scope,
+		payload: append([]byte(nil), payload...),
+	})
+	return nil
+}
+
+func (p *recordingRowPublisher) PublishSessionEventWake(_ context.Context, storageKey string) error {
+	p.wakes = append(p.wakes, storageKey)
+	return nil
+}
+
+func TestPublishCurrentRowWakesTranscriptStream(t *testing.T) {
+	publisher := &recordingRowPublisher{}
+	rowPublisher := &RowPublisher{
+		Fetcher: fakeRowFetcher{
+			ok: true,
+			record: sessionmodel.SessionRecord{
+				ID:        "42",
+				Email:     "user@example.com",
+				Mode:      sessionmodel.ClaudeGUIMode,
+				Scope:     "team-a",
+				Visible:   true,
+				Status:    "Active",
+				CreatedAt: "2026-05-21T00:00:00Z",
+				UpdatedAt: "2026-05-21T00:00:01Z",
+			},
+		},
+		Publisher: publisher,
+		Scope:     "team-a",
+	}
+
+	rowPublisher.PublishCurrentRow(context.Background(), "User@Example.COM", "42")
+
+	if len(publisher.rows) != 1 {
+		t.Fatalf("row publishes = %d, want 1", len(publisher.rows))
+	}
+	if got := publisher.rows[0].email; got != "user@example.com" {
+		t.Fatalf("row email = %q, want lowercase owner", got)
+	}
+	if len(publisher.wakes) != 1 {
+		t.Fatalf("event wakes = %d, want 1", len(publisher.wakes))
+	}
+	if want := sessionmodel.SessionStorageKey("team-a", "42"); publisher.wakes[0] != want {
+		t.Fatalf("event wake storage key = %q, want %q", publisher.wakes[0], want)
+	}
+}

--- a/docs/product-inspirations.md
+++ b/docs/product-inspirations.md
@@ -38,6 +38,11 @@ state is separate from work state.
   sidebar/session state, but transcript rows are rendered only from the
   conversation ledger; browser-local startup drafts are not a transcript
   source.
+- A first prompt typed on the splash screen is written to the durable
+  conversation ledger before startup status, so the visible transcript begins
+  with the user's message instead of client-only optimism. If attachments need
+  pod-local paths, the user row is still written at creation time and the
+  executable turn submission reuses that durable row after upload.
 - Provider-specific event streams are adapter inputs. The frontend renders the
   Tank conversation protocol, not raw provider wire formats.
 - Transcript deep links resolve through the durable conversation ledger. A

--- a/docs/tank-conversation-protocol.md
+++ b/docs/tank-conversation-protocol.md
@@ -402,6 +402,51 @@ Body:
 { "last_read_order_key": "001..." }
 ```
 
+Launch-time durable chat turn submission:
+
+`POST /api/sessions`
+
+Body:
+
+```json
+{
+  "mode": "claude_gui",
+  "repos": ["owner/repo"],
+  "initial_turn": {
+    "client_nonce": "turn_abc123",
+    "prompt": "Implement the change",
+    "model": "claude-sonnet-4-6",
+    "permission_mode": "bypassPermissions",
+    "skill_name": "test"
+  }
+}
+```
+
+When `initial_turn` is present for an SDK chat session, the backend validates
+the turn before creating the session. After `manager.Create` returns, the
+backend writes the `user_message.created` and `turn.submitted` boundary events
+directly to `session_events` with timestamps that sort before the session
+startup `session.status` row, then publishes the durable JetStream
+`submit_turn` command without waiting for the pod to become Ready. JetStream is
+the readiness buffer; the runner consumes the command after it starts. This is
+the only path for a no-attachment first prompt from the splash composer, so the
+first visible transcript row is the user's launch message, followed by durable
+startup status and then runner output.
+
+Hermes/no-pod chat sessions use the same `initial_turn` create boundary, but
+the bridge writes the boundary events and starts the Hermes run directly rather
+than publishing a JetStream command.
+
+Attachment-backed SDK launches set `initial_turn.deferred=true`. The create
+request still writes `user_message.created` before startup status, using the
+user's text plus attachment names as the durable display text. After the pod is
+ready and files are uploaded into the workspace, the SPA submits the same
+`client_nonce` to `POST /api/sessions/{session_id}/turns` with
+`existing_user_message=true`; the backend writes only `turn.submitted` and
+publishes the runnable command whose prompt contains the pod-local attachment
+paths. This preserves one user bubble and one turn id while keeping file bytes
+on the existing workspace upload path.
+
 Durable SDK turn submission:
 
 `POST /api/sessions/{session_id}/turns`
@@ -415,15 +460,20 @@ Body:
   "model": "claude-sonnet-4-6",
   "permission_mode": "bypassPermissions",
   "skill_name": "test",
+  "existing_user_message": false,
   "follow_up": true
 }
 ```
 
-The backend validates session ownership and SDK runtime, publishes
-`user_message.created` and `turn.submitted` events to the session bus, then
-publishes a durable JetStream `submit_turn` command keyed by `client_nonce`.
-The runner consumes commands through a durable per-session/per-provider
-consumer and calls JetStream `working()` while a long turn is in flight.
+The backend validates session ownership and SDK runtime, requires the session
+pod to be ready, writes `user_message.created` and `turn.submitted` boundary
+events directly to `session_events`, then publishes a durable JetStream
+`submit_turn` command keyed by `client_nonce`. The runner consumes commands
+through a durable per-session/per-provider consumer and calls JetStream
+`working()` while a long turn is in flight.
+When `existing_user_message=true`, the user row must already have been written
+by the launch-time create boundary, so this endpoint writes `turn.submitted`
+only.
 Command ack happens only after the corresponding durable terminal event is
 published. Claude `ScheduleWakeup` is handled pod-side: the agent-runner extracts
 the tool_use, holds a `setTimeout` for `delaySeconds`, and at fire time publishes

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -828,6 +828,8 @@ function moveSessionId(order: string[], movedId: string, targetId: string): stri
 // future config mode doesn't grow an OR chain.
 const CONFIG_MODES = new Set<SessionMode>(["config", "codex_config"]);
 const CHAT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "hermes_gui"]);
+const SDK_CHAT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server"]);
+const CREATE_TIME_INITIAL_TURN_MODES = new Set<SessionMode>([...SDK_CHAT_MODES, "hermes_gui"]);
 const CLAUDE_ROLLOUT_MODES = new Set<SessionMode>(["claude_cli", "api_key"]);
 const CODEX_ROLLOUT_MODES = new Set<SessionMode>(["codex_cli"]);
 const GUI_ROLLOUT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "hermes_gui"]);
@@ -1970,6 +1972,14 @@ function composeSkillPrompt(mode: SessionMode, name: SkillStateName, text: strin
   const trigger = skillTrigger(MODE_MENU_ICONS[mode] === "anthropic", name);
   const trimmed = text.trim();
   return trimmed ? `${trigger}\n\n${trimmed}` : trigger;
+}
+
+function composeLaunchUserPrompt(text: string, attachments: { name: string }[]): string {
+  const trimmed = text.trim();
+  if (attachments.length === 0) return trimmed;
+  const attachmentList = attachments.map((attachment) => `- ${attachment.name}`).join("\n");
+  const attachmentText = `Attachments:\n${attachmentList}`;
+  return trimmed ? `${trimmed}\n\n${attachmentText}` : attachmentText;
 }
 
 function initialMessageModeDirective(mode: InitialMessageMode): string {
@@ -7662,7 +7672,7 @@ function ChatPane({
   }
 
   useEffect(() => {
-    if (!visible || session.status !== "Active" || !historyBootstrapped) return;
+    if (!visible || !CHAT_MODES.has(session.mode) || !historyBootstrapped) return;
     sdkEventSourceRef.current?.close();
     sdkEventSourceRef.current = openSdkEventStream();
     return () => {
@@ -7671,7 +7681,7 @@ function ChatPane({
     };
   // openSdkEventStream closes over the current session cursor and reducer state.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyBootstrapped, visible, session.id, session.status]);
+  }, [historyBootstrapped, visible, session.id, session.mode]);
 
   const submitStatus =
     runStatus === "running" || runStatus === "stopping"
@@ -10015,11 +10025,43 @@ export function App() {
       (seedPrompt || pendingHomeAttachments.length > 0 || requestedInitialSkillName) &&
       CHAT_MODES.has(mode);
     const seedClientNonce = seedTurnRequested ? newForkTurnId() : "";
+    const seedModel =
+      selectedProvider === "anthropic" || selectedProvider === "codex"
+        ? (selectedHomeModelId === CODEX_ACCOUNT_DEFAULT_MODEL_ID ? "" : selectedHomeModelId)
+        : "";
+    const seedEffort =
+      selectedProvider === "anthropic" || selectedProvider === "codex"
+        ? selectedHomeEffortId
+        : "";
+    const seedInitialTurnAtCreate =
+      seedTurnRequested && CREATE_TIME_INITIAL_TURN_MODES.has(mode);
+    const seedTurnDeferredAtCreate =
+      seedInitialTurnAtCreate && SDK_CHAT_MODES.has(mode) && pendingHomeAttachments.length > 0;
+    const seedTurnSubmittedAtCreate = seedInitialTurnAtCreate && !seedTurnDeferredAtCreate;
+    const launchUserPrompt = composeLaunchUserPrompt(seedPrompt, pendingHomeAttachments);
+    const createTimeTurnPrompt = requestedInitialSkillName
+      ? composeSkillPrompt(mode, requestedInitialSkillName, launchUserPrompt)
+      : launchUserPrompt;
+    const initialTurnPayload = seedInitialTurnAtCreate
+      ? {
+          client_nonce: seedClientNonce,
+          prompt: createTimeTurnPrompt,
+          ...(seedTurnDeferredAtCreate ? { deferred: true } : {}),
+          model: seedModel,
+          ...(seedEffort ? { effort: seedEffort } : {}),
+          permission_mode: initialPermissionMode,
+          ...(requestedInitialSkillName ? { skill_name: requestedInitialSkillName } : {}),
+        }
+      : undefined;
     try {
       const res = await authedFetch("/api/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode, repos }),
+        body: JSON.stringify({
+          mode,
+          repos,
+          ...(initialTurnPayload ? { initial_turn: initialTurnPayload } : {}),
+        }),
       });
       if (!res.ok) throw new Error(`create failed: ${res.status}`);
       let created: Session = normalizeSession(await res.json());
@@ -10062,23 +10104,19 @@ export function App() {
         setHomeSessionName("");
         setHomeEditingTitle(false);
       }
+      if (seedInitialTurnAtCreate && requestedInitialSkillName === "test") {
+        void markCreatedSessionTestState(created.id).catch((e) => {
+          setError(String(e));
+        });
+      }
       // Belt-and-braces reconcile in the background — the lifecycle SSE
       // wake from session.created should beat this in practice. Does not
       // gate the UI.
       void refresh();
-      // If the caller seeded an initial prompt from the home composer, wait
-      // for the pod to become ready and submit it as the first turn. Only
-      // chat modes have a turn endpoint; non-chat modes ignore the prompt
-      // because the home composer would not have surfaced a sensible target.
-      if (seedTurnRequested) {
-        const model =
-          selectedProvider === "anthropic" || selectedProvider === "codex"
-            ? (selectedHomeModelId === CODEX_ACCOUNT_DEFAULT_MODEL_ID ? "" : selectedHomeModelId)
-            : "";
-        const effort =
-          selectedProvider === "anthropic" || selectedProvider === "codex"
-            ? selectedHomeEffortId
-            : "";
+      // Create-time submitted launch turns are already durable. Deferred
+      // launch turns already have their user row; after readiness this path
+      // uploads files and writes only the turn.submitted boundary.
+      if (seedTurnRequested && !seedTurnSubmittedAtCreate) {
         try {
           const readySession = await waitForSessionReady(created.id);
           setSessions((prev) => prev.map((s) => (s.id === created.id ? readySession : s)));
@@ -10130,10 +10168,11 @@ export function App() {
             body: JSON.stringify({
               client_nonce: seedClientNonce,
               prompt: turnPrompt,
-              model,
-              ...(effort ? { effort } : {}),
+              model: seedModel,
+              ...(seedEffort ? { effort: seedEffort } : {}),
               permission_mode: initialPermissionMode,
               ...(requestedInitialSkillName ? { skill_name: requestedInitialSkillName } : {}),
+              ...(seedTurnDeferredAtCreate ? { existing_user_message: true } : {}),
               follow_up: false,
             }),
           });

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -116,7 +116,7 @@ test("chat live stream waits for timeline bootstrap", () => {
   assert.equal(appSource.includes("historyBootstrapped"), true);
   assert.match(
     appSource,
-    /if \(!visible \|\| session\.status !== "Active" \|\| !historyBootstrapped\) return;/,
+    /if \(!visible \|\| !CHAT_MODES\.has\(session\.mode\) \|\| !historyBootstrapped\) return;/,
   );
 });
 
@@ -124,6 +124,12 @@ test("startup transcript rows come from durable conversation events", () => {
   assert.equal(appSource.includes("startupTranscript"), false);
   assert.equal(appSource.includes("sessionStartupDrafts"), false);
   assert.equal(appSource.includes("startupDraft"), false);
+  assert.equal(appSource.includes("initial_turn"), true);
+  assert.equal(appSource.includes("CREATE_TIME_INITIAL_TURN_MODES"), true);
+  assert.equal(appSource.includes("composeLaunchUserPrompt"), true);
+  assert.equal(appSource.includes("seedTurnDeferredAtCreate"), true);
+  assert.match(appSource, /existing_user_message: true/);
+  assert.match(appSource, /if \(seedTurnRequested && !seedTurnSubmittedAtCreate\) \{/);
   assert.equal(conversationReducerSource.includes('"session.status"'), true);
   assert.match(
     appSource,


### PR DESCRIPTION
## Summary
- persist launch-time initial turns at session creation so the first transcript row is durable user input
- cover SDK, deferred attachment, and Hermes launch paths without duplicate user bubbles
- wake transcript streams for DB-triggered session.status rows and add CI Postgres ordering coverage

## Verification
- go test ./...
- npm test -- src/migrationPolicy.test.ts
- npm run build
- git diff --check