### PR TITLE
Store session runtime model config

### DIFF
--- a/agent-runner/src/runner.ts
+++ b/agent-runner/src/runner.ts
@@ -55,6 +55,7 @@ import {
   type SessionCommandRecord,
 } from "./sessionCommands.js";
 import { truncateEventIfOversized } from "../../runner-shared/sessionBus.js";
+import { reportRuntimeConfig } from "../../runner-shared/runtimeConfig.js";
 import {
   askUserQuestionPendingGauge,
   askUserQuestionWaitSeconds,
@@ -608,6 +609,9 @@ export class Runner {
     };
 
     this.sdkQuery = this.launchSdkQuery(options);
+    void reportRuntimeConfig(this.cfg, { model, effort }).catch((err) => {
+      console.warn("runtime config report failed:", err);
+    });
     this.resolveSdkReady();
   }
 

--- a/backend-go/cmd/tank-operator/auth_session_test.go
+++ b/backend-go/cmd/tank-operator/auth_session_test.go
@@ -278,6 +278,21 @@ func (r *testSessionRegistry) SetRolloutState(_ context.Context, _, _ string, _ 
 func (r *testSessionRegistry) SetCloneState(_ context.Context, _, _ string, _ map[string]any) error {
 	return nil
 }
+func (r *testSessionRegistry) SetRuntimeConfig(_ context.Context, email, sessionID, model, effort string) error {
+	records := r.records[email]
+	if records == nil {
+		return nil
+	}
+	record, ok := records[sessionID]
+	if !ok {
+		return nil
+	}
+	record.RuntimeModel = model
+	record.RuntimeEffort = effort
+	record.RuntimeConfiguredAt = time.Now().UTC().Format(time.RFC3339Nano)
+	records[sessionID] = record
+	return nil
+}
 func (r *testSessionRegistry) Reorder(_ context.Context, _ string, orderedIDs []string) ([]string, error) {
 	return orderedIDs, nil
 }

--- a/backend-go/cmd/tank-operator/handlers_internal.go
+++ b/backend-go/cmd/tank-operator/handlers_internal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
 	"github.com/nelsong6/tank-operator/backend-go/internal/kubeexec"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
 )
 
@@ -135,6 +136,8 @@ func (s *appServer) handleInternalCreateSession(w http.ResponseWriter, r *http.R
 
 	var body struct {
 		Mode            string         `json:"mode"`
+		Model           string         `json:"model,omitempty"`
+		Effort          string         `json:"effort,omitempty"`
 		GlimmungContext map[string]any `json:"glimmung_context"`
 		Name            string         `json:"name"`
 		Repos           []string       `json:"repos"`
@@ -142,14 +145,20 @@ func (s *appServer) handleInternalCreateSession(w http.ResponseWriter, r *http.R
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		body.Mode = ""
 	}
+	mode := sessionmodel.NormalizeSessionMode(body.Mode)
 
 	repos, err := validateRepoSlugs(body.Repos)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if len(repos) > 0 && !sessionModeSupportsRepos(body.Mode) {
+	if len(repos) > 0 && !sessionModeSupportsRepos(mode) {
 		writeError(w, http.StatusBadRequest, errReposUnsupportedForMode.Error())
+		return
+	}
+	runConfig, status, detail := validateCreateRunConfig(mode, body.Model, body.Effort)
+	if status != 0 {
+		writeError(w, status, detail)
 		return
 	}
 
@@ -161,10 +170,12 @@ func (s *appServer) handleInternalCreateSession(w http.ResponseWriter, r *http.R
 	// of scope for the repos feature.
 	info, err := s.mgr.Create(r.Context(), sessions.CreateOptions{
 		Owner:           user.ActorEmail,
-		Mode:            body.Mode,
+		Mode:            mode,
 		GlimmungContext: body.GlimmungContext,
 		RequestedAt:     body.Name,
 		Repos:           repos,
+		Model:           runConfig.Model,
+		Effort:          runConfig.Effort,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/backend-go/cmd/tank-operator/handlers_internal_session_events.go
+++ b/backend-go/cmd/tank-operator/handlers_internal_session_events.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
 )
 
 type internalSessionPodCaller struct {
@@ -53,6 +56,83 @@ func (s *appServer) handleInternalSessionTurnTerminal(w http.ResponseWriter, r *
 		"terminal": true,
 		"event":    event,
 	})
+}
+
+func (s *appServer) handleInternalSessionRuntimeConfig(w http.ResponseWriter, r *http.Request) {
+	caller, ok := s.requireInternalSessionPodCaller(w, r)
+	if !ok {
+		return
+	}
+	sessionID := strings.TrimSpace(r.PathValue("session_id"))
+	if sessionID == "" {
+		recordSessionRuntimeConfigUpdate("unknown", "bad_request")
+		writeError(w, http.StatusBadRequest, "missing session_id")
+		return
+	}
+	if sessionID != caller.SessionID {
+		recordSessionRuntimeConfigUpdate("unknown", "forbidden")
+		writeError(w, http.StatusForbidden, "session target does not match caller pod")
+		return
+	}
+
+	var body struct {
+		Model  string `json:"model"`
+		Effort string `json:"effort"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		recordSessionRuntimeConfigUpdate("unknown", "bad_request")
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	if s.mgr == nil {
+		recordSessionRuntimeConfigUpdate("unknown", "manager_unavailable")
+		writeError(w, http.StatusServiceUnavailable, "session manager unavailable")
+		return
+	}
+	model := strings.TrimSpace(body.Model)
+	if model != "" && validateTurnArg(model) == "" {
+		recordSessionRuntimeConfigUpdate("unknown", "bad_request")
+		writeError(w, http.StatusBadRequest, "model is invalid")
+		return
+	}
+
+	info, err := s.mgr.GetRegisteredByOwner(r.Context(), caller.Email, sessionID)
+	if err != nil {
+		recordSessionRuntimeConfigUpdate("unknown", "not_found")
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	provider, ok := sdkProviderForMode(info.Mode)
+	if !ok {
+		recordSessionRuntimeConfigUpdate("unknown", "bad_request")
+		writeError(w, http.StatusBadRequest, "session mode does not support SDK runtime config")
+		return
+	}
+	effortInput := strings.TrimSpace(body.Effort)
+	effort := validateEffort(provider, effortInput)
+	if effortInput != "" && effort == "" {
+		recordSessionRuntimeConfigUpdate(provider, "bad_request")
+		if provider == "codex" {
+			writeError(w, http.StatusBadRequest, "effort is invalid; want one of low|medium|high|xhigh")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "effort is invalid; want one of low|medium|high|xhigh|max")
+		return
+	}
+
+	updated, err := s.mgr.SetRuntimeConfig(r.Context(), caller.Email, sessionID, model, effort)
+	if err != nil {
+		if errors.Is(err, sessions.ErrNotFound) {
+			recordSessionRuntimeConfigUpdate(provider, "not_found")
+			writeError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		recordSessionRuntimeConfigUpdate(provider, "update_failed")
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	recordSessionRuntimeConfigUpdate(provider, "ok")
+	writeJSON(w, http.StatusOK, updated)
 }
 
 func (s *appServer) requireInternalSessionPodCaller(w http.ResponseWriter, r *http.Request) (internalSessionPodCaller, bool) {

--- a/backend-go/cmd/tank-operator/handlers_internal_test.go
+++ b/backend-go/cmd/tank-operator/handlers_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
 	"github.com/nelsong6/tank-operator/backend-go/internal/profiles"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
 	"github.com/nelsong6/tank-operator/backend-go/internal/store"
 )
 
@@ -249,6 +252,47 @@ func TestHandleInternalSessionTurnTerminalRejectsOtherSession(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleInternalSessionRuntimeConfigRecordsAppliedConfig(t *testing.T) {
+	server := internalSessionRuntimeServer(t, "12")
+	registry := newTestSessionRegistry(sessionmodel.SessionRecord{
+		ID:      "12",
+		Email:   "owner@example.test",
+		Mode:    sessionmodel.CodexGUIMode,
+		Visible: true,
+		Status:  "Active",
+		Model:   "gpt-5.5",
+		Effort:  "xhigh",
+	})
+	server.mgr = sessions.NewManager(server.k8s, nil, server.namespace, registry, nil, sessions.ManagerOptions{})
+	req := httptest.NewRequest(http.MethodPut, "/api/internal/sessions/12/runtime-config", strings.NewReader(`{
+		"model":"gpt-5.5",
+		"effort":"xhigh"
+	}`))
+	req.SetPathValue("session_id", "12")
+	req.Header.Set("Authorization", "Bearer session-token")
+	rec := httptest.NewRecorder()
+
+	server.handleInternalSessionRuntimeConfig(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body sessions.Info
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.RuntimeModel != "gpt-5.5" || body.RuntimeEffort != "xhigh" || body.RuntimeConfiguredAt == nil || *body.RuntimeConfiguredAt == "" {
+		t.Fatalf("runtime config response = %#v", body)
+	}
+	record, ok, err := registry.Get(context.Background(), "owner@example.test", "12")
+	if err != nil || !ok {
+		t.Fatalf("registry Get ok=%v err=%v", ok, err)
+	}
+	if record.RuntimeModel != "gpt-5.5" || record.RuntimeEffort != "xhigh" || record.RuntimeConfiguredAt == "" {
+		t.Fatalf("registry runtime config = %#v", record)
 	}
 }
 

--- a/backend-go/cmd/tank-operator/handlers_session_list_events_test.go
+++ b/backend-go/cmd/tank-operator/handlers_session_list_events_test.go
@@ -181,6 +181,40 @@ func TestMarshalRowUpdateIncludesSidebarPosition(t *testing.T) {
 	}
 }
 
+func TestMarshalRowUpdateIncludesSessionRunConfig(t *testing.T) {
+	payload, err := sessioncontroller.MarshalRowUpdate(sessionmodel.SessionRecord{
+		ID:                  "8",
+		Email:               "u@example.com",
+		Scope:               "default",
+		Visible:             true,
+		Status:              "Active",
+		Model:               "gpt-5.5",
+		Effort:              "xhigh",
+		RuntimeModel:        "gpt-5.5",
+		RuntimeEffort:       "xhigh",
+		RuntimeConfiguredAt: "2026-05-21T00:00:00Z",
+		RowVersion:          99,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe struct {
+		Row struct {
+			Model               string `json:"model"`
+			Effort              string `json:"effort"`
+			RuntimeModel        string `json:"runtime_model"`
+			RuntimeEffort       string `json:"runtime_effort"`
+			RuntimeConfiguredAt string `json:"runtime_configured_at"`
+		} `json:"row"`
+	}
+	if err := json.Unmarshal(payload, &probe); err != nil {
+		t.Fatal(err)
+	}
+	if probe.Row.Model != "gpt-5.5" || probe.Row.Effort != "xhigh" || probe.Row.RuntimeModel != "gpt-5.5" || probe.Row.RuntimeEffort != "xhigh" || probe.Row.RuntimeConfiguredAt == "" {
+		t.Fatalf("run config row = %#v", probe.Row)
+	}
+}
+
 // TestMarshalRowUpdateRepos pins the SSE wire contract for the
 // repo-selection field: always an array, never absent, even when
 // the row has no repos picked. The SPA reads this directly into the

--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -119,24 +119,34 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 	}
 	var body struct {
 		Mode        string                           `json:"mode"`
+		Model       string                           `json:"model,omitempty"`
+		Effort      string                           `json:"effort,omitempty"`
 		Repos       []string                         `json:"repos"`
 		InitialTurn *createSessionInitialTurnRequest `json:"initial_turn,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		body.Mode = ""
+		body.Model = ""
+		body.Effort = ""
 		body.Repos = nil
 		body.InitialTurn = nil
 	}
+	mode := sessionmodel.NormalizeSessionMode(body.Mode)
 	repos, err := validateRepoSlugs(body.Repos)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if len(repos) > 0 && !sessionModeSupportsRepos(body.Mode) {
+	if len(repos) > 0 && !sessionModeSupportsRepos(mode) {
 		writeError(w, http.StatusBadRequest, errReposUnsupportedForMode.Error())
 		return
 	}
-	initialTurn, status, detail := validateCreateSessionInitialTurn(body.Mode, body.InitialTurn)
+	runConfig, status, detail := validateCreateRunConfig(mode, body.Model, body.Effort)
+	if status != 0 {
+		writeError(w, status, detail)
+		return
+	}
+	initialTurn, status, detail := validateCreateSessionInitialTurn(mode, body.InitialTurn)
 	if status != 0 {
 		writeError(w, status, detail)
 		return
@@ -145,7 +155,7 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusServiceUnavailable, "initial_turn submit path unavailable")
 		return
 	}
-	if body.InitialTurn != nil && !initialTurn.Deferred && !sessionmodel.IsNoPodMode(body.Mode) && s.sessionBus == nil {
+	if body.InitialTurn != nil && !initialTurn.Deferred && !sessionmodel.IsNoPodMode(mode) && s.sessionBus == nil {
 		writeError(w, http.StatusServiceUnavailable, "initial_turn submit path unavailable")
 		return
 	}
@@ -158,8 +168,10 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 	}
 	info, err := s.mgr.Create(r.Context(), sessions.CreateOptions{
 		Owner:       owner,
-		Mode:        body.Mode,
+		Mode:        mode,
 		Repos:       repos,
+		Model:       runConfig.Model,
+		Effort:      runConfig.Effort,
 		RequestedAt: requestedAt,
 	})
 	if err != nil {
@@ -763,6 +775,8 @@ func (s *appServer) handleCreateSessionWithContext(w http.ResponseWriter, r *htt
 		ValidationURL         string   `json:"validation_url"`
 		CallerEmail           string   `json:"caller_email"`
 		Mode                  string   `json:"mode"`
+		Model                 string   `json:"model,omitempty"`
+		Effort                string   `json:"effort,omitempty"`
 		Repos                 []string `json:"repos"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -774,6 +788,7 @@ func (s *appServer) handleCreateSessionWithContext(w http.ResponseWriter, r *htt
 	if body.CallerEmail != "" {
 		email = body.CallerEmail
 	}
+	mode := sessionmodel.NormalizeSessionMode(body.Mode)
 
 	glimmungContext := map[string]any{}
 	if body.GlimmungRunRef != "" {
@@ -794,16 +809,23 @@ func (s *appServer) handleCreateSessionWithContext(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if len(repos) > 0 && !sessionModeSupportsRepos(body.Mode) {
+	if len(repos) > 0 && !sessionModeSupportsRepos(mode) {
 		writeError(w, http.StatusBadRequest, errReposUnsupportedForMode.Error())
+		return
+	}
+	runConfig, status, detail := validateCreateRunConfig(mode, body.Model, body.Effort)
+	if status != 0 {
+		writeError(w, status, detail)
 		return
 	}
 
 	info, err := s.mgr.Create(r.Context(), sessions.CreateOptions{
 		Owner:           email,
-		Mode:            body.Mode,
+		Mode:            mode,
 		GlimmungContext: glimmungContext,
 		Repos:           repos,
+		Model:           runConfig.Model,
+		Effort:          runConfig.Effort,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -427,6 +427,35 @@ type sdkTurnRequest struct {
 	OriginSessionID string
 }
 
+type sessionRunConfig struct {
+	Model  string
+	Effort string
+}
+
+func validateCreateRunConfig(mode, rawModel, rawEffort string) (sessionRunConfig, int, string) {
+	modelInput := strings.TrimSpace(rawModel)
+	effortInput := strings.TrimSpace(rawEffort)
+	if modelInput == "" && effortInput == "" {
+		return sessionRunConfig{}, 0, ""
+	}
+	provider, ok := sdkProviderForMode(mode)
+	if !ok {
+		return sessionRunConfig{}, http.StatusBadRequest, "model and effort are only supported for SDK chat sessions"
+	}
+	model := validateTurnArg(modelInput)
+	if modelInput != "" && model == "" {
+		return sessionRunConfig{}, http.StatusBadRequest, "model is invalid"
+	}
+	effort := validateEffort(provider, effortInput)
+	if effortInput != "" && effort == "" {
+		if provider == "codex" {
+			return sessionRunConfig{}, http.StatusBadRequest, "effort is invalid; want one of low|medium|high|xhigh"
+		}
+		return sessionRunConfig{}, http.StatusBadRequest, "effort is invalid; want one of low|medium|high|xhigh|max"
+	}
+	return sessionRunConfig{Model: model, Effort: effort}, 0, ""
+}
+
 func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string, req sdkTurnRequest) (map[string]string, int, string) {
 	createdAt := req.CreatedAt
 	if createdAt.IsZero() {
@@ -506,8 +535,14 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 	// runner trusts whatever lands on the wire and has no rejection path
 	// of its own, so the choke point is here. Empty is allowed and means
 	// "use the runner's baked-in default" — that mapping is preserved.
+	model := validateTurnArg(req.Model)
 	effort := validateEffort(provider, strings.TrimSpace(req.Effort))
-	if strings.TrimSpace(req.Effort) != "" && effort == "" {
+	registered, regErr := s.mgr.GetRegisteredByOwner(ctx, email, sessionID)
+	hasSessionRunConfig := regErr == nil && (registered.Model != "" || registered.Effort != "")
+	if hasSessionRunConfig {
+		model = registered.Model
+		effort = registered.Effort
+	} else if strings.TrimSpace(req.Effort) != "" && effort == "" {
 		if provider == "codex" {
 			return nil, http.StatusBadRequest, "effort is invalid; want one of low|medium|high|xhigh"
 		}
@@ -565,7 +600,7 @@ func (s *appServer) enqueueSDKTurn(ctx context.Context, email, sessionID string,
 		TurnID:            turnID,
 		ClientNonce:       clientNonce,
 		Prompt:            prompt,
-		Model:             validateTurnArg(req.Model),
+		Model:             model,
 		Effort:            effort,
 		PermissionMode:    validateTurnArg(req.PermissionMode),
 		SkillName:         skillName,

--- a/backend-go/cmd/tank-operator/handlers_turns_test.go
+++ b/backend-go/cmd/tank-operator/handlers_turns_test.go
@@ -143,6 +143,44 @@ func TestEnqueueSessionTurnPublishesSDKCommand(t *testing.T) {
 	}
 }
 
+func TestEnqueueSessionTurnUsesSessionOwnedRunConfig(t *testing.T) {
+	bus := &recordingSessionBus{}
+	registry := newTestSessionRegistry(sessionmodel.SessionRecord{
+		ID:      "63",
+		Email:   "user@example.com",
+		Mode:    sessionmodel.ClaudeGUIMode,
+		Visible: true,
+		Model:   "claude-opus-4-7",
+		Effort:  "high",
+	})
+	app := testTurnsAppWithRegistry(
+		t,
+		bus,
+		registry,
+		sdkSessionPod("session-63", "63", "user@example.com", sessionmodel.ClaudeGUIMode, "agent-runner"),
+	)
+	req := authedTurnRequest(t, "63", `{
+		"client_nonce":"turn-session-config",
+		"prompt":"hello",
+		"model":"claude-sonnet-4-6",
+		"effort":"bogus"
+	}`)
+	resp := httptest.NewRecorder()
+
+	app.handleEnqueueSessionTurn(resp, req)
+
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if len(bus.commands) != 1 {
+		t.Fatalf("published commands = %d, want 1", len(bus.commands))
+	}
+	got := bus.commands[0]
+	if got.Model != "claude-opus-4-7" || got.Effort != "high" {
+		t.Fatalf("command run config = model %q effort %q, want session-owned model/effort", got.Model, got.Effort)
+	}
+}
+
 func TestCreateSessionInitialTurnPersistsBeforeStartupStatus(t *testing.T) {
 	bus := &recordingSessionBus{}
 	app := testTurnsApp(t, bus)
@@ -884,6 +922,13 @@ func testTurnsApp(t *testing.T, bus sessionCommandBus, pods ...*corev1.Pod) *app
 		namespace:     ns,
 		sessionScope:  "default",
 	}
+}
+
+func testTurnsAppWithRegistry(t *testing.T, bus sessionCommandBus, registry sessions.SessionRegistry, pods ...*corev1.Pod) *appServer {
+	t.Helper()
+	app := testTurnsApp(t, bus, pods...)
+	app.mgr = sessions.NewManager(app.k8s, nil, app.namespace, registry, nil, sessions.ManagerOptions{})
+	return app
 }
 
 func sdkSessionPod(name, sessionID, email, mode, runnerContainer string) *corev1.Pod {

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -236,6 +236,39 @@ var sessionReposSelectedTotal = promauto.NewCounterVec(
 	[]string{"count_bucket"},
 )
 
+var sessionRuntimeConfigUpdateTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tank_session_runtime_config_update_total",
+		Help: "Session runtime config reports from pod-side runners, labeled by provider and bounded result.",
+	},
+	[]string{"provider", "result"},
+)
+
+func recordSessionRuntimeConfigUpdate(provider, result string) {
+	sessionRuntimeConfigUpdateTotal.WithLabelValues(
+		sessionRuntimeConfigProviderLabel(provider),
+		sessionRuntimeConfigResultLabel(result),
+	).Inc()
+}
+
+func sessionRuntimeConfigProviderLabel(provider string) string {
+	switch provider {
+	case "claude", "codex":
+		return provider
+	default:
+		return "unknown"
+	}
+}
+
+func sessionRuntimeConfigResultLabel(result string) string {
+	switch result {
+	case "ok", "bad_request", "forbidden", "not_found", "manager_unavailable", "update_failed":
+		return result
+	default:
+		return "other"
+	}
+}
+
 // --- Browser stream auth metrics ---
 //
 // Native EventSource cannot attach Authorization headers, so the SPA mints

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -174,6 +174,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/internal/sessions/{session_id}", s.handleInternalPatchSession)
 	mux.HandleFunc("GET /api/internal/sessions/{session_id}/capabilities", s.handleInternalSessionCapabilities)
 	mux.HandleFunc("GET /api/internal/sessions/{session_id}/turns/{turn_id}/terminal", s.handleInternalSessionTurnTerminal)
+	mux.HandleFunc("PUT /api/internal/sessions/{session_id}/runtime-config", s.handleInternalSessionRuntimeConfig)
 	mux.HandleFunc("POST /api/internal/sessions/{session_id}/test-state", s.handleInternalSetTestState)
 	mux.HandleFunc("POST /api/internal/sessions/{session_id}/rollout-state", s.handleInternalSetRolloutState)
 	mux.HandleFunc("POST /api/internal/sessions/{session_id}/clone-state", s.handleInternalSetCloneState)

--- a/backend-go/internal/pgstore/migrations.go
+++ b/backend-go/internal/pgstore/migrations.go
@@ -195,6 +195,24 @@ var schemaMigrations = []string{
 	`ALTER TABLE sessions
 		ADD COLUMN IF NOT EXISTS clone_state jsonb`,
 
+	// Session-owned model configuration. `model`/`effort` are the
+	// durable run options requested at session creation and used for
+	// every SDK submit_turn; per-turn model overrides are ignored once
+	// these are present. `runtime_*` is written back by the pod-side
+	// runner after it has handed the options to the executable/SDK,
+	// giving the UI an applied-config surface instead of echoing the
+	// launch picker.
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS model text NOT NULL DEFAULT ''`,
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS effort text NOT NULL DEFAULT ''`,
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS runtime_model text NOT NULL DEFAULT ''`,
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS runtime_effort text NOT NULL DEFAULT ''`,
+	`ALTER TABLE sessions
+		ADD COLUMN IF NOT EXISTS runtime_configured_at timestamptz`,
+
 	// `session_events` â€” the durable transcript ledger. Partition key in
 	// Cosmos was `tank_session_id`; in Postgres the same field is the high
 	// cardinality column we always filter and order by, so it leads the index.

--- a/backend-go/internal/sessioncontroller/row_publisher.go
+++ b/backend-go/internal/sessioncontroller/row_publisher.go
@@ -140,10 +140,15 @@ type rowWireShape struct {
 	// sessions/sessions.go → Info). Repos is non-nil-on-the-wire so
 	// the SPA never has to special-case "absent vs. empty"; clone
 	// state is omitted until the repo-cloner init container writes back.
-	Repos           []string       `json:"repos"`
-	CloneState      map[string]any `json:"clone_state,omitempty"`
-	SidebarPosition int64          `json:"sidebar_position"`
-	RowVersion      int64          `json:"row_version"`
+	Repos               []string       `json:"repos"`
+	CloneState          map[string]any `json:"clone_state,omitempty"`
+	Model               string         `json:"model,omitempty"`
+	Effort              string         `json:"effort,omitempty"`
+	RuntimeModel        string         `json:"runtime_model,omitempty"`
+	RuntimeEffort       string         `json:"runtime_effort,omitempty"`
+	RuntimeConfiguredAt string         `json:"runtime_configured_at,omitempty"`
+	SidebarPosition     int64          `json:"sidebar_position"`
+	RowVersion          int64          `json:"row_version"`
 }
 
 // MarshalRowUpdate produces the JSON wire payload for a single row.
@@ -162,26 +167,31 @@ func MarshalRowUpdate(record sessionmodel.SessionRecord) ([]byte, error) {
 	}
 	wire := RowUpdatePayload{
 		Row: rowWireShape{
-			ID:              record.ID,
-			Owner:           record.Email,
-			Mode:            record.Mode,
-			Scope:           record.Scope,
-			PodName:         record.PodName,
-			Name:            record.Name,
-			Visible:         record.Visible,
-			Status:          record.Status,
-			RequestedAt:     record.RequestedAt,
-			CreatedAt:       record.CreatedAt,
-			UpdatedAt:       record.UpdatedAt,
-			ReadyAt:         record.ReadyAt,
-			TerminatingAt:   record.TerminatingAt,
-			ActivitySummary: activity,
-			TestState:       record.TestState,
-			RolloutState:    record.RolloutState,
-			Repos:           repos,
-			CloneState:      record.CloneState,
-			SidebarPosition: record.SidebarPosition,
-			RowVersion:      record.RowVersion,
+			ID:                  record.ID,
+			Owner:               record.Email,
+			Mode:                record.Mode,
+			Scope:               record.Scope,
+			PodName:             record.PodName,
+			Name:                record.Name,
+			Visible:             record.Visible,
+			Status:              record.Status,
+			RequestedAt:         record.RequestedAt,
+			CreatedAt:           record.CreatedAt,
+			UpdatedAt:           record.UpdatedAt,
+			ReadyAt:             record.ReadyAt,
+			TerminatingAt:       record.TerminatingAt,
+			ActivitySummary:     activity,
+			TestState:           record.TestState,
+			RolloutState:        record.RolloutState,
+			Repos:               repos,
+			CloneState:          record.CloneState,
+			Model:               record.Model,
+			Effort:              record.Effort,
+			RuntimeModel:        record.RuntimeModel,
+			RuntimeEffort:       record.RuntimeEffort,
+			RuntimeConfiguredAt: record.RuntimeConfiguredAt,
+			SidebarPosition:     record.SidebarPosition,
+			RowVersion:          record.RowVersion,
 		},
 		Cursor: fmt.Sprintf("%d", record.RowVersion),
 	}

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -144,6 +144,19 @@ type SessionRecord struct {
 	// until the init container writes back the first state.
 	CloneState map[string]any
 
+	// Model/Effort are the session-owned run configuration accepted at
+	// create time. Runners consume these values through submit_turn
+	// commands rather than trusting per-turn browser state.
+	Model  string
+	Effort string
+
+	// RuntimeModel/RuntimeEffort are written by the runner after it
+	// hands options to the provider executable/SDK. This is the applied
+	// configuration surface the UI renders in the composer footer.
+	RuntimeModel        string
+	RuntimeEffort       string
+	RuntimeConfiguredAt string
+
 	// SidebarPosition is the durable user-facing sort key for the
 	// session list. Larger values render earlier. It is intentionally
 	// separate from RowVersion: row_version is the live-update cursor

--- a/backend-go/internal/sessionregistry/registry.go
+++ b/backend-go/internal/sessionregistry/registry.go
@@ -54,6 +54,11 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 			rollout_state,
 			COALESCE(repos, '{}'::text[]),
 			clone_state,
+			model,
+			effort,
+			runtime_model,
+			runtime_effort,
+			COALESCE(to_char(runtime_configured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS runtime_configured_at,
 			sidebar_position,
 			row_version
 		FROM sessions
@@ -75,6 +80,7 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 			visible                                                     bool
 			activitySummary, testState, rolloutState, cloneState        []byte
 			repos                                                       []string
+			model, effort, runtimeModel, runtimeEffort, runtimeAt       string
 			sidebarPosition, rowVersion                                 int64
 		)
 		if err := rows.Scan(
@@ -82,7 +88,9 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 			&requestedAt, &createdAt, &updatedAt,
 			&status, &readyAt, &terminatingAt,
 			&activitySummary, &testState, &rolloutState,
-			&repos, &cloneState, &sidebarPosition,
+			&repos, &cloneState, &model, &effort,
+			&runtimeModel, &runtimeEffort, &runtimeAt,
+			&sidebarPosition,
 			&rowVersion,
 		); err != nil {
 			return nil, err
@@ -91,26 +99,31 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 			mode = sessionmodel.DefaultSessionMode
 		}
 		records = append(records, sessionmodel.SessionRecord{
-			ID:              sessionID,
-			Email:           normalized,
-			Mode:            mode,
-			Scope:           s.scope,
-			PodName:         podName,
-			Name:            name,
-			Visible:         visible,
-			RequestedAt:     requestedAt,
-			CreatedAt:       createdAt,
-			UpdatedAt:       updatedAt,
-			Status:          status,
-			ReadyAt:         readyAt,
-			TerminatingAt:   terminatingAt,
-			ActivitySummary: activitySummary,
-			TestState:       unmarshalJSONB(testState),
-			RolloutState:    unmarshalJSONB(rolloutState),
-			Repos:           repos,
-			CloneState:      unmarshalJSONB(cloneState),
-			SidebarPosition: sidebarPosition,
-			RowVersion:      rowVersion,
+			ID:                  sessionID,
+			Email:               normalized,
+			Mode:                mode,
+			Scope:               s.scope,
+			PodName:             podName,
+			Name:                name,
+			Visible:             visible,
+			RequestedAt:         requestedAt,
+			CreatedAt:           createdAt,
+			UpdatedAt:           updatedAt,
+			Status:              status,
+			ReadyAt:             readyAt,
+			TerminatingAt:       terminatingAt,
+			ActivitySummary:     activitySummary,
+			TestState:           unmarshalJSONB(testState),
+			RolloutState:        unmarshalJSONB(rolloutState),
+			Repos:               repos,
+			CloneState:          unmarshalJSONB(cloneState),
+			Model:               model,
+			Effort:              effort,
+			RuntimeModel:        runtimeModel,
+			RuntimeEffort:       runtimeEffort,
+			RuntimeConfiguredAt: runtimeAt,
+			SidebarPosition:     sidebarPosition,
+			RowVersion:          rowVersion,
 		})
 	}
 	return records, rows.Err()

--- a/backend-go/internal/sessionregistry/write.go
+++ b/backend-go/internal/sessionregistry/write.go
@@ -85,12 +85,12 @@ func (s *Store) Upsert(ctx context.Context, record sessionmodel.SessionRecord) e
 			mode, pod_name, name, visible,
 			requested_at, created_at, updated_at,
 			status, ready_at,
-			repos, sidebar_position
+			repos, model, effort, sidebar_position
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7,
 			$8, COALESCE($9, now()), $10,
 			COALESCE(NULLIF($11, ''), 'Pending'), $12,
-			$13, COALESCE(NULLIF($14, 0), nextval('sessions_row_version_seq'))
+			$13, $14, $15, COALESCE(NULLIF($16, 0), nextval('sessions_row_version_seq'))
 		)
 		ON CONFLICT (email, session_scope, session_id) DO UPDATE
 		SET mode         = EXCLUDED.mode,
@@ -120,8 +120,33 @@ func (s *Store) Upsert(ctx context.Context, record sessionmodel.SessionRecord) e
 		status,
 		nullableTimestamp(readyAt),
 		repos,
+		strings.TrimSpace(record.Model),
+		strings.TrimSpace(record.Effort),
 		sidebarPosition,
 	)
+	return err
+}
+
+// SetRuntimeConfig records the model/effort options the pod-side runner
+// actually handed to the provider executable or SDK. The intended session
+// config is immutable after create; this applied surface is allowed to
+// update on runner restart so the UI reflects the current process.
+func (s *Store) SetRuntimeConfig(ctx context.Context, email, sessionID, model, effort string) error {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	sessionID = strings.TrimSpace(sessionID)
+	if normalized == "" || sessionID == "" {
+		return nil
+	}
+	const q = `
+		UPDATE sessions
+		SET runtime_model         = $4,
+			runtime_effort        = $5,
+			runtime_configured_at = now(),
+			updated_at            = now(),
+			row_version           = nextval('sessions_row_version_seq')
+		WHERE email = $1 AND session_scope = $2 AND session_id = $3
+	`
+	_, err := s.pool.Exec(ctx, q, normalized, s.scope, sessionID, strings.TrimSpace(model), strings.TrimSpace(effort))
 	return err
 }
 
@@ -234,26 +259,34 @@ func (s *Store) Get(ctx context.Context, owner, sessionID string) (sessionmodel.
 			rollout_state,
 			COALESCE(repos, '{}'::text[]),
 			clone_state,
+			model,
+			effort,
+			runtime_model,
+			runtime_effort,
+			COALESCE(to_char(runtime_configured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS runtime_configured_at,
 			sidebar_position,
 			row_version
 		FROM sessions
 		WHERE email = $1 AND session_scope = $2 AND session_id = $3
 	`
 	var (
-		mode, podName, requestedAt, createdAt, updatedAt     string
-		status, readyAt, terminatingAt                       string
-		name                                                 *string
-		visible                                              bool
-		activitySummary, testState, rolloutState, cloneState []byte
-		repos                                                []string
-		sidebarPosition, rowVersion                          int64
+		mode, podName, requestedAt, createdAt, updatedAt      string
+		status, readyAt, terminatingAt                        string
+		name                                                  *string
+		visible                                               bool
+		activitySummary, testState, rolloutState, cloneState  []byte
+		repos                                                 []string
+		model, effort, runtimeModel, runtimeEffort, runtimeAt string
+		sidebarPosition, rowVersion                           int64
 	)
 	err := s.pool.QueryRow(ctx, q, normalized, s.scope, sessionID).Scan(
 		&mode, &podName, &name, &visible,
 		&requestedAt, &createdAt, &updatedAt,
 		&status, &readyAt, &terminatingAt,
 		&activitySummary, &testState, &rolloutState,
-		&repos, &cloneState, &sidebarPosition,
+		&repos, &cloneState, &model, &effort,
+		&runtimeModel, &runtimeEffort, &runtimeAt,
+		&sidebarPosition,
 		&rowVersion,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -266,26 +299,31 @@ func (s *Store) Get(ctx context.Context, owner, sessionID string) (sessionmodel.
 		mode = sessionmodel.DefaultSessionMode
 	}
 	record := sessionmodel.SessionRecord{
-		ID:              sessionID,
-		Email:           normalized,
-		Mode:            mode,
-		Scope:           s.scope,
-		PodName:         podName,
-		Name:            name,
-		Visible:         visible,
-		RequestedAt:     requestedAt,
-		CreatedAt:       createdAt,
-		UpdatedAt:       updatedAt,
-		Status:          status,
-		ReadyAt:         readyAt,
-		TerminatingAt:   terminatingAt,
-		ActivitySummary: activitySummary,
-		TestState:       unmarshalJSONB(testState),
-		RolloutState:    unmarshalJSONB(rolloutState),
-		Repos:           repos,
-		CloneState:      unmarshalJSONB(cloneState),
-		SidebarPosition: sidebarPosition,
-		RowVersion:      rowVersion,
+		ID:                  sessionID,
+		Email:               normalized,
+		Mode:                mode,
+		Scope:               s.scope,
+		PodName:             podName,
+		Name:                name,
+		Visible:             visible,
+		RequestedAt:         requestedAt,
+		CreatedAt:           createdAt,
+		UpdatedAt:           updatedAt,
+		Status:              status,
+		ReadyAt:             readyAt,
+		TerminatingAt:       terminatingAt,
+		ActivitySummary:     activitySummary,
+		TestState:           unmarshalJSONB(testState),
+		RolloutState:        unmarshalJSONB(rolloutState),
+		Repos:               repos,
+		CloneState:          unmarshalJSONB(cloneState),
+		Model:               model,
+		Effort:              effort,
+		RuntimeModel:        runtimeModel,
+		RuntimeEffort:       runtimeEffort,
+		RuntimeConfiguredAt: runtimeAt,
+		SidebarPosition:     sidebarPosition,
+		RowVersion:          rowVersion,
 	}
 	return record, true, nil
 }

--- a/backend-go/internal/sessions/manager.go
+++ b/backend-go/internal/sessions/manager.go
@@ -266,6 +266,11 @@ type CreateOptions struct {
 	// the registry row and threads them into the pod manifest for the
 	// repo-cloner init container.
 	Repos []string
+	// Model/Effort are the session-owned SDK run configuration. The
+	// HTTP handler validates provider-specific effort values before
+	// calling Create; Manager persists them unchanged.
+	Model  string
+	Effort string
 }
 
 // Create creates a new session pod and registers it in the registry.
@@ -284,6 +289,8 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 	if repos == nil {
 		repos = []string{}
 	}
+	model := opts.Model
+	effort := opts.Effort
 
 	// hermes_gui (and any future no-pod mode) short-circuits the K8s
 	// pod-create path. The session exists as a Postgres registry row +
@@ -300,7 +307,7 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 		// no-pod. The repos arg is threaded for forward-compat with
 		// any future no-pod mode that wants repo metadata visible in
 		// the SPA without pod-side cloning.
-		return m.createNoPodSession(ctx, owner, mode, requestedAt, repos)
+		return m.createNoPodSession(ctx, owner, mode, requestedAt, repos, model, effort)
 	}
 
 	// Lazy re-resolution for first-install ordering.
@@ -368,6 +375,8 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 			RequestedAt: requestedAt,
 			UpdatedAt:   requestedAt,
 			Repos:       repos,
+			Model:       model,
+			Effort:      effort,
 		}); regErr != nil {
 			slog.Warn("create registry upsert failed",
 				"session_id", sessionID, "owner", owner, "error", regErr)
@@ -405,6 +414,8 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 		RequestedAt: &requestedAt,
 		CreatedAt:   createdAt,
 		Repos:       repos,
+		Model:       model,
+		Effort:      effort,
 	}
 
 	// Refresh the registry row with the K8s-assigned created_at so the
@@ -421,6 +432,8 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 			CreatedAt:   *createdAt,
 			UpdatedAt:   requestedAt,
 			Repos:       repos,
+			Model:       model,
+			Effort:      effort,
 		}); regErr != nil {
 			slog.Warn("create registry created_at refresh failed",
 				"session_id", sessionID, "owner", owner, "error", regErr)
@@ -469,7 +482,7 @@ func (m *Manager) Delete(ctx context.Context, owner, sessionID string) error {
 // makes sense for the external backend — here, "Active" once the row is
 // written. Reaper does not touch no-pod sessions because reaper lists
 // pods, not registry rows.
-func (m *Manager) createNoPodSession(ctx context.Context, owner, mode, requestedAt string, repos []string) (Info, error) {
+func (m *Manager) createNoPodSession(ctx context.Context, owner, mode, requestedAt string, repos []string, model, effort string) (Info, error) {
 	sessionID, err := m.nextSessionID(ctx)
 	if err != nil {
 		return Info{}, err
@@ -493,6 +506,8 @@ func (m *Manager) createNoPodSession(ctx context.Context, owner, mode, requested
 		Status:      "Active",
 		ReadyAt:     now,
 		Repos:       repos,
+		Model:       model,
+		Effort:      effort,
 	}
 	if m.registry != nil {
 		if regErr := m.registry.Upsert(ctx, rec); regErr != nil {
@@ -515,6 +530,8 @@ func (m *Manager) createNoPodSession(ctx context.Context, owner, mode, requested
 		CreatedAt:   &now,
 		ReadyAt:     &now,
 		Repos:       repos,
+		Model:       model,
+		Effort:      effort,
 	}
 	m.publishRow(ctx, owner, sessionID)
 	return info, nil
@@ -554,6 +571,9 @@ func (m *Manager) SetName(ctx context.Context, owner, sessionID string, name *st
 	}
 	m.publishRow(ctx, owner, sessionID)
 
+	if registered, err := m.GetRegisteredByOwner(ctx, owner, sessionID); err == nil {
+		return registered, nil
+	}
 	return m.GetByOwner(ctx, owner, sessionID)
 }
 
@@ -616,6 +636,24 @@ func (m *Manager) SetCloneState(ctx context.Context, owner, sessionID string, st
 	}
 	m.publishRow(ctx, owner, sessionID)
 	return m.GetByOwner(ctx, owner, sessionID)
+}
+
+type runtimeConfigRegistry interface {
+	SetRuntimeConfig(ctx context.Context, email, sessionID, model, effort string) error
+}
+
+// SetRuntimeConfig records the model/effort the runner actually applied
+// to the provider executable/SDK and publishes the updated session row.
+func (m *Manager) SetRuntimeConfig(ctx context.Context, owner, sessionID, model, effort string) (Info, error) {
+	registry, ok := m.registry.(runtimeConfigRegistry)
+	if !ok {
+		return Info{}, ErrNotFound
+	}
+	if err := registry.SetRuntimeConfig(ctx, owner, sessionID, model, effort); err != nil {
+		return Info{}, err
+	}
+	m.publishRow(ctx, owner, sessionID)
+	return m.GetRegisteredByOwner(ctx, owner, sessionID)
 }
 
 // ReorderSessions persists the complete visible sidebar order for one

--- a/backend-go/internal/sessions/manager_test.go
+++ b/backend-go/internal/sessions/manager_test.go
@@ -266,6 +266,38 @@ func TestManagerReorderPersistsAndPublishesEveryRow(t *testing.T) {
 	}
 }
 
+func TestManagerSetRuntimeConfigPersistsAndPublishes(t *testing.T) {
+	registry := &managerTestRegistry{
+		records: []sessionmodel.SessionRecord{
+			{
+				ID:      "8",
+				Email:   "nelson@romaine.life",
+				Mode:    sessionmodel.CodexGUIMode,
+				Visible: true,
+				Status:  "Active",
+			},
+		},
+	}
+	emitter := &recordingRowEmitter{}
+	mgr := &Manager{
+		client:    fake.NewSimpleClientset(),
+		namespace: sessionmodel.SessionsNamespace,
+		registry:  registry,
+		emitter:   emitter,
+	}
+
+	info, err := mgr.SetRuntimeConfig(context.Background(), "nelson@romaine.life", "8", "gpt-5.5", "xhigh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.RuntimeModel != "gpt-5.5" || info.RuntimeEffort != "xhigh" || info.RuntimeConfiguredAt == nil || *info.RuntimeConfiguredAt == "" {
+		t.Fatalf("runtime config info = %#v", info)
+	}
+	if strings.Join(emitter.ids, ",") != "8" {
+		t.Fatalf("published ids = %v, want [8]", emitter.ids)
+	}
+}
+
 func assertSkillStateActive(t *testing.T, label string, state map[string]any, want bool) {
 	t.Helper()
 	if got := state["active"]; got != want {
@@ -334,6 +366,18 @@ func (r *managerTestRegistry) SetRolloutState(context.Context, string, string, m
 }
 
 func (r *managerTestRegistry) SetCloneState(context.Context, string, string, map[string]any) error {
+	return nil
+}
+
+func (r *managerTestRegistry) SetRuntimeConfig(_ context.Context, email, sessionID, model, effort string) error {
+	for i, record := range r.records {
+		if strings.EqualFold(record.Email, email) && record.ID == sessionID {
+			r.records[i].RuntimeModel = model
+			r.records[i].RuntimeEffort = effort
+			r.records[i].RuntimeConfiguredAt = "2026-05-21T00:00:00Z"
+			return nil
+		}
+	}
 	return nil
 }
 

--- a/backend-go/internal/sessions/sessions.go
+++ b/backend-go/internal/sessions/sessions.go
@@ -66,6 +66,14 @@ type Info struct {
 	// from the sessions.activity_summary column (Phase 2);
 	// nil for sessions that haven't produced any chat activity yet.
 	Activity *sessionactivity.ActivitySummary `json:"activity,omitempty"`
+	// Model/Effort are the durable session-owned run options. Runtime*
+	// fields are written back by the runner after it applies the config
+	// to the provider executable/SDK.
+	Model               string  `json:"model,omitempty"`
+	Effort              string  `json:"effort,omitempty"`
+	RuntimeModel        string  `json:"runtime_model,omitempty"`
+	RuntimeEffort       string  `json:"runtime_effort,omitempty"`
+	RuntimeConfiguredAt *string `json:"runtime_configured_at,omitempty"`
 }
 
 type Reader struct {
@@ -223,21 +231,26 @@ func infoFromRecord(owner string, record sessionmodel.SessionRecord) Info {
 		repos = []string{}
 	}
 	info := Info{
-		ID:              record.ID,
-		PodName:         optionalString(record.PodName),
-		Owner:           owner,
-		Status:          status,
-		Mode:            sessionmodel.NormalizeSessionMode(record.Mode),
-		RequestedAt:     firstString(record.RequestedAt, record.CreatedAt),
-		CreatedAt:       optionalString(record.CreatedAt),
-		ReadyAt:         optionalString(record.ReadyAt),
-		Name:            record.Name,
-		TestState:       record.TestState,
-		RolloutState:    record.RolloutState,
-		Repos:           repos,
-		CloneState:      record.CloneState,
-		RowVersion:      record.RowVersion,
-		SidebarPosition: record.SidebarPosition,
+		ID:                  record.ID,
+		PodName:             optionalString(record.PodName),
+		Owner:               owner,
+		Status:              status,
+		Mode:                sessionmodel.NormalizeSessionMode(record.Mode),
+		RequestedAt:         firstString(record.RequestedAt, record.CreatedAt),
+		CreatedAt:           optionalString(record.CreatedAt),
+		ReadyAt:             optionalString(record.ReadyAt),
+		Name:                record.Name,
+		TestState:           record.TestState,
+		RolloutState:        record.RolloutState,
+		Repos:               repos,
+		CloneState:          record.CloneState,
+		RowVersion:          record.RowVersion,
+		SidebarPosition:     record.SidebarPosition,
+		Model:               record.Model,
+		Effort:              record.Effort,
+		RuntimeModel:        record.RuntimeModel,
+		RuntimeEffort:       record.RuntimeEffort,
+		RuntimeConfiguredAt: optionalString(record.RuntimeConfiguredAt),
 	}
 	if activity := parseActivitySummary(record.ActivitySummary); activity != nil {
 		info.Activity = activity

--- a/codex-runner/src/appServerTransport.ts
+++ b/codex-runner/src/appServerTransport.ts
@@ -37,6 +37,7 @@ type AppServerTransportOptions = {
     request: AppServerUserInputRequest,
     signal?: AbortSignal,
   ) => Promise<AppServerUserInputResponse>;
+  onRuntimeConfigApplied?: (threadOptions: ThreadOptions) => void;
 };
 
 type PendingRequest = {
@@ -253,6 +254,7 @@ export class CodexAppServerTransport {
     const id = typeof thread?.id === "string" ? thread.id : undefined;
     if (!id) throw new Error("codex app-server thread/start response did not include thread.id");
     this.threadID = id;
+    this.opts.onRuntimeConfigApplied?.(threadOptions);
     this.activeQueue?.push({ kind: "event", event: { type: "thread.started", thread_id: id } });
     return id;
   }

--- a/codex-runner/src/runner.ts
+++ b/codex-runner/src/runner.ts
@@ -54,6 +54,7 @@ import {
   type SessionCommandRecord,
 } from "./sessionCommands.js";
 import { truncateEventIfOversized } from "../../runner-shared/sessionBus.js";
+import { reportRuntimeConfig } from "../../runner-shared/runtimeConfig.js";
 import {
   commandsConsumedTotal,
   eventTruncatedTotal,
@@ -345,9 +346,19 @@ export class Runner {
             cwd: cfg.workspace,
             onRequestUserInput: (request, requestSignal) =>
               this.requestAppServerUserInput(request, requestSignal),
+            onRuntimeConfigApplied: (threadOptions) =>
+              this.reportAppliedRuntimeConfig(threadOptions),
           })
         : null;
     this.codexAdapter = new CodexTankEventAdapter(cfg);
+  }
+
+  private reportAppliedRuntimeConfig(threadOptions: ThreadOptions): void {
+    const model = String(threadOptions.model ?? "").trim();
+    const effort = String(threadOptions.modelReasoningEffort ?? "").trim();
+    void reportRuntimeConfig(this.cfg, { model, effort }).catch((err) => {
+      console.warn("runtime config report failed:", err);
+    });
   }
 
   // Run until externally aborted. Each iteration awaits one user
@@ -375,7 +386,9 @@ export class Runner {
         if (next.done) break;
         const { text: input, clientNonce, commandRecord } = next.value;
         if (!this.appServerTransport && !this.thread) {
-          this.thread = this.codex.startThread(threadOptionsForCommand(this.cfg, commandRecord));
+          const threadOptions = threadOptionsForCommand(this.cfg, commandRecord);
+          this.thread = this.codex.startThread(threadOptions);
+          this.reportAppliedRuntimeConfig(threadOptions);
         }
         const turnSeq = ++this.turnSeq;
         if (

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -69,6 +69,9 @@ All metric names are prefixed `tank_`. The full namespace:
   `execution_failed`. `tank_runner_provider_control_total{action,outcome}`
   counts bounded provider control calls, including Claude foreground-task
   backgrounding before interrupt and the interrupt signal itself.
+- `tank_session_runtime_config_update_total` - pod-side runner reports of
+  the model/effort actually applied to the provider runtime. Labels:
+  `provider` (`claude`, `codex`, `unknown`) and bounded `result`.
 - `tank_api_proxy_*` — api-proxy ext_proc counters/histograms. Single
   label: `provider` ("claude" or "codex"), bound from `PROXY_PROVIDER`.
 - `tank_mcp_auth_proxy_*` — sidecar counters/histograms. Label

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -315,6 +315,11 @@ interface Session {
   // clone_state is the per-repo repo-cloner init-container outcome.
   // Optional until the cloner writes back.
   clone_state?: Record<string, unknown> | null;
+  model?: string;
+  effort?: string;
+  runtime_model?: string;
+  runtime_effort?: string;
+  runtime_configured_at?: string | null;
   sidebar_position?: number;
 }
 
@@ -796,6 +801,12 @@ function normalizeSession(session: Session): Session {
   // array so downstream renderers can `.map` without a guard.
   next.repos = Array.isArray(session.repos) ? session.repos : [];
   next.clone_state = session.clone_state ?? null;
+  next.model = typeof session.model === "string" ? session.model : "";
+  next.effort = typeof session.effort === "string" ? session.effort : "";
+  next.runtime_model = typeof session.runtime_model === "string" ? session.runtime_model : "";
+  next.runtime_effort = typeof session.runtime_effort === "string" ? session.runtime_effort : "";
+  next.runtime_configured_at =
+    typeof session.runtime_configured_at === "string" ? session.runtime_configured_at : null;
   return next;
 }
 
@@ -2655,6 +2666,37 @@ const CODEX_EFFORTS: EffortOption[] = [
 ];
 const DEFAULT_CODEX_MODEL_ID = "gpt-5.5";
 const DEFAULT_CODEX_EFFORT_ID = "xhigh";
+
+function modelOptionsForMode(mode: SessionMode): ModelOption[] {
+  if (mode === "claude_gui") return CLAUDE_MODELS;
+  if (mode === "codex_gui" || mode === "codex_exec_gui" || mode === "codex_app_server") {
+    return CODEX_MODELS;
+  }
+  return [];
+}
+
+function effortOptionsForMode(mode: SessionMode): EffortOption[] {
+  if (mode === "claude_gui") return CLAUDE_EFFORTS;
+  if (mode === "codex_gui" || mode === "codex_exec_gui" || mode === "codex_app_server") {
+    return CODEX_EFFORTS;
+  }
+  return [];
+}
+
+function modelDisplayLabel(mode: SessionMode, modelId: string): string {
+  const trimmed = modelId.trim();
+  if (!trimmed && (mode === "codex_gui" || mode === "codex_exec_gui" || mode === "codex_app_server")) {
+    return "Codex account default";
+  }
+  if (!trimmed) return "";
+  return modelOptionsForMode(mode).find((option) => option.id === trimmed)?.label ?? trimmed;
+}
+
+function effortDisplayLabel(mode: SessionMode, effortId: string): string {
+  const trimmed = effortId.trim();
+  if (!trimmed) return "";
+  return effortOptionsForMode(mode).find((option) => option.id === trimmed)?.label ?? trimmed;
+}
 
 // Per-user run-pane preferences. localStorage-backed, shared across all
 // sessions in this browser. Keys mirror cloudcli's QuickSettings.
@@ -5654,20 +5696,39 @@ function ChatPane({
   // because the runners seal model + effort from the first submit_turn —
   // the splash screen is where the user adjusts the defaults before a
   // session is created.
-  const initialModelId = isClaude
-    ? (CLAUDE_MODELS.some((opt) => opt.id === runPrefs.claudeModelId)
-        ? runPrefs.claudeModelId
-        : DEFAULT_CLAUDE_MODEL_ID)
-    : (CODEX_MODELS.some((opt) => opt.id === runPrefs.codexModelId)
-        ? runPrefs.codexModelId
-        : DEFAULT_CODEX_MODEL_ID);
-  const initialEffortId = isClaude
-    ? (CLAUDE_EFFORTS.some((opt) => opt.id === runPrefs.claudeEffort)
-        ? runPrefs.claudeEffort
-        : DEFAULT_CLAUDE_EFFORT_ID)
-    : (CODEX_EFFORTS.some((opt) => opt.id === runPrefs.codexEffort)
-        ? runPrefs.codexEffort
-        : DEFAULT_CODEX_EFFORT_ID);
+  // Existing sessions prefer the durable session-owned run config; browser
+  // prefs are only the fallback for older rows that do not have it.
+  const configuredModelId = (session.model ?? "").trim();
+  const configuredEffortId = (session.effort ?? "").trim();
+  const hasConfiguredSessionRunConfig = Boolean(configuredModelId || configuredEffortId);
+  const modelOptions = modelOptionsForMode(session.mode);
+  const effortOptions = effortOptionsForMode(session.mode);
+  const preferredModelId = isClaude
+    ? runPrefs.claudeModelId
+    : isCodex
+      ? runPrefs.codexModelId
+      : "";
+  const preferredEffortId = isClaude
+    ? runPrefs.claudeEffort
+    : isCodex
+      ? runPrefs.codexEffort
+      : "";
+  const fallbackModelId = isClaude
+    ? DEFAULT_CLAUDE_MODEL_ID
+    : isCodex
+      ? DEFAULT_CODEX_MODEL_ID
+      : "";
+  const fallbackEffortId = isClaude
+    ? DEFAULT_CLAUDE_EFFORT_ID
+    : isCodex
+      ? DEFAULT_CODEX_EFFORT_ID
+      : "";
+  const initialModelId = hasConfiguredSessionRunConfig
+    ? (configuredModelId || (isCodex ? CODEX_ACCOUNT_DEFAULT_MODEL_ID : fallbackModelId))
+    : (modelOptions.some((opt) => opt.id === preferredModelId) ? preferredModelId : fallbackModelId);
+  const initialEffortId = hasConfiguredSessionRunConfig
+    ? (configuredEffortId || fallbackEffortId)
+    : (effortOptions.some((opt) => opt.id === preferredEffortId) ? preferredEffortId : fallbackEffortId);
   const [selectedModelId] = useState<string>(initialModelId);
   const [selectedEffortId] = useState<string>(initialEffortId);
   // Run timing — drives the streaming status pill's elapsed counter and the
@@ -7834,7 +7895,27 @@ function ChatPane({
   const currentSkillState = currentSessionSkillState(testState, rolloutState);
   const testActionActive = currentSkillState === "test";
   const rolloutActionActive = currentSkillState === "rollout";
-  const contextWindow = getContextWindow(selectedModelId);
+  const appliedModelId = (session.runtime_model ?? "").trim();
+  const appliedEffortId = (session.runtime_effort ?? "").trim();
+  const hasAppliedRuntimeConfig = Boolean(session.runtime_configured_at);
+  const configuredDisplayModelId =
+    selectedModelId === CODEX_ACCOUNT_DEFAULT_MODEL_ID ? "" : selectedModelId;
+  const configuredModelLabel =
+    modelDisplayLabel(session.mode, configuredDisplayModelId) || "default model";
+  const configuredEffortLabel = effortDisplayLabel(session.mode, selectedEffortId);
+  const modelChipLabel = hasAppliedRuntimeConfig
+    ? (modelDisplayLabel(session.mode, appliedModelId) || "Default model")
+    : "Model pending";
+  const effortChipLabel = hasAppliedRuntimeConfig
+    ? effortDisplayLabel(session.mode, appliedEffortId)
+    : "";
+  const modelChipTitle = hasAppliedRuntimeConfig
+    ? `Runtime applied: ${modelChipLabel}${effortChipLabel ? ` / ${effortChipLabel}` : ""}`
+    : `Waiting for runner report. Intended: ${configuredModelLabel}${configuredEffortLabel ? ` / ${configuredEffortLabel}` : ""}`;
+  const modelForContext = selectedModelId === CODEX_ACCOUNT_DEFAULT_MODEL_ID
+    ? DEFAULT_CODEX_MODEL_ID
+    : selectedModelId;
+  const contextWindow = getContextWindow(modelForContext);
 
   const focusComposerTextarea = useCallback((): boolean => {
     const textarea = composerWrapRef.current?.querySelector("textarea") as HTMLTextAreaElement | null;
@@ -8952,6 +9033,19 @@ function ChatPane({
                   </span>
                 )}
               </button>
+              {(isClaude || isCodex) && (
+                <span
+                  className={`run-model-chip${hasAppliedRuntimeConfig ? "" : " is-pending"}`}
+                  title={modelChipTitle}
+                  aria-label={modelChipTitle}
+                >
+                  <BrainIcon className="run-model-chip-icon" aria-hidden="true" />
+                  <span className="run-model-chip-label">{modelChipLabel}</span>
+                  {effortChipLabel && (
+                    <span className="run-model-chip-effort">{effortChipLabel}</span>
+                  )}
+                </span>
+              )}
             </>
           }
         />
@@ -9506,6 +9600,11 @@ export function App() {
       activity: undefined, // activities live in the parallel sessionActivities map
       repos: Array.isArray(row.repos) ? row.repos : [],
       clone_state: (row.clone_state as Record<string, unknown> | undefined) ?? null,
+      model: row.model ?? "",
+      effort: row.effort ?? "",
+      runtime_model: row.runtime_model ?? "",
+      runtime_effort: row.runtime_effort ?? "",
+      runtime_configured_at: row.runtime_configured_at ?? null,
     };
   }
 
@@ -9537,6 +9636,12 @@ export function App() {
       rollout_state: raw.rollout_state ?? undefined,
       repos: Array.isArray(raw.repos) ? raw.repos.map(String) : [],
       clone_state: raw.clone_state ?? undefined,
+      model: typeof raw.model === "string" ? raw.model : undefined,
+      effort: typeof raw.effort === "string" ? raw.effort : undefined,
+      runtime_model: typeof raw.runtime_model === "string" ? raw.runtime_model : undefined,
+      runtime_effort: typeof raw.runtime_effort === "string" ? raw.runtime_effort : undefined,
+      runtime_configured_at:
+        typeof raw.runtime_configured_at === "string" ? raw.runtime_configured_at : undefined,
       sidebar_position: sidebarPosition,
       row_version: rowVersion,
     };
@@ -10152,6 +10257,8 @@ export function App() {
       selectedProvider === "anthropic" || selectedProvider === "codex"
         ? selectedHomeEffortId
         : "";
+    const sessionModel = SDK_CHAT_MODES.has(mode) ? seedModel : "";
+    const sessionEffort = SDK_CHAT_MODES.has(mode) ? seedEffort : "";
     const seedInitialTurnAtCreate =
       seedTurnRequested && CREATE_TIME_INITIAL_TURN_MODES.has(mode);
     const seedTurnDeferredAtCreate =
@@ -10166,8 +10273,6 @@ export function App() {
           client_nonce: seedClientNonce,
           prompt: createTimeTurnPrompt,
           ...(seedTurnDeferredAtCreate ? { deferred: true } : {}),
-          model: seedModel,
-          ...(seedEffort ? { effort: seedEffort } : {}),
           permission_mode: initialPermissionMode,
           ...(requestedInitialSkillName ? { skill_name: requestedInitialSkillName } : {}),
         }
@@ -10179,6 +10284,7 @@ export function App() {
         body: JSON.stringify({
           mode,
           repos,
+          ...(sessionModel || sessionEffort ? { model: sessionModel, effort: sessionEffort } : {}),
           ...(initialTurnPayload ? { initial_turn: initialTurnPayload } : {}),
         }),
       });
@@ -10287,8 +10393,6 @@ export function App() {
             body: JSON.stringify({
               client_nonce: seedClientNonce,
               prompt: turnPrompt,
-              model: seedModel,
-              ...(seedEffort ? { effort: seedEffort } : {}),
               permission_mode: initialPermissionMode,
               ...(requestedInitialSkillName ? { skill_name: requestedInitialSkillName } : {}),
               ...(seedTurnDeferredAtCreate ? { existing_user_message: true } : {}),
@@ -10341,7 +10445,12 @@ export function App() {
       const res = await authedFetch("/api/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode }),
+        body: JSON.stringify({
+          mode,
+          ...(SDK_CHAT_MODES.has(mode) && (request.model || request.effort)
+            ? { model: request.model, effort: request.effort }
+            : {}),
+        }),
       });
       if (!res.ok) {
         let detail = `fork failed: ${res.status}`;
@@ -10371,10 +10480,6 @@ export function App() {
         body: JSON.stringify({
           client_nonce: newForkTurnId(),
           prompt,
-          model: request.model,
-          // Same omit-when-empty rule as enqueueSdkTurn: don't carry an
-          // empty effort on the wire for Codex forks.
-          ...(request.effort ? { effort: request.effort } : {}),
           permission_mode: request.permissionMode,
           follow_up: false,
           origin_session_id: request.sourceSession.id,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3754,6 +3754,47 @@ button:disabled {
   height: 1.1rem;
 }
 
+.run-model-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+  min-width: 0;
+  max-width: min(17rem, 34vw);
+  height: 2rem;
+  padding: 0 0.65rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text-body);
+  font-family: var(--font-primary);
+  font-size: 0.75rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.run-model-chip.is-pending {
+  color: var(--text-muted);
+  border-color: rgba(148, 163, 184, 0.14);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.run-model-chip-icon {
+  width: 0.95rem;
+  height: 0.95rem;
+  flex: 0 0 auto;
+}
+
+.run-model-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.run-model-chip-effort {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
 .run-composer-action-btn {
   text-decoration: none;
 }

--- a/frontend/src/modelEffortDefaults.test.ts
+++ b/frontend/src/modelEffortDefaults.test.ts
@@ -98,3 +98,21 @@ test("enqueueSdkTurn forwards effort on the POST body so the runner sees the use
   // the property MUST be present when run.effort is set.
   assert.match(appSource, /\.\.\.\(run\.effort \? \{ effort: run\.effort \} : \{\}\)/);
 });
+
+test("createSession forwards model and effort as session-owned config", () => {
+  assert.match(appSource, /const sessionModel = SDK_CHAT_MODES\.has\(mode\) \? seedModel : "";/);
+  assert.match(appSource, /const sessionEffort = SDK_CHAT_MODES\.has\(mode\) \? seedEffort : "";/);
+  assert.match(
+    appSource,
+    /\.\.\.\(sessionModel \|\| sessionEffort \? \{ model: sessionModel, effort: sessionEffort \} : \{\}\)/,
+  );
+  assert.doesNotMatch(appSource, /initialTurnPayload[\s\S]{0,400}model: seedModel/);
+});
+
+test("forkSessionFromMessage forwards model and effort on create, not the first turn", () => {
+  assert.match(
+    appSource,
+    /SDK_CHAT_MODES\.has\(mode\) && \(request\.model \|\| request\.effort\)[\s\S]{0,120}\{ model: request\.model, effort: request\.effort \}/,
+  );
+  assert.doesNotMatch(appSource, /client_nonce: newForkTurnId\(\)[\s\S]{0,160}model: request\.model/);
+});

--- a/frontend/src/sessionStore.test.ts
+++ b/frontend/src/sessionStore.test.ts
@@ -229,12 +229,22 @@ test("normalizeSessionRowUpdate rejects malformed payloads", () => {
       session_scope: "default",
       visible: true,
       status: "Active",
+      model: "gpt-5.5",
+      effort: "xhigh",
+      runtime_model: "gpt-5.5",
+      runtime_effort: "xhigh",
+      runtime_configured_at: "2026-05-21T00:00:00Z",
       sidebar_position: 7,
       row_version: 1,
     },
   });
   assert.ok(good, "valid payload must parse");
   assert.equal(good!.row.id, "8");
+  assert.equal(good!.row.model, "gpt-5.5");
+  assert.equal(good!.row.effort, "xhigh");
+  assert.equal(good!.row.runtime_model, "gpt-5.5");
+  assert.equal(good!.row.runtime_effort, "xhigh");
+  assert.equal(good!.row.runtime_configured_at, "2026-05-21T00:00:00Z");
   assert.equal(good!.row.sidebar_position, 7);
   assert.equal(good!.row.row_version, 1);
 });

--- a/frontend/src/sessionStore.ts
+++ b/frontend/src/sessionStore.ts
@@ -69,6 +69,11 @@ export interface SessionRow {
   // until the cloner writes back; null/missing means
   // "no clone state yet" rather than "clone succeeded."
   clone_state?: Record<string, unknown>;
+  model?: string;
+  effort?: string;
+  runtime_model?: string;
+  runtime_effort?: string;
+  runtime_configured_at?: string;
   // Durable user-facing order for the sidebar. Larger values render
   // earlier. This is intentionally separate from row_version so
   // status/test/rollout/activity updates do not reshuffle rows.
@@ -339,6 +344,11 @@ export function normalizeSessionRowUpdate(value: unknown): SessionRowUpdatePaylo
       clone_state: isRecord(rowRaw.clone_state)
         ? (rowRaw.clone_state as Record<string, unknown>)
         : undefined,
+      model: stringField(rowRaw, "model") ?? undefined,
+      effort: stringField(rowRaw, "effort") ?? undefined,
+      runtime_model: stringField(rowRaw, "runtime_model") ?? undefined,
+      runtime_effort: stringField(rowRaw, "runtime_effort") ?? undefined,
+      runtime_configured_at: stringField(rowRaw, "runtime_configured_at") ?? undefined,
       sidebar_position: sidebarPosition,
       row_version: rowVersion,
     },

--- a/runner-shared/runtimeConfig.d.ts
+++ b/runner-shared/runtimeConfig.d.ts
@@ -1,0 +1,6 @@
+import type { SessionBusConfig } from "./sessionBus.js";
+
+export function reportRuntimeConfig(
+  cfg: SessionBusConfig,
+  payload: { model?: string; effort?: string },
+): Promise<boolean>;

--- a/runner-shared/runtimeConfig.js
+++ b/runner-shared/runtimeConfig.js
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+
+function trimTrailingSlashes(value) {
+    return String(value || "").replace(/\/+$/, "");
+}
+
+export async function reportRuntimeConfig(cfg, payload) {
+    const baseURL = trimTrailingSlashes(cfg.operatorInternalURL || "");
+    const tokenPath = cfg.operatorTokenPath || "";
+    if (!baseURL || !tokenPath || !cfg.sessionId) {
+        return false;
+    }
+    const token = (await readFile(tokenPath, "utf8")).trim();
+    const url = `${baseURL}/api/internal/sessions/${encodeURIComponent(cfg.sessionId)}/runtime-config`;
+    const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model: String(payload?.model ?? "").trim(),
+            effort: String(payload?.effort ?? "").trim(),
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`runtime config report failed: ${response.status}`);
+    }
+    return true;
+}


### PR DESCRIPTION
## Summary
- Persist session-owned model and effort settings at session creation and use them for subsequent turns.
- Let Claude and Codex runners report the runtime-applied model/effort back to the operator.
- Display the runner-confirmed model near the composer controls, with a pending state until the executable reports applied config.

## Verification
- backend-go: go test ./...
- frontend: npm test -- --runInBand
- frontend: npm run build
- agent-runner: npm run build
- agent-runner: npm test -- --runInBand
- codex-runner: npm run build
- codex-runner: npm test -- --runInBand
- Browser smoke check against local Vite dev server