### PR TITLE
Add feature contract documentation gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+-
+
+## Feature Contracts
+
+Affected contracts:
+- [ ] Transcript
+- [ ] Transcript Navigation
+- [ ] Session Bar
+- [ ] Session Lifecycle
+- [ ] Agent Runners
+- [ ] Auth And Streams
+- [ ] Artifacts And Files
+- [ ] None
+
+Evidence:
+-

--- a/.github/workflows/pr-feature-contracts.yml
+++ b/.github/workflows/pr-feature-contracts.yml
@@ -1,0 +1,45 @@
+name: PR Feature Contracts
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check feature contract section
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request?.body || "";
+
+            const requiredMarkers = [
+              "## Feature Contracts",
+              "Affected contracts:",
+              "Evidence:",
+            ];
+            const missing = requiredMarkers.filter((marker) => !body.includes(marker));
+            if (missing.length > 0) {
+              core.setFailed(`PR body is missing required Feature Contracts markers: ${missing.join(", ")}`);
+              return;
+            }
+
+            const affected = body.match(/Affected contracts:\s*([\s\S]*?)\n\s*Evidence:/i)?.[1] || "";
+            const evidence = body.match(/Evidence:\s*([\s\S]*)/i)?.[1] || "";
+            const checkedContract = /- \[[xX]\] /.test(affected);
+            const evidenceText = evidence
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line && line !== "-" && !line.startsWith("<!--"));
+
+            if (!checkedContract) {
+              core.setFailed("PR body must check at least one affected contract, including None when no contract applies.");
+              return;
+            }
+            if (evidenceText.length === 0) {
+              core.setFailed("PR body must include concrete Feature Contracts evidence.");
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,20 @@ or cleanup work. Read
 [docs/product-inspirations.md](docs/product-inspirations.md) when making
 product or architecture decisions.
 
+Read [docs/features/README.md](docs/features/README.md) and the relevant
+feature contract before substantial work on a core feature. The policy docs set
+the repo-wide quality bar; the feature contracts translate that bar into
+feature-specific invariants and acceptance evidence. A PR that changes a core
+feature should name the affected contract and explain how the implementation
+proves the contract still holds.
+
+Before opening a PR, fill out the Feature Contracts section from the PR
+template. If the PR touches a contracted feature, name the affected contracts
+and provide concrete evidence for each one. "Tests pass" is not enough unless
+the test directly proves the contract invariant. Do not mark a PR ready, ask
+for merge, or merge it yourself when the Feature Contracts section is missing
+or incomplete.
+
 Read [docs/diagnostic-discipline.md](docs/diagnostic-discipline.md) before
 investigating any bug or incident on this repo. The other three docs above
 describe the quality bar for *writing* code; this one describes how to

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,53 @@
+# Feature Contracts
+
+The repo-wide policy docs describe the quality bar:
+
+- [migration-policy.md](../migration-policy.md)
+- [product-inspirations.md](../product-inspirations.md)
+- [quality-timeframes.md](../quality-timeframes.md)
+- [diagnostic-discipline.md](../diagnostic-discipline.md)
+
+Feature contracts translate those rules into concrete, reviewable invariants
+for the parts of Tank that can visibly lie to the user.
+
+Read the relevant contract before planning or implementing substantial work in
+that area. A PR that touches a contracted feature should name the contract and
+show the evidence that the contract still holds. Evidence can be a unit test,
+integration test, browser test, metric, alert, migration guard, or direct
+runtime observation, depending on the risk.
+
+## Contracts
+
+- [Agent Runners](agent-runners/contract.md)
+- [Artifacts And Files](artifacts-and-files/contract.md)
+- [Auth And Streams](auth-and-streams/contract.md)
+- [Session Bar](session-bar/contract.md)
+- [Session Lifecycle](session-lifecycle/contract.md)
+- [Transcript](transcript/contract.md)
+- [Transcript Navigation](transcript-navigation/contract.md)
+
+## When To Add A Contract
+
+Add or expand a feature contract when a feature:
+
+- can show state that contradicts the durable system;
+- crosses browser, orchestrator, runner, database, or Kubernetes boundaries;
+- depends on live streams, reconnect, retry, or rollout behavior;
+- has controls where "appeared to work" is different from "durably worked";
+- has already produced a user-trust bug.
+
+Small static UI, isolated copy changes, and one-off internal helpers usually do
+not need their own contract. They inherit the global policy docs.
+
+## PR Review Rule
+
+For any contracted feature, reviewers should ask:
+
+- Which contract does this PR touch?
+- Which invariant could the PR break?
+- What evidence proves the invariant still holds?
+- Does refresh, reconnect, restart, or rollout reveal state the live UI missed?
+- Is any old path, fallback, or browser-local source of truth being kept alive?
+
+If the answer depends on "it should probably work," the PR is not complete by
+the repo quality standard.

--- a/docs/features/_template.md
+++ b/docs/features/_template.md
@@ -1,0 +1,42 @@
+# Feature Name Contract
+
+This contract translates the repo-wide policy docs into feature-specific rules
+for this feature.
+
+## Product Model
+
+Describe what the feature is for, what user trust depends on, and which product
+inspirations matter most for this feature.
+
+## Sources Of Truth
+
+Name the durable tables, event types, external systems, or Kubernetes resources
+that own the visible state. Also name any live transports that are delivery
+mechanisms only.
+
+## Migration Rules
+
+Name old paths, compatibility layers, browser-local state, fallback reads, and
+obsolete tests that must not survive a migration.
+
+## Live Behavior
+
+Define what must happen without refresh, reconnect, or manual retry during
+normal operation.
+
+## Failure And Recovery
+
+Define expected behavior across reloads, reconnects, stale credentials,
+orchestrator rollouts, runner restarts, pod termination, and external service
+failures. Be explicit about the boundary where durability stops.
+
+## Observability
+
+Name the metrics, logs, durable events, alerts, or diagnostic queries that must
+exist when this feature misbehaves.
+
+## Acceptance Checks
+
+List the concrete checks required before a PR touching this feature can be
+called complete. Prefer checks that prove the product invariant instead of the
+implementation detail.

--- a/docs/features/agent-runners/contract.md
+++ b/docs/features/agent-runners/contract.md
@@ -1,0 +1,77 @@
+# Agent Runners Contract
+
+This contract applies to GUI chat runners, command delivery, provider adapters,
+tool approvals, interruptions, scheduled wakeups, and runner-produced Tank
+events.
+
+## Product Model
+
+Runners turn durable user intent into provider work and durable Tank events.
+They are not UI helpers and they are not the source of product history. Their
+job is to consume commands, call providers or tools, and emit events that let
+the rest of the product reconstruct what happened.
+
+## Sources Of Truth
+
+- JetStream commands own delivery of runner work while the session pod is
+  alive.
+- `session_events` owns the durable conversation and run outcome.
+- Provider SDK streams are adapter input only.
+- Runner process memory may hold in-flight provider state but must not be the
+  only record of user-visible completed work.
+
+## Migration Rules
+
+- Do not keep provider-specific frontend render paths after provider events
+  have moved behind the Tank protocol.
+- Do not ack a command before the durable terminal event required by the user
+  action has been published.
+- Do not keep fallback command paths, polling paths, or local-only stop
+  handling after a command/event path exists.
+- Delete old tests that assert provider raw events as UI behavior; replace them
+  with Tank protocol contract tests.
+
+## Live Behavior
+
+- A submitted user turn produces a durable `turn.submitted`, runner progress,
+  and exactly one terminal turn outcome.
+- Stop/interrupt remains pending until a durable interrupted, completed,
+  failed, or already-terminal event resolves it.
+- Tool approval replies are routed to the intended provider item and resolved
+  durably.
+- Runner events must wake transcript and session-list followers after
+  persistence.
+- A runner must not require an open browser to continue work.
+
+## Failure And Recovery
+
+- Browser disconnect and orchestrator rollout must not cancel runner work while
+  the session pod and runner remain alive.
+- Runner-process restart may lose in-process state that is explicitly outside
+  the durability boundary, such as current provider call state or pod-local
+  scheduled wakeups.
+- Command redelivery must be idempotent through command keys, turn IDs, or
+  provider item IDs.
+- Provider failures must become durable failure events instead of silent
+  strandings.
+
+## Observability
+
+- Metrics must distinguish command published, consumed, acked, redelivered,
+  failed, and terminal-event-emitted outcomes.
+- Runner metrics and backend metrics must be comparable so a bug can be
+  localized between command delivery, runner execution, persistence, and live
+  client delivery.
+- Silent strandings, where a requested action has no terminal event, are a
+  counted bug class.
+
+## Acceptance Checks
+
+- A normal turn reaches exactly one durable terminal event.
+- Stop/interrupt produces one durable resolution and clears visible pending
+  state from that durable resolution.
+- Command redelivery does not duplicate user-visible transcript entries.
+- Provider output is converted to Tank protocol before browser rendering
+  depends on it.
+- Runner work continues across browser disconnect and remains reconstructable
+  from durable events.

--- a/docs/features/artifacts-and-files/contract.md
+++ b/docs/features/artifacts-and-files/contract.md
@@ -1,0 +1,66 @@
+# Artifacts And Files Contract
+
+This contract applies to files produced by sessions, raw file/image access,
+copy/download controls, artifact links, and browser display of protected
+session-owned resources.
+
+## Product Model
+
+Artifacts and files are part of the session workspace experience. The user
+should be able to inspect and retrieve outputs without leaking protected URLs,
+depending on stale browser auth, or confusing a transient preview with durable
+session state.
+
+## Sources Of Truth
+
+- The live session pod filesystem owns files while the pod is alive.
+- Durable session metadata owns whether a session exists, who owns it, and
+  which pod/workspace the file request belongs to.
+- Artifact transcript events and message metadata own user-visible links to
+  files.
+- Browser object URLs are display handles only, not durable file references.
+
+## Migration Rules
+
+- Do not render protected raw API URLs directly in browser-native elements that
+  cannot attach bearer auth.
+- Do not keep unauthenticated file routes for browser convenience.
+- Do not preserve old file-link shapes after moving to authenticated blob
+  fetch or signed/mediated access.
+- Do not imply file durability after session-pod death unless a separate
+  durable artifact store exists for that file.
+
+## Live Behavior
+
+- Protected file previews fetch through authenticated code paths and render
+  from browser object URLs or another safe carrier.
+- Artifact links in the transcript remain tied to durable transcript metadata.
+- Stale auth during file access follows the same recovery expectations as
+  other protected browser fetches.
+- Copy/download controls must report failure when the file is unavailable
+  rather than showing success from local UI state.
+
+## Failure And Recovery
+
+- Browser reload can recreate previews from durable transcript metadata while
+  the pod and file still exist.
+- Session-pod death makes pod-local files unavailable unless they were copied
+  into a durable artifact store.
+- File-not-found, forbidden, stale-auth, and pod-gone errors should be visible
+  and distinguishable.
+
+## Observability
+
+- Metrics should cover raw file fetches, preview blob fetches, auth failures,
+  not-found responses, pod-gone responses, and download failures.
+- Logs should identify session id, file identifier/path class, route, and
+  caller without leaking protected contents.
+
+## Acceptance Checks
+
+- Browser-native previews do not use raw protected API URLs directly.
+- Authenticated blob fetches recover from stale auth or show explicit failure.
+- A copied/downloaded file is tied to an existing session and authorized user.
+- Pod-gone and file-not-found states are visible and diagnostically distinct.
+- Transcript artifact links can be reconstructed after reload while the file is
+  still inside the durability boundary.

--- a/docs/features/auth-and-streams/contract.md
+++ b/docs/features/auth-and-streams/contract.md
@@ -1,0 +1,77 @@
+# Auth And Streams Contract
+
+This contract applies to browser auth, protected fetches, EventSource streams,
+terminal WebSocket auth carriers, stream tickets, token refresh, and
+cross-service service-principal calls.
+
+## Product Model
+
+Authentication should be boring and recoverable. Streams should be durable
+followers, not private state channels. A valid user should not need to refresh
+the page to turn a stale credential, missed wake, or reconnect into correct
+product state.
+
+## Sources Of Truth
+
+- auth.romaine.life JWTs own caller identity and role.
+- `/api/auth/me` owns Tank's current acceptance decision for the browser.
+- `profiles` owns per-user profile and GitHub installation state.
+- Stream tickets are short-lived carriers for browser-native EventSource only.
+- Durable feature tables and event ledgers own product state; streams deliver
+  changes.
+
+## Migration Rules
+
+- Tank must not mint local browser JWTs or maintain a Tank-local JWKS.
+- Native EventSource must not carry bearer tokens in query strings.
+- WebSocket query-token carriers are allowed only where browser APIs cannot
+  set `Authorization`.
+- Do not keep unauthenticated fallback routes, compatibility auth paths, or raw
+  API URLs for browser-native protected resources.
+- Auth fixes must not be accepted as live-state fixes unless they prove the
+  feature cursor followers converge.
+
+## Live Behavior
+
+- Protected fetches use the current auth.romaine.life bearer token and recover
+  from stale stored tokens through the bootstrap/refresh path.
+- Browser EventSource streams mint scoped opaque stream tickets through normal
+  bearer auth before opening.
+- Stream handlers authenticate the ticket, bind it to the requested stream
+  kind and scope, and then follow durable state from the requested cursor.
+- An open stream must emit later persisted events without requiring the browser
+  to reconnect.
+- Heartbeat, wake, reconnect, and visibility transitions must drain durable
+  events until caught up.
+
+## Failure And Recovery
+
+- Expired or invalid browser tokens must produce explicit auth recovery, not a
+  silently stale UI.
+- Expired stream tickets should fail before stream open or force reconnect with
+  a newly minted ticket.
+- Unknown stream cursors trigger explicit resync.
+- Service-principal calls must carry actor identity where user scoping is
+  required.
+
+## Observability
+
+- Metrics must separate auth bootstrap failure, bearer verification failure,
+  stream-ticket mint failure, ticket validation failure, stream open, stream
+  reconnect, resync, heartbeat, emitted event, and cursor lag.
+- Logs for auth failures should include route, stream kind, and scope without
+  logging tokens.
+- User-visible stale-state reports must be diagnosable by comparing durable
+  tail, stream cursor, and browser-applied cursor.
+
+## Acceptance Checks
+
+- EventSource URL construction uses stream tickets and never bearer query
+  strings.
+- Stream tickets are scoped and single-purpose enough to prevent cross-stream
+  or cross-session use.
+- A stale stored JWT refreshes before protected fetches and ticket minting.
+- With a stream already open, later durable events are emitted without
+  reconnect.
+- Unknown cursor and invalid ticket paths produce explicit resync/auth failure
+  behavior rather than silent gaps.

--- a/docs/features/session-bar/contract.md
+++ b/docs/features/session-bar/contract.md
@@ -1,0 +1,78 @@
+# Session Bar Contract
+
+This contract applies to the left session list, active-session row, status
+chips, unread counts, age/timer labels, delete controls, and other sidebar
+state derived from session activity.
+
+## Product Model
+
+The session bar is a compact control surface for choosing and managing live
+sessions. It must not present state that contradicts the durable session and
+turn ledgers. It may be optimistic about selection and hover UI, but not about
+work completion, deletion, unread counts, or running state.
+
+## Sources Of Truth
+
+- `session_registry` owns session identity, owner, mode, lifecycle, pod
+  metadata, repositories, and clone state.
+- `session_events` owns turn activity and terminal run outcomes.
+- `sessions.activity_summary` is a projection for sidebar display; it must
+  converge from durable events and not replace them as the investigation
+  source of truth.
+- Session-list SSE wakes the browser to refetch or apply durable session
+  changes; it is not the source of state.
+
+## Migration Rules
+
+- Do not keep browser-local running, unread, or delete-success state that can
+  contradict durable state.
+- Do not treat a control as complete before the durable terminal event or
+  registry state confirms it.
+- Do not preserve old polling paths as a fallback after the contracted live
+  path exists.
+- When replacing sidebar state ownership, delete stale selectors, tests, and
+  display branches that still read the old source.
+
+## Live Behavior
+
+- Status chips converge without refresh when the durable run state changes.
+- A terminal turn event clears running/stopping state without requiring a page
+  reload.
+- Unread counts and read markers derive from durable cursor/read state.
+- Session create, delete, and lifecycle changes reach every open session list
+  owned by the user through the contracted live path.
+- The selected row may update immediately for navigation, but durable state
+  must correct it without manual refresh.
+
+## Failure And Recovery
+
+- Browser reconnect resumes session-list delivery from a durable or explicit
+  snapshot boundary.
+- Stale auth must surface as an authentication recovery path, not as silent
+  stale sidebar state.
+- Orchestrator rollout must not leave a session row permanently running when
+  durable terminal state exists.
+- Pod deletion is terminal for the session lifecycle and must be reflected as
+  such rather than hidden behind a retry loop.
+
+## Observability
+
+- Metrics must distinguish session-list stream open, reconnect, resync,
+  heartbeat, emitted change, auth failure, and server error.
+- A mismatch between `sessions.activity_summary` and terminal
+  `session_events` must be diagnosable and should be counted or alerted when
+  it affects user-visible running state.
+- Delete and stop controls need outcome metrics that separate requested,
+  confirmed, failed, and already-terminal states.
+
+## Acceptance Checks
+
+- A turn terminal event updates the session row from running/stopping to the
+  terminal display state without refresh.
+- A new unread message increments unread state for non-selected sessions and
+  clears through the durable read cursor.
+- Delete does not appear complete until the durable session lifecycle confirms
+  it.
+- Reconnect or resync produces the same session bar state as a fresh load.
+- Tests cover a projection lag or missed wake scenario and prove the sidebar
+  catches up from durable state.

--- a/docs/features/session-lifecycle/contract.md
+++ b/docs/features/session-lifecycle/contract.md
@@ -1,0 +1,71 @@
+# Session Lifecycle Contract
+
+This contract applies to creating, loading, readying, stopping, deleting, and
+terminating sessions, including the session pod boundary.
+
+## Product Model
+
+A Tank session is a user-owned pod-backed workspace with explicit lifecycle
+state. The product should make the lifecycle legible without pretending that a
+dead pod can be resurrected or that a request succeeded before durable state
+confirms it.
+
+## Sources Of Truth
+
+- `session_registry` owns session rows and lifecycle metadata.
+- Kubernetes owns pod existence and pod phase.
+- `session_events` owns user-visible chat/run lifecycle events.
+- `sessions.activity_summary` may summarize current activity, but durable
+  lifecycle and event rows explain the state.
+
+## Migration Rules
+
+- Do not keep old lifecycle branches, route aliases, pod allocators, or tests
+  once a lifecycle path has moved.
+- Do not introduce compatibility for unknown callers during lifecycle
+  migrations.
+- Do not use browser-only session state to stand in for durable lifecycle
+  state.
+- Do not silently continue a session after the pod-death boundary.
+
+## Live Behavior
+
+- Creating a session writes durable session state before the UI depends on the
+  new session.
+- Loading and ready status shown to the user must be durable when it appears in
+  transcript or sidebar state.
+- Session readiness should arrive through the live path without forcing a
+  transcript or session-list reset.
+- Stop/delete controls must move through requested and confirmed states that
+  match durable outcomes.
+
+## Failure And Recovery
+
+- Browser disconnect, orchestrator rollout, and runner-process restart are
+  inside the durability boundary while the same session pod is alive.
+- Session-pod death is outside the messaging durability boundary. The session
+  is terminal because the `emptyDir` workspace is gone.
+- Failed create, load, stop, and delete operations must leave visible failure
+  state and durable or observable evidence.
+- Repeated actions should be idempotent or return the already-terminal durable
+  state.
+
+## Observability
+
+- Metrics must cover create, load, ready, stop, delete, pod-watch, and terminal
+  outcomes.
+- There must be enough durable and live telemetry to distinguish pod failure,
+  runner failure, stream failure, and browser display lag.
+- Stuck loading/running/deleting states need counters or alerts once they
+  exceed their product boundary.
+
+## Acceptance Checks
+
+- Create produces a durable session row and the expected initial events before
+  user-visible live state depends on them.
+- Ready state appears without transcript reset or session-list refresh.
+- Stop/delete controls require durable confirmation before success display.
+- Pod death moves the session to the terminal lifecycle state expected by the
+  product.
+- Repeating a lifecycle command after success returns or displays the durable
+  terminal state rather than failing ambiguously.

--- a/docs/features/transcript-navigation/contract.md
+++ b/docs/features/transcript-navigation/contract.md
@@ -1,0 +1,100 @@
+# Transcript Navigation Contract
+
+This contract applies to where the user lands in a transcript, how transcript
+position is preserved, how historical pages load, how copied message links
+resolve, and how live-tail behavior interacts with a reader who is not at the
+tail.
+
+## Product Model
+
+Transcript navigation is orientation over a durable conversation ledger. It is
+not message ownership; the [Transcript](../transcript/contract.md) contract
+owns which messages exist and how they are delivered. This feature owns whether
+the user remains oriented while those messages render.
+
+Normal session navigation lands at the live tail. Historical position is
+explicit user intent only: copied message links, manual back-pagination, and
+deliberate history navigation. New live messages should be noticeable without
+yanking the viewport away from a user reading history.
+
+## Sources Of Truth
+
+- `session_events.order_key` owns durable transcript position.
+- Server timeline pages own bounded windows around durable cursors.
+- Copied message links may name rendered timeline IDs, but the server must
+  translate them to durable cursors.
+- Durable read state owns unread/new indicators when the indicator affects
+  session or transcript state.
+- Browser scroll offsets are layout state only; they are not transcript
+  position source of truth.
+
+## Migration Rules
+
+- Do not persist or restore browser-local scroll position as normal session
+  navigation state.
+- Do not make the browser DOM the resolver for deep links or copied message
+  anchors.
+- Do not keep hidden compatibility paths that infer historical position from
+  old local storage keys, previous session selection, or transient viewport
+  offsets.
+- Do not put non-transcript UI such as "continuing previous conversation" or
+  "beginning of conversation" into the scroll flow unless it is part of the
+  durable transcript model.
+- Delete tests that pin old scroll-restoration behavior when the intended
+  behavior is live-tail navigation or durable cursor anchoring.
+
+## Live Behavior
+
+- Opening a session normally lands at the live tail.
+- Opening a copied message link lands on a bounded page around that durable
+  message cursor.
+- Manual back-pagination prepends older messages while preserving the user's
+  visual anchor.
+- Manual forward-pagination appends newer historical messages without jumping
+  the anchor unexpectedly.
+- New live messages append at the tail without moving the viewport when the
+  user is reading history.
+- Returning to the live tail is an explicit state transition.
+- Load, ready, reconnect, and resync must not reset the viewport unless the
+  user has explicitly returned to live tail or the current cursor is invalid.
+
+## Failure And Recovery
+
+- Browser reload reconstructs the intended navigation state from durable
+  cursor inputs, not from DOM position.
+- Valid durable cursors resume to an equivalent bounded transcript window.
+- Unknown or expired cursors trigger explicit resync or a clear fallback to the
+  live tail; they must not silently show a misleading historical position.
+- Reconnect and visibility changes continue from the current navigation mode:
+  live-tail mode follows the tail, while historical mode preserves the anchor
+  and surfaces new activity separately.
+- If a target message was deleted or is outside the durability boundary, the UI
+  should show a clear unavailable-target state.
+
+## Observability
+
+- There must be a way to distinguish live-tail mode from historical-anchor mode
+  in client telemetry when diagnosing jumps or missed messages.
+- Timeline page requests should log or count anchor type, direction, and
+  cursor validity without logging message contents.
+- Resync, invalid cursor, anchor-not-found, and unexpected viewport-reset
+  cases should be observable as user-trust navigation failures.
+- A report that "refresh moved me" or "new messages moved the transcript"
+  should be diagnosable from durable cursor inputs plus client navigation
+  telemetry.
+
+## Acceptance Checks
+
+- Normal session open lands at the live tail.
+- A copied message link resolves through a durable cursor and lands on the
+  target message after reload.
+- Back-pagination preserves the visible anchor while older messages are
+  prepended.
+- Live messages received while reading history do not move the viewport to the
+  tail.
+- Returning to live tail resumes live-follow behavior and clears the separate
+  new-message affordance.
+- Load, ready, reconnect, and resync do not introduce scroll jumps in either
+  live-tail mode or historical-anchor mode.
+- Legacy browser-local scroll restoration cannot reappear without failing a
+  migration guard or contract test.

--- a/docs/features/transcript/contract.md
+++ b/docs/features/transcript/contract.md
@@ -1,0 +1,85 @@
+# Transcript Contract
+
+This contract applies to the GUI chat transcript ledger: the first prompt,
+startup status, provider output, tool events, and live delivery into the
+visible conversation. Viewport anchoring, deep links, historical pagination,
+read position, and live-tail navigation are covered by
+[Transcript Navigation](../transcript-navigation/contract.md).
+
+## Product Model
+
+The transcript is a durable conversation ledger with a live tail. It should
+feel like a mature messaging surface: refresh may recover from a broken browser
+state, but refresh must not be required for normal progress.
+
+The browser DOM is not the source of truth. Provider streams are adapter input,
+not the rendered protocol. The frontend renders the Tank conversation protocol
+from durable events.
+
+## Sources Of Truth
+
+- `session_events` owns transcript entries and ordering.
+- `order_key` owns transcript order and cursor movement.
+- `session.status` events own startup notices shown inside the transcript.
+- Provider SDK events are inputs that must be converted to Tank events before
+  the UI depends on them.
+- SSE is a live follower of durable events, not the transcript store.
+
+## Migration Rules
+
+- Browser-local startup drafts are not transcript rows.
+- Client-only "loading" or "continuing" transcript placeholders are prohibited
+  when a durable event exists or can be written.
+- A first prompt typed on the splash screen must be written durably before
+  startup status events.
+- Old provider-specific transcript render paths must be deleted when replaced
+  by Tank protocol rendering.
+- Refresh-only recovery must not be accepted as proof that live transcript
+  delivery works.
+
+## Live Behavior
+
+- A new transcript begins with the user's first durable message when the user
+  provided one.
+- Startup notices appear as durable `session.status` transcript entries after
+  the first user message.
+- An already-open transcript client must receive and render post-cursor durable
+  events without reload.
+- The live stream must keep draining persisted events until caught up whenever
+  it wakes, reconnects, heartbeats, or resumes from visibility changes.
+- A reconnect from an unknown cursor must trigger explicit resync instead of
+  silently skipping a gap.
+- Ready/load transitions must not reset, reorder, or replace the transcript.
+
+## Failure And Recovery
+
+- Browser reload replays from durable history and may repair local display
+  state, but reload is not part of the happy path.
+- Browser disconnect resumes from a durable cursor.
+- Orchestrator rollout and runner-process restart must not lose already
+  persisted transcript events.
+- Session-pod death is the lifecycle boundary. Tank does not promise to
+  resurrect the `emptyDir` workspace or continue a dead pod's conversation.
+
+## Observability
+
+- There must be a way to compare an open client's last applied cursor with the
+  durable tail for the session.
+- Stream open, reconnect, resync, heartbeat, emitted-event, and error counters
+  must distinguish auth failure from live cursor lag.
+- User-trust bugs should be diagnosable by querying `session_events` first,
+  then live stream telemetry.
+- A durable terminal event that exists but is not visible in an open transcript
+  must leave enough telemetry to localize the miss.
+
+## Acceptance Checks
+
+- Creating a session from a splash prompt writes the user message before
+  startup status.
+- `session.status` loading and ready entries render from durable events.
+- With an SSE stream already open at cursor X, persisting later transcript
+  events causes the browser to render them without refresh.
+- Reconnect from a valid cursor replays missed events exactly once.
+- Reconnect from an unknown cursor triggers explicit resync.
+- A browser or integration check proves that load/ready does not reset the
+  transcript.


### PR DESCRIPTION
## Summary

- add feature contract docs and template for core Tank feature areas
- add PR template Feature Contracts section
- add lightweight PR-body CI check requiring affected contracts and evidence
- update CLAUDE.md so agents treat the Feature Contracts section as a PR gate

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] None

Evidence:
- Docs/process-only change; no contracted runtime feature implementation changed.
- `git diff --check` passed.
- Markdown link resolution for `docs/features` passed.
- Local simulation of the PR-body check passed for a filled PR body and failed for missing/blank bodies.