### PR TITLE
Add per-session SSE wake-fabric stethoscope

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_client_metrics_session_events.go
+++ b/backend-go/cmd/tank-operator/handlers_client_metrics_session_events.go
@@ -1,0 +1,116 @@
+// Client-side telemetry ingestion for the per-session SSE event
+// stream consumer. Pairs with frontend/src/sessionEventStreamTelemetry.ts.
+// The browser emits semantic events (opened, tank_event_received,
+// stream_silent_while_running, resync_required, stream_error,
+// closed); the orchestrator buckets them into bounded Prometheus
+// labels — the SPA never sets labels directly so a misbehaving
+// client can't blow the active-series budget.
+//
+// This is the candidate-B / candidate-C stethoscope on the browser
+// side. Combined with the server-side counters in observability.go
+// it tells whether the wake fabric, the SSE socket, or the SPA
+// reducer is the layer where events are getting dropped. Per
+// memory/feedback_no_devtools_build_surfaces_instead.md — the
+// browser cannot reach for devtools so this surface is the only
+// way the client gets to participate in diagnosis.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+)
+
+const (
+	sessionEventStreamMetricsMaxBodyBytes = 64 * 1024
+	sessionEventStreamMetricsMaxEvents    = 100
+)
+
+type sessionEventStreamMetricsRequest struct {
+	Events []sessionEventStreamMetricEvent `json:"events"`
+}
+
+type sessionEventStreamMetricEvent struct {
+	Event        string   `json:"event"`
+	EventType    string   `json:"eventType,omitempty"`
+	SessionMode  string   `json:"sessionMode"`
+	IdleSeconds  *float64 `json:"idleSeconds,omitempty"`
+	WhileRunning *bool    `json:"whileRunning,omitempty"`
+}
+
+func (s *appServer) handleSessionEventStreamMetrics(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	if !user.IsHuman() {
+		recordSessionEventStreamClientReport("denied_role")
+		writeError(w, http.StatusForbidden, "human user required")
+		return
+	}
+
+	var body sessionEventStreamMetricsRequest
+	limited := http.MaxBytesReader(w, r.Body, sessionEventStreamMetricsMaxBodyBytes)
+	decoder := json.NewDecoder(limited)
+	if err := decoder.Decode(&body); err != nil {
+		recordSessionEventStreamClientReport("invalid_json")
+		writeError(w, http.StatusBadRequest, "invalid session-event stream metrics payload")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		recordSessionEventStreamClientReport("invalid_json")
+		writeError(w, http.StatusBadRequest, "invalid session-event stream metrics payload")
+		return
+	}
+	if len(body.Events) > sessionEventStreamMetricsMaxEvents {
+		recordSessionEventStreamClientReport("too_many_events")
+		writeError(w, http.StatusBadRequest, "too many session-event stream metric events")
+		return
+	}
+	for _, event := range body.Events {
+		if !validSessionEventStreamMetricNumbers(event) {
+			recordSessionEventStreamClientReport("invalid_value")
+			writeError(w, http.StatusBadRequest, "invalid session-event stream metric value")
+			return
+		}
+	}
+	for _, event := range body.Events {
+		recordSessionEventStreamClientEvent(event)
+	}
+	recordSessionEventStreamClientReport("ok")
+	writeJSON(w, http.StatusAccepted, map[string]any{"accepted": len(body.Events)})
+}
+
+func validSessionEventStreamMetricNumbers(event sessionEventStreamMetricEvent) bool {
+	if event.IdleSeconds != nil {
+		if math.IsNaN(*event.IdleSeconds) || math.IsInf(*event.IdleSeconds, 0) {
+			return false
+		}
+		if *event.IdleSeconds < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+var sessionEventStreamClientEventLabels = map[string]struct{}{
+	"opened":                      {},
+	"tank_event_received":         {},
+	"ready":                       {},
+	"stream_silent_while_running": {},
+	"resync_required":             {},
+	"stream_error":                {},
+	"closed_unmount":              {},
+	"closed_error":                {},
+	"reconnect_scheduled":         {},
+}
+
+func sessionEventStreamClientEventLabel(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if _, ok := sessionEventStreamClientEventLabels[raw]; ok {
+		return raw
+	}
+	return "other"
+}

--- a/backend-go/cmd/tank-operator/handlers_client_metrics_session_events_test.go
+++ b/backend-go/cmd/tank-operator/handlers_client_metrics_session_events_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+)
+
+func TestSessionEventStreamMetricsAcceptsValidBatch(t *testing.T) {
+	app := adminTestServer(t)
+	body := bytes.NewBufferString(`{"events":[
+		{"event":"opened","sessionMode":"claude_gui"},
+		{"event":"tank_event_received","eventType":"user_message.created","sessionMode":"claude_gui"},
+		{"event":"stream_silent_while_running","sessionMode":"claude_gui","idleSeconds":42.5,"whileRunning":true},
+		{"event":"closed_unmount","sessionMode":"claude_gui"}
+	]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/session-events-stream", body)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, otherUser, auth.RoleUser))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	app.handleSessionEventStreamMetrics(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestSessionEventStreamMetricsRejectsServicePrincipal(t *testing.T) {
+	app := adminTestServer(t)
+	body := bytes.NewBufferString(`{"events":[]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/session-events-stream", body)
+	req.Header.Set("Authorization", "Bearer "+signedServiceToken(t, "svc@example.com", "user@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	app.handleSessionEventStreamMetrics(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for service principal", resp.Code)
+	}
+}
+
+func TestSessionEventStreamMetricsRejectsInvalidJSON(t *testing.T) {
+	app := adminTestServer(t)
+	body := strings.NewReader(`{"events":[{`)
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/session-events-stream", body)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, otherUser, auth.RoleUser))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	app.handleSessionEventStreamMetrics(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", resp.Code)
+	}
+}
+
+func TestSessionEventStreamMetricsRejectsNaNIdleSeconds(t *testing.T) {
+	app := adminTestServer(t)
+	body := bytes.NewBufferString(`{"events":[{"event":"stream_silent_while_running","sessionMode":"claude_gui","idleSeconds":-1}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/session-events-stream", body)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, otherUser, auth.RoleUser))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	app.handleSessionEventStreamMetrics(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("negative idleSeconds should be rejected; got %d", resp.Code)
+	}
+}
+
+func TestSessionEventStreamClientEventLabelClamp(t *testing.T) {
+	if got := sessionEventStreamClientEventLabel("opened"); got != "opened" {
+		t.Fatalf("opened label = %q", got)
+	}
+	if got := sessionEventStreamClientEventLabel("malicious-event-name"); got != "other" {
+		t.Fatalf("unknown event should clamp to other, got %q", got)
+	}
+	if got := sessionEventStreamClientResultLabel("malicious"); got != "other" {
+		t.Fatalf("unknown result should clamp to other, got %q", got)
+	}
+	if got := sessionEventTypeLabel("not-a-real-type"); got != "other" {
+		t.Fatalf("unknown event_type should clamp to other, got %q", got)
+	}
+	if got := sessionEventTypeLabel("user_message.created"); got != "user_message.created" {
+		t.Fatalf("known event_type should pass through, got %q", got)
+	}
+}

--- a/backend-go/cmd/tank-operator/handlers_debug_session_event_streams.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_event_streams.go
@@ -1,0 +1,84 @@
+// Admin-only debug surface for the per-session SSE event stream
+// handlers. Returns the in-memory registry's snapshot — every open
+// stream's wake/page/emit state — so an operator (or the AI support
+// agent reading via gh + kubectl) can answer "did a wake arrive on
+// the subject I expected" / "did the page read return anything" /
+// "is the cursor advancing" without browser devtools.
+//
+// Per memory/feedback_no_devtools_build_surfaces_instead.md the
+// user-trust constraint on this repo is that observability lives
+// behind curl-able endpoints. This is the per-replica counterpart
+// of the Prometheus counters in observability.go: the counters
+// answer "is this happening at scale", this endpoint answers "what
+// is happening to THIS specific stream right now."
+package main
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionstream"
+)
+
+func (s *appServer) handleDebugSessionEventStreams(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	if user.Role != "admin" {
+		writeError(w, http.StatusForbidden, "admin role required")
+		return
+	}
+
+	// Optional session_id filter — when an operator already knows
+	// which session is misbehaving, filtering at the endpoint cuts
+	// noise on busy replicas. Empty filter returns every open stream.
+	sessionFilter := strings.TrimSpace(r.URL.Query().Get("session_id"))
+
+	now := time.Now()
+	all := s.streamRegistry.Snapshot(now)
+	filtered := all
+	if sessionFilter != "" {
+		filtered = make([]sessionstream.Snapshot, 0, len(all))
+		for _, snap := range all {
+			if snap.SessionID == sessionFilter {
+				filtered = append(filtered, snap)
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"scope":       s.sessionScope,
+		"replica_at":  now.UTC().Format(time.RFC3339Nano),
+		"open_count":  len(all),
+		"matched":     len(filtered),
+		"streams":     filtered,
+		"session_id":  sessionFilter,
+		"description": debugSessionEventStreamsDescription,
+	})
+}
+
+// debugSessionEventStreamsDescription is rendered into the JSON
+// response so an operator running `curl | jq` sees the meaning of
+// each field without leaving the terminal. Per docs/quality-
+// timeframes.md "Observability exists for the bugs a user would
+// otherwise have to guess about."
+const debugSessionEventStreamsDescription = `Per-open-SSE-handler diagnostic surface for /api/sessions/{id}/events.
+
+How to read the candidate-A wake-key-mismatch signature: wakes_received
+stays at 0 even while the durable ledger gains new rows for this session
+(check tank_session_event_wake_published_total at /metrics). The
+last_wake_subject field shows what subject NATS is delivering on (if
+anything); the storage_key field shows what the handler subscribed for.
+
+How to read the candidate-B zombie-SSE signature: last_emit_at is
+seconds-fresh, then stops advancing while heartbeats_sent keeps
+climbing. The client-side tank_session_event_client_*_total counters
+(POST /api/client-metrics/session-events-stream) tell you whether the
+browser is still receiving anything.
+
+How to read the candidate-C reducer-drop signature: emits_total keeps
+climbing on the server, but the matching client-side
+tank_session_event_client_received_total{event_type} stays flat for the
+same event_type. The server is emitting, the browser is filtering.`

--- a/backend-go/cmd/tank-operator/handlers_debug_session_event_streams_test.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_event_streams_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionstream"
+)
+
+func TestDebugSessionEventStreamsAdminGate(t *testing.T) {
+	app := adminTestServer(t)
+	app.streamRegistry = sessionstream.NewRegistry()
+	app.sessionScope = "default"
+
+	t.Run("non-admin role 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-streams", nil)
+		req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, otherUser, auth.RoleUser))
+		resp := httptest.NewRecorder()
+		app.handleDebugSessionEventStreams(resp, req)
+		if resp.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403; body = %s", resp.Code, resp.Body.String())
+		}
+	})
+
+	t.Run("unauthenticated 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-streams", nil)
+		resp := httptest.NewRecorder()
+		app.handleDebugSessionEventStreams(resp, req)
+		if resp.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.Code)
+		}
+	})
+
+	t.Run("admin gets empty registry", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-streams", nil)
+		req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+		resp := httptest.NewRecorder()
+		app.handleDebugSessionEventStreams(resp, req)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["open_count"].(float64) != 0 {
+			t.Fatalf("open_count = %v, want 0 on empty registry", body["open_count"])
+		}
+		if streams, _ := body["streams"].([]any); len(streams) != 0 {
+			t.Fatalf("streams len = %d, want 0", len(streams))
+		}
+		if body["scope"] != "default" {
+			t.Fatalf("scope = %v, want default", body["scope"])
+		}
+	})
+}
+
+func TestDebugSessionEventStreamsReturnsRegisteredState(t *testing.T) {
+	app := adminTestServer(t)
+	app.streamRegistry = sessionstream.NewRegistry()
+	app.sessionScope = "default"
+
+	opened := time.Now().Add(-2 * time.Second)
+	stateOne := sessionstream.NewStreamState("stream-1", "63", "63", adminEmail, opened, "")
+	stateTwo := sessionstream.NewStreamState("stream-2", "64", "64", adminEmail, opened.Add(time.Second), "abc100")
+	app.streamRegistry.Register(stateOne)
+	app.streamRegistry.Register(stateTwo)
+
+	stateOne.RecordWake(opened.Add(500*time.Millisecond), "tank.live.63.wake")
+	stateOne.RecordPageRead(opened.Add(501*time.Millisecond), 3)
+	stateOne.RecordEmit(opened.Add(502*time.Millisecond), "abc20", "user_message.created", "abc20")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-streams", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+	app.handleDebugSessionEventStreams(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	streams, _ := body["streams"].([]any)
+	if len(streams) != 2 {
+		t.Fatalf("streams len = %d, want 2", len(streams))
+	}
+	first, _ := streams[0].(map[string]any)
+	if first["stream_id"] != "stream-1" {
+		t.Fatalf("expected stream-1 first (sorted by opened_at), got %v", first["stream_id"])
+	}
+	if first["wakes_received"].(float64) != 1 {
+		t.Fatalf("wakes_received = %v, want 1", first["wakes_received"])
+	}
+	if first["last_wake_subject"] != "tank.live.63.wake" {
+		t.Fatalf("last_wake_subject = %v", first["last_wake_subject"])
+	}
+	if first["last_emit_event_type"] != "user_message.created" {
+		t.Fatalf("last_emit_event_type = %v", first["last_emit_event_type"])
+	}
+	if first["cursor_after_order_key"] != "abc20" {
+		t.Fatalf("cursor_after_order_key = %v", first["cursor_after_order_key"])
+	}
+	if first["pages_read_non_empty"].(float64) != 1 {
+		t.Fatalf("pages_read_non_empty = %v", first["pages_read_non_empty"])
+	}
+}
+
+func TestDebugSessionEventStreamsSessionFilter(t *testing.T) {
+	app := adminTestServer(t)
+	app.streamRegistry = sessionstream.NewRegistry()
+	app.sessionScope = "default"
+
+	opened := time.Now()
+	app.streamRegistry.Register(sessionstream.NewStreamState("a", "10", "10", adminEmail, opened, ""))
+	app.streamRegistry.Register(sessionstream.NewStreamState("b", "20", "20", adminEmail, opened, ""))
+	app.streamRegistry.Register(sessionstream.NewStreamState("c", "20", "20", adminEmail, opened.Add(time.Second), ""))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-streams?session_id=20", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+	app.handleDebugSessionEventStreams(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d", resp.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &body)
+	if body["matched"].(float64) != 2 {
+		t.Fatalf("matched = %v, want 2 streams on session_id=20", body["matched"])
+	}
+	if body["open_count"].(float64) != 3 {
+		t.Fatalf("open_count = %v, want 3 (all open streams across all sessions)", body["open_count"])
+	}
+	if body["session_id"] != "20" {
+		t.Fatalf("session_id = %v", body["session_id"])
+	}
+}

--- a/backend-go/cmd/tank-operator/handlers_session_events.go
+++ b/backend-go/cmd/tank-operator/handlers_session_events.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionstream"
 	"github.com/nelsong6/tank-operator/backend-go/internal/store"
 )
 
@@ -175,11 +177,29 @@ func (s *appServer) handleSessionEventStream(w http.ResponseWriter, r *http.Requ
 		sessionEventStreamReconnectTotal.Add(1)
 	}
 
+	// Per-stream diagnostic state. The registry is the source of
+	// truth for the /api/debug/session-event-streams admin endpoint;
+	// it has to be registered before SubscribeWakesWithRecorder fires
+	// any callbacks so the first wake (which can race the subscribe
+	// in low-latency clusters) lands on a registered state object.
+	streamID := auth.RandomHex(16)
+	storageKey := sessionmodel.SessionStorageKey(s.sessionScope, sessionID)
+	state := sessionstream.NewStreamState(
+		streamID,
+		sessionID,
+		storageKey,
+		user.Email,
+		time.Now(),
+		cursor.AfterOrderKey,
+	)
+	s.streamRegistry.Register(state)
+	defer s.streamRegistry.Deregister(streamID)
+
 	notify := make(<-chan struct{})
 	unsubscribe := func() {}
 	if s.sessionBus != nil {
 		var err error
-		notify, unsubscribe, err = s.sessionBus.SubscribeWakes(r.Context(), sessionID)
+		notify, unsubscribe, err = s.sessionBus.SubscribeWakesWithRecorder(r.Context(), sessionID, state)
 		if err != nil {
 			sessionEventWakeSubscribeFailures.Add(1)
 			recordSessionEventStreamError()
@@ -202,24 +222,29 @@ func (s *appServer) handleSessionEventStream(w http.ResponseWriter, r *http.Requ
 	slog.Info("session event stream open",
 		"session_id", sessionID,
 		"email", user.Email,
+		"stream_id", streamID,
+		"storage_key", storageKey,
 		"last_order_key", cursor.AfterOrderKey,
 		"resumed", cursor.AfterOrderKey != "",
 	)
 	defer slog.Info("session event stream close",
 		"session_id", sessionID,
 		"email", user.Email,
+		"stream_id", streamID,
 	)
 
 	heartbeat := time.NewTicker(sessionEventStreamHeartbeat)
 	defer heartbeat.Stop()
 
 	for {
-		hasMore, count, err := s.writeSessionEventStreamPage(r.Context(), w, sessionID, &cursor)
+		cursorBefore := cursor.AfterOrderKey
+		hasMore, count, err := s.writeSessionEventStreamPage(r.Context(), w, sessionID, &cursor, state)
 		if err != nil {
 			recordSessionEventStreamError()
 			slog.Warn("session event stream page failed",
 				"session_id", sessionID,
 				"email", user.Email,
+				"stream_id", streamID,
 				"last_order_key", cursor.AfterOrderKey,
 				"error", err,
 			)
@@ -231,11 +256,14 @@ func (s *appServer) handleSessionEventStream(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		flusher.Flush()
+		state.RecordPageRead(time.Now(), count)
 		if count > 0 {
-			slog.Debug("session event stream emitted events",
+			slog.Info("session event stream emitted events",
 				"session_id", sessionID,
+				"stream_id", streamID,
 				"count", count,
-				"last_order_key", cursor.AfterOrderKey,
+				"cursor_before", cursorBefore,
+				"cursor_after", cursor.AfterOrderKey,
 				"has_more", hasMore,
 			)
 		}
@@ -249,13 +277,14 @@ func (s *appServer) handleSessionEventStream(w http.ResponseWriter, r *http.Requ
 		case <-notify:
 		case <-heartbeat.C:
 			sessionEventStreamHeartbeatTotal.Add(1)
+			state.RecordHeartbeat(time.Now())
 			fmt.Fprint(w, ": keep-alive\n\n")
 			flusher.Flush()
 		}
 	}
 }
 
-func (s *appServer) writeSessionEventStreamPage(ctx context.Context, w http.ResponseWriter, sessionID string, cursor *store.SessionEventCursor) (bool, int, error) {
+func (s *appServer) writeSessionEventStreamPage(ctx context.Context, w http.ResponseWriter, sessionID string, cursor *store.SessionEventCursor, state *sessionstream.StreamState) (bool, int, error) {
 	eventStore := s.sessionEvents
 	if eventStore == nil {
 		eventStore = store.StubSessionEventStore{}
@@ -275,6 +304,9 @@ func (s *appServer) writeSessionEventStreamPage(ctx context.Context, w http.Resp
 		cursor.AfterOrderKey = orderKey
 		count++
 		sessionEventStreamEmittedTotal.Add(1)
+		eventType, _ := event["type"].(string)
+		recordSessionEventStreamEmittedByType(eventType)
+		state.RecordEmit(time.Now(), orderKey, eventType, orderKey)
 	}
 	if page.NextOrderKey != "" {
 		cursor.AfterOrderKey = page.NextOrderKey

--- a/backend-go/cmd/tank-operator/handlers_turns_test.go
+++ b/backend-go/cmd/tank-operator/handlers_turns_test.go
@@ -79,6 +79,14 @@ func (*recordingSessionBus) SubscribeWakes(context.Context, string) (<-chan stru
 	return make(chan struct{}), func() {}, nil
 }
 
+// SubscribeWakesWithRecorder is the per-stream-aware variant. Tests
+// that drive the SSE handler observe the recorder through the
+// registry surface; for the existing turns/list tests the recorder
+// argument is unused.
+func (*recordingSessionBus) SubscribeWakesWithRecorder(context.Context, string, sessionbus.WakeRecorder) (<-chan struct{}, func(), error) {
+	return make(chan struct{}), func() {}, nil
+}
+
 // PublishSessionRowUpdate + SubscribeSessionRowUpdates are the row-
 // update wire surface (Phase 3 of docs/session-list-redesign.md).
 // Tests don't drive the sidebar SSE so the recorder no-ops both.

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionregistry"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionstream"
 	"github.com/nelsong6/tank-operator/backend-go/internal/store"
 )
 
@@ -328,6 +329,7 @@ func main() {
 		verifier:                 verifier,
 		gitHubInstallStates:      gitHubInstallStates,
 		streamAuthTickets:        streamAuthTickets,
+		streamRegistry:           sessionstream.NewRegistry(),
 		namespace:                namespace,
 		sessionScope:             sessionScope,
 		sessionServiceAccount:    sessionServiceAccount,

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -139,6 +140,40 @@ var (
 		Name: "tank_session_list_event_publish_failure_total",
 		Help: "Per-owner typed session-list event publishes that failed against NATS.",
 	})
+	// Wake success counters + persist→wake latency. The published vs
+	// received delta is the candidate-A stethoscope (see
+	// docs/quality-timeframes.md observability requirement and the
+	// /api/debug/session-event-streams admin endpoint for per-session
+	// resolution). Unlabeled aggregates per docs/observability.md
+	// cardinality rules; per-storage-key resolution lives in the slog
+	// line and the admin endpoint's stream snapshot, not in labels.
+	sessionEventWakePublishedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_wake_published_total",
+		Help: "Per-session SSE wakes successfully published to NATS by the persister or direct-writer call sites.",
+	})
+	sessionEventWakeReceivedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_event_wake_received_total",
+		Help: "Per-session SSE wakes received by orchestrator-side NATS subscribers (the SSE handler's notify path).",
+	})
+	sessionEventPersistToWakeSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "tank_session_event_persist_to_wake_seconds",
+		Help:    "Duration from session_events row Upsert returning to the NATS wake publish completing.",
+		Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+	})
+	// Per-event-type emit counter — the candidate-C stethoscope. When
+	// the server's emit-by-type vs the client's receive-by-type
+	// (tank_session_event_client_received_total, ingested through
+	// POST /api/client-metrics/session-events-stream) diverge for a
+	// specific event_type, the SPA reducer is dropping events
+	// silently. Event types are a closed enum at
+	// internal/conversation/types.go — bounded cardinality.
+	sessionEventStreamEmittedByTypeTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_session_event_stream_emitted_by_type_total",
+			Help: "Events emitted to a connected SSE consumer, labeled by Tank event type.",
+		},
+		[]string{"event_type"},
+	)
 
 	// turnInterruptRequestTotal counts stop requests posted to /interrupt,
 	// labeled by outcome at each exit point. Steady-state expectation:
@@ -315,6 +350,85 @@ func streamAuthTicketResultLabel(result string) string {
 	switch result {
 	case "ok", "invalid", "denied", "store_unavailable", "store_error":
 		return result
+	default:
+		return "other"
+	}
+}
+
+// --- Browser session-event stream telemetry ---
+//
+// The candidate-B and candidate-C stethoscope on the browser side. The
+// SPA's sessionEventStreamTelemetry.ts emits one event per opened /
+// received / silent / closed / error transition; the orchestrator
+// buckets the labels server-side. Cardinality budget: 10 events ×
+// 13 modes = 130 base + 15 event_types × 13 modes = 195 receive +
+// 13 mode × 10 silent histogram buckets = 130 → ~455 series.
+
+var (
+	sessionEventStreamClientReportsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_session_event_client_reports_total",
+			Help: "Browser session-event stream metric report requests, labeled by bounded result.",
+		},
+		[]string{"result"},
+	)
+	sessionEventStreamClientEventsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_session_event_client_events_total",
+			Help: "Semantic browser-side SSE stream events reported by the SPA, labeled by event + session_mode.",
+		},
+		[]string{"event", "session_mode"},
+	)
+	// sessionEventStreamClientReceivedTotal is the candidate-C
+	// stethoscope: divergence between this counter and the
+	// server-side tank_session_event_stream_emitted_by_type_total
+	// for the same event_type means the SPA reducer is dropping
+	// events the SSE handler emitted.
+	sessionEventStreamClientReceivedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_session_event_client_received_total",
+			Help: "Tank conversation events the SPA observed via the per-session SSE stream, labeled by event type + session_mode.",
+		},
+		[]string{"event_type", "session_mode"},
+	)
+	// sessionEventStreamClientSilentSeconds is the candidate-B
+	// histogram. When the SPA sits with a connected SSE but receives
+	// no tank events for N seconds while a turn is running, it
+	// observes the idle duration here. p95 climbing into the
+	// minutes is the zombie-connection signature.
+	sessionEventStreamClientSilentSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "tank_session_event_client_stream_silent_seconds",
+			Help:    "Browser-observed duration the per-session SSE remained silent while a turn was in flight.",
+			Buckets: []float64{1, 5, 15, 30, 60, 120, 300, 600, 1800},
+		},
+		[]string{"session_mode"},
+	)
+)
+
+func recordSessionEventStreamClientReport(result string) {
+	sessionEventStreamClientReportsTotal.WithLabelValues(sessionEventStreamClientResultLabel(result)).Inc()
+}
+
+func recordSessionEventStreamClientEvent(event sessionEventStreamMetricEvent) {
+	mode := chatScrollSessionModeLabel(event.SessionMode)
+	eventLabel := sessionEventStreamClientEventLabel(event.Event)
+	sessionEventStreamClientEventsTotal.WithLabelValues(eventLabel, mode).Inc()
+	if eventLabel == "tank_event_received" {
+		sessionEventStreamClientReceivedTotal.WithLabelValues(
+			sessionEventTypeLabel(event.EventType),
+			mode,
+		).Inc()
+	}
+	if eventLabel == "stream_silent_while_running" && event.IdleSeconds != nil {
+		sessionEventStreamClientSilentSeconds.WithLabelValues(mode).Observe(*event.IdleSeconds)
+	}
+}
+
+func sessionEventStreamClientResultLabel(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "ok", "invalid_json", "invalid_value", "too_many_events", "denied_role":
+		return raw
 	default:
 		return "other"
 	}
@@ -721,6 +835,9 @@ func (promPersisterMetrics) RecordTransientFailure() {
 
 // promWakeMetrics satisfies sessionbus.WakeMetrics so the bus can increment
 // wake/event-publish failure counters without importing prometheus directly.
+// The published/received pair powers the candidate-A wake-key-mismatch
+// stethoscope; the persist→wake duration histogram catches a slow-publish
+// tail the simple failure counter cannot.
 type promWakeMetrics struct{}
 
 func (promWakeMetrics) RecordSessionEventWakePublishFailed() {
@@ -729,6 +846,52 @@ func (promWakeMetrics) RecordSessionEventWakePublishFailed() {
 
 func (promWakeMetrics) RecordSessionListEventPublishFailed() {
 	sessionListEventPublishFailureTotal.Inc()
+}
+
+func (promWakeMetrics) RecordSessionEventWakePublished() {
+	sessionEventWakePublishedTotal.Inc()
+}
+
+func (promWakeMetrics) RecordSessionEventWakeReceived() {
+	sessionEventWakeReceivedTotal.Inc()
+}
+
+func (promWakeMetrics) RecordSessionEventPersistToWakeDuration(seconds float64) {
+	if seconds < 0 {
+		seconds = 0
+	}
+	sessionEventPersistToWakeSeconds.Observe(seconds)
+}
+
+// recordSessionEventStreamEmittedByType is the per-event-type bump that
+// pairs with the existing unlabeled tank_session_event_stream_emitted_total.
+// Event type is bucketed against the closed enum in
+// internal/conversation/types.go; unknown shapes collapse to "other" so
+// label cardinality stays bounded if a producer regresses.
+func recordSessionEventStreamEmittedByType(eventType string) {
+	sessionEventStreamEmittedByTypeTotal.WithLabelValues(sessionEventTypeLabel(eventType)).Inc()
+}
+
+func sessionEventTypeLabel(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "user_message.created",
+		"turn.submitted",
+		"turn.started",
+		"turn.completed",
+		"turn.failed",
+		"turn.command_failed",
+		"turn.interrupt_requested",
+		"turn.interrupted",
+		"session.status",
+		"item.started",
+		"item.completed",
+		"item.failed",
+		"tool.approval_requested",
+		"tool.approval_resolved":
+		return raw
+	default:
+		return "other"
+	}
 }
 
 // promNATSConnectionMetrics satisfies sessionbus.ConnectionMetrics so the

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionstream"
 	"github.com/nelsong6/tank-operator/backend-go/internal/store"
 )
 
@@ -41,6 +42,11 @@ type appServer struct {
 	verifier                 *auth.Verifier
 	gitHubInstallStates      gitHubInstallStateStore
 	streamAuthTickets        streamAuthTicketStore
+	// streamRegistry tracks every open /api/sessions/{id}/events SSE
+	// handler so the /api/debug/session-event-streams admin endpoint
+	// can surface per-stream wake/page/emit state for diagnosis.
+	// Wired at boot in main.go.
+	streamRegistry           *sessionstream.Registry
 	namespace                string
 	sessionScope             string
 	sessionServiceAccount    string
@@ -77,6 +83,11 @@ type sessionCommandBus interface {
 	PublishCommand(context.Context, sessionbus.Command) error
 	PublishSessionEventWake(context.Context, string) error
 	SubscribeWakes(context.Context, string) (<-chan struct{}, func(), error)
+	// SubscribeWakesWithRecorder is the per-stream-aware variant of
+	// SubscribeWakes used by the session event SSE handler so the
+	// admin endpoint can answer "did a wake arrive on the subject I
+	// expected, for this specific browser?" without devtools.
+	SubscribeWakesWithRecorder(ctx context.Context, sessionID string, recorder sessionbus.WakeRecorder) (<-chan struct{}, func(), error)
 	PublishSessionRowUpdate(ctx context.Context, email, scope string, payload []byte) error
 	SubscribeSessionRowUpdates(ctx context.Context, email, scope string) (<-chan []byte, func(), error)
 }
@@ -94,6 +105,10 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/design/selection/latest", s.handleGetLatestDesignSelection)
 	mux.HandleFunc("POST /api/design/selection", s.handlePostDesignSelection)
 	mux.HandleFunc("POST /api/client-metrics/chat-scroll", s.handleChatScrollMetrics)
+	// Browser-side SSE event stream telemetry — the candidate-B
+	// (zombie SSE) and candidate-C (reducer drop) stethoscope on the
+	// client side. Pairs with server-side counters in observability.go.
+	mux.HandleFunc("POST /api/client-metrics/session-events-stream", s.handleSessionEventStreamMetrics)
 
 	// Auth.
 	mux.HandleFunc("GET /api/auth/me", s.handleMe)
@@ -131,6 +146,12 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	// able server-side observability that replaces "share a Network
 	// tab screenshot."
 	mux.HandleFunc("GET /api/debug/session-list-state", s.handleDebugSessionListState)
+	// Admin-only debug surface for the chat-side SSE stream registry.
+	// Returns per-open-stream state (wakes/pages/emits/cursor) so an
+	// operator can distinguish wake-key-mismatch from zombie-SSE from
+	// reducer-drop without browser devtools. Per
+	// memory/feedback_no_devtools_build_surfaces_instead.md.
+	mux.HandleFunc("GET /api/debug/session-event-streams", s.handleDebugSessionEventStreams)
 	mux.HandleFunc("PUT /api/sessions/order", s.handleReorderSessions)
 	mux.HandleFunc("DELETE /api/sessions/{session_id}", s.handleDeleteSession)
 	mux.HandleFunc("GET /api/sessions/{session_id}", s.handleGetSession)

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -90,20 +90,48 @@ type noopPersisterMetrics struct{}
 func (noopPersisterMetrics) RecordSchemaRejected()   {}
 func (noopPersisterMetrics) RecordTransientFailure() {}
 
-// WakeMetrics receives counters for wake/event publish failures. The bus
+// WakeMetrics receives counters for wake/event publish failures, the
+// success path, and the end-to-end persist→wake latency. The bus
 // records here before returning the error to the caller; callers that
 // silently drop the error (Manager mutations that just want
 // fire-and-forget) still get visibility into "NATS is down". Wired to
 // prometheus in cmd/tank-operator/observability.go.
+//
+// The published/received split is the stethoscope for the candidate-A
+// wake-key-mismatch failure mode (per the diagnosis in
+// memory/feedback_no_devtools_build_surfaces_instead.md context): when
+// published >> received over the same window for the same SSE stream's
+// lifetime, the persister is firing wakes on a subject the subscriber
+// is not listening for. Both counters are unlabeled aggregates — the
+// per-session subject lives in the slog line and the admin endpoint's
+// stream snapshot, not in metric labels.
 type WakeMetrics interface {
 	RecordSessionEventWakePublishFailed()
 	RecordSessionListEventPublishFailed()
+	RecordSessionEventWakePublished()
+	RecordSessionEventWakeReceived()
+	RecordSessionEventPersistToWakeDuration(seconds float64)
 }
 
 type noopWakeMetrics struct{}
 
-func (noopWakeMetrics) RecordSessionEventWakePublishFailed()  {}
-func (noopWakeMetrics) RecordSessionListEventPublishFailed() {}
+func (noopWakeMetrics) RecordSessionEventWakePublishFailed()           {}
+func (noopWakeMetrics) RecordSessionListEventPublishFailed()           {}
+func (noopWakeMetrics) RecordSessionEventWakePublished()               {}
+func (noopWakeMetrics) RecordSessionEventWakeReceived()                {}
+func (noopWakeMetrics) RecordSessionEventPersistToWakeDuration(float64) {}
+
+// WakeRecorder is the optional per-stream hook SubscribeWakes calls
+// from the NATS message callback. The SSE handler passes its
+// sessionstream.StreamState, which records the wake's wall-clock
+// timestamp + the subject the NATS payload arrived on. This is what
+// powers the admin endpoint's per-stream `last_wake_at` /
+// `last_wake_subject` fields — the only way to distinguish "no wake
+// ever fired for this session" from "a wake fired but the page read
+// returned nothing" without browser devtools.
+type WakeRecorder interface {
+	RecordWake(at time.Time, subject string)
+}
 
 type Bus struct {
 	nc          *nats.Conn
@@ -343,12 +371,35 @@ func (b *Bus) SubscribeSessionRowUpdates(ctx context.Context, email, scope strin
 }
 
 func (b *Bus) SubscribeWakes(ctx context.Context, sessionID string) (<-chan struct{}, func(), error) {
+	return b.SubscribeWakesWithRecorder(ctx, sessionID, nil)
+}
+
+// SubscribeWakesWithRecorder is the per-stream-aware variant of
+// SubscribeWakes. The optional recorder is invoked from the NATS
+// message callback so the per-session SSE stream's last_wake_at /
+// last_wake_subject / wakes_received state stays accurate even when
+// the buffered notify channel is already full. The metrics counter
+// fires once per NATS delivery (not once per noticed wake) so the
+// published-vs-received delta in observability stays correct under
+// burst.
+//
+// SubscribeWakes (no recorder) is preserved for tests and any
+// caller that doesn't need per-stream attribution.
+func (b *Bus) SubscribeWakesWithRecorder(ctx context.Context, sessionID string, recorder WakeRecorder) (<-chan struct{}, func(), error) {
 	if b == nil {
 		return nil, func() {}, fmt.Errorf("session bus unavailable")
 	}
 	storageKey := sessionmodel.SessionStorageKey(b.scope, sessionID)
 	ch := make(chan struct{}, 1)
-	sub, err := b.nc.Subscribe(WakeSubject(storageKey), func(*nats.Msg) {
+	sub, err := b.nc.Subscribe(WakeSubject(storageKey), func(msg *nats.Msg) {
+		b.wakeMetrics.RecordSessionEventWakeReceived()
+		if recorder != nil {
+			subject := ""
+			if msg != nil {
+				subject = msg.Subject
+			}
+			recorder.RecordWake(time.Now(), subject)
+		}
 		select {
 		case ch <- struct{}{}:
 		default:
@@ -470,15 +521,33 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, msg persist
 	if err := store.Upsert(ctx, event); err != nil {
 		return err
 	}
+	upsertedAt := time.Now()
 	storageKey, _ := event["tank_session_id"].(string)
 	if storageKey == "" {
 		sessionID, _ := event["session_id"].(string)
 		storageKey = sessionmodel.SessionStorageKey(b.scope, sessionID)
 	}
 	if storageKey != "" && b.nc != nil {
-		if err := b.nc.Publish(WakeSubject(storageKey), nil); err != nil {
+		subject := WakeSubject(storageKey)
+		if err := b.nc.Publish(subject, nil); err != nil {
 			return err
 		}
+		// Success path: record both the published counter and the
+		// persist→wake latency. The published vs received delta in
+		// observability is the candidate-A stethoscope; the latency
+		// histogram catches the "we publish but something between
+		// Upsert and Publish is slow" tail (cancelled context, slow
+		// NATS flush) that would otherwise be invisible to the
+		// existing failure counter.
+		b.wakeMetrics.RecordSessionEventWakePublished()
+		b.wakeMetrics.RecordSessionEventPersistToWakeDuration(time.Since(upsertedAt).Seconds())
+		slog.Info("session event persister wake published",
+			"subject", subject,
+			"storage_key", storageKey,
+			"event_type", stringField(event, "type"),
+			"order_key", stringField(event, "order_key"),
+			"tank_session_id", stringField(event, "tank_session_id"),
+		)
 	}
 	if b.lifecycle != nil {
 		if err := b.lifecycle.EmitChatActivityDelta(ctx, event); err != nil {
@@ -489,6 +558,18 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, msg persist
 		}
 	}
 	return nil
+}
+
+// stringField is a defensive accessor for the persister's slog lines.
+// Returns "" instead of panicking when the field is missing or not a
+// string — the persister already validates schema, so this is purely
+// for the diagnostic log boundary.
+func stringField(event map[string]any, key string) string {
+	if event == nil {
+		return ""
+	}
+	v, _ := event[key].(string)
+	return v
 }
 
 func eventTypeForLog(data []byte) string {

--- a/backend-go/internal/sessionstream/registry.go
+++ b/backend-go/internal/sessionstream/registry.go
@@ -1,0 +1,300 @@
+// Package sessionstream tracks the live state of every open
+// /api/sessions/{id}/events SSE handler so admin operators can curl a
+// diagnostic surface that explains why a specific browser stopped
+// receiving live transcript events without having to read browser
+// devtools. Per memory/feedback_no_devtools_build_surfaces_instead.md
+// the user-trust constraint on this repo is that observability lives
+// behind curl-able endpoints, slog lines, and Prometheus — never the
+// browser network panel.
+//
+// The registry is in-memory and per-replica. The admin endpoint reads
+// one replica at a time; that matches the operational shape (we run
+// one orchestrator replica at a time today, and SSE handlers are bound
+// to a specific replica's TCP socket regardless).
+//
+// What the registry answers, paired with the new Prometheus counters
+// in observability.go:
+//   - "Is the wake plumbing live for this session?" — compare
+//     LastWakeAt against the persister's
+//     tank_session_event_wake_published_total rate for the same window.
+//   - "Did the SSE handler emit events post-wake?" — compare LastEmitAt
+//     and EmitsTotal against the durable ledger's row count.
+//   - "Is the connection zombie?" — LastWakeAt fresh, LastEmitAt fresh,
+//     but the browser claims no events arrived. That points the diagnosis
+//     at the client / proxy layer instead of the backend wake fabric.
+package sessionstream
+
+import (
+	"sync"
+	"time"
+)
+
+// StreamState is the per-open-SSE-handler diagnostic state. One
+// instance is owned by exactly one SSE handler goroutine, but the
+// admin endpoint reads a snapshot under the embedded mutex.
+//
+// Field names match what the admin endpoint emits as JSON; if you
+// add a field, also surface it in Snapshot() so the diagnostic
+// stays complete.
+type StreamState struct {
+	streamID   string
+	sessionID  string
+	storageKey string
+	email      string
+	openedAt   time.Time
+
+	mu                  sync.Mutex
+	lastWakeAt          time.Time
+	lastWakeSubject     string
+	lastPageReadAt      time.Time
+	lastPageEmitCount   int
+	lastEmitAt          time.Time
+	lastEmitOrderKey    string
+	lastEmitEventType   string
+	cursorAfterOrderKey string
+	lastHeartbeatAt     time.Time
+
+	wakesReceived     int64
+	pagesReadEmpty    int64
+	pagesReadNonEmpty int64
+	emitsTotal        int64
+	heartbeatsSent    int64
+}
+
+// NewStreamState constructs the state for one freshly opened SSE handler.
+// The constructor is the only place streamID / sessionID / storageKey /
+// email / openedAt are set — they're identity, not mutable state.
+func NewStreamState(streamID, sessionID, storageKey, email string, openedAt time.Time, initialCursor string) *StreamState {
+	return &StreamState{
+		streamID:            streamID,
+		sessionID:           sessionID,
+		storageKey:          storageKey,
+		email:               email,
+		openedAt:            openedAt,
+		cursorAfterOrderKey: initialCursor,
+	}
+}
+
+// RecordWake is called from the NATS subscribe callback whenever a
+// wake fires for this stream's storage key. The subject is recorded
+// alongside the timestamp so the admin endpoint can distinguish wakes
+// arriving on a scope-prefixed key vs a bare-session-id key — the
+// candidate-A signature for wake key mismatch in non-default scopes.
+func (s *StreamState) RecordWake(now time.Time, subject string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastWakeAt = now
+	s.lastWakeSubject = subject
+	s.wakesReceived++
+}
+
+// RecordPageRead is called after each writeSessionEventStreamPage
+// completes, whether or not it emitted any events. Distinguishing
+// empty reads from non-empty ones lets the admin endpoint show
+// "we keep getting woken but the read finds nothing" — the candidate-B
+// signature for read-replica visibility lag or a cursor that has
+// jumped past pending rows.
+func (s *StreamState) RecordPageRead(now time.Time, emitCount int) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastPageReadAt = now
+	s.lastPageEmitCount = emitCount
+	if emitCount == 0 {
+		s.pagesReadEmpty++
+	} else {
+		s.pagesReadNonEmpty++
+	}
+}
+
+// RecordEmit is called for each tank-event written to the SSE socket.
+// The cursor advance is recorded so the admin endpoint can compare
+// against the durable ledger's tip.
+func (s *StreamState) RecordEmit(now time.Time, orderKey, eventType, cursorAfter string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastEmitAt = now
+	s.lastEmitOrderKey = orderKey
+	s.lastEmitEventType = eventType
+	if cursorAfter != "" {
+		s.cursorAfterOrderKey = cursorAfter
+	}
+	s.emitsTotal++
+}
+
+// RecordHeartbeat is called on each keep-alive frame the handler
+// writes during idle. A stream with rising HeartbeatsSent but flat
+// EmitsTotal is the canonical "SSE is alive, no events flowing"
+// shape — useful even before we add the matching client-side
+// receipt counter.
+func (s *StreamState) RecordHeartbeat(now time.Time) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastHeartbeatAt = now
+	s.heartbeatsSent++
+}
+
+// Snapshot is the wire shape the admin endpoint returns. RFC3339Nano
+// timestamps are zero-valued (empty string) until the first event of
+// each kind fires, which lets the JSON consumer distinguish "never"
+// from "long ago."
+type Snapshot struct {
+	StreamID            string `json:"stream_id"`
+	SessionID           string `json:"session_id"`
+	StorageKey          string `json:"storage_key"`
+	Email               string `json:"email"`
+	OpenedAt            string `json:"opened_at"`
+	OpenSeconds         float64 `json:"open_seconds"`
+	LastWakeAt          string `json:"last_wake_at,omitempty"`
+	LastWakeSubject     string `json:"last_wake_subject,omitempty"`
+	LastPageReadAt      string `json:"last_page_read_at,omitempty"`
+	LastPageEmitCount   int    `json:"last_page_emit_count"`
+	LastEmitAt          string `json:"last_emit_at,omitempty"`
+	LastEmitOrderKey    string `json:"last_emit_order_key,omitempty"`
+	LastEmitEventType   string `json:"last_emit_event_type,omitempty"`
+	CursorAfterOrderKey string `json:"cursor_after_order_key,omitempty"`
+	LastHeartbeatAt     string `json:"last_heartbeat_at,omitempty"`
+
+	WakesReceived     int64 `json:"wakes_received"`
+	PagesReadEmpty    int64 `json:"pages_read_empty"`
+	PagesReadNonEmpty int64 `json:"pages_read_non_empty"`
+	EmitsTotal        int64 `json:"emits_total"`
+	HeartbeatsSent    int64 `json:"heartbeats_sent"`
+}
+
+// Snapshot copies the state under the lock so the admin endpoint can
+// JSON-encode without holding the stream's mutex during I/O.
+func (s *StreamState) Snapshot(now time.Time) Snapshot {
+	if s == nil {
+		return Snapshot{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Snapshot{
+		StreamID:            s.streamID,
+		SessionID:           s.sessionID,
+		StorageKey:          s.storageKey,
+		Email:               s.email,
+		OpenedAt:            formatTime(s.openedAt),
+		OpenSeconds:         now.Sub(s.openedAt).Seconds(),
+		LastWakeAt:          formatTime(s.lastWakeAt),
+		LastWakeSubject:     s.lastWakeSubject,
+		LastPageReadAt:      formatTime(s.lastPageReadAt),
+		LastPageEmitCount:   s.lastPageEmitCount,
+		LastEmitAt:          formatTime(s.lastEmitAt),
+		LastEmitOrderKey:    s.lastEmitOrderKey,
+		LastEmitEventType:   s.lastEmitEventType,
+		CursorAfterOrderKey: s.cursorAfterOrderKey,
+		LastHeartbeatAt:     formatTime(s.lastHeartbeatAt),
+		WakesReceived:       s.wakesReceived,
+		PagesReadEmpty:      s.pagesReadEmpty,
+		PagesReadNonEmpty:   s.pagesReadNonEmpty,
+		EmitsTotal:          s.emitsTotal,
+		HeartbeatsSent:      s.heartbeatsSent,
+	}
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// Registry is the process-wide map of open SSE handlers. Safe for
+// concurrent use. One Registry per orchestrator process.
+type Registry struct {
+	mu      sync.RWMutex
+	streams map[string]*StreamState
+}
+
+// NewRegistry constructs an empty registry. The orchestrator wires
+// exactly one instance into appServer at boot.
+func NewRegistry() *Registry {
+	return &Registry{streams: make(map[string]*StreamState)}
+}
+
+// Register adds a fresh stream's state. The streamID is the registry
+// key — generated by the caller (the SSE handler) so the caller can
+// hold the pointer for cheap per-event updates and deregister at
+// close time without re-keying.
+func (r *Registry) Register(state *StreamState) {
+	if r == nil || state == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.streams[state.streamID] = state
+}
+
+// Deregister removes a closed stream's state. Safe to call with an
+// unknown streamID (no-op) so the SSE handler's defer doesn't need
+// to coordinate with Register's race window.
+func (r *Registry) Deregister(streamID string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.streams, streamID)
+}
+
+// Snapshot returns a per-stream snapshot of every currently-open
+// stream. Sorted by OpenedAt ascending so admin endpoint output is
+// stable across calls (operators scrolling a long list during
+// diagnosis don't see rows shuffle on refresh).
+func (r *Registry) Snapshot(now time.Time) []Snapshot {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	streams := make([]*StreamState, 0, len(r.streams))
+	for _, s := range r.streams {
+		streams = append(streams, s)
+	}
+	r.mu.RUnlock()
+
+	out := make([]Snapshot, 0, len(streams))
+	for _, s := range streams {
+		out = append(out, s.Snapshot(now))
+	}
+	sortSnapshotsByOpenedAtAsc(out)
+	return out
+}
+
+// Len returns the number of currently registered streams. Tests
+// assert against this to verify Register/Deregister balance.
+func (r *Registry) Len() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.streams)
+}
+
+func sortSnapshotsByOpenedAtAsc(snapshots []Snapshot) {
+	// Insertion sort: snapshots count is at most "currently open SSE
+	// streams" which is bounded by active browsers, well under 100 on
+	// this cluster's scale. Avoids pulling sort just for this.
+	for i := 1; i < len(snapshots); i++ {
+		current := snapshots[i]
+		j := i - 1
+		for j >= 0 && snapshots[j].OpenedAt > current.OpenedAt {
+			snapshots[j+1] = snapshots[j]
+			j--
+		}
+		snapshots[j+1] = current
+	}
+}

--- a/backend-go/internal/sessionstream/registry_test.go
+++ b/backend-go/internal/sessionstream/registry_test.go
@@ -1,0 +1,173 @@
+package sessionstream
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRegisterDeregisterBalance(t *testing.T) {
+	reg := NewRegistry()
+	now := time.Now()
+
+	a := NewStreamState("stream-a", "42", "42", "alice@example.com", now, "")
+	b := NewStreamState("stream-b", "42", "42", "bob@example.com", now, "100")
+	reg.Register(a)
+	reg.Register(b)
+	if got := reg.Len(); got != 2 {
+		t.Fatalf("Len after Register x2 = %d, want 2", got)
+	}
+	reg.Deregister("stream-a")
+	if got := reg.Len(); got != 1 {
+		t.Fatalf("Len after one Deregister = %d, want 1", got)
+	}
+	reg.Deregister("missing")
+	if got := reg.Len(); got != 1 {
+		t.Fatalf("Deregister of unknown stream changed Len: %d", got)
+	}
+	reg.Deregister("stream-b")
+	if got := reg.Len(); got != 0 {
+		t.Fatalf("Len after final Deregister = %d, want 0", got)
+	}
+}
+
+func TestSnapshotCarriesIdentityAndCounters(t *testing.T) {
+	reg := NewRegistry()
+	opened := time.Now().Add(-3 * time.Second)
+	s := NewStreamState("stream-x", "160", "160", "user@example.com", opened, "")
+	reg.Register(s)
+
+	wakeAt := opened.Add(1 * time.Second)
+	s.RecordWake(wakeAt, "tank.live.160.wake")
+	s.RecordPageRead(wakeAt.Add(1*time.Millisecond), 2)
+	s.RecordEmit(wakeAt.Add(2*time.Millisecond), "abc123", "user_message.created", "abc123")
+	s.RecordEmit(wakeAt.Add(3*time.Millisecond), "abc124", "turn.submitted", "abc124")
+	s.RecordHeartbeat(wakeAt.Add(15 * time.Second))
+
+	now := opened.Add(20 * time.Second)
+	snap := reg.Snapshot(now)
+	if len(snap) != 1 {
+		t.Fatalf("len snap = %d, want 1", len(snap))
+	}
+	got := snap[0]
+	if got.StreamID != "stream-x" || got.SessionID != "160" || got.StorageKey != "160" || got.Email != "user@example.com" {
+		t.Fatalf("identity drift: %+v", got)
+	}
+	if got.WakesReceived != 1 {
+		t.Fatalf("WakesReceived = %d, want 1", got.WakesReceived)
+	}
+	if got.PagesReadNonEmpty != 1 || got.PagesReadEmpty != 0 {
+		t.Fatalf("PagesRead split = (empty=%d, non=%d), want (0, 1)", got.PagesReadEmpty, got.PagesReadNonEmpty)
+	}
+	if got.EmitsTotal != 2 {
+		t.Fatalf("EmitsTotal = %d, want 2", got.EmitsTotal)
+	}
+	if got.HeartbeatsSent != 1 {
+		t.Fatalf("HeartbeatsSent = %d, want 1", got.HeartbeatsSent)
+	}
+	if got.LastEmitOrderKey != "abc124" || got.LastEmitEventType != "turn.submitted" {
+		t.Fatalf("LastEmit drift: order_key=%q type=%q", got.LastEmitOrderKey, got.LastEmitEventType)
+	}
+	if got.CursorAfterOrderKey != "abc124" {
+		t.Fatalf("CursorAfterOrderKey = %q, want abc124", got.CursorAfterOrderKey)
+	}
+	if got.LastWakeSubject != "tank.live.160.wake" {
+		t.Fatalf("LastWakeSubject = %q", got.LastWakeSubject)
+	}
+	if got.OpenSeconds < 20 || got.OpenSeconds > 21 {
+		t.Fatalf("OpenSeconds = %v, want ~20", got.OpenSeconds)
+	}
+	if got.OpenedAt == "" {
+		t.Fatalf("OpenedAt should be formatted, got empty string")
+	}
+}
+
+// TestEmptyPageReadDistinct ensures pages_read_empty vs pages_read_non_empty
+// correctly distinguishes the candidate-B signature: wake fires but the
+// read returns no rows. That divergence (wakes_received > 0,
+// pages_read_non_empty == 0, pages_read_empty > 0) is the smoking gun.
+func TestEmptyPageReadDistinct(t *testing.T) {
+	s := NewStreamState("stream-y", "100", "100", "u@e.com", time.Now(), "")
+	now := time.Now()
+	s.RecordPageRead(now, 0)
+	s.RecordPageRead(now.Add(time.Millisecond), 0)
+	s.RecordPageRead(now.Add(2*time.Millisecond), 5)
+	snap := s.Snapshot(now.Add(time.Second))
+	if snap.PagesReadEmpty != 2 {
+		t.Fatalf("PagesReadEmpty = %d, want 2", snap.PagesReadEmpty)
+	}
+	if snap.PagesReadNonEmpty != 1 {
+		t.Fatalf("PagesReadNonEmpty = %d, want 1", snap.PagesReadNonEmpty)
+	}
+	if snap.LastPageEmitCount != 5 {
+		t.Fatalf("LastPageEmitCount = %d, want 5 (most recent)", snap.LastPageEmitCount)
+	}
+}
+
+func TestSnapshotSortStableByOpenedAt(t *testing.T) {
+	reg := NewRegistry()
+	base := time.Now()
+	// Insert out of order; expect snapshots sorted ascending by OpenedAt.
+	reg.Register(NewStreamState("c", "3", "3", "c@e.com", base.Add(2*time.Second), ""))
+	reg.Register(NewStreamState("a", "1", "1", "a@e.com", base, ""))
+	reg.Register(NewStreamState("b", "2", "2", "b@e.com", base.Add(1*time.Second), ""))
+	snaps := reg.Snapshot(base.Add(10 * time.Second))
+	if len(snaps) != 3 {
+		t.Fatalf("snap len = %d", len(snaps))
+	}
+	if snaps[0].StreamID != "a" || snaps[1].StreamID != "b" || snaps[2].StreamID != "c" {
+		t.Fatalf("snapshot order = %s/%s/%s, want a/b/c", snaps[0].StreamID, snaps[1].StreamID, snaps[2].StreamID)
+	}
+}
+
+func TestNilReceiversAreNoOps(t *testing.T) {
+	// Guards: SSE handler defers RecordWake / Deregister; nil-safety
+	// keeps a stub-mode deployment (no NATS, no registry) from
+	// panicking on first wake.
+	var r *Registry
+	r.Register(NewStreamState("x", "1", "1", "u@e.com", time.Now(), ""))
+	r.Deregister("x")
+	if r.Len() != 0 {
+		t.Fatalf("nil registry should report Len() == 0")
+	}
+	if got := r.Snapshot(time.Now()); got != nil {
+		t.Fatalf("nil registry Snapshot() should be nil")
+	}
+
+	var s *StreamState
+	s.RecordWake(time.Now(), "x")
+	s.RecordPageRead(time.Now(), 1)
+	s.RecordEmit(time.Now(), "1", "session.status", "1")
+	s.RecordHeartbeat(time.Now())
+	if got := (s.Snapshot(time.Now())); got != (Snapshot{}) {
+		t.Fatalf("nil state Snapshot() should be zero value, got %+v", got)
+	}
+}
+
+// TestConcurrentRecordAndSnapshot exercises the locking around
+// per-stream state updates. RecordWake / RecordEmit run from the
+// stream's own goroutine, but Snapshot reads from the admin
+// endpoint goroutine. The race detector should stay quiet.
+func TestConcurrentRecordAndSnapshot(t *testing.T) {
+	s := NewStreamState("stream-z", "9", "9", "u@e.com", time.Now(), "")
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			s.RecordWake(time.Now(), "tank.live.9.wake")
+			s.RecordEmit(time.Now(), "k", "user_message.created", "k")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = s.Snapshot(time.Now())
+		}
+	}()
+	wg.Wait()
+	snap := s.Snapshot(time.Now())
+	if snap.WakesReceived != 200 || snap.EmitsTotal != 200 {
+		t.Fatalf("counter loss under concurrent updates: wakes=%d emits=%d", snap.WakesReceived, snap.EmitsTotal)
+	}
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,6 +51,35 @@ All metric names are prefixed `tank_`. The full namespace:
   `at_bottom`, and `has_scroll_parent`. The endpoint never exposes
   `session_id`, email, raw route paths, or user-supplied event names as
   labels; unknown values collapse to `other` / `unknown`.
+- `tank_session_event_wake_published_total` /
+  `tank_session_event_wake_received_total` /
+  `tank_session_event_persist_to_wake_seconds` — the per-session SSE
+  wake fabric stethoscope. Published vs received delta over the same
+  window is the candidate-A wake-key-mismatch signature (the persister
+  is publishing to a subject the SSE subscriber is not listening for).
+  All unlabeled aggregates per the cardinality rules below; per-stream
+  resolution lives in `GET /api/debug/session-event-streams`
+  (admin-only) and in the persister's `slog.Info("session event
+  persister wake published", subject=..., storage_key=...,
+  event_type=..., order_key=..., tank_session_id=...)` line.
+- `tank_session_event_stream_emitted_by_type_total{event_type}` —
+  per-Tank-event-type counter paired with
+  `tank_session_event_client_received_total{event_type, session_mode}`.
+  Divergence is the candidate-C reducer-drop signature (server emitted,
+  browser didn't render). `event_type` is the closed enum from
+  `internal/conversation/types.go`; unknown shapes collapse to
+  `other`.
+- `tank_session_event_client_*` — browser-reported per-session SSE
+  stream diagnostics ingested through
+  `POST /api/client-metrics/session-events-stream`. Bounded labels:
+  `event` (opened, ready, tank_event_received,
+  stream_silent_while_running, resync_required, stream_error,
+  closed_unmount, closed_error, reconnect_scheduled),
+  `session_mode`, and on the `_received_total` variant `event_type`.
+  The `_stream_silent_seconds{session_mode}` histogram is the
+  candidate-B zombie-SSE detector: the browser's silence watchdog
+  observes the idle interval whenever a connected stream has gone
+  >30 s without emitting events while a turn is in flight.
 - `tank_turn_interrupt_request_total` — counter of stop requests posted
   to `/interrupt`. Single label `outcome` with three bounded values:
   `persisted`, `persist_failed`, `publish_failed`. Steady-state
@@ -76,6 +105,27 @@ All metric names are prefixed `tank_`. The full namespace:
   label: `provider` ("claude" or "codex"), bound from `PROXY_PROVIDER`.
 - `tank_mcp_auth_proxy_*` — sidecar counters/histograms. Label
   `mcp_server` is bounded by the LISTENERS table in `server.py`.
+
+## Per-stream debug surface
+
+`GET /api/debug/session-event-streams` (admin-only) returns the
+in-memory snapshot of every open `/api/sessions/{id}/events` SSE
+handler on the queried orchestrator replica. Each stream row carries
+`opened_at`, `last_wake_at`, `last_wake_subject`, `last_page_read_at`,
+`last_emit_at`, `last_emit_order_key`, `last_emit_event_type`,
+`cursor_after_order_key`, `wakes_received`, `pages_read_empty`,
+`pages_read_non_empty`, `emits_total`, and `heartbeats_sent`. The
+endpoint accepts a `?session_id=<id>` filter for focused diagnosis.
+
+Pair it with the Prometheus counters above: if the durable ledger has
+new rows for a session but the matching stream's `wakes_received`
+counter stays at 0, the persister is publishing to a subject the
+subscriber is not listening for (candidate A); if `wakes_received`
+climbs but `emits_total` stays flat, the page read returned nothing
+(candidate B for read-replica visibility lag, or the cursor jumped
+past pending rows); if `emits_total` climbs on the server but the
+matching browser's `tank_session_event_client_received_total` stays
+flat, the SPA reducer is dropping (candidate C).
 
 ## Cardinality rules
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,11 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { AUTH_TOKEN_UPDATED_EVENT, authedEventSource, authedFetch, bootstrapAuth, getStoredToken, logout, startLogin } from "./auth";
+import {
+  createSilenceWatchdog,
+  logSessionEventStreamEvent,
+  type SilenceWatchdog,
+} from "./sessionEventStreamTelemetry";
 import { requiresGitHubOnboarding, type SessionRole } from "./authPolicy";
 import {
   initialConversationState,
@@ -5880,6 +5885,15 @@ function ChatPane({
   const sessionIdRef = useRef(session.id);
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
+  // runningRef is read from the SSE silence watchdog so we can tell
+  // whether a silent stream was silent *during a turn* (the
+  // candidate-B signature) or just idle. Mirrors the visibleRef
+  // pattern — kept in sync on every render.
+  const runningRef = useRef(false);
+  runningRef.current = running;
+  // silenceWatchdogRef holds the per-open-stream SilenceWatchdog
+  // instance; the SSE open path arms it, the cleanup path stops it.
+  const silenceWatchdogRef = useRef<SilenceWatchdog | null>(null);
   const [sdkConnectionState, setSdkConnectionState] =
     useState<SdkConnectionState>("idle");
   const currentRunRef = useRef<{
@@ -7805,6 +7819,7 @@ function ChatPane({
       );
     } catch {
       setSdkConnectionState("connection_lost");
+      logSessionEventStreamEvent("reconnect_scheduled", { sessionMode: session.mode });
       scheduleSdkEventStreamReconnect();
       return null;
     }
@@ -7813,8 +7828,20 @@ function ChatPane({
       return null;
     }
     sdkEventSourceRef.current = source;
+    logSessionEventStreamEvent("opened", { sessionMode: session.mode });
+    // Build a fresh silence watchdog for this stream. Per-open
+    // lifecycle so a reconnect produces independent histogram
+    // observations.
+    silenceWatchdogRef.current?.stop();
+    silenceWatchdogRef.current = createSilenceWatchdog({
+      sessionMode: session.mode,
+      isRunning: () => runningRef.current,
+    });
+    silenceWatchdogRef.current.reset();
     source.addEventListener("ready", () => {
       setSdkConnectionState("connected");
+      silenceWatchdogRef.current?.reset();
+      logSessionEventStreamEvent("ready", { sessionMode: session.mode });
     });
     source.addEventListener("tank-event", (event) => {
       const message = event as MessageEvent;
@@ -7825,6 +7852,16 @@ function ChatPane({
         return;
       }
       if (!isJsonObject(parsed)) return;
+      // Telemetry first: even if applySdkDurableEvent's filter
+      // would drop this event (the candidate-C reducer-drop case),
+      // the receipt counter must still increment so the
+      // server-emit vs client-receive divergence is observable.
+      const eventType = typeof parsed.type === "string" ? parsed.type : "";
+      logSessionEventStreamEvent("tank_event_received", {
+        sessionMode: session.mode,
+        eventType,
+      });
+      silenceWatchdogRef.current?.reset();
       applySdkDurableEvent(parsed);
     });
     source.addEventListener("resync_required", () => {
@@ -7832,6 +7869,7 @@ function ChatPane({
       if (sdkEventSourceRef.current === source) sdkEventSourceRef.current = null;
       setSdkConnectionState("resyncing");
       sdkTimelineCursorRef.current = null;
+      logSessionEventStreamEvent("resync_required", { sessionMode: session.mode });
       void refreshSdkRunHistoryResult(true, undefined, "resync").finally(() => {
         if (sessionIdRef.current !== session.id) return;
         sdkEventSourceRef.current?.close();
@@ -7843,12 +7881,14 @@ function ChatPane({
       source.close();
       if (sdkEventSourceRef.current === source) sdkEventSourceRef.current = null;
       setSdkConnectionState("connection_lost");
+      logSessionEventStreamEvent("stream_error", { sessionMode: session.mode });
       scheduleSdkEventStreamReconnect();
     });
     source.onerror = () => {
       source.close();
       if (sdkEventSourceRef.current === source) sdkEventSourceRef.current = null;
       setSdkConnectionState("connection_lost");
+      logSessionEventStreamEvent("closed_error", { sessionMode: session.mode });
       scheduleSdkEventStreamReconnect();
     };
     return source;
@@ -7866,6 +7906,15 @@ function ChatPane({
       }
       sdkEventSourceRef.current?.close();
       sdkEventSourceRef.current = null;
+      // Telemetry: closed by effect cleanup (session change, pane
+      // hidden, history reset). Pairs with closed_error from
+      // source.onerror so an operator can distinguish "we tore
+      // down" from "the socket died."
+      if (silenceWatchdogRef.current) {
+        silenceWatchdogRef.current.stop();
+        silenceWatchdogRef.current = null;
+        logSessionEventStreamEvent("closed_unmount", { sessionMode: session.mode });
+      }
     };
   // openSdkEventStream closes over the current session cursor and reducer state.
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -10,6 +10,7 @@ const appSource = readSource("./App.tsx");
 const authSource = readSource("./auth.ts");
 const conversationReducerSource = readSource("./conversationReducer.ts");
 const chatScrollTelemetrySource = readSource("./chatScrollTelemetry.ts");
+const sessionEventStreamTelemetrySource = readSource("./sessionEventStreamTelemetry.ts");
 const longChatDebugSource = readSource("./LongChatDebugPage.tsx");
 const mainSource = readSource("./main.tsx");
 const indexCssSource = readSource("./index.css");
@@ -261,6 +262,34 @@ test("chat back-pagination keeps the focused load button mounted while loading",
   assert.equal(appSource.includes("aria-disabled={sdkLoadingOlder || undefined}"), true);
   assert.equal(appSource.includes("aria-busy={sdkLoadingOlder || undefined}"), true);
   assert.equal(appSource.includes("run-transcript-load-older-passive"), false);
+});
+
+test("session-event SSE stream emits browser-side observability", () => {
+  // The candidate-B (zombie SSE) + candidate-C (reducer-drop)
+  // stethoscope on the browser side. If a future refactor silently
+  // removes the telemetry hooks, this guard breaks before the
+  // diagnostic-only observability metric quietly stops shipping.
+  assert.equal(
+    sessionEventStreamTelemetrySource.includes("/api/client-metrics/session-events-stream"),
+    true,
+  );
+  assert.equal(sessionEventStreamTelemetrySource.includes("createSilenceWatchdog"), true);
+  assert.equal(sessionEventStreamTelemetrySource.includes("stream_silent_while_running"), true);
+  assert.equal(appSource.includes('logSessionEventStreamEvent("opened"'), true);
+  assert.equal(appSource.includes('logSessionEventStreamEvent("tank_event_received"'), true);
+  assert.equal(appSource.includes('logSessionEventStreamEvent("resync_required"'), true);
+  assert.equal(appSource.includes('logSessionEventStreamEvent("stream_error"'), true);
+  assert.equal(appSource.includes('logSessionEventStreamEvent("closed_error"'), true);
+  assert.equal(appSource.includes('logSessionEventStreamEvent("closed_unmount"'), true);
+  assert.equal(appSource.includes("silenceWatchdogRef"), true);
+  // The receipt-count telemetry MUST observe before the reducer
+  // filter; if a future change swaps the order, the candidate-C
+  // signature would be invisible (server-emit vs client-receive
+  // delta would be measured at the wrong layer).
+  assert.match(
+    appSource,
+    /logSessionEventStreamEvent\("tank_event_received"[\s\S]{0,200}applySdkDurableEvent/,
+  );
 });
 
 test("chat scroll diagnostics are prometheus backed", () => {

--- a/frontend/src/sessionEventStreamTelemetry.test.ts
+++ b/frontend/src/sessionEventStreamTelemetry.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createSilenceWatchdog } from "./sessionEventStreamTelemetry";
+
+// SilenceWatchdog is the candidate-B detector on the browser side.
+// These tests pin its behavior so a future refactor cannot quietly
+// turn the metric off (the watchdog must publish observations while
+// silence persists, must respect the whileRunning predicate, and
+// must stop cleanly on stop()).
+
+test("watchdog publishes a metric after idleThresholdMs", () => {
+  let nowMs = 1_000;
+  const scheduled: Array<{ fn: () => void; delay: number; handle: number }> = [];
+  let nextHandle = 1;
+  const setTimeoutFn = ((fn: () => void, delay: number) => {
+    const handle = nextHandle++;
+    scheduled.push({ fn, delay, handle });
+    return handle;
+  }) as unknown as typeof window.setTimeout;
+  const clearTimeoutFn = ((handle: number) => {
+    const i = scheduled.findIndex((s) => s.handle === handle);
+    if (i >= 0) scheduled.splice(i, 1);
+  }) as unknown as typeof window.clearTimeout;
+  const emits: Array<{ idleSeconds: number; whileRunning: boolean }> = [];
+  const watchdog = createSilenceWatchdog({
+    sessionMode: "claude_gui",
+    idleThresholdMs: 30_000,
+    isRunning: () => true,
+    setTimeoutFn,
+    clearTimeoutFn,
+    now: () => nowMs,
+    emit: (_event, detail) => emits.push({ idleSeconds: detail.idleSeconds, whileRunning: detail.whileRunning }),
+  });
+
+  watchdog.reset();
+  assert.equal(scheduled.length, 1, "reset should schedule one timer");
+  assert.equal(scheduled[0]!.delay, 30_000);
+
+  // Advance clock + fire timer.
+  nowMs = 31_000;
+  const fired = scheduled.shift()!;
+  fired.fn();
+
+  assert.equal(emits.length, 1);
+  assert.equal(emits[0]!.whileRunning, true);
+  assert.ok(emits[0]!.idleSeconds >= 30 && emits[0]!.idleSeconds < 31);
+
+  // Re-arm after fire — silence still ongoing means we keep observing.
+  assert.equal(scheduled.length, 1, "watchdog should re-arm after firing");
+
+  watchdog.stop();
+});
+
+test("watchdog reset clears the pending timer", () => {
+  const scheduled: Array<{ fn: () => void; delay: number; handle: number }> = [];
+  let nextHandle = 1;
+  const setTimeoutFn = ((fn: () => void, delay: number) => {
+    const handle = nextHandle++;
+    scheduled.push({ fn, delay, handle });
+    return handle;
+  }) as unknown as typeof window.setTimeout;
+  const clearTimeoutFn = ((handle: number) => {
+    const i = scheduled.findIndex((s) => s.handle === handle);
+    if (i >= 0) scheduled.splice(i, 1);
+  }) as unknown as typeof window.clearTimeout;
+  const watchdog = createSilenceWatchdog({
+    sessionMode: "claude_gui",
+    idleThresholdMs: 30_000,
+    isRunning: () => true,
+    setTimeoutFn,
+    clearTimeoutFn,
+    now: () => 0,
+    emit: () => assert.fail("should not fire after reset clears"),
+  });
+  watchdog.reset();
+  assert.equal(scheduled.length, 1);
+  watchdog.reset(); // clears and re-arms
+  assert.equal(scheduled.length, 1, "outstanding timer should be cleared on re-reset");
+  watchdog.stop();
+  assert.equal(scheduled.length, 0, "stop() should clear the timer");
+});
+
+test("watchdog reports whileRunning=false outside a turn", () => {
+  let nowMs = 0;
+  const scheduled: Array<{ fn: () => void; delay: number }> = [];
+  const setTimeoutFn = ((fn: () => void, delay: number) => {
+    scheduled.push({ fn, delay });
+    return scheduled.length;
+  }) as unknown as typeof window.setTimeout;
+  const clearTimeoutFn = ((_handle: number) => undefined) as unknown as typeof window.clearTimeout;
+  const emits: Array<{ whileRunning: boolean }> = [];
+  const watchdog = createSilenceWatchdog({
+    sessionMode: "claude_gui",
+    idleThresholdMs: 30_000,
+    isRunning: () => false,
+    setTimeoutFn,
+    clearTimeoutFn,
+    now: () => nowMs,
+    emit: (_event, detail) => emits.push({ whileRunning: detail.whileRunning }),
+  });
+  watchdog.reset();
+  nowMs = 31_000;
+  scheduled[0]!.fn();
+  assert.equal(emits.length, 1);
+  assert.equal(emits[0]!.whileRunning, false, "still emits metric — operator reads idleSeconds for both states");
+  watchdog.stop();
+});

--- a/frontend/src/sessionEventStreamTelemetry.ts
+++ b/frontend/src/sessionEventStreamTelemetry.ts
@@ -1,0 +1,219 @@
+import { authedFetch } from "./auth";
+
+// Per-session SSE event-stream telemetry. The candidate-B (zombie SSE)
+// and candidate-C (reducer-drop) stethoscope on the browser side.
+// Console logging is opt-in per browser with localStorage.tankDebug
+// = "session-events" (or a comma-separated list including that token).
+//
+// Production observability is Prometheus-backed: semantic browser
+// events batch to the orchestrator at
+// POST /api/client-metrics/session-events-stream, which owns the
+// bounded metric labels (per docs/observability.md cardinality rules).
+
+const DEBUG_STORAGE_KEY = "tankDebug";
+const DEBUG_TOKEN = "session-events";
+const CONSOLE_PREFIX = "[tank/session-events]";
+const METRICS_ENDPOINT = "/api/client-metrics/session-events-stream";
+const MAX_BATCH_EVENTS = 60;
+const FLUSH_DELAY_MS = 1_000;
+
+// Closed-enum bounded labels. Mirrors the allowlist on the server side
+// in handlers_client_metrics_session_events.go — keep them in sync.
+export type SessionEventStreamMetricName =
+  | "opened"
+  | "ready"
+  | "tank_event_received"
+  | "stream_silent_while_running"
+  | "resync_required"
+  | "stream_error"
+  | "closed_unmount"
+  | "closed_error"
+  | "reconnect_scheduled";
+
+interface SessionEventStreamMetricPayload {
+  event: SessionEventStreamMetricName;
+  sessionMode: string;
+  eventType?: string;
+  idleSeconds?: number;
+  whileRunning?: boolean;
+}
+
+let pendingMetrics: SessionEventStreamMetricPayload[] = [];
+let flushTimer: number | null = null;
+
+export function isSessionEventStreamDebugEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(DEBUG_STORAGE_KEY) ?? "";
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .includes(DEBUG_TOKEN);
+  } catch {
+    return false;
+  }
+}
+
+export function logSessionEventStreamEvent(
+  event: SessionEventStreamMetricName,
+  detail: {
+    sessionMode: string;
+    eventType?: string;
+    idleSeconds?: number;
+    whileRunning?: boolean;
+  },
+): void {
+  enqueue({
+    event,
+    sessionMode: clampString(detail.sessionMode) || "unknown",
+    eventType: detail.eventType ? clampString(detail.eventType) : undefined,
+    idleSeconds:
+      typeof detail.idleSeconds === "number" && Number.isFinite(detail.idleSeconds) && detail.idleSeconds >= 0
+        ? detail.idleSeconds
+        : undefined,
+    whileRunning: typeof detail.whileRunning === "boolean" ? detail.whileRunning : undefined,
+  });
+  if (isSessionEventStreamDebugEnabled()) {
+    // Console-side trace mirrors the prom event for the rare cases
+    // where the operator is sitting at a browser tab during the bug
+    // and wants per-event ordering without round-tripping through
+    // /metrics scrape intervals.
+    console.log(`${CONSOLE_PREFIX} ${event}`, detail);
+  }
+}
+
+export function flushSessionEventStreamMetricsForTest(): void {
+  if (flushTimer !== null && typeof window !== "undefined") {
+    if (typeof window.clearTimeout === "function") {
+      window.clearTimeout(flushTimer);
+    }
+    flushTimer = null;
+  }
+  flush();
+}
+
+function enqueue(payload: SessionEventStreamMetricPayload): void {
+  if (typeof window === "undefined") return;
+  pendingMetrics.push(payload);
+  if (pendingMetrics.length >= MAX_BATCH_EVENTS) {
+    flush();
+    return;
+  }
+  scheduleFlush();
+}
+
+function scheduleFlush(): void {
+  if (typeof window === "undefined" || flushTimer !== null) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    flush();
+  }, FLUSH_DELAY_MS);
+}
+
+function flush(): void {
+  if (typeof window === "undefined" || pendingMetrics.length === 0) return;
+  const events = pendingMetrics.splice(0, MAX_BATCH_EVENTS);
+  if (typeof fetch !== "function") return;
+  authedFetch(METRICS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ events }),
+    keepalive: true,
+  }).catch(() => undefined);
+  if (pendingMetrics.length > 0) scheduleFlush();
+}
+
+function clampString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, 80);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", flush);
+}
+
+// SilenceWatchdog wraps a 30s "I haven't seen a tank event" timer per
+// SSE consumer. The caller resets the timer on every tank-event and on
+// open; if the timer fires while a turn is in flight, the watchdog
+// emits a stream_silent_while_running metric with the observed idle
+// duration. Designed to be cheap (one setTimeout per session pane,
+// reset on every event) and harmless (no behavior change, no
+// reconnect) so it never masks the underlying bug.
+export interface SilenceWatchdogOptions {
+  sessionMode: string;
+  /** Threshold above which the watchdog publishes a silent metric. */
+  idleThresholdMs?: number;
+  /** Returns true when a turn is currently in flight on this pane. */
+  isRunning: () => boolean;
+  /** Hook for tests to stub window.setTimeout. */
+  setTimeoutFn?: typeof window.setTimeout;
+  /** Hook for tests to stub window.clearTimeout. */
+  clearTimeoutFn?: typeof window.clearTimeout;
+  /** Hook for tests to stub Date.now(). */
+  now?: () => number;
+  /** Hook for tests to capture emit calls without touching the global queue. */
+  emit?: (event: SessionEventStreamMetricName, detail: {
+    sessionMode: string;
+    idleSeconds: number;
+    whileRunning: boolean;
+  }) => void;
+}
+
+export interface SilenceWatchdog {
+  /** Restarts the silence countdown. Call on stream open + each event. */
+  reset(): void;
+  /** Cancels the watchdog. Call when the stream closes. */
+  stop(): void;
+}
+
+export function createSilenceWatchdog(options: SilenceWatchdogOptions): SilenceWatchdog {
+  const threshold = options.idleThresholdMs ?? 30_000;
+  const setTimeoutFn = options.setTimeoutFn ?? window.setTimeout.bind(window);
+  const clearTimeoutFn = options.clearTimeoutFn ?? window.clearTimeout.bind(window);
+  const nowFn = options.now ?? Date.now;
+  const emit =
+    options.emit ??
+    ((event, detail) =>
+      logSessionEventStreamEvent(event, detail));
+  let timer: ReturnType<typeof setTimeoutFn> | null = null;
+  let startedAt = nowFn();
+  let stopped = false;
+
+  function arm(): void {
+    if (stopped) return;
+    timer = setTimeoutFn(() => {
+      timer = null;
+      if (stopped) return;
+      const idleSeconds = (nowFn() - startedAt) / 1000;
+      const whileRunning = options.isRunning();
+      emit("stream_silent_while_running", {
+        sessionMode: options.sessionMode,
+        idleSeconds,
+        whileRunning,
+      });
+      // Re-arm so a continuously-silent stream keeps producing
+      // observations every threshold; without re-arming a long stall
+      // would emit exactly one point and look like a brief blip on
+      // the histogram.
+      startedAt = nowFn();
+      arm();
+    }, threshold);
+  }
+
+  return {
+    reset(): void {
+      if (stopped) return;
+      if (timer !== null) clearTimeoutFn(timer);
+      startedAt = nowFn();
+      arm();
+    },
+    stop(): void {
+      stopped = true;
+      if (timer !== null) {
+        clearTimeoutFn(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/k8s/templates/grafana-dashboard.yaml
+++ b/k8s/templates/grafana-dashboard.yaml
@@ -281,6 +281,102 @@ data:
           ]
         },
         {
+          "id": 18,
+          "title": "SSE wake fabric: published vs received (5m rate)",
+          "description": "Candidate-A wake-key-mismatch stethoscope. Published (persister + direct writers) should track received (orchestrator-side NATS subscribers) closely. A sustained gap means wakes are firing on subjects nobody is subscribed to — typically the storage_key shape drifted between producer and SSE handler in a non-default scope. Aggregate-only; per-stream resolution lives at GET /api/debug/session-event-streams (admin only).",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 72 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(tank_session_event_wake_published_total[5m]))",
+              "legendFormat": "published"
+            },
+            {
+              "expr": "sum(rate(tank_session_event_wake_received_total[5m]))",
+              "legendFormat": "received"
+            },
+            {
+              "expr": "sum(rate(tank_session_event_wake_publish_failure_total[5m]))",
+              "legendFormat": "publish_failed"
+            }
+          ]
+        },
+        {
+          "id": 19,
+          "title": "Persist→wake latency p50 / p95 / p99",
+          "description": "Histogram tail of the time between session_events Upsert returning and the NATS wake publish completing. Steady-state should be single-digit milliseconds. A growing p95 is the early indicator of NATS slowness that the wake-publish failure counter only catches once the publish actually errors out.",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 72 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "s" } },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(tank_session_event_persist_to_wake_seconds_bucket[5m])))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(tank_session_event_persist_to_wake_seconds_bucket[5m])))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(tank_session_event_persist_to_wake_seconds_bucket[5m])))",
+              "legendFormat": "p99"
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "title": "Server emit vs browser receive by event type (5m rate)",
+          "description": "Candidate-C reducer-drop stethoscope. Server-side emit-by-type from the SSE handler, plotted alongside the browser-side receive-by-type from POST /api/client-metrics/session-events-stream. A persistent gap on a specific event_type means the SPA reducer is dropping that type silently — the server sent it, the browser didn't render it. Network batching introduces a small lag; sustained >5% divergence is the signal.",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 80 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum by (event_type) (rate(tank_session_event_stream_emitted_by_type_total[5m]))",
+              "legendFormat": "server emit {{`{{ event_type }}`}}"
+            },
+            {
+              "expr": "sum by (event_type) (rate(tank_session_event_client_received_total[5m]))",
+              "legendFormat": "client receive {{`{{ event_type }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 21,
+          "title": "Browser SSE silent-while-running (p95 over 30m)",
+          "description": "Candidate-B zombie-SSE stethoscope. The browser's silence watchdog observes the idle interval whenever a connected stream has gone >30s without a tank-event while a turn is in flight. p95 climbing into the minute-range is the canonical signature: TCP socket is alive (browser thinks connected), no events flowing, no error fires. Pair with id 18 — if wake_received is healthy but this histogram climbs, the failure is between the orchestrator and the browser (proxy / LB idle timeout), not inside the wake fabric.",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 80 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "s" } },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, session_mode) (rate(tank_session_event_client_stream_silent_seconds_bucket[30m])))",
+              "legendFormat": "p95 {{`{{ session_mode }}`}}"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, session_mode) (rate(tank_session_event_client_stream_silent_seconds_bucket[30m])))",
+              "legendFormat": "p99 {{`{{ session_mode }}`}}"
+            }
+          ]
+        },
+        {
+          "id": 22,
+          "title": "Browser SSE lifecycle events (5m rate)",
+          "description": "Browser-reported SSE lifecycle, labeled by event. Climbing closed_error / reconnect_scheduled rates correlate with a proxy / LB / network instability layer the server-side wake counters cannot see. opened, ready, tank_event_received are the healthy-volume baseline.",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 88 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum by (event) (rate(tank_session_event_client_events_total[5m]))",
+              "legendFormat": "{{`{{ event }}`}}"
+            }
+          ]
+        },
+        {
           "id": 17,
           "title": "Inferred warm-spawn ratio (24h)",
           "description": "Fraction of session pods spawned in the last 24h (across the production sessions namespace and every test-slot sessions namespace) that completed in under 10s. Bimodal-distribution proxy for cache hits: warm pulls cluster at 2-3s, cold pulls at 27-33s, the 10s threshold sits in the empty middle. Drift downward suggests nodes are losing the image cache more often OR FailedScheduling is delaying spawns beyond 10s. Drift upward suggests cache distribution is improving (e.g. after a pre-pull DaemonSet ships).",

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -159,6 +159,130 @@ spec:
             summary: "tank-operator wake/event publishes to NATS are failing"
             runbook: "SSE clients will lag behind durable state until the next heartbeat or cursor-resume reconnect. Check NATS health in the nats namespace."
 
+        # ----- Per-session SSE wake-fabric stethoscope -----
+        #
+        # The three alerts below correspond to the candidate-A / B / C
+        # failure shapes catalogued in docs/observability.md →
+        # "Per-stream debug surface" and the persister's slog.Info
+        # "session event persister wake published" line.
+        #
+        # Candidate A — wake-key mismatch. The persister fires wakes on
+        # a subject the SSE handler is not subscribed for. Symptom:
+        # wakes_published climbs, wakes_received does not. Threshold:
+        # 5% sustained divergence over 10m, severity warning (user-
+        # visible only when an actual wake is lost; SSE clients catch
+        # up on next heartbeat or reconnect).
+        - alert: TankSessionEventWakeDeliveryGap
+          expr: |
+            (
+              sum(rate(tank_session_event_wake_published_total[10m]))
+                - sum(rate(tank_session_event_wake_received_total[10m]))
+            )
+              / clamp_min(sum(rate(tank_session_event_wake_published_total[10m])), 0.001)
+              > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "session-event wakes are being published faster than they are received"
+            runbook: |
+              The persister (or a direct-writer call site) is publishing
+              to a per-session wake subject that no SSE handler is
+              subscribed for. The most common cause is a storage_key
+              shape drift between producer and subscriber in a
+              non-default scope. Resolve per-session via
+              GET /api/debug/session-event-streams (admin only): if a
+              specific stream shows wakes_received=0 while
+              tank_session_event_wake_published_total is climbing for
+              the same window, last_wake_subject will be empty and
+              storage_key will show what the handler expected to
+              receive on. Check
+              backend-go/internal/sessionmodel.SessionStorageKey and
+              the runner's TANK_SESSION_STORAGE_KEY env vs.
+              cmd/tank-operator's sessionScope.
+
+        # Candidate B — zombie SSE. The browser's silence watchdog
+        # observes long idle intervals while a turn is in flight.
+        # Threshold: p95 > 60s for 30m. The watchdog re-arms after
+        # firing so a continuous stall produces multiple histogram
+        # points; the 30m window keeps a single bad session from
+        # paging.
+        - alert: TankSessionEventBrowserStreamSilent
+          expr: |
+            histogram_quantile(
+              0.95,
+              sum by (le, session_mode) (rate(tank_session_event_client_stream_silent_seconds_bucket[30m]))
+            ) > 60
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "p95 browser SSE silent-while-running > 60s on session_mode={{`{{ $labels.session_mode }}`}}"
+            runbook: |
+              The browser's silence watchdog is observing SSE streams
+              that stay TCP-alive (no onerror fires) but receive no
+              tank events for >30s while a turn is in flight.
+              Canonical zombie-connection signature: proxy / LB has
+              dropped the data path without sending FIN. Compare with
+              TankSessionEventWakeDeliveryGap — if wake_published vs
+              wake_received are healthy, the failure is between the
+              orchestrator and the browser, not in the wake fabric.
+              Likely surface: ingress / load balancer idle timeout.
+
+        # Candidate C — reducer drop. Server emits a Tank event the
+        # browser never confirms receiving. Threshold: 5% sustained
+        # divergence on the same event_type for 10m. Sum across
+        # session_mode on both sides so a mode-specific reducer bug
+        # doesn't get hidden by a healthy mode.
+        - alert: TankSessionEventClientEmitDivergence
+          expr: |
+            (
+              sum by (event_type) (rate(tank_session_event_stream_emitted_by_type_total[10m]))
+                - sum by (event_type) (rate(tank_session_event_client_received_total[10m]))
+            )
+              / clamp_min(sum by (event_type) (rate(tank_session_event_stream_emitted_by_type_total[10m])), 0.001)
+              > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "server emits of event_type={{`{{ $labels.event_type }}`}} exceed browser receipts by >5%"
+            runbook: |
+              The SSE handler is emitting Tank events the SPA reducer
+              is filtering out before rendering. Inspect
+              frontend/src/App.tsx → applySdkDurableEvent +
+              isTankConversationEvent for the failing event_type; the
+              counters increment from the SSE onmessage listener
+              before the reducer filter, so any drop here is purely
+              a frontend rendering concern.
+
+        # Persist→wake latency tail. Catches "the publish is slow but
+        # not failing" — the existing wake_publish_failure_total only
+        # increments on outright errors. p99 > 100ms for 10m is the
+        # signal that NATS is degraded enough to be user-visible on
+        # the live-render path even though SSE clients still get the
+        # events eventually.
+        - alert: TankSessionEventPersistToWakeSlow
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le) (rate(tank_session_event_persist_to_wake_seconds_bucket[10m]))
+            ) > 0.1
+          for: 10m
+          labels:
+            severity: info
+          annotations:
+            summary: "session-event persist→wake p99 > 100ms for 10m"
+            runbook: |
+              NATS publish from the persister is taking longer than
+              expected. SSE clients will see the events but with
+              user-perceptible lag. Compare with tank_nats_disconnect_total
+              and tank_nats_async_error_total — sustained publish
+              latency tail with no connection flaps points at NATS
+              server load (memory pressure on the JetStream stream,
+              slow consumer warnings). Diagnostic only — does not
+              page.
+
         - alert: TankStreamAuthTicketStoreFailures
           expr: rate(tank_stream_auth_ticket_total{result=~"store_unavailable|store_error"}[10m]) > 0
           for: 5m


### PR DESCRIPTION
## Summary

- Adds the observability needed to diagnose why a browser sometimes only sees session-event SSE updates after a manual refresh, without changing any product behavior.
- Distinguishes wake-key-mismatch (A) vs zombie-SSE (B) vs SPA-reducer-drop (C) from Grafana panels + PrometheusRule alerts + a single admin debug endpoint, with no need to reach for browser devtools.
- New: `GET /api/debug/session-event-streams` (admin-gated per-stream snapshot), 4 new Prom metrics on the wake fabric, per-event-type emit + receive split, a 30s browser silence watchdog, 5 Grafana panels, 4 PrometheusRule alerts.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Auth And Streams
- [ ] Transcript Navigation
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Artifacts And Files
- [ ] None

Evidence:
- **Transcript contract — "refresh must not be required for normal progress" / "SSE is a live follower of durable events":** This PR does not change either invariant; it adds the diagnostic surface required to *prove* when the invariant is being violated. Before this change, the live failure was only visible to the user as "refresh fixes it" with no telemetry. After this change, server-side `tank_session_event_wake_published_total` vs `_wake_received_total` shows whether wakes are reaching the SSE handler; per-stream state at `/api/debug/session-event-streams` shows whether the cursor is advancing for a specific session; client-side `tank_session_event_client_received_total{event_type}` matched against server emit-by-type counters localizes whether the reducer is filtering. `migrationPolicy.test.ts` pins every telemetry hook (including that the receipt counter is observed **before** the reducer filter — a future PR cannot quietly move it post-filter and hide candidate-C drops).
- **Auth And Streams contract — "streams should be durable followers, not private state channels" / "a valid user should not need to refresh the page to turn a stale credential, missed wake, or reconnect into correct product state":** Same invariant; this PR adds the per-stream registry (`internal/sessionstream`) that the SSE handler keeps in sync with `last_wake_at`, `last_wake_subject`, `wakes_received`, `pages_read_empty`/`non_empty`, `emits_total`, and the cursor it has advanced past. The `WakeMetrics` interface gains `RecordSessionEventWakePublished` / `RecordSessionEventWakeReceived` / `RecordSessionEventPersistToWakeDuration` so the published-vs-received delta is auditable from Prometheus alone. `tank_session_event_client_stream_silent_seconds_bucket` lets the browser observe and report SSE silence while a turn is running so the proxy/LB layer is no longer invisible. None of the existing auth or stream-ticket flows change (the stream-ticket TTL, the `/api/auth/stream-ticket` route, the `Last-Event-ID` cursor semantics, and the resync_required path are untouched).
- **Test pass surface (not load-bearing on its own per CLAUDE.md, but documented):** `go test ./...` clean across all backend packages (`backend-go/internal/sessionstream` new tests cover registry concurrency, snapshot ordering, candidate-B empty-page-read distinction, and nil-safety; `cmd/tank-operator/handlers_debug_session_event_streams_test.go` pins the admin gate + JSON shape; `handlers_client_metrics_session_events_test.go` pins the bounded-label clamping). `npm test` 169/169 (telemetry watchdog tests pin idle-threshold firing, reset behavior, and the `whileRunning` predicate; `migrationPolicy.test.ts` adds the new pinning block). `helm template` renders 22 dashboard panels (5 new at ids 18-22) and 4 new alert rules without errors.

## Test plan

- [ ] Confirm CI green (go-backend.yml + frontend tests + helm-template gate + PR feature-contracts check).
- [ ] After deploy: hit `/api/debug/session-event-streams` with an admin bot token (via `/authromaine`) and confirm the JSON shape matches the documented fields.
- [ ] After deploy: verify the 5 new Grafana panels render in the `Tank Operator` dashboard (ids 18-22) and that `tank_session_event_wake_published_total` shows non-zero increments under normal traffic.
- [ ] After deploy: trigger a reproduction of the "refresh required to see assistant response" symptom on a real session and use the new panels + admin endpoint to localize candidate A vs B vs C. Capture the resolved candidate label as the next follow-up PR's anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)