### PR TITLE
Add app chrome capability ledger

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 Affected contracts:
 - [ ] Transcript
 - [ ] Transcript Navigation
+- [ ] App Chrome
 - [ ] Session Bar
 - [ ] Session Lifecycle
 - [ ] Agent Runners

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ the test directly proves the contract invariant. Do not mark a PR ready, ask
 for merge, or merge it yourself when the Feature Contracts section is missing
 or incomplete.
 
+When adding or substantially changing named product behavior, check whether the
+relevant feature folder needs a `capabilities.md` entry. Capability ledgers are
+for behavior a future agent should be able to name, audit, or retire without
+reconstructing the intent from chat history.
+
 Read [docs/diagnostic-discipline.md](docs/diagnostic-discipline.md) before
 investigating any bug or incident on this repo. The other three docs above
 describe the quality bar for *writing* code; this one describes how to

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -19,6 +19,7 @@ runtime observation, depending on the risk.
 ## Contracts
 
 - [Agent Runners](agent-runners/contract.md)
+- [App Chrome](app-chrome/contract.md)
 - [Artifacts And Files](artifacts-and-files/contract.md)
 - [Auth And Streams](auth-and-streams/contract.md)
 - [Observability](observability/contract.md)
@@ -40,11 +41,34 @@ Add or expand a feature contract when a feature:
 Small static UI, isolated copy changes, and one-off internal helpers usually do
 not need their own contract. They inherit the global policy docs.
 
+## Capability Ledgers
+
+Contracts describe the durable invariants for a feature area. Capability
+ledgers give named product behavior a stable handle before and after it ships.
+
+Use a `capabilities.md` file inside the relevant feature folder when a new
+behavior is complex enough that future agents should not have to reconstruct
+the intent from chat history or PR archaeology. Each capability entry should
+include:
+
+- a stable name;
+- status such as `proposed`, `in progress`, `active`, `shipped`, or `retired`;
+- intent;
+- affected contracts;
+- required or shipped evidence.
+
+Do not use capability ledgers as a backlog for every small idea. Add an entry
+when the behavior affects user trust, navigation, durability, lifecycle,
+cross-feature coordination, or a top-level product surface. When a capability
+settles into a permanent invariant, fold the invariant into `contract.md` and
+keep the capability entry as the named history of why it exists.
+
 ## PR Review Rule
 
 For any contracted feature, reviewers should ask:
 
 - Which contract does this PR touch?
+- Does this PR add or change a named capability?
 - Which invariant could the PR break?
 - What evidence proves the invariant still holds?
 - Does refresh, reconnect, restart, or rollout reveal state the live UI missed?

--- a/docs/features/_capabilities-template.md
+++ b/docs/features/_capabilities-template.md
@@ -1,0 +1,24 @@
+# Feature Name Capabilities
+
+This ledger names user-facing behavior under this feature area. It is not a
+backlog. Add entries only when the behavior needs a stable handle for planning,
+review, tests, incident follow-up, or retirement.
+
+## Capability Name
+
+Status: proposed | in progress | active | shipped | retired
+
+Intent:
+Describe what the behavior is supposed to do for the user.
+
+Affected contracts:
+- Feature Name
+
+Contract impact:
+- Name the invariants this capability must preserve or add.
+
+Evidence:
+- For proposed or in-progress capabilities, name the evidence required before
+  shipping.
+- For shipped capabilities, link PRs, tests, metrics, debug endpoints, or
+  browser observations that prove the behavior.

--- a/docs/features/_template.md
+++ b/docs/features/_template.md
@@ -3,6 +3,11 @@
 This contract translates the repo-wide policy docs into feature-specific rules
 for this feature.
 
+If the feature area contains named user-facing behavior that is still evolving,
+track it in a sibling `capabilities.md` file. The contract owns permanent
+invariants; the capability ledger owns named behavior, status, intent, and
+evidence history.
+
 ## Product Model
 
 Describe what the feature is for, what user trust depends on, and which product

--- a/docs/features/app-chrome/capabilities.md
+++ b/docs/features/app-chrome/capabilities.md
@@ -1,0 +1,88 @@
+# App Chrome Capabilities
+
+This ledger names top-level app chrome behavior. These entries are not a
+backlog; they are stable handles for product surfaces that future agents should
+recognize during planning, review, testing, and retirement.
+
+## Help Menu
+
+Status: active
+
+Intent:
+Expose support, documentation, diagnostics, and product guidance without
+interrupting the active session.
+
+Affected contracts:
+- App Chrome
+- Observability, when the menu exposes diagnostics or operator-facing state
+
+Contract impact:
+- Help actions must not mutate session state.
+- Internal diagnostic/help routes must fail visibly when unavailable or
+  unauthorized.
+- Links and labels should remain stable enough for users and agents to find
+  support paths during incidents.
+
+Evidence:
+- PRs changing Help menu behavior should verify links/actions resolve or fail
+  visibly.
+- PRs adding diagnostics from Help should cite the Observability contract and
+  the metric, debug endpoint, log, or dashboard evidence involved.
+
+## Settings Menu
+
+Status: active
+
+Intent:
+Let the user inspect or modify account, application, and session preferences
+from a predictable top-level surface.
+
+Affected contracts:
+- App Chrome
+- Auth And Streams, when settings expose account/auth behavior
+- Session Lifecycle, when settings affect session creation or runtime behavior
+
+Contract impact:
+- Product-affecting settings are durable when they are meant to survive reloads
+  or apply across sessions/devices.
+- Browser-local settings are intentionally local and do not masquerade as
+  account or session policy.
+- Mutating settings show pending, confirmed, and failure states based on the
+  responsible backend or durable store.
+
+Evidence:
+- PRs adding durable settings should prove reload behavior and backend
+  confirmation.
+- PRs adding browser-local settings should state the local-only scope.
+- PRs touching account/auth settings should cite Auth And Streams evidence.
+
+## Shells Menu
+
+Status: active
+
+Intent:
+Let the user discover, open, switch, or manage shell-oriented surfaces without
+losing orientation in the active session.
+
+Affected contracts:
+- App Chrome
+- Session Lifecycle, when shell availability follows session or pod state
+- Agent Runners, terminal, or a future Shells contract when shell process
+  lifecycle becomes its own contracted feature
+
+Contract impact:
+- Shell availability reflects current session and runtime state without
+  requiring refresh.
+- Shell open/switch/manage actions do not appear successful before the
+  underlying surface confirms attachment or availability.
+- Shell menu state must not contradict terminal/session lifecycle state.
+- If Shells grows independent attach/detach, tab, process, or reconnect
+  semantics, split it into its own feature contract.
+
+Evidence:
+- PRs changing Shells should prove current availability is reflected without
+  refresh.
+- PRs adding shell lifecycle actions should prove confirmed/failure states from
+  the backend or terminal surface.
+- PRs expanding shell process semantics should either update this ledger or add
+  a dedicated Shells contract.

--- a/docs/features/app-chrome/contract.md
+++ b/docs/features/app-chrome/contract.md
@@ -1,0 +1,98 @@
+# App Chrome Contract
+
+This contract applies to the persistent application chrome around the active
+work surface: top bar controls, top-right menus, account/help/settings entry
+points, shell-discovery entry points, and global actions that remain visible
+while the user works inside a session.
+
+## Product Model
+
+App chrome is the stable frame around Tank's session product. It should help
+the user orient, inspect account or environment state, and reach global
+actions without interrupting the active session or hiding product-critical
+state behind ambiguous controls.
+
+Top-level controls are product commitments. If a button or menu can mutate
+durable state, attach to a live surface, or expose operational diagnostics, it
+must behave like the rest of Tank: explicit state, durable confirmation where
+needed, visible failure, and no browser-only source of truth for product
+behavior.
+
+## Sources Of Truth
+
+- Auth state comes from auth.romaine.life JWT validation and `/api/auth/me`.
+- Durable user or account settings live in server-owned storage, not only
+  browser memory, when they affect product behavior across reloads, devices, or
+  sessions.
+- Session and shell availability come from session registry, pod/session
+  lifecycle, and the relevant terminal or runner surfaces.
+- External help/documentation URLs are content references; they are not product
+  state.
+- Menu open/closed state, hover state, and focus state are browser UI state
+  only.
+
+## Migration Rules
+
+- Do not preserve old top-level controls, menu entries, or keyboard paths after
+  a global action moves.
+- Do not hide critical session, auth, or lifecycle state only inside a menu.
+- Do not store product-affecting settings only in `localStorage` unless the
+  setting is explicitly scoped as browser-local.
+- Do not let multiple menu entries trigger subtly different implementations of
+  the same global action.
+- Do not add a top-level button for a complex behavior without naming the
+  capability in this feature area's ledger or a more specific feature ledger.
+
+## Live Behavior
+
+- Top-right menus open predictably, close predictably, preserve focus, and do
+  not steal focus from active transcript or terminal input except during direct
+  user interaction.
+- Menu contents reflect current auth, session, and shell availability without
+  requiring a page refresh.
+- Actions that mutate durable state show pending, success, and failure states
+  based on backend confirmation.
+- Links to help, diagnostics, account, and settings surfaces fail visibly when
+  unavailable.
+- App chrome should remain visually stable when live session state changes; it
+  should not cause transcript or terminal layout jumps unrelated to the user's
+  action.
+
+## Failure And Recovery
+
+- Browser reload reconstructs app chrome from durable auth/session/settings
+  state and known route state.
+- Stale auth must produce explicit auth recovery or signed-out state, not
+  broken menus.
+- If shell or session availability cannot be loaded, the shell/menu affordance
+  should show unavailable or retryable state instead of acting on stale local
+  assumptions.
+- External help links may fail outside Tank's control, but internal help and
+  diagnostic actions should report route or authorization failures clearly.
+
+## Observability
+
+- User-trust actions launched from app chrome need the same outcome telemetry
+  as the underlying feature they call.
+- Settings changes that affect product behavior should be observable as
+  requested, confirmed, failed, or reverted.
+- Shell menu actions should emit enough telemetry to distinguish unavailable
+  shell surface, stale session state, auth failure, and frontend display lag.
+- A report that a top-right menu showed stale or contradictory state should be
+  diagnosable from durable auth/session/settings state plus client telemetry,
+  not only browser devtools.
+
+## Acceptance Checks
+
+- Help, Settings, and Shells menu entries are named in
+  [capabilities.md](capabilities.md) while they remain top-level product
+  surfaces.
+- Menu open/close behavior does not disrupt active transcript or terminal
+  input outside direct user interaction.
+- Product-affecting settings persist through reload when they are intended to
+  be durable, and browser-local settings are labeled as local-only in the
+  implementation/docs.
+- Shells menu state reflects current session/shell availability without
+  refresh.
+- Any app-chrome action that delegates to another contracted feature cites that
+  feature's evidence in the PR body.


### PR DESCRIPTION
## Summary

- add App Chrome as a feature contract for top-level app controls and menus
- add an App Chrome capability ledger covering Help, Settings, and Shells
- document the capability-ledger pattern and add a reusable template
- add App Chrome to the PR contract checklist and agent guidance

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [x] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Docs/process-only change; no runtime app chrome implementation changed.
- `git diff --check` passed.
- Markdown link resolution for `docs/features` passed.
- Trailing-whitespace scan for feature docs and PR template passed.
- Local simulation of the PR-body check passed with App Chrome selected and evidence filled.