### PR TITLE
Remove run-status pill; route per-turn status through the transcript

### DIFF
--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -125,6 +125,17 @@ var (
 		Help: "Persister failures the persister chose to NAK for retry (infrastructure-side, retryable).",
 	})
 
+	// Durable per-turn failure surface (turn.failed / turn.command_failed).
+	// Replaces the SPA run-status pill as the "every session is failing"
+	// observability surface: with the pill removed, this counter is how
+	// Grafana / alert rules detect provider-credential storms and other
+	// session-affecting failures. Labels: source (claude/codex/tank) and
+	// reason from payload.reason (e.g. provider_failure, command_failed).
+	transcriptTurnFailureTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_transcript_turn_failure_total",
+		Help: "Durable turn.failed / turn.command_failed events persisted to session_events, partitioned by producer source and payload reason.",
+	}, []string{"source", "reason"})
+
 	// Wake-publish failures. The bus records here before returning the
 	// error to the caller. Per-session wakes drive the chat-window SSE;
 	// per-owner session-list events drive the sidebar SSE (replaced
@@ -831,6 +842,10 @@ func (promPersisterMetrics) RecordSchemaRejected() {
 
 func (promPersisterMetrics) RecordTransientFailure() {
 	recordSessionEventPersistTransientFailure()
+}
+
+func (promPersisterMetrics) RecordTurnFailurePersisted(source string, reason string) {
+	transcriptTurnFailureTotal.WithLabelValues(source, reason).Inc()
 }
 
 // promWakeMetrics satisfies sessionbus.WakeMetrics so the bus can increment

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -83,12 +83,22 @@ func (noopLifecycleEmitter) EmitChatActivityDelta(_ context.Context, _ map[strin
 type PersisterMetrics interface {
 	RecordSchemaRejected()
 	RecordTransientFailure()
+	// RecordTurnFailurePersisted increments when a durable turn-terminal
+	// failure event (turn.failed / turn.command_failed) lands in the
+	// session_events ledger. Labels carry the producer source ("claude",
+	// "codex", "tank") and the failure reason from payload.reason (e.g.
+	// "provider_failure", "command_failed"). Replaces the SPA pill as the
+	// user-trust-failure observability surface: with the pill gone, this
+	// counter is how we notice "every session is failing" without browser
+	// devtools. Steady-state expectation: low and bursty.
+	RecordTurnFailurePersisted(source string, reason string)
 }
 
 type noopPersisterMetrics struct{}
 
-func (noopPersisterMetrics) RecordSchemaRejected()   {}
-func (noopPersisterMetrics) RecordTransientFailure() {}
+func (noopPersisterMetrics) RecordSchemaRejected()                      {}
+func (noopPersisterMetrics) RecordTransientFailure()                    {}
+func (noopPersisterMetrics) RecordTurnFailurePersisted(string, string)  {}
 
 // WakeMetrics receives counters for wake/event publish failures, the
 // success path, and the end-to-end persist→wake latency. The bus
@@ -465,7 +475,7 @@ type persistableMessage interface {
 // handlePersistMessage routes one bus message through the store and acks /
 // NAKs / terminates based on the outcome.
 func (b *Bus) handlePersistMessage(ctx context.Context, store EventStore, metrics PersisterMetrics, msg persistableMessage) {
-	err := b.persistOneEvent(ctx, store, msg)
+	err := b.persistOneEvent(ctx, store, metrics, msg)
 	if err == nil {
 		if ackErr := msg.Ack(); ackErr != nil {
 			slog.Warn("session bus event ack failed", "subject", msg.Subject(), "error", ackErr)
@@ -505,7 +515,7 @@ func (b *Bus) handlePersistMessage(ctx context.Context, store EventStore, metric
 // does not cause the persister to NAK — the chat event is already
 // durable, and the sidebar will catch up via cursor-resume on the next
 // SSE reconnect.
-func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, msg persistableMessage) error {
+func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, metrics PersisterMetrics, msg persistableMessage) error {
 	var event map[string]any
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
 		// Invalid JSON is a producer-side bug that can never succeed on
@@ -520,6 +530,28 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, msg persist
 	}
 	if err := store.Upsert(ctx, event); err != nil {
 		return err
+	}
+	// Record turn-failure persistence right after the durable write
+	// commits. This is the observability surface that replaced the SPA
+	// run-status pill: with the pill gone, "every codex_gui session is
+	// failing" must be visible from outside the browser (Grafana / alert
+	// rules), not by looking at the pill turn red. The reason label comes
+	// from payload.reason so a Codex auth storm vs a generic
+	// provider_failure spike are distinguishable; the source label
+	// (claude/codex/tank) lets per-provider alerts fire independently.
+	if eventType, _ := event["type"].(string); eventType == string(conversation.EventTurnFailed) || eventType == string(conversation.EventTurnCommandFailed) {
+		source, _ := event["source"].(string)
+		reason := ""
+		if payload, ok := event["payload"].(map[string]any); ok {
+			reason, _ = payload["reason"].(string)
+		}
+		if source == "" {
+			source = "unknown"
+		}
+		if reason == "" {
+			reason = "unknown"
+		}
+		metrics.RecordTurnFailurePersisted(source, reason)
 	}
 	upsertedAt := time.Now()
 	storageKey, _ := event["tank_session_id"].(string)

--- a/backend-go/internal/sessionbus/bus_test.go
+++ b/backend-go/internal/sessionbus/bus_test.go
@@ -25,12 +25,21 @@ func (r *recordingStore) Upsert(_ context.Context, event map[string]any) error {
 }
 
 type recordingMetrics struct {
-	schemaRejected   int
-	transientFailure int
+	schemaRejected      int
+	transientFailure    int
+	turnFailureRecorded []turnFailureRecord
+}
+
+type turnFailureRecord struct {
+	source string
+	reason string
 }
 
 func (m *recordingMetrics) RecordSchemaRejected()   { m.schemaRejected++ }
 func (m *recordingMetrics) RecordTransientFailure() { m.transientFailure++ }
+func (m *recordingMetrics) RecordTurnFailurePersisted(source string, reason string) {
+	m.turnFailureRecorded = append(m.turnFailureRecorded, turnFailureRecord{source: source, reason: reason})
+}
 
 type stubMsg struct {
 	subject  string
@@ -177,6 +186,106 @@ func TestPersistMessageTerminatesInvalidJSON(t *testing.T) {
 	if metrics.transientFailure != 0 {
 		t.Fatalf("transient counter = %d, want 0 — invalid JSON is permanent not transient",
 			metrics.transientFailure)
+	}
+}
+
+// TestPersistMessageRecordsTurnFailureCounter pins the user-trust observability
+// surface that replaced the SPA run-status pill. With the pill removed, the
+// tank_transcript_turn_failure_total counter is how Grafana / alert rules
+// detect "every codex_gui session is failing" (e.g. the Codex auth
+// refresh_token_reused storm that motivated the pill removal). The counter
+// must label by source (claude/codex/tank) and reason (payload.reason) so
+// per-provider alerts fire independently.
+func TestPersistMessageRecordsTurnFailureCounter(t *testing.T) {
+	bus := &Bus{scope: "default"}
+	store := &recordingStore{}
+	metrics := &recordingMetrics{}
+	raw, _ := json.Marshal(map[string]any{
+		"event_id":   "evt-fail-1",
+		"session_id": "63",
+		"actor":      "runner",
+		"source":     "codex",
+		"type":       "turn.failed",
+		"created_at": "2026-05-12T00:00:00.000Z",
+		"order_key":  "order-fail-1",
+		"visibility": "durable",
+		"turn_id":    "turn-1",
+		"payload": map[string]any{
+			"reason": "provider_failure",
+			"error":  "rate limit exceeded",
+		},
+	})
+	msg := &stubMsg{subject: "tank.session.63.events", data: raw}
+
+	bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+	if msg.acked != 1 {
+		t.Fatalf("acked = %d, want 1", msg.acked)
+	}
+	if len(metrics.turnFailureRecorded) != 1 {
+		t.Fatalf("turn-failure counter recorded %d times, want 1", len(metrics.turnFailureRecorded))
+	}
+	got := metrics.turnFailureRecorded[0]
+	if got.source != "codex" {
+		t.Fatalf("source label = %q, want %q", got.source, "codex")
+	}
+	if got.reason != "provider_failure" {
+		t.Fatalf("reason label = %q, want %q", got.reason, "provider_failure")
+	}
+}
+
+func TestPersistMessageRecordsCommandFailedCounter(t *testing.T) {
+	bus := &Bus{scope: "default"}
+	store := &recordingStore{}
+	metrics := &recordingMetrics{}
+	raw, _ := json.Marshal(map[string]any{
+		"event_id":   "evt-cmdfail-1",
+		"session_id": "63",
+		"actor":      "system",
+		"source":     "tank",
+		"type":       "turn.command_failed",
+		"created_at": "2026-05-12T00:00:00.000Z",
+		"order_key":  "order-cmdfail-1",
+		"visibility": "durable",
+		"turn_id":    "turn-1",
+		"payload": map[string]any{
+			"reason": "command_failed",
+		},
+	})
+	msg := &stubMsg{subject: "tank.session.63.events", data: raw}
+
+	bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+	if len(metrics.turnFailureRecorded) != 1 {
+		t.Fatalf("turn-failure counter recorded %d times, want 1 for turn.command_failed", len(metrics.turnFailureRecorded))
+	}
+	got := metrics.turnFailureRecorded[0]
+	if got.source != "tank" || got.reason != "command_failed" {
+		t.Fatalf("label tuple = (%q, %q), want (tank, command_failed)", got.source, got.reason)
+	}
+}
+
+func TestPersistMessageDoesNotRecordTurnFailureForSuccess(t *testing.T) {
+	bus := &Bus{scope: "default"}
+	store := &recordingStore{}
+	metrics := &recordingMetrics{}
+	raw, _ := json.Marshal(map[string]any{
+		"event_id":   "evt-ok-1",
+		"session_id": "63",
+		"actor":      "runner",
+		"source":     "codex",
+		"type":       "turn.completed",
+		"created_at": "2026-05-12T00:00:00.000Z",
+		"order_key":  "order-ok-1",
+		"visibility": "durable",
+		"turn_id":    "turn-1",
+	})
+	msg := &stubMsg{subject: "tank.session.63.events", data: raw}
+
+	bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+	if len(metrics.turnFailureRecorded) != 0 {
+		t.Fatalf("turn-failure counter fired on turn.completed (%d times); the counter is for failures only", len(metrics.turnFailureRecorded))
 	}
 }
 

--- a/codex-runner/src/appServerTransport.ts
+++ b/codex-runner/src/appServerTransport.ts
@@ -55,6 +55,25 @@ function abortError(message = "turn interrupted"): Error {
   return err;
 }
 
+// Unwrap a Codex app-server JSONRPC `error` notification's params into a
+// readable string. params?.error is often a structured `{code, type, message,
+// param}` object (e.g. token_expired); coercing it with String() yielded
+// "[object Object]" in the durable turn.failed payload, hiding the real cause.
+function codexErrorMessage(params: JsonRecord | undefined): string {
+  const candidate = params?.error ?? params?.message;
+  if (typeof candidate === "string" && candidate.length > 0) return candidate;
+  if (candidate && typeof candidate === "object") {
+    const message = (candidate as { message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+    try {
+      return JSON.stringify(candidate);
+    } catch {
+      // fall through to generic
+    }
+  }
+  return "codex app-server error";
+}
+
 class AsyncEventQueue {
   private readonly items: QueuedEvent[] = [];
   private readonly waiters: Array<(item: QueuedEvent | null) => void> = [];
@@ -400,7 +419,7 @@ export class CodexAppServerTransport {
     if (method === "error") {
       queue.push({
         kind: "event",
-        event: { type: "error", message: String(params?.message ?? params?.error ?? "codex app-server error") },
+        event: { type: "error", message: codexErrorMessage(params) },
       });
     }
   }

--- a/frontend/public/assets/avatars/ATTRIBUTION.md
+++ b/frontend/public/assets/avatars/ATTRIBUTION.md
@@ -16,11 +16,11 @@ Asset notes:
 - Subject-centred crop per `HINTS` in the normalize script — wide scene
   stills (e.g. Muldoon's "clever girl" or Nedry on the dock) get a
   positional hint so the focal point survives the square crop.
-- Rendered through `.session-avatar` / `.run-msg-ai-icon` /
-  `.run-status-avatar` (see `frontend/src/index.css`) at 22–42px,
-  `object-fit: contain`, circle-clipped, no backdrop or padding — the
-  source PNG itself is the visible shape, so subjects that don't fill
-  the square frame read as floating silhouettes at the small sizes.
+- Rendered through `.session-avatar` and `.run-msg-ai-icon` (see
+  `frontend/src/index.css`) at 42px, `object-fit: contain`, circle-clipped,
+  no backdrop or padding — the source PNG itself is the visible shape, so
+  subjects that don't fill the square frame read as floating silhouettes at
+  the small sizes.
 
 Reproducing the asset set:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2469,26 +2469,6 @@ function isImagePath(path: string): boolean {
 // Verbs cycled by the streaming status pill. Matches cloudcli's
 // ClaudeStatus rotation so the user sees motion even when the model
 // hasn't sent any text deltas yet.
-const STREAM_VERBS = [
-  "Thinking",
-  "Processing",
-  "Analyzing",
-  "Working",
-  "Computing",
-  "Reasoning",
-] as const;
-
-// Format a Claude tool name for display in the status pill.
-// "Bash" → "Bash"
-// "mcp__github__create_pull_request" → "github · create pull request"
-function formatToolLabel(toolName: string): string {
-  const stripped = toolName.replace(/^mcp__/, "");
-  const [server, ...rest] = stripped.split("__");
-  if (rest.length === 0) return server;
-  const action = rest.join("__").replace(/_/g, " ");
-  return `${server} · ${action}`;
-}
-
 // Context-window sizes per model. Used for the usage % ring. The 1M
 // variant of Opus is a separate id; for everything else, 200k is the
 // shipping default.
@@ -2522,14 +2502,6 @@ function totalContextTokens(u: ClaudeUsage | undefined): number {
     (u.cache_creation_input_tokens ?? 0) +
     (u.cache_read_input_tokens ?? 0)
   );
-}
-
-function formatStreamElapsed(ms: number): string {
-  const sec = Math.floor(ms / 1000);
-  if (sec < 60) return `${sec}s`;
-  const m = Math.floor(sec / 60);
-  const s = sec % 60;
-  return `${m}m ${s}s`;
 }
 
 interface SlashCommand {
@@ -5896,13 +5868,8 @@ function ChatPane({
     onAutoRenameConsumed();
   }, [autoRename, session.id, session.name, onAutoRenameConsumed]);
   const [runStatus, setRunStatus] = useState<LocalRunStatus>("idle");
-  const [activeToolName, setActiveToolName] = useState<string | null>(null);
-  const activeToolNameRef = useRef<string | null>(null);
   const activeToolUseIdRef = useRef<string | null>(null);
   const scheduledWakeupRef = useRef(false);
-  // Mirrors cloudcli's ClaudeStatus idle state: persists last status text
-  // after the run ends (amber/static pill) instead of vanishing.
-  const [lastStatusText, setLastStatusText] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<RunTab>("chat");
   const [backgroundView, setBackgroundView] = useState<BackgroundView>("shells");
   const [selectedBackgroundId, setSelectedBackgroundId] = useState<string | null>(null);
@@ -5956,11 +5923,6 @@ function ChatPane({
     : (effortOptions.some((opt) => opt.id === preferredEffortId) ? preferredEffortId : fallbackEffortId);
   const [selectedModelId] = useState<string>(initialModelId);
   const [selectedEffortId] = useState<string>(initialEffortId);
-  // Run timing — drives the streaming status pill's elapsed counter and the
-  // rotating action verb / animated dots. Both refresh on a single 250ms
-  // interval while running so the bar updates without a per-element timer.
-  const [runStartedAt, setRunStartedAt] = useState<number | null>(null);
-  const [now, setNow] = useState<number>(() => Date.now());
   // Context tokens used in the most recent assistant turn.
   const [tokensUsed, setTokensUsed] = useState(0);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
@@ -6232,18 +6194,14 @@ function ChatPane({
     if (sdkActive) {
       setRunStatus(projection.runStatus === "stopping" ? "stopping" : "running");
       setRunning(true);
-      setRunStartedAt((startedAt) => startedAt ?? Date.now());
-      setNow(Date.now());
       return;
     }
 
     setRunning(false);
     if (projection.runStatus === "error") {
       setRunStatus("error");
-      setLastStatusText("Error");
     } else if (projection.runStatus === "stopped") {
       setRunStatus("done");
-      setLastStatusText("Stopped");
     } else {
       setRunStatus((prev) => (prev === "running" ? "done" : prev));
     }
@@ -6563,14 +6521,6 @@ function ChatPane({
     return () => window.clearInterval(interval);
   }, [session.id, session.status, visible]);
 
-  // Tick `now` every 250ms while running. 250 is the LCM-ish for the dot
-  // animation (500ms cycle) and the elapsed counter (1s display step) —
-  // one timer drives both without per-element setIntervals.
-  useEffect(() => {
-    if (!running) return;
-    const id = window.setInterval(() => setNow(Date.now()), 250);
-    return () => window.clearInterval(id);
-  }, [running]);
 
   // Auto-send the next queued message once the current run finishes.
   useEffect(() => {
@@ -7665,9 +7615,7 @@ function ChatPane({
     if (isScheduleWakeupToolName(toolName ?? undefined)) {
       scheduledWakeupRef.current = true;
     }
-    activeToolNameRef.current = toolName;
     activeToolUseIdRef.current = toolName ? toolUseId : null;
-    setActiveToolName(toolName);
   }
 
   function openSlashCommandMenu() {
@@ -7718,7 +7666,6 @@ function ChatPane({
     try {
       await interruptSdkTurn(turnID);
     } catch (err) {
-      setLastStatusText("Stop failed");
       const id = nextEntryId("sdk-interrupt-error");
       appendSdkRealtimeEntries(
         markLocalEntries(
@@ -7782,7 +7729,6 @@ function ChatPane({
     try {
       await stopBackgroundTask(entry);
     } catch (err) {
-      setLastStatusText("Stop failed");
       const id = nextEntryId("background-stop-error");
       appendSdkRealtimeEntries(
         markLocalEntries(
@@ -8005,9 +7951,6 @@ function ChatPane({
     setRunStatus("running");
     setRunning(true);
     setActiveTool(null);
-    setLastStatusText(null);
-    setRunStartedAt(Date.now());
-    setNow(Date.now());
     // The form clears the textarea internally on submit but doesn't
     // always fire an input event in time, so my mirror lingers and the
     // X-clear button stays visible. Force the mirror clean.
@@ -8024,7 +7967,6 @@ function ChatPane({
         setRunning(false);
         setRunStatus("error");
         setSdkConnectionState("idle");
-        setLastStatusText("Error");
         const id = nextEntryId("sdk-submit-error");
         appendSdkRealtimeEntries(
           markLocalEntries(
@@ -8050,13 +7992,6 @@ function ChatPane({
     const durationMs = Date.now() - run.turnStart;
     updateSdkLastAssistantDuration(durationMs);
     if (terminal.status === "done") {
-      setLastStatusText(
-        scheduledWakeupRef.current
-          ? "Wakeup scheduled"
-          : activeToolNameRef.current
-            ? `Used ${formatToolLabel(activeToolNameRef.current)}`
-            : "Done",
-      );
       setRunStatus("done");
       // Turn-complete sound is fired by the App-level SSE consumer
       // on the always-on /api/sessions/events stream, NOT here. Per
@@ -8067,10 +8002,8 @@ function ChatPane({
       // listener covers this same transition for both visible and
       // background sessions.
     } else if (terminal.status === "stopped") {
-      setLastStatusText("Stopped");
       setRunStatus("done");
     } else {
-      setLastStatusText(activeToolNameRef.current ? `Used ${formatToolLabel(activeToolNameRef.current)}` : "Error");
       setRunStatus("error");
     }
     scheduledWakeupRef.current = false;
@@ -8389,20 +8322,6 @@ function ChatPane({
     return () => window.removeEventListener("keydown", onKey, true);
   }, [activeTab, focusComposerTextarea, visible]);
 
-  // Streaming-pill computeds — only meaningful while running.
-  const elapsedMs = runStartedAt != null ? Math.max(0, now - runStartedAt) : 0;
-  const elapsedLabel = formatStreamElapsed(elapsedMs);
-  const dotPhase = Math.floor(now / 500) % 3; // 0..2
-  const dots = ".".repeat(dotPhase + 1);
-  const isStopping = runStatus === "stopping";
-  // When a tool call is in flight, show its name. Otherwise cycle the
-  // generic verbs every 3s (matches cloudcli's ClaudeStatus pattern).
-  const verbIndex = Math.floor(now / 3000) % STREAM_VERBS.length;
-  const verb = isStopping
-    ? "Stopping"
-    : activeToolName
-    ? `Using ${formatToolLabel(activeToolName)}`
-    : STREAM_VERBS[verbIndex];
   const connectionLabel = sdkConnectionLabel(sdkConnectionState);
 
   async function sendInputReply(
@@ -9009,47 +8928,20 @@ function ChatPane({
         )}
       </>)}
       floatingBetweenBodyAndComposer={(<>
-      {/* Streaming status pill — pinned between transcript and composer
-          while the run is in flight. Provider icon, rotating verb +
-          animated dots, elapsed counter, Stop button with ESC hint. */}
-      {activeTab === "chat" && (running || lastStatusText !== null) && (
+      {/* Connectivity banner — only renders when the SSE stream is degraded
+          (connecting / connection_lost / resyncing). Healthy stream → no
+          banner. Replaces the connection label that used to ride on the
+          run-status pill. Run status itself (streaming / stopping / error)
+          now lives on the composer's Submit↔Stop button, and per-turn
+          errors land as durable transcript meta lines via the reducer +
+          projection path. */}
+      {activeTab === "chat" && connectionLabel && (
         <div
-          className={`run-status-bar${!running ? " run-status-bar-idle" : ""}`}
+          className="run-connection-banner"
           role="status"
           aria-live="polite"
         >
-          <span className="run-status-icon">
-            <AgentAvatarIcon avatar={sessionAvatar} className="run-status-avatar" />
-          </span>
-          <span className="run-status-text">
-            <span className="run-status-verb">{running ? verb : lastStatusText}</span>
-            {running && (
-              <span className="run-status-dots" aria-hidden="true">
-                {dots}
-              </span>
-            )}
-          </span>
-          {connectionLabel && (
-            <span className="run-status-connection">{connectionLabel}</span>
-          )}
-          {running && (
-            <>
-              <span className="run-status-elapsed" title="elapsed">
-                {elapsedLabel}
-              </span>
-              <button
-                type="button"
-                className="run-status-stop"
-                onClick={cancelRun}
-                disabled={isStopping}
-                aria-label={isStopping ? "Stopping generation" : "Stop generating"}
-              >
-                <SquareIcon className="run-status-stop-icon" aria-hidden="true" />
-                <span>{isStopping ? "Stopping" : "Stop"}</span>
-                {!isStopping && <kbd className="run-status-kbd">ESC</kbd>}
-              </button>
-            </>
-          )}
+          <span className="run-connection-label">{connectionLabel}</span>
         </div>
       )}
 

--- a/frontend/src/conversationProjection.test.ts
+++ b/frontend/src/conversationProjection.test.ts
@@ -70,6 +70,107 @@ test("turn.interrupt_requested renders a 'Stop requested' meta chip at its order
   }
 });
 
+test("turn.failed projects as an error meta line at its order_key", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "hi" },
+      }),
+      ev("2", "turn.submitted", { client_nonce: "run-1" }),
+      ev("3", "turn.started", { source: "codex" }),
+      ev("4", "turn.failed", {
+        source: "codex",
+        payload: { reason: "provider_failure", error: "rate limit exceeded" },
+      }),
+    ]),
+  );
+
+  assert.equal(projection.runStatus, "error");
+  assert.equal(projection.failed, true);
+  const metas = projection.entries.filter((entry) => entry.kind === "meta");
+  assert.equal(metas.length, 1, "turn.failed should produce one meta entry");
+  const meta = metas[0];
+  if (meta.kind === "meta") {
+    assert.equal(meta.meta.title, "Turn failed");
+    assert.equal(meta.meta.detail, "rate limit exceeded");
+    assert.equal(meta.meta.severity, "error");
+    assert.equal(meta.turnId, "turn-1");
+    assert.equal(meta.orderKey, "0004");
+  }
+});
+
+test("turn.failed with structured-error object unwraps .message into the meta detail", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "hi" },
+      }),
+      ev("2", "turn.failed", {
+        source: "codex",
+        payload: {
+          reason: "provider_failure",
+          error: { code: "token_expired", message: "auth token expired" },
+        },
+      }),
+    ]),
+  );
+
+  const meta = projection.entries.find((entry) => entry.kind === "meta");
+  assert.ok(meta, "turn.failed should produce a meta entry");
+  if (meta?.kind === "meta") {
+    assert.equal(meta.meta.detail, "auth token expired");
+  }
+});
+
+test("turn.interrupted projects as an info 'Stopped' meta line; not 'failed'", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "long task" },
+      }),
+      ev("2", "turn.submitted", { client_nonce: "run-1" }),
+      ev("3", "turn.started", { source: "codex" }),
+      ev("4", "turn.interrupted", {
+        source: "codex",
+        payload: { reason: "client_interrupt" },
+      }),
+    ]),
+  );
+
+  assert.equal(projection.failed, false);
+  const metas = projection.entries.filter((entry) => entry.kind === "meta");
+  assert.equal(metas.length, 1);
+  const meta = metas[0];
+  if (meta.kind === "meta") {
+    assert.equal(meta.meta.title, "Stopped");
+    assert.equal(meta.meta.severity, "info");
+  }
+});
+
+test("turn.completed produces no meta entry — success speaks through the bubble", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "hi" },
+      }),
+      ev("2", "turn.submitted", { client_nonce: "run-1" }),
+      ev("3", "turn.started", { source: "codex" }),
+      ev("4", "turn.completed", { source: "codex" }),
+    ]),
+  );
+
+  const metas = projection.entries.filter((entry) => entry.kind === "meta");
+  assert.equal(metas.length, 0);
+});
+
 test("session.status projects as a system transcript message", () => {
   const projection = projectConversationState(
     reduceConversationEvents([
@@ -442,7 +543,13 @@ test("canonical duplicate delivery converges before projection", () => {
     reduceConversationEvents([...events, ...events]),
   );
 
-  assert.equal(projection.entries.length, 1);
+  // Two entries: the user message + the "Stopped" transcript meta line
+  // derived from turn.interrupted. Duplicate delivery must not double either.
+  assert.equal(projection.entries.length, 2);
+  const messageEntries = projection.entries.filter((e) => e.kind === "message");
+  const metaEntries = projection.entries.filter((e) => e.kind === "meta");
+  assert.equal(messageEntries.length, 1);
+  assert.equal(metaEntries.length, 1);
   assert.equal(projection.stopped, true);
   assert.equal(projection.failed, false);
 });

--- a/frontend/src/conversationProjection.ts
+++ b/frontend/src/conversationProjection.ts
@@ -192,6 +192,11 @@ export function projectConversationState(
         orderKey: request.orderKey,
       },
     })),
+    // Per-turn terminal failures and interruptions become durable transcript
+    // meta lines, replacing the floating run-status pill. turn.completed
+    // emits no meta entry — successful completion speaks through the
+    // assistant bubble itself.
+    ...turnTerminalMetaEntries(state),
   ]), state.turnTerminals);
 
   const activeItem = activeToolItem(state);
@@ -360,6 +365,46 @@ function annotateTurnTerminals(
       turnTerminalEventId: terminal.sourceEventId,
     };
   });
+}
+
+function turnTerminalMetaEntries(
+  state: ConversationReducerState,
+): Array<{ index: number; orderKey: string | undefined; entry: ConversationViewEntry }> {
+  const baseIndex =
+    state.messages.length +
+    state.items.length +
+    state.backgroundTasks.length +
+    state.interruptRequests.length;
+  const out: Array<{ index: number; orderKey: string | undefined; entry: ConversationViewEntry }> = [];
+  let offset = 0;
+  for (const terminal of Object.values(state.turnTerminals)) {
+    if (terminal.status === "completed") continue;
+    const isFailed = terminal.status === "failed";
+    const title = isFailed ? "Turn failed" : "Stopped";
+    const detail = isFailed
+      ? terminal.detail ?? "The provider returned an error."
+      : "Turn stopped by user.";
+    out.push({
+      index: baseIndex + offset,
+      orderKey: terminal.orderKey,
+      entry: {
+        id: `turn-terminal:${terminal.sourceEventId}`,
+        kind: "meta",
+        meta: {
+          title,
+          detail,
+          severity: isFailed ? "error" : "info",
+        },
+        turnId: terminal.turnId,
+        clientNonce: terminal.clientNonce,
+        time: terminal.time,
+        sourceEventId: terminal.sourceEventId,
+        orderKey: terminal.orderKey,
+      },
+    });
+    offset += 1;
+  }
+  return out;
 }
 
 function compareNullableString(a: string | undefined, b: string | undefined): number {

--- a/frontend/src/conversationReducer.ts
+++ b/frontend/src/conversationReducer.ts
@@ -70,6 +70,10 @@ export interface ConversationTurnTerminal {
   orderKey?: string;
   time: string;
   sourceEventId: string;
+  // Unwrapped error text for failed/command_failed turns. Drives the
+  // transcript meta line that renders at the turn's terminal order_key.
+  // Undefined on completed/interrupted turns.
+  detail?: string;
 }
 
 export interface ConversationBackgroundTask {
@@ -281,6 +285,7 @@ function applyTurnTerminal(
   status: ConversationTurnTerminalStatus,
 ): ConversationReducerState {
   if (!event.turn_id) return state;
+  const detail = status === "failed" ? errorText(event) ?? undefined : undefined;
   return {
     ...state,
     turnTerminals: {
@@ -292,6 +297,7 @@ function applyTurnTerminal(
         orderKey: event.order_key,
         time: event.created_at,
         sourceEventId: event.event_id,
+        ...(detail ? { detail } : {}),
       },
     },
   };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4490,24 +4490,28 @@ textarea.run-files-viewer-editor:focus {
   cursor: default;
 }
 
-/* Streaming status bar — sits between transcript and composer while the
-   run is in flight. Matches cloudcli's ClaudeStatus shape: provider icon
-   on the left, rotating action verb + animated dots, elapsed counter on
-   the right, destructive Stop pill with ESC kbd hint. Hidden when idle. */
-.run-status-bar {
+/* SSE connectivity banner — only renders when the live event stream is
+   degraded (connecting / connection_lost / resyncing). Healthy stream:
+   no banner. Replaces the old run-status pill's connectionLabel slot;
+   run status now lives on the composer's Submit↔Stop button and per-turn
+   errors are durable transcript meta lines. */
+.run-connection-banner {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  justify-content: center;
   margin: 0 var(--space-5) var(--space-2);
-  padding: 0.55rem 0.75rem 0.55rem 0.85rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgba(52, 211, 153, 0.22);
-  background: linear-gradient(180deg, rgba(52, 211, 153, 0.08), rgba(52, 211, 153, 0.03));
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  background: linear-gradient(180deg, rgba(251, 191, 36, 0.08), rgba(251, 191, 36, 0.03));
   font-family: var(--font-primary);
-  font-size: var(--text-sm);
-  box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.04);
-  animation: run-status-pulse 2.4s ease-in-out infinite;
+  font-size: var(--text-xs);
+}
+
+.run-connection-label {
+  color: rgba(251, 191, 36, 0.85);
+  letter-spacing: 0.02em;
 }
 
 /* "Load earlier messages" pill — sits at the top of the transcript when
@@ -4547,130 +4551,6 @@ textarea.run-files-viewer-editor:focus {
   margin: var(--space-3) auto var(--space-2);
   color: var(--danger, #f87171);
   font-size: var(--text-xs);
-}
-
-@keyframes run-status-pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.04); }
-  50%      { box-shadow: 0 0 0 6px rgba(52, 211, 153, 0.10); }
-}
-
-/* Idle/done state — amber static pill, no pulse. Mirrors cloudcli's
-   ClaudeStatus amber indicator when isLoading=false but status is set. */
-.run-status-bar-idle {
-  animation: none;
-  border-color: rgba(251, 191, 36, 0.25);
-  background: linear-gradient(180deg, rgba(251, 191, 36, 0.07), rgba(251, 191, 36, 0.03));
-  box-shadow: none;
-}
-
-.run-status-bar-idle .run-status-verb {
-  color: rgba(251, 191, 36, 0.85);
-}
-
-.run-status-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.4rem;
-  height: 1.4rem;
-  border-radius: 999px;
-}
-
-.run-status-avatar {
-  width: 1.4rem;
-  height: 1.4rem;
-  border-radius: 999px;
-  object-fit: contain;
-}
-
-.run-status-text {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.05rem;
-  color: var(--text-primary);
-  font-weight: 500;
-  white-space: nowrap;
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.run-status-verb {
-  letter-spacing: 0.01em;
-}
-
-.run-status-dots {
-  display: inline-block;
-  width: 1.5em;
-  text-align: left;
-  color: rgba(255, 255, 255, 0.6);
-  font-variant-numeric: tabular-nums;
-}
-
-.run-status-connection {
-  flex: 0 0 auto;
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  white-space: nowrap;
-}
-
-.run-status-elapsed {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-  padding: 0 0.25rem;
-}
-
-.run-status-stop {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.55rem 0.3rem 0.5rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(239, 68, 68, 0.38);
-  background: rgba(239, 68, 68, 0.12);
-  color: #fecaca;
-  font-family: var(--font-primary);
-  font-size: 0.78rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition:
-    background var(--motion-fast, 120ms) ease,
-    border-color var(--motion-fast, 120ms) ease,
-    color var(--motion-fast, 120ms) ease;
-}
-
-.run-status-stop:hover {
-  background: rgba(239, 68, 68, 0.2);
-  border-color: rgba(239, 68, 68, 0.55);
-  color: #fee2e2;
-}
-
-.run-status-stop:disabled {
-  cursor: progress;
-  opacity: 0.75;
-}
-
-.run-status-stop-icon {
-  width: 0.85rem;
-  height: 0.85rem;
-  fill: currentColor;
-}
-
-.run-status-kbd {
-  display: inline-block;
-  padding: 0.05rem 0.35rem;
-  margin-left: 0.15rem;
-  border-radius: 0.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(0, 0, 0, 0.25);
-  color: rgba(255, 255, 255, 0.7);
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  letter-spacing: 0.04em;
-  line-height: 1.4;
 }
 
 /* Per-message footer — timestamp + message actions, hover-revealed. */

--- a/frontend/src/sessionAvatars.tsx
+++ b/frontend/src/sessionAvatars.tsx
@@ -12,11 +12,10 @@ export type AgentAvatar = {
 // frontend/public/assets/avatars/ and are served at /assets/avatars/<file>.
 // See ATTRIBUTION.md in that directory for sourcing/licensing notes.
 //
-// Render contract (see index.css .session-avatar / .run-status-avatar /
-// .run-msg-ai-icon): square frame, object-fit: contain, 22-42px display
-// size. All three surfaces are circle-cropped and run edge-to-edge with
-// no backdrop or padding, so the source image itself is the visible
-// shape. The JP1 sources are scene stills (not transparent silhouettes),
+// Render contract (see index.css .session-avatar / .run-msg-ai-icon):
+// square frame, object-fit: contain, 42px display size. Both surfaces are
+// circle-cropped and run edge-to-edge with no backdrop or padding, so the
+// source image itself is the visible shape. The JP1 sources are scene stills (not transparent silhouettes),
 // so the per-slug CROPS in scripts/normalize-jp1-avatars.py are tuned to
 // put the dark subject in the circle and push bright sky / clothing out
 // of frame — anything brighter than the sidebar bg reads as a filled

--- a/frontend/src/styleguide/avatars.tsx
+++ b/frontend/src/styleguide/avatars.tsx
@@ -7,9 +7,8 @@
 // Contract (see also docs/styleguide-contract.md in the glimmung repo):
 // when you change AGENT_AVATARS, the .session-avatar render contract,
 // or how avatars get assigned to sessions, update this page in the same
-// PR. The avatar pool's other render contexts (.run-msg-ai-icon,
-// .run-status-avatar) live here too because the picker drives all three
-// at once.
+// PR. The avatar pool's other render context (.run-msg-ai-icon) lives
+// here too because the picker drives both at once.
 
 import { useState } from "react";
 import { ProviderIcon } from "../providerIcons";
@@ -57,13 +56,11 @@ export function StyleguideAvatars() {
           (<code>getSessionAvatar</code>). Sources live under{" "}
           <code>frontend/public/assets/avatars/jp1-*.png</code>. Three
           render contexts ship: <code>.session-avatar</code> in the sidebar
-          (42px, circle-cropped, edge-to-edge — no backdrop or padding),{" "}
+          (42px, circle-cropped, edge-to-edge — no backdrop or padding) and{" "}
           <code>.run-msg-ai-icon</code> on transcript messages (also 42px,
           matching the sidebar so the avatar reads the same in both
-          surfaces), <code>.run-status-avatar</code> in the run-status pill
-          (~22px, circle-cropped, edge-to-edge). All three are the source
-          PNG clipped to a circle with no chrome, so the picker drives
-          every surface at once.
+          surfaces). Both are the source PNG clipped to a circle with no
+          chrome, so the picker drives every surface at once.
         </p>
 
         {selectedAvatar && (
@@ -261,33 +258,6 @@ export function StyleguideAvatars() {
                 </div>
               </div>
 
-              {/* run-status pill — square */}
-              <div style={{ flex: "0 0 auto" }}>
-                <div
-                  style={{
-                    fontSize: "var(--text-xs)",
-                    color: "var(--text-muted)",
-                    marginBottom: 6,
-                  }}
-                >
-                  status pill · <code>.run-status-avatar</code> · ~22px · circle
-                </div>
-                <div
-                  className="run-status-bar run-status-bar-idle"
-                  role="status"
-                  style={{ display: "inline-flex", alignItems: "center" }}
-                >
-                  <span className="run-status-icon">
-                    <AgentAvatarIcon
-                      avatar={selectedAvatar}
-                      className="run-status-avatar"
-                    />
-                  </span>
-                  <span className="run-status-text">
-                    <span className="run-status-verb">Done</span>
-                  </span>
-                </div>
-              </div>
             </div>
           </section>
         )}

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -643,6 +643,40 @@ const blocked = [
   // (cutover hygiene for in-flight stragglers); the pattern below
   // matches only the dispatch-to-acceptInterrupt shape, not the
   // defensive drop.
+  // Run-status pill retired in favor of routing per-turn status through
+  // the durable transcript + composer (docs/features/transcript/contract.md
+  // names session_events as the source of truth; quality-timeframes.md's
+  // review heuristic "local UI state that can contradict durable state"
+  // describes the pill exactly). Per-turn failures now produce
+  // ConversationViewEntry meta entries from the reducer's turn.failed /
+  // turn.command_failed / turn.interrupted cases; the composer's
+  // PromptInputSubmit handles Submit↔Stop. Block reintroduction of the
+  // pill JSX, its state machinery, and the helper functions that only
+  // existed to fill the pill's rotating verb / elapsed counter slots.
+  {
+    name: "removed run-status-bar CSS class",
+    pattern: /\brun-status-bar\b/,
+  },
+  {
+    name: "removed run-status-avatar CSS class",
+    pattern: /\brun-status-avatar\b/,
+  },
+  {
+    name: "removed lastStatusText pill mirror state",
+    pattern: /\b(?:setLastStatusText|lastStatusText)\b/,
+  },
+  {
+    name: "removed STREAM_VERBS pill verb cycle",
+    pattern: /\bSTREAM_VERBS\b/,
+  },
+  {
+    name: "removed formatStreamElapsed pill elapsed helper",
+    pattern: /\bformatStreamElapsed\b/,
+  },
+  {
+    name: "removed formatToolLabel pill verb helper",
+    pattern: /\bformatToolLabel\b/,
+  },
   {
     name: "retired interrupt-on-data-plane dispatch",
     // Anchored on `.startCommandConsumer(...)` so the control-plane


### PR DESCRIPTION
## Summary

- Delete the floating run-status pill (`.run-status-bar` and its supporting state). It duplicated state already in the durable `session_events` ledger and could lag, contradict the transcript, or — as in the Codex auth `refresh_token_reused` incident that motivated this PR — surface only the literal word "Error" while the upstream cause was hidden by a runner-side `String()` coercion that produced `"[object Object]"` in the durable payload.
- Per-turn failure events (`turn.failed`, `turn.command_failed`, `turn.interrupted`) now produce durable transcript meta entries via the reducer + projection path. The composer's `PromptInputSubmit` (already wired with `submitStatus` / `onStop` / `isStopping`) is the Submit↔Stop affordance. Connectivity degradation surfaces as a top-of-pane banner; healthy stream → no banner.
- Fix `String(params?.error)` at `codex-runner/src/appServerTransport.ts:403` so structured provider errors (e.g. `{code: token_expired, message: ...}`) land in `turn.failed.payload.error` as a readable string, not `"[object Object]"`.
- New `tank_transcript_turn_failure_total{source, reason}` counter on durable turn-failure persistence — replaces the SPA pill as the user-trust observability surface.
- Migration guards in `scripts/check-removed-chat-runtime.mjs` block reintroduction of the pill JSX class, its mirror state, and the helper functions that only existed to fill the pill's slots.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [x] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Transcript contract** (\`docs/features/transcript/contract.md\`): \`session_events\` remains the source of truth; the new meta entries are derived from \`turnTerminals\` (which is itself populated from durable \`turn.failed\` / \`turn.command_failed\` / \`turn.interrupted\` events). Ordering is preserved via \`order_key\`. Reload-replay positions the meta entries identically because \`turnTerminalMetaEntries()\` reads from durable state, not from any local optimism. Reducer/projection tests in \`frontend/src/conversationProjection.test.ts\` cover the new meta-line emission for both string and structured-error payloads, the negative case (\`turn.completed\` -> no meta entry), and idempotency under duplicate event delivery.
- **App Chrome**: floating pill (\`.run-status-bar\`) deleted; CSS removed; styleguide updated. The composer-level Submit↔Stop affordance was already in place and is now the only run-status surface. ESC binding (document-level, gated on \`running\`) stays as-is.
- **Observability**: new \`tank_transcript_turn_failure_total{source, reason}\` counter exposed via the existing \`promauto\` registry and \`/metrics\` endpoint. Tests in \`backend-go/internal/sessionbus/bus_test.go\` pin the counter wiring (source/reason labels from \`payload\`, no fire on \`turn.completed\`). Bridges the gap left by the pill: a Codex auth storm or any "every session is failing" condition is now visible from Grafana / alert rules instead of from staring at a red pill.

Verification:
- \`npm test\` (frontend): 181 / 181 pass
- \`go test ./...\` (backend): clean, all packages
- \`npm test\` (codex-runner): 32 / 32 pass
- \`npm test\` (agent-runner): 46 / 46 pass
- \`helm template k8s --values k8s/values.yaml\`: clean
- \`node scripts/check-removed-chat-runtime.mjs\`: no forbidden surfaces
- \`node scripts/check-tank-conversation-contract.mjs\`: contract matches
- \`npm run build\` (frontend): production build clean

UI verification not possible from this session — explicit non-evidence: the durable + projection layer is covered by tests, the composer affordance is unchanged, but visual confirmation that the transcript meta lines render correctly should be eyeballed in a slot deploy before merge.

## Follow-up (queued as a separate PR, depends on this landing)

\`session.status:failed\` producer for sustained provider-credential failures (the Codex \`refresh_token_reused\` storm that surfaced the unhelpful "Error" pill). The schema slot is already in place — \`session.status\` payload accepts \`status: "failed"\` and the contract test pins the enum. The follow-up adds the orchestrator-side detection / fan-out / recovery state machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)