### PR TITLE
Fix transcript launch bootstrap jank

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6299,20 +6299,15 @@ function ChatPane({
       initialTimelineBootstrapState(initialSessionId, sdkWindowEpochRef.current),
   );
   const historyBootstrapped = timelineBootstrap.status === "ready";
-  const previousSessionStatusRef = useRef(session.status);
-  // Toggled briefly when entries are restored from backend history so we can
-  // show a "Continuing previous conversation" hint.
-  const [continueHintVisible, setContinueHintVisible] = useState(false);
 
   // History replay hits the canonical event log written by the pod-side
   // runner, then renders through the same reducer/projection path used for
   // live SDK frames.
   function refreshSdkRunHistory(
-    showHint: boolean,
     clearRealtime = false,
     source: SdkHistoryRefreshSource = "history",
   ): Promise<boolean> {
-    return refreshSdkRunHistoryResult(showHint, clearRealtime, undefined, source).then(
+    return refreshSdkRunHistoryResult(clearRealtime, undefined, source).then(
       (result) => result.replayed,
     );
   }
@@ -6331,7 +6326,6 @@ function ChatPane({
   // transcript deep link, which the backend resolves from timeline_id to
   // order_key and returns as a bounded window around that persisted cursor.
   function refreshSdkRunHistoryResult(
-    showHint: boolean,
     clearRealtime = false,
     clientNonce?: string,
     source: SdkHistoryRefreshSource = "history",
@@ -6481,10 +6475,6 @@ function ChatPane({
       if (scrollToLatestOnReady) {
         timelineBootstrapScrollToLatestRef.current = false;
         requestScrollToLatest("auto", source);
-      }
-      if (showHint) {
-        setContinueHintVisible(true);
-        window.setTimeout(() => setContinueHintVisible(false), 3000);
       }
       return { replayed: true, terminal };
     };
@@ -6705,7 +6695,6 @@ function ChatPane({
     const refreshEpoch = sdkWindowEpochRef.current;
     const source = timelineBootstrapSourceRef.current;
     const clearRealtime = timelineBootstrapClearRealtimeRef.current;
-    const showHint = source === "history" && entries.length === 0;
     const run = currentRunRef.current;
     dispatchTimelineBootstrap({
       type: "loading",
@@ -6713,7 +6702,6 @@ function ChatPane({
       epoch: refreshEpoch,
     });
     const refresh = refreshSdkRunHistoryResult(
-      showHint,
       clearRealtime,
       run?.id,
       source,
@@ -6759,21 +6747,6 @@ function ChatPane({
   // should not resubscribe an in-flight bootstrap.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.id, session.mode, timelineBootstrap.epoch, timelineBootstrap.status, visible]);
-
-  useEffect(() => {
-    const previous = previousSessionStatusRef.current;
-    previousSessionStatusRef.current = session.status;
-    if (previous === session.status) return;
-    if (!visible || !historyBootstrapped) return;
-    if (session.status !== "Active" && session.status !== "Failed") return;
-    resetSdkTimelineBootstrapState("session-status-transition", {
-      source: "history",
-      clearRealtime: false,
-    });
-  // resetSdkTimelineBootstrapState closes over current refs and must run with
-  // the latest session id/status when this effect fires.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyBootstrapped, session.status, visible]);
 
   useEffect(() => {
     if (activeTab !== "files" || filesAvailable) return;
@@ -7065,7 +7038,6 @@ function ChatPane({
     currentRunRef.current = null;
     activeInterruptTargetRef.current = null;
     setQueuedMessages([]);
-    setContinueHintVisible(false);
     setRunStatus("idle");
     setRunning(false);
   // resetSdkTimelineBootstrapState intentionally closes over current session
@@ -7703,7 +7675,7 @@ function ChatPane({
     setRunning(false);
     setSdkConnectionState("idle");
     if (options.refreshHistory ?? false) {
-      void refreshSdkRunHistory(false, options.clearRealtime ?? false, "terminal-refresh");
+      void refreshSdkRunHistory(options.clearRealtime ?? false, "terminal-refresh");
     }
   }
 
@@ -7762,7 +7734,7 @@ function ChatPane({
       if (sdkEventSourceRef.current === source) sdkEventSourceRef.current = null;
       setSdkConnectionState("resyncing");
       sdkTimelineCursorRef.current = null;
-      void refreshSdkRunHistoryResult(false, true, undefined, "resync").finally(() => {
+      void refreshSdkRunHistoryResult(true, undefined, "resync").finally(() => {
         if (sessionIdRef.current !== session.id) return;
         sdkEventSourceRef.current?.close();
         sdkEventSourceRef.current = null;
@@ -8470,24 +8442,7 @@ function ChatPane({
               >
                 {sdkLoadingOlder ? "Loading earlier messages…" : "Load earlier messages"}
               </button>
-            ) : sdkFoundOldest && renderedEntries.length > 0 ? (
-              <div
-                className="run-transcript-beginning"
-                role="status"
-                aria-label="Beginning of conversation"
-              >
-                <span className="run-transcript-beginning-rule" aria-hidden="true" />
-                <span className="run-transcript-beginning-label">
-                  Beginning of conversation
-                </span>
-                <span className="run-transcript-beginning-rule" aria-hidden="true" />
-              </div>
             ) : null}
-            {continueHintVisible && (
-              <div className="run-continue-hint" role="status">
-                Continuing previous conversation
-              </div>
-            )}
             <RunMessages
               entries={renderedEntries}
               avatar={sessionAvatar}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3683,37 +3683,6 @@ button:disabled {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
-/* Beginning-of-conversation divider — replaces the back-paginate button
-   once foundOldest flips true. Rule-flanked label so the user can tell
-   they hit the head of the ledger instead of just a silent scroll-stop.
-   Slack/Discord both ship this divider; the visual is intentionally
-   quieter than the load-older pill it replaces because it's an end-state,
-   not an action. */
-.run-transcript-beginning {
-  align-self: stretch;
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  margin: var(--space-4) auto var(--space-3);
-  padding: 0 var(--space-5);
-  color: var(--text-muted);
-  font-family: var(--font-primary);
-  font-size: var(--text-xs);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.run-transcript-beginning-rule {
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-}
-
-.run-transcript-beginning-label {
-  flex-shrink: 0;
-  font-weight: 500;
-}
-
 /* Composer textarea — taller, more breathing room. Auto-grows with
    content (CSS field-sizing-content from AI Elements) up to max-h. */
 .run-composer-textarea {
@@ -4383,34 +4352,8 @@ textarea.run-files-viewer-editor:focus {
   animation: run-status-pulse 2.4s ease-in-out infinite;
 }
 
-/* Brief banner shown above the transcript when entries are restored from
-   localStorage on mount or from the backend history endpoint. Auto-fades
-   after 3s via React state. */
-.run-continue-hint {
-  align-self: center;
-  margin: var(--space-3) auto var(--space-2);
-  padding: 0.4rem 0.85rem;
-  border-radius: 999px;
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-elevated);
-  color: var(--text-muted);
-  font-family: var(--font-primary);
-  font-size: var(--text-xs);
-  letter-spacing: 0.02em;
-  animation: run-continue-hint-fade 3s ease-out forwards;
-}
-
-@keyframes run-continue-hint-fade {
-  0%   { opacity: 0; transform: translateY(-4px); }
-  10%  { opacity: 1; transform: translateY(0); }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
-}
-
 /* "Load earlier messages" pill — sits at the top of the transcript when
-   the loaded window doesn't yet include the head of the ledger. Visual
-   sibling of .run-continue-hint, with a stronger affordance because
-   it's an action, not a status. */
+   the loaded window doesn't yet include the head of the ledger. */
 .run-transcript-load-older {
   align-self: center;
   margin: var(--space-3) auto var(--space-2);

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -133,6 +133,11 @@ test("startup transcript rows come from durable conversation events", () => {
   assert.equal(appSource.includes("startupTranscript"), false);
   assert.equal(appSource.includes("sessionStartupDrafts"), false);
   assert.equal(appSource.includes("startupDraft"), false);
+  assert.equal(appSource.includes("Continuing previous conversation"), false);
+  assert.equal(appSource.includes("run-continue-hint"), false);
+  assert.equal(appSource.includes("run-transcript-beginning"), false);
+  assert.equal(appSource.includes("Beginning of conversation"), false);
+  assert.equal(appSource.includes("session-status-transition"), false);
   assert.equal(appSource.includes("initial_turn"), true);
   assert.equal(appSource.includes("CREATE_TIME_INITIAL_TURN_MODES"), true);
   assert.equal(appSource.includes("composeLaunchUserPrompt"), true);


### PR DESCRIPTION
## Summary
- remove browser-local transcript chrome: `Continuing previous conversation` and the `Beginning of conversation` divider
- stop resetting/reloading the transcript when session lifecycle status flips to Active/Failed
- add migration-policy guards so startup transcript rows stay durable-ledger-only

## Diagnosis
A live probe on session 158 captured the UI inserting local transcript-flow elements before durable rows: `Loading conversation...` -> `BEGINNING OF CONVERSATION` + `Continuing previous conversation` -> durable user/status rows underneath -> hint removal moving rows upward. The durable ledger was ordered correctly; the jank came from frontend bootstrap chrome and a status-transition reset path.

## Tests
- npm test
- npm run build
- git diff --check HEAD~1..HEAD