### PR TITLE
Fix codex_config CLI shell 400 from sandbox-agent

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_terminal.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal.go
@@ -3,16 +3,60 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
+	"time"
 
 	"github.com/coder/websocket"
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 )
 
-// handleCLIProcess creates a process through the pod-local sandbox-agent API.
+// cliProcess* describe the long-lived in-pod shell the
+// /api/sessions/{id}/cli-process endpoint hands the SPA. Bash login shell in
+// /workspace, TTY+interactive so the sandbox-agent terminal WebSocket carries
+// keystrokes (codex login --device-auth lives behind this). The orchestrator
+// owns the command — not the SPA — so a browser can't pick what binary runs
+// inside the pod.
+var (
+	cliProcessCommand = "bash"
+	cliProcessArgs    = []string{"-l"}
+	cliProcessCwd     = "/workspace"
+)
+
+// sandboxAgentBootWait bounds the wait for the in-pod sandbox-agent HTTP
+// server to start accepting connections after the pod is Ready. The kubelet
+// readiness probe isn't wired on the claude container, so podReady fires the
+// moment the container is started — sandbox-agent may still be running the
+// install-tank-docs.sh prelude or downloading via `npx -y` on fresh images.
+const sandboxAgentBootWait = 30 * time.Second
+
+type sandboxProcessInfo struct {
+	ID      string   `json:"id"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+	Status  string   `json:"status"`
+}
+
+type sandboxProcessList struct {
+	Processes []sandboxProcessInfo `json:"processes"`
+}
+
+type sandboxProcessCreate struct {
+	Command     string   `json:"command"`
+	Args        []string `json:"args"`
+	Cwd         string   `json:"cwd,omitempty"`
+	Interactive bool     `json:"interactive"`
+	TTY         bool     `json:"tty"`
+}
+
+// handleCLIProcess returns a long-lived bash process id for the in-browser
+// terminal. Reuses an already-running shell if one matches the canonical
+// shape; otherwise creates one through the pod-local sandbox-agent API.
 func (s *appServer) handleCLIProcess(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAuth(w, r)
 	if !ok {
@@ -26,31 +70,129 @@ func (s *appServer) handleCLIProcess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+	baseURL := fmt.Sprintf("http://%s:%d", podIP, sessionmodel.SandboxAgentPort)
+	processID, err := findOrCreateSandboxCLIProcess(r.Context(), http.DefaultClient, baseURL)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
+		writeError(w, http.StatusBadGateway, err.Error())
 		return
 	}
+	writeJSON(w, http.StatusOK, map[string]string{"process_id": processID})
+}
 
-	agentURL := fmt.Sprintf("http://%s:%d/v1/processes", podIP, sessionmodel.SandboxAgentPort)
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, agentURL, bytes.NewReader(body))
+// findOrCreateSandboxCLIProcess looks for an already-running shell matching
+// the canonical CLI-process shape and returns its id; otherwise it asks
+// sandbox-agent to spawn one. The GET is retried on transport errors during
+// sandbox-agent's boot window — the readiness probe sits on the container,
+// not the HTTP server, so podReady can race the listener.
+func findOrCreateSandboxCLIProcess(ctx context.Context, client *http.Client, baseURL string) (string, error) {
+	processesURL := baseURL + "/v1/processes"
+
+	deadline := time.Now().Add(sandboxAgentBootWait)
+	var (
+		list   sandboxProcessList
+		lastErr error
+	)
+	for {
+		list, lastErr = sandboxListProcesses(ctx, client, processesURL)
+		if lastErr == nil {
+			break
+		}
+		// Only retry transport-level failures (the listener isn't up
+		// yet). A successful HTTP response with a 4xx/5xx body is a
+		// real protocol error and shouldn't be papered over.
+		var protoErr *sandboxAgentProtocolError
+		if errors.As(lastErr, &protoErr) {
+			return "", lastErr
+		}
+		if time.Now().After(deadline) {
+			return "", lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+
+	for _, p := range list.Processes {
+		if p.Command == cliProcessCommand &&
+			slices.Equal(p.Args, cliProcessArgs) &&
+			p.Status == "running" {
+			return p.ID, nil
+		}
+	}
+
+	body, err := json.Marshal(sandboxProcessCreate{
+		Command:     cliProcessCommand,
+		Args:        cliProcessArgs,
+		Cwd:         cliProcessCwd,
+		Interactive: true,
+		TTY:         true,
+	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+		return "", fmt.Errorf("marshal sandbox-agent request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, processesURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build sandbox-agent request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "sandbox agent: "+err.Error())
-		return
+		return "", fmt.Errorf("sandbox-agent create: %w", err)
 	}
 	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode >= 400 {
+		return "", &sandboxAgentProtocolError{
+			op:     "POST /v1/processes",
+			status: resp.StatusCode,
+			body:   string(respBody),
+		}
+	}
+	var info sandboxProcessInfo
+	if err := json.Unmarshal(respBody, &info); err != nil {
+		return "", fmt.Errorf("sandbox-agent create response not JSON: %w (body=%q)", err, string(respBody))
+	}
+	if info.ID == "" {
+		return "", fmt.Errorf("sandbox-agent create response missing id (body=%q)", string(respBody))
+	}
+	return info.ID, nil
+}
 
-	respBody, _ := io.ReadAll(resp.Body)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
-	_, _ = w.Write(respBody)
+func sandboxListProcesses(ctx context.Context, client *http.Client, processesURL string) (sandboxProcessList, error) {
+	var out sandboxProcessList
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, processesURL, nil)
+	if err != nil {
+		return out, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return out, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode >= 400 {
+		return out, &sandboxAgentProtocolError{
+			op:     "GET /v1/processes",
+			status: resp.StatusCode,
+			body:   string(body),
+		}
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return out, fmt.Errorf("sandbox-agent list response not JSON: %w (body=%q)", err, string(body))
+	}
+	return out, nil
+}
+
+type sandboxAgentProtocolError struct {
+	op     string
+	status int
+	body   string
+}
+
+func (e *sandboxAgentProtocolError) Error() string {
+	return fmt.Sprintf("sandbox-agent %s returned %d: %s", e.op, e.status, e.body)
 }
 
 // handleSandboxTerminalProxy proxies a WebSocket terminal connection to sandbox-agent.

--- a/backend-go/cmd/tank-operator/handlers_terminal_test.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestFindOrCreateSandboxCLIProcess_CreatesFreshShell locks in the recovery
+// from PR #437 — when no matching shell exists, the helper must POST a
+// concrete payload (the SPA does not send one). Asserts the wire body matches
+// the canonical {bash, -l, /workspace, interactive, tty} shape.
+func TestFindOrCreateSandboxCLIProcess_CreatesFreshShell(t *testing.T) {
+	var createBody sandboxProcessCreate
+	var creates atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/processes":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessList{Processes: nil})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/processes":
+			creates.Add(1)
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessInfo{
+				ID:      "proc-new",
+				Command: createBody.Command,
+				Args:    createBody.Args,
+				Status:  "running",
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
+	}
+	if id != "proc-new" {
+		t.Errorf("process id = %q, want %q", id, "proc-new")
+	}
+	if got := creates.Load(); got != 1 {
+		t.Errorf("create calls = %d, want 1", got)
+	}
+	if createBody.Command != "bash" {
+		t.Errorf("create command = %q, want bash", createBody.Command)
+	}
+	if len(createBody.Args) != 1 || createBody.Args[0] != "-l" {
+		t.Errorf("create args = %v, want [-l]", createBody.Args)
+	}
+	if createBody.Cwd != "/workspace" {
+		t.Errorf("create cwd = %q, want /workspace", createBody.Cwd)
+	}
+	if !createBody.Interactive {
+		t.Errorf("create interactive = false, want true")
+	}
+	if !createBody.TTY {
+		t.Errorf("create tty = false, want true")
+	}
+}
+
+// TestFindOrCreateSandboxCLIProcess_ReusesRunningShell guards the idempotence
+// the Python original had — opening the run-shell panel a second time must
+// not fan out a second sandbox-agent process.
+func TestFindOrCreateSandboxCLIProcess_ReusesRunningShell(t *testing.T) {
+	var creates atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/processes":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessList{Processes: []sandboxProcessInfo{
+				{ID: "proc-stale", Command: "bash", Args: []string{"-l"}, Status: "exited"},
+				{ID: "proc-other", Command: "vim", Args: []string{"foo.txt"}, Status: "running"},
+				{ID: "proc-live", Command: "bash", Args: []string{"-l"}, Status: "running"},
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/processes":
+			creates.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
+	}
+	if id != "proc-live" {
+		t.Errorf("process id = %q, want proc-live", id)
+	}
+	if got := creates.Load(); got != 0 {
+		t.Errorf("create calls = %d, want 0 (helper should reuse)", got)
+	}
+}
+
+// TestFindOrCreateSandboxCLIProcess_RetriesTransportErrors covers the
+// sandbox-agent boot window. The kubelet probe is wired on the container,
+// not the in-container HTTP listener — so podReady can race the listener for
+// a few seconds on a cold pod (especially with `npx -y` fetching the package
+// on a fresh node).
+func TestFindOrCreateSandboxCLIProcess_RetriesTransportErrors(t *testing.T) {
+	var listCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/processes":
+			if listCalls.Add(1) == 1 {
+				// Simulate listener-not-up by hijacking and
+				// closing without a response — httptest can't
+				// `refuse connection` mid-test, but a
+				// closed connection produces the same
+				// transport-level error class on the client.
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatal("response writer is not a hijacker")
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack: %v", err)
+				}
+				_ = conn.Close()
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessList{Processes: nil})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/processes":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessInfo{
+				ID: "proc-after-retry", Command: "bash", Args: []string{"-l"}, Status: "running",
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	id, err := findOrCreateSandboxCLIProcess(ctx, srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
+	}
+	if id != "proc-after-retry" {
+		t.Errorf("process id = %q, want proc-after-retry", id)
+	}
+	if listCalls.Load() < 2 {
+		t.Errorf("list calls = %d, want >= 2 (one failure + one retry)", listCalls.Load())
+	}
+}
+
+// TestFindOrCreateSandboxCLIProcess_PropagatesProtocolError ensures we don't
+// retry on a real 4xx/5xx HTTP response — the listener IS up, it's saying no.
+// Looping on that would hide real bugs.
+func TestFindOrCreateSandboxCLIProcess_PropagatesProtocolError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/processes" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"type":"about:blank","title":"Internal Server Error"}`)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	_, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var protoErr *sandboxAgentProtocolError
+	if !errors.As(err, &protoErr) {
+		t.Errorf("error type = %T, want *sandboxAgentProtocolError; err=%v", err, err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("returned after %v — protocol error should be fast-fail, not retried", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- The Python→Go orchestrator rewrite ([#437](https://github.com/nelsong6/tank-operator/pull/437)) reduced `handleCLIProcess` to a body-passthrough proxy. The SPA was never updated to send the payload the Python original constructed server-side, so every `POST /api/sessions/{id}/cli-process` reached sandbox-agent as `POST /v1/processes` with an empty body → `400 CLI process create failed: 400` in the run-shell error strip. Latent for ~11 days because nobody had opened a `codex_config` or `config` session in that window; surfaced when the Codex auth token died.
- Restore server-side payload construction: list-first and reuse a matching running shell, otherwise create one with `{command: bash, args: [-l], cwd: /workspace, interactive: true, tty: true}`. The orchestrator owns the command shape — the browser shouldn't get to pick what binary runs inside the pod.
- Retry `GET /v1/processes` on transport errors during a 30s boot window (kubelet probe isn't wired on the `claude` container, so podReady fires before sandbox-agent's listener is necessarily up — especially on `npx -y` cold-cache). Fast-fail on protocol errors so real listener-up bugs surface.

## Feature Contracts

Affected contracts:
- [x] None

No contracted feature names `/cli-process` or the sandbox-agent terminal-bootstrap surface. Session-lifecycle's "terminal outcomes" line is about lifecycle terminality (pod death), not the in-browser shell endpoint. If we end up writing a contract for the codex-credentials refresh flow, this handler's reuse-or-create invariant is the obvious thing to encode.

Evidence:
- New httptest coverage in `backend-go/cmd/tank-operator/handlers_terminal_test.go`:
  - `_CreatesFreshShell` — asserts the on-wire POST body is the canonical `{bash, [-l], /workspace, interactive, tty}` shape (the exact contract the SPA could not previously satisfy).
  - `_ReusesRunningShell` — opening the panel twice must not fan out a second sandbox-agent process; matches against `command + args + status=running`, ignoring exited shells and unrelated processes.
  - `_RetriesTransportErrors` — boot-race recovery: first list fails with a closed connection, second succeeds.
  - `_PropagatesProtocolError` — a 4xx/5xx with a real response body fast-fails (no retry loop hiding real bugs).
- `go vet ./...` clean, `go test ./cmd/tank-operator/ -count=1` green.

## Test plan

- [ ] Open a `codex_config` session in tank.romaine.life, confirm the in-browser terminal loads (no "CLI process create failed: 400" red text).
- [ ] Run `codex login --device-auth` end-to-end and click **save**; confirm Key Vault `codex-credentials` gets the refreshed blob (check via `az keyvault secret show` or by reopening a `codex_gui` session).
- [ ] Close and reopen the run-shell panel on the same session; confirm the terminal reattaches to the same shell instead of spawning a new one (no extra process visible at `kubectl exec -c claude session-... -- curl localhost:2468/v1/processes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)