### PR TITLE
Fix stale browser auth after JWT expiry

### DIFF
--- a/backend-go/cmd/tank-operator/auth_session_test.go
+++ b/backend-go/cmd/tank-operator/auth_session_test.go
@@ -188,6 +188,34 @@ func TestHandleCreateStreamTicketScopesSessionEventTicket(t *testing.T) {
 	}
 }
 
+func TestHandleCreateStreamTicketAllowsServiceActor(t *testing.T) {
+	app := adminTestServer(t)
+	tickets := &fakeStreamAuthTicketStore{}
+	app.streamAuthTickets = tickets
+	app.sessionScope = "default"
+	request := httptest.NewRequest(http.MethodPost, "/api/auth/stream-ticket", strings.NewReader(`{
+		"stream": "session-list"
+	}`))
+	request.Header.Set("Authorization", "Bearer "+signedServiceToken(
+		t,
+		"pod-orchestrator@service.tank-operator.romaine.life",
+		otherUser,
+	))
+	response := httptest.NewRecorder()
+
+	app.handleCreateStreamTicket(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", response.Code, response.Body.String())
+	}
+	if tickets.created.Email != "pod-orchestrator@service.tank-operator.romaine.life" ||
+		tickets.created.ActorEmail != otherUser ||
+		tickets.created.Role != auth.RoleService ||
+		tickets.created.StreamKind != streamKindSessionList ||
+		tickets.created.SessionID != "" {
+		t.Fatalf("created ticket = %#v", tickets.created)
+	}
+}
+
 type testSessionRegistry struct {
 	records map[string]map[string]sessionmodel.SessionRecord
 }

--- a/backend-go/cmd/tank-operator/handlers_auth.go
+++ b/backend-go/cmd/tank-operator/handlers_auth.go
@@ -104,11 +104,6 @@ func (s *appServer) handleCreateStreamTicket(w http.ResponseWriter, r *http.Requ
 	if !ok {
 		return
 	}
-	if !user.IsHuman() {
-		recordStreamAuthTicket("create", "", "denied")
-		writeError(w, http.StatusForbidden, "human user required")
-		return
-	}
 	if s.streamAuthTickets == nil {
 		recordStreamAuthTicket("create", "", "store_unavailable")
 		writeError(w, http.StatusServiceUnavailable, "stream auth ticket store not configured")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,7 +72,7 @@ import {
   XIcon,
   type LucideIcon,
 } from "lucide-react";
-import { authedEventSource, authedFetch, bootstrapAuth, getStoredToken, logout, startLogin } from "./auth";
+import { AUTH_TOKEN_UPDATED_EVENT, authedEventSource, authedFetch, bootstrapAuth, getStoredToken, logout, startLogin } from "./auth";
 import { requiresGitHubOnboarding, type SessionRole } from "./authPolicy";
 import {
   initialConversationState,
@@ -5704,6 +5704,9 @@ function ChatPane({
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
   const [selectedFileLine, setSelectedFileLine] = useState<number | null>(null);
   const [fileContentLoading, setFileContentLoading] = useState(false);
+  const [fileRawImageUrl, setFileRawImageUrl] = useState<string | null>(null);
+  const [fileRawImageLoading, setFileRawImageLoading] = useState(false);
+  const [fileRawImageError, setFileRawImageError] = useState<string | null>(null);
   // Edit-mode bookkeeping for the file viewer.
   const [fileDraft, setFileDraft] = useState<string | null>(null);
   const [fileSaving, setFileSaving] = useState(false);
@@ -6811,6 +6814,40 @@ function ChatPane({
       cancelled = true;
     };
   }, [filesAvailable, selectedFile, session.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setFileRawImageUrl(null);
+    setFileRawImageError(null);
+    setFileRawImageLoading(false);
+    if (!filesAvailable || !selectedFile?.binary || !isImagePath(selectedFile.path)) {
+      return () => undefined;
+    }
+    setFileRawImageLoading(true);
+    void authedFetch(
+      `/api/sessions/${session.id}/files/raw?path=${encodeURIComponent(selectedFile.path)}`,
+    )
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+        return res.blob();
+      })
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setFileRawImageUrl(objectUrl);
+        setFileRawImageLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setFileRawImageError(String((err as Error).message ?? err));
+        setFileRawImageLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [filesAvailable, selectedFile?.binary, selectedFile?.path, session.id]);
 
   useEffect(() => {
     if (session.status !== "Active") {
@@ -8237,11 +8274,23 @@ function ChatPane({
                   </div>
                 ) : selectedFile.binary && isImagePath(selectedFile.path) ? (
                   <div className="run-files-viewer-image-wrap">
-                    <img
-                      className="run-files-viewer-image"
-                      alt={selectedFile.path}
-                      src={`/api/sessions/${session.id}/files/raw?path=${encodeURIComponent(selectedFile.path)}`}
-                    />
+                    {fileRawImageLoading ? (
+                      <div className="run-files-status">
+                        <Loader2Icon size={14} className="run-spin" aria-hidden="true" />
+                        <span>Loading image...</span>
+                      </div>
+                    ) : fileRawImageError ? (
+                      <div className="run-files-status">
+                        <AlertCircleIcon size={14} aria-hidden="true" />
+                        <span>Image preview failed.</span>
+                      </div>
+                    ) : fileRawImageUrl ? (
+                      <img
+                        className="run-files-viewer-image"
+                        alt={selectedFile.path}
+                        src={fileRawImageUrl}
+                      />
+                    ) : null}
                   </div>
                 ) : selectedFile.binary ? (
                   <div className="run-files-status">
@@ -8921,15 +8970,23 @@ function CliProcessTerminal({
 }) {
   const [processId, setProcessId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [clientToken, setClientToken] = useState<string | undefined>(() => getStoredToken() ?? undefined);
   const client = useMemo(
     () =>
       new SandboxAgent({
         baseUrl: `${location.origin}/api/sessions/${session.id}/sandbox-agent`,
-        token: getStoredToken() ?? undefined,
+        token: clientToken,
         skipHealthCheck: true,
       }),
-    [session.id],
+    [clientToken, session.id],
   );
+
+  useEffect(() => {
+    const syncToken = () => setClientToken(getStoredToken() ?? undefined);
+    syncToken();
+    window.addEventListener(AUTH_TOKEN_UPDATED_EVENT, syncToken);
+    return () => window.removeEventListener(AUTH_TOKEN_UPDATED_EVENT, syncToken);
+  }, [session.id]);
 
   useEffect(() => {
     if (!visible) return;
@@ -8941,7 +8998,10 @@ function CliProcessTerminal({
         return (await res.json()) as { process_id: string };
       })
       .then((body) => {
-        if (!cancelled) setProcessId(body.process_id);
+        if (!cancelled) {
+          setClientToken(getStoredToken() ?? undefined);
+          setProcessId(body.process_id);
+        }
       })
       .catch((err) => {
         if (!cancelled) setError(String((err as Error).message ?? err));

--- a/frontend/src/auth.test.ts
+++ b/frontend/src/auth.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  authedFetch,
   authedEventSourceURL,
   bootstrapAuth,
   clearStoredToken,
@@ -63,6 +64,61 @@ test("bootstrapAuth stores and presents the upstream auth.romaine.life JWT direc
     assert.equal(user?.email, "user@example.test");
     assert.equal(getStoredToken(), "upstream.jwt");
     assert.deepEqual(calls, ["/api/config", "https://auth.test/api/auth/token", "/api/auth/me"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;
+  }
+});
+
+test("authedFetch refreshes an expired JWT and retries the original request", async () => {
+  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const originalFetch = globalThis.fetch;
+  const storage = new Map<string, string>([
+    ["auth-romaine-jwt", "expired.jwt"],
+  ]);
+  let protectedAttempts = 0;
+
+  (globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => storage.clear(),
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === "/api/config") {
+      return jsonResponse({ auth_url: "https://auth.test" });
+    }
+    if (url === "https://auth.test/api/auth/token") {
+      return jsonResponse({ token: "fresh.jwt" });
+    }
+    if (url === "/api/sessions/123") {
+      protectedAttempts += 1;
+      const authorization = new Headers(init?.headers).get("Authorization");
+      if (protectedAttempts === 1) {
+        assert.equal(authorization, "Bearer expired.jwt");
+        return new Response("expired", { status: 401 });
+      }
+      assert.equal(authorization, "Bearer fresh.jwt");
+      assert.equal(init?.method, "DELETE");
+      return new Response(null, { status: 204 });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  try {
+    const res = await authedFetch("/api/sessions/123", { method: "DELETE" });
+    assert.equal(res.status, 204);
+    assert.equal(protectedAttempts, 2);
+    assert.equal(getStoredToken(), "fresh.jwt");
   } finally {
     globalThis.fetch = originalFetch;
     (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -22,8 +22,10 @@ interface SessionUser {
 }
 
 const TOKEN_KEY = "auth-romaine-jwt";
+export const AUTH_TOKEN_UPDATED_EVENT = "tank-auth-token-updated";
 
 let cachedConfig: AppConfig | null = null;
+let tokenRefreshInFlight: Promise<string | null> | null = null;
 
 async function fetchConfig(): Promise<AppConfig> {
   if (cachedConfig) return cachedConfig;
@@ -61,6 +63,7 @@ async function fetchMe(token: string): Promise<SessionUser> {
 function storeToken(token: string): void {
   try {
     localStorage.setItem(TOKEN_KEY, token);
+    dispatchTokenUpdated();
     return;
   } catch (err) {
     if (!isQuotaExceeded(err)) throw err;
@@ -75,6 +78,7 @@ function storeToken(token: string): void {
     }
   }
   localStorage.setItem(TOKEN_KEY, token);
+  dispatchTokenUpdated();
 }
 
 function isQuotaExceeded(err: unknown): boolean {
@@ -88,6 +92,34 @@ export function getStoredToken(): string | null {
 
 export function clearStoredToken(): void {
   localStorage.removeItem(TOKEN_KEY);
+  dispatchTokenUpdated();
+}
+
+function dispatchTokenUpdated(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(AUTH_TOKEN_UPDATED_EVENT));
+}
+
+async function refreshStoredToken(): Promise<string | null> {
+  if (tokenRefreshInFlight) return tokenRefreshInFlight;
+  tokenRefreshInFlight = (async () => {
+    let config: AppConfig;
+    try {
+      config = await fetchConfig();
+    } catch {
+      return null;
+    }
+    const upstreamJWT = await fetchUpstreamJWT(config.auth_url);
+    if (!upstreamJWT) {
+      clearStoredToken();
+      return null;
+    }
+    storeToken(upstreamJWT);
+    return upstreamJWT;
+  })().finally(() => {
+    tokenRefreshInFlight = null;
+  });
+  return tokenRefreshInFlight;
 }
 
 export type StreamTicketRequest =
@@ -188,10 +220,37 @@ export async function logout(): Promise<void> {
   window.location.assign("/");
 }
 
-/** fetch wrapper that adds the Bearer token. */
+function authedInit(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  token: string | null,
+): RequestInit {
+  const headers = new Headers(input instanceof Request ? input.headers : undefined);
+  new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  } else {
+    headers.delete("Authorization");
+  }
+  return { ...init, headers };
+}
+
+/** fetch wrapper that adds the Bearer token and refreshes it once on 401. */
 export async function authedFetch(input: RequestInfo, init: RequestInit = {}): Promise<Response> {
-  const token = getStoredToken();
-  const headers = new Headers(init.headers);
-  if (token) headers.set("Authorization", `Bearer ${token}`);
-  return fetch(input, { ...init, headers });
+  let token = getStoredToken();
+  if (!token) {
+    token = await refreshStoredToken();
+  }
+  const first = await fetch(input, authedInit(input, init, token));
+  if (first.status !== 401) return first;
+
+  const latest = getStoredToken();
+  const refreshed = latest && latest !== token ? latest : await refreshStoredToken();
+  if (!refreshed) return first;
+
+  const retry = await fetch(input, authedInit(input, init, refreshed));
+  if (retry.status === 401 && getStoredToken() === refreshed) {
+    clearStoredToken();
+  }
+  return retry;
 }

--- a/frontend/src/chatScrollTelemetry.ts
+++ b/frontend/src/chatScrollTelemetry.ts
@@ -1,4 +1,4 @@
-import { getStoredToken } from "./auth";
+import { authedFetch } from "./auth";
 
 // Chat transcript scroll telemetry. Console logging is opt-in per browser with
 // `localStorage.tankDebug = "chat-scroll"` or a comma-separated list that
@@ -122,18 +122,10 @@ function scheduleFlush(): void {
 function flushChatScrollMetrics(): void {
   if (typeof window === "undefined" || pendingMetrics.length === 0) return;
   const events = pendingMetrics.splice(0, MAX_BATCH_EVENTS);
-  let token: string | null = null;
-  try {
-    token = getStoredToken();
-  } catch {
-    return;
-  }
-  if (!token) return;
   if (typeof fetch !== "function") return;
-  fetch(METRICS_ENDPOINT, {
+  authedFetch(METRICS_ENDPOINT, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ events }),

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -129,6 +129,12 @@ test("browser EventSource streams use opaque stream tickets, not bearer query st
   assert.match(appSource, /authedEventSource\([\s\S]{0,400}stream: "session-list"/);
 });
 
+test("browser-native protected resources are not loaded with raw API URLs", () => {
+  assert.equal(appSource.includes('src={`/api/sessions/${session.id}/files/raw'), false);
+  assert.equal(appSource.includes("URL.createObjectURL(blob)"), true);
+  assert.match(appSource, /authedFetch\([\s\S]{0,120}\/files\/raw\?path=/);
+});
+
 test("startup transcript rows come from durable conversation events", () => {
   assert.equal(appSource.includes("startupTranscript"), false);
   assert.equal(appSource.includes("sessionStartupDrafts"), false);


### PR DESCRIPTION
## Summary
- refresh the stored auth.romaine JWT inside `authedFetch` after a 401 and retry the protected request once
- route telemetry, protected raw image previews, and terminal SandboxAgent token handoff through refreshed browser auth state
- allow service-actor stream ticket minting so automation visibility continues to work with the auth.romaine service-token path

## Why
A browser tab could keep an expired `auth-romaine-jwt` in localStorage. Refreshing the page ran auth bootstrap and got a fresh JWT, which is why delete worked only after reload. The app needed an in-session refresh path, plus a sweep for browser-native protected surfaces that cannot attach Authorization directly.

## Tests
- `npm test`
- `npm run build`
- `go test ./...`
- `git diff --check`