### PR TITLE
Restore codex_config / config / pi_config wizard flow

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_terminal.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal.go
@@ -16,17 +16,46 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 )
 
-// cliProcess* describe the long-lived in-pod shell the
-// /api/sessions/{id}/cli-process endpoint hands the SPA. Bash login shell in
-// /workspace, TTY+interactive so the sandbox-agent terminal WebSocket carries
-// keystrokes (codex login --device-auth lives behind this). The orchestrator
-// owns the command — not the SPA — so a browser can't pick what binary runs
-// inside the pod.
-var (
-	cliProcessCommand = "bash"
-	cliProcessArgs    = []string{"-l"}
-	cliProcessCwd     = "/workspace"
-)
+// cliProcessLaunchForMode picks the sandbox-agent process shape for the
+// in-browser CLI shell. The orchestrator owns this — not the SPA — so the
+// browser can't dictate what binary runs inside the pod.
+//
+// The "config" modes are credential-refresh wizards: the shell boots already
+// running the right `login` invocation, then drops to interactive bash so the
+// user can poke around or rerun the login if it fails. Any other mode gets a
+// plain login bash. See session-pod-bootstrap.sh for the matching per-mode
+// on-disk seeding (~/.codex/config.toml, ~/.claude/settings.json, etc.) that
+// these login commands depend on.
+func cliProcessLaunchForMode(mode string) sandboxProcessCreate {
+	base := sandboxProcessCreate{
+		Command:     "bash",
+		Cwd:         "/workspace",
+		Interactive: true,
+		TTY:         true,
+	}
+	switch mode {
+	case sessionmodel.CodexConfigMode:
+		// codex login --device-auth is the headless-friendly OAuth
+		// flow — prints a URL + one-time code instead of trying to
+		// open a localhost callback unreachable from a pod. The auth
+		// blob lands at $HOME/.codex/auth.json once the user completes
+		// the device flow; the save-credentials button harvests it.
+		base.Args = []string{"-lc", "codex login --device-auth; exec bash"}
+	case sessionmodel.ConfigMode:
+		// claude /login walks through OAuth; the resulting blob lands
+		// at $HOME/.claude/.credentials.json for the save-credentials
+		// button.
+		base.Args = []string{"-lc", "claude /login; exec bash"}
+	case sessionmodel.PiConfigMode:
+		// Pi's /login is a slash command inside the interactive `pi`
+		// REPL, not a CLI subcommand. Drop into pi, let the user
+		// /login, then back to bash on exit.
+		base.Args = []string{"-lc", `printf "Run /login in Pi to authenticate.\n\n"; pi; exec bash`}
+	default:
+		base.Args = []string{"-l"}
+	}
+	return base
+}
 
 // sandboxAgentBootWait bounds the wait for the in-pod sandbox-agent HTTP
 // server to start accepting connections after the pod is Ready. The kubelet
@@ -64,6 +93,12 @@ func (s *appServer) handleCLIProcess(w http.ResponseWriter, r *http.Request) {
 	}
 	sessionID := r.PathValue("session_id")
 
+	info, err := s.mgr.GetByOwner(r.Context(), user.Email, sessionID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "session not ready: "+err.Error())
+		return
+	}
+
 	podIP, _, err := s.mgr.GetTerminalEndpoint(r.Context(), user.Email, sessionID)
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, "session not ready: "+err.Error())
@@ -71,7 +106,8 @@ func (s *appServer) handleCLIProcess(w http.ResponseWriter, r *http.Request) {
 	}
 
 	baseURL := fmt.Sprintf("http://%s:%d", podIP, sessionmodel.SandboxAgentPort)
-	processID, err := findOrCreateSandboxCLIProcess(r.Context(), http.DefaultClient, baseURL)
+	launch := cliProcessLaunchForMode(info.Mode)
+	processID, err := findOrCreateSandboxCLIProcess(r.Context(), http.DefaultClient, baseURL, launch)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, err.Error())
 		return
@@ -80,16 +116,21 @@ func (s *appServer) handleCLIProcess(w http.ResponseWriter, r *http.Request) {
 }
 
 // findOrCreateSandboxCLIProcess looks for an already-running shell matching
-// the canonical CLI-process shape and returns its id; otherwise it asks
+// the requested launch shape and returns its id; otherwise it asks
 // sandbox-agent to spawn one. The GET is retried on transport errors during
 // sandbox-agent's boot window — the readiness probe sits on the container,
 // not the HTTP server, so podReady can race the listener.
-func findOrCreateSandboxCLIProcess(ctx context.Context, client *http.Client, baseURL string) (string, error) {
+//
+// The matching predicate uses the same (command, args) tuple the launch
+// carries, so opening the codex_config panel a second time after a fresh
+// reload reattaches to the same codex-login shell instead of spawning a
+// second device-auth flow against the same auth.json.
+func findOrCreateSandboxCLIProcess(ctx context.Context, client *http.Client, baseURL string, launch sandboxProcessCreate) (string, error) {
 	processesURL := baseURL + "/v1/processes"
 
 	deadline := time.Now().Add(sandboxAgentBootWait)
 	var (
-		list   sandboxProcessList
+		list    sandboxProcessList
 		lastErr error
 	)
 	for {
@@ -115,20 +156,14 @@ func findOrCreateSandboxCLIProcess(ctx context.Context, client *http.Client, bas
 	}
 
 	for _, p := range list.Processes {
-		if p.Command == cliProcessCommand &&
-			slices.Equal(p.Args, cliProcessArgs) &&
+		if p.Command == launch.Command &&
+			slices.Equal(p.Args, launch.Args) &&
 			p.Status == "running" {
 			return p.ID, nil
 		}
 	}
 
-	body, err := json.Marshal(sandboxProcessCreate{
-		Command:     cliProcessCommand,
-		Args:        cliProcessArgs,
-		Cwd:         cliProcessCwd,
-		Interactive: true,
-		TTY:         true,
-	})
+	body, err := json.Marshal(launch)
 	if err != nil {
 		return "", fmt.Errorf("marshal sandbox-agent request: %w", err)
 	}

--- a/backend-go/cmd/tank-operator/handlers_terminal_test.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal_test.go
@@ -7,15 +7,75 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 )
+
+// defaultLaunch mirrors the cli launch shape for non-config modes (plain bash
+// login shell). Used as a stand-in by the generic helper tests so they don't
+// have to thread a mode through every call.
+var defaultLaunch = cliProcessLaunchForMode("")
+
+// TestCliProcessLaunchForMode_ConfigWizards pins the credential-refresh
+// wizard contracts. Each "*_config" mode boots straight into the
+// provider-specific login command (the user shouldn't have to know what to
+// type), then drops to interactive bash so the shell stays usable after the
+// login completes. Regression target: 650c282 deleted these auto-launches.
+func TestCliProcessLaunchForMode_ConfigWizards(t *testing.T) {
+	cases := []struct {
+		mode     string
+		wantArgs []string
+	}{
+		{sessionmodel.CodexConfigMode, []string{"-lc", "codex login --device-auth; exec bash"}},
+		{sessionmodel.ConfigMode, []string{"-lc", "claude /login; exec bash"}},
+		{sessionmodel.PiConfigMode, []string{"-lc", `printf "Run /login in Pi to authenticate.\n\n"; pi; exec bash`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mode, func(t *testing.T) {
+			launch := cliProcessLaunchForMode(tc.mode)
+			if launch.Command != "bash" {
+				t.Errorf("command = %q, want bash", launch.Command)
+			}
+			if !reflect.DeepEqual(launch.Args, tc.wantArgs) {
+				t.Errorf("args = %v, want %v", launch.Args, tc.wantArgs)
+			}
+			if launch.Cwd != "/workspace" {
+				t.Errorf("cwd = %q, want /workspace", launch.Cwd)
+			}
+			if !launch.Interactive || !launch.TTY {
+				t.Errorf("interactive=%v tty=%v, both want true", launch.Interactive, launch.TTY)
+			}
+		})
+	}
+}
+
+// TestCliProcessLaunchForMode_NonConfigDefault covers cli/gui/exec modes and
+// the unknown-mode fallback. These don't have a wizard to auto-run, so they
+// drop to a plain login shell.
+func TestCliProcessLaunchForMode_NonConfigDefault(t *testing.T) {
+	for _, mode := range []string{
+		sessionmodel.ClaudeCLIMode,
+		sessionmodel.CodexCLIMode,
+		sessionmodel.CodexGUIMode,
+		"", "unknown_mode_4242",
+	} {
+		t.Run(mode, func(t *testing.T) {
+			launch := cliProcessLaunchForMode(mode)
+			if !reflect.DeepEqual(launch.Args, []string{"-l"}) {
+				t.Errorf("args = %v, want [-l] for non-wizard mode", launch.Args)
+			}
+		})
+	}
+}
 
 // TestFindOrCreateSandboxCLIProcess_CreatesFreshShell locks in the recovery
 // from PR #437 — when no matching shell exists, the helper must POST a
 // concrete payload (the SPA does not send one). Asserts the wire body matches
-// the canonical {bash, -l, /workspace, interactive, tty} shape.
+// the launch shape the caller passed in.
 func TestFindOrCreateSandboxCLIProcess_CreatesFreshShell(t *testing.T) {
 	var createBody sandboxProcessCreate
 	var creates atomic.Int32
@@ -44,7 +104,7 @@ func TestFindOrCreateSandboxCLIProcess_CreatesFreshShell(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL)
+	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL, defaultLaunch)
 	if err != nil {
 		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
 	}
@@ -57,7 +117,7 @@ func TestFindOrCreateSandboxCLIProcess_CreatesFreshShell(t *testing.T) {
 	if createBody.Command != "bash" {
 		t.Errorf("create command = %q, want bash", createBody.Command)
 	}
-	if len(createBody.Args) != 1 || createBody.Args[0] != "-l" {
+	if !reflect.DeepEqual(createBody.Args, []string{"-l"}) {
 		t.Errorf("create args = %v, want [-l]", createBody.Args)
 	}
 	if createBody.Cwd != "/workspace" {
@@ -71,9 +131,44 @@ func TestFindOrCreateSandboxCLIProcess_CreatesFreshShell(t *testing.T) {
 	}
 }
 
+// TestFindOrCreateSandboxCLIProcess_CreateMatchesLaunch threads the per-mode
+// launch all the way through and asserts the on-wire body carries it.
+// Regression target: codex_config dropping to plain bash instead of running
+// codex login.
+func TestFindOrCreateSandboxCLIProcess_CreateMatchesLaunch(t *testing.T) {
+	var createBody sandboxProcessCreate
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/processes":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessList{Processes: nil})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/processes":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessInfo{
+				ID: "proc-codex", Command: createBody.Command, Args: createBody.Args, Status: "running",
+			})
+		}
+	}))
+	defer srv.Close()
+
+	launch := cliProcessLaunchForMode(sessionmodel.CodexConfigMode)
+	if _, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL, launch); err != nil {
+		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
+	}
+	if !reflect.DeepEqual(createBody.Args, launch.Args) {
+		t.Errorf("create args = %v, want %v (per-mode launch must reach sandbox-agent)", createBody.Args, launch.Args)
+	}
+}
+
 // TestFindOrCreateSandboxCLIProcess_ReusesRunningShell guards the idempotence
 // the Python original had — opening the run-shell panel a second time must
-// not fan out a second sandbox-agent process.
+// not fan out a second sandbox-agent process. The matching tuple is
+// (command, args, status=running), so a stale exited bash with the same args
+// doesn't count and an unrelated running process doesn't count.
 func TestFindOrCreateSandboxCLIProcess_ReusesRunningShell(t *testing.T) {
 	var creates atomic.Int32
 
@@ -95,7 +190,7 @@ func TestFindOrCreateSandboxCLIProcess_ReusesRunningShell(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL)
+	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL, defaultLaunch)
 	if err != nil {
 		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
 	}
@@ -104,6 +199,35 @@ func TestFindOrCreateSandboxCLIProcess_ReusesRunningShell(t *testing.T) {
 	}
 	if got := creates.Load(); got != 0 {
 		t.Errorf("create calls = %d, want 0 (helper should reuse)", got)
+	}
+}
+
+// TestFindOrCreateSandboxCLIProcess_ReuseMatchesPerModeLaunch confirms the
+// reuse predicate uses the *requested* args, not a hardcoded shape. A panel
+// reopen on a codex_config session should reattach to the codex-login shell,
+// not the plain-bash shell from some other tab.
+func TestFindOrCreateSandboxCLIProcess_ReuseMatchesPerModeLaunch(t *testing.T) {
+	codexLaunch := cliProcessLaunchForMode(sessionmodel.CodexConfigMode)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/processes" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sandboxProcessList{Processes: []sandboxProcessInfo{
+				{ID: "proc-plain", Command: "bash", Args: []string{"-l"}, Status: "running"},
+				{ID: "proc-codex", Command: codexLaunch.Command, Args: codexLaunch.Args, Status: "running"},
+			}})
+			return
+		}
+		t.Errorf("unexpected request: %s %s — reuse should have hit", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	id, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL, codexLaunch)
+	if err != nil {
+		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
+	}
+	if id != "proc-codex" {
+		t.Errorf("process id = %q, want proc-codex (per-mode launch must match the right process)", id)
 	}
 }
 
@@ -150,7 +274,7 @@ func TestFindOrCreateSandboxCLIProcess_RetriesTransportErrors(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	id, err := findOrCreateSandboxCLIProcess(ctx, srv.Client(), srv.URL)
+	id, err := findOrCreateSandboxCLIProcess(ctx, srv.Client(), srv.URL, defaultLaunch)
 	if err != nil {
 		t.Fatalf("findOrCreateSandboxCLIProcess: %v", err)
 	}
@@ -177,7 +301,7 @@ func TestFindOrCreateSandboxCLIProcess_PropagatesProtocolError(t *testing.T) {
 	defer srv.Close()
 
 	start := time.Now()
-	_, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL)
+	_, err := findOrCreateSandboxCLIProcess(context.Background(), srv.Client(), srv.URL, defaultLaunch)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/backend-go/cmd/tank-operator/session_pod_bootstrap_script_test.go
+++ b/backend-go/cmd/tank-operator/session_pod_bootstrap_script_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSessionPodBootstrapScript_PerMode executes the in-pod bootstrap script
+// against each wizard mode in a temp HOME and asserts the right config files
+// land on disk. This is the regression guard the deletion in 650c282 (which
+// labelled this script "dead") didn't have — the bootstrap is load-bearing
+// for codex_config / config / pi_config and a future "remove this, looks
+// dead" PR should be blocked by a failing test, not by user reports.
+func TestSessionPodBootstrapScript_PerMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The script uses POSIX paths and heredocs that are awkward
+		// to invoke through Windows bash semantics. CI Linux runs it.
+		t.Skip("bootstrap script test runs on POSIX only")
+	}
+
+	scriptPath, err := filepath.Abs("../../../k8s/session-config/session-pod-bootstrap.sh")
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script not at expected path %s: %v", scriptPath, err)
+	}
+
+	cases := []struct {
+		mode      string
+		wantFiles map[string]string // path-suffix → expected-content-substring
+	}{
+		{
+			mode: "codex_config",
+			wantFiles: map[string]string{
+				".codex/config.toml": `cli_auth_credentials_store = "file"`,
+			},
+		},
+		{
+			mode: "config",
+			wantFiles: map[string]string{
+				".claude/settings.json": `"theme":"dark"`,
+				".claude.json":          `"hasCompletedOnboarding": true`,
+			},
+		},
+		{
+			mode: "pi_config",
+			wantFiles: map[string]string{
+				".pi/agent/AGENTS.md": "Tank Pi Config Session",
+			},
+		},
+		{
+			mode:      "codex_cli",
+			wantFiles: map[string]string{".codex/config.toml": `cli_auth_credentials_store = "file"`},
+		},
+		{
+			mode:      "claude_gui",
+			wantFiles: nil, // non-wizard, no seeding
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.mode, func(t *testing.T) {
+			home := t.TempDir()
+			cmd := exec.Command("bash", scriptPath)
+			cmd.Env = append(os.Environ(),
+				"HOME="+home,
+				"TANK_SESSION_MODE="+tc.mode,
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("script failed: %v\noutput:\n%s", err, string(out))
+			}
+
+			for suffix, wantSubstr := range tc.wantFiles {
+				path := filepath.Join(home, suffix)
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Errorf("expected file %s missing: %v", path, err)
+					continue
+				}
+				if !strings.Contains(string(data), wantSubstr) {
+					t.Errorf("file %s missing expected content %q\ngot:\n%s", path, wantSubstr, string(data))
+				}
+			}
+
+			if tc.mode == "claude_gui" {
+				// Defensive: no-seeding modes really must not write to HOME.
+				entries, _ := os.ReadDir(home)
+				if len(entries) > 0 {
+					t.Errorf("non-wizard mode wrote to HOME: %v", entries)
+				}
+			}
+		})
+	}
+}

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -177,6 +177,7 @@ var sessionConfigMounts = []struct{ key, mountPath string }{
 	{"agent-runner-launch.sh", "/opt/tank/agent-runner-launch.sh"},
 	{"codex-runner-launch.sh", "/opt/tank/codex-runner-launch.sh"},
 	{"repo-cloner.sh", "/opt/tank/repo-cloner.sh"},
+	{"session-pod-bootstrap.sh", "/opt/tank/session-pod-bootstrap.sh"},
 }
 
 // noClaudeHijackModes are modes that should not receive the OAuth gateway / api proxy host aliases.
@@ -325,6 +326,11 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	// Environment variables for the claude container.
 	env := []any{
 		map[string]any{"name": "SANDBOX_AGENT_PORT", "value": itoa(opts.SandboxAgentPort)},
+		// TANK_SESSION_MODE drives session-pod-bootstrap.sh's per-mode
+		// seeding (~/.codex/config.toml, ~/.claude/settings.json, etc.).
+		// Also surfaced inside the user's shell, so `echo $TANK_SESSION_MODE`
+		// works when debugging in-pod.
+		map[string]any{"name": "TANK_SESSION_MODE", "value": mode},
 		map[string]any{"name": "TANK_GLIMMUNG_CONTEXT_JSON", "value": opts.GlimmungContextJSON},
 		map[string]any{"name": "TANK_GLIMMUNG_RUN_REF", "value": glimmungField(opts.GlimmungContextJSON, "glimmung_run_ref")},
 		map[string]any{"name": "TANK_GLIMMUNG_ISSUE_REF", "value": glimmungField(opts.GlimmungContextJSON, "glimmung_issue_ref")},
@@ -505,7 +511,10 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		"imagePullPolicy": "Always",
 		"command": []any{
 			"bash", "-lc",
-			"if [ -f /opt/tank/session-config/install-tank-docs.sh ]; then sh /opt/tank/session-config/install-tank-docs.sh || true; fi; if command -v sandbox-agent >/dev/null 2>&1; then sandbox_agent_cmd=sandbox-agent; else sandbox_agent_cmd='npx -y @sandbox-agent/cli@0.4.2'; fi; exec $sandbox_agent_cmd server --host 0.0.0.0 --port " + itoa(opts.SandboxAgentPort) + " --no-token --no-telemetry",
+			"if [ -f /opt/tank/session-config/install-tank-docs.sh ]; then sh /opt/tank/session-config/install-tank-docs.sh || true; fi; " +
+				"if [ -f /opt/tank/session-pod-bootstrap.sh ]; then bash /opt/tank/session-pod-bootstrap.sh || true; fi; " +
+				"if command -v sandbox-agent >/dev/null 2>&1; then sandbox_agent_cmd=sandbox-agent; else sandbox_agent_cmd='npx -y @sandbox-agent/cli@0.4.2'; fi; " +
+				"exec $sandbox_agent_cmd server --host 0.0.0.0 --port " + itoa(opts.SandboxAgentPort) + " --no-token --no-telemetry",
 		},
 		"ports":        []any{map[string]any{"name": "sandbox-agent", "containerPort": opts.SandboxAgentPort}},
 		"env":          env,

--- a/backend-go/internal/sessionmodel/testdata/manifest_fixture.json
+++ b/backend-go/internal/sessionmodel/testdata/manifest_fixture.json
@@ -13,7 +13,7 @@
     "claude_command": [
       "bash",
       "-lc",
-      "if [ -f /opt/tank/session-config/install-tank-docs.sh ]; then sh /opt/tank/session-config/install-tank-docs.sh || true; fi; if command -v sandbox-agent >/dev/null 2>&1; then sandbox_agent_cmd=sandbox-agent; else sandbox_agent_cmd='npx -y @sandbox-agent/cli@0.4.2'; fi; exec $sandbox_agent_cmd server --host 0.0.0.0 --port 2468 --no-token --no-telemetry"
+      "if [ -f /opt/tank/session-config/install-tank-docs.sh ]; then sh /opt/tank/session-config/install-tank-docs.sh || true; fi; if [ -f /opt/tank/session-pod-bootstrap.sh ]; then bash /opt/tank/session-pod-bootstrap.sh || true; fi; if command -v sandbox-agent >/dev/null 2>&1; then sandbox_agent_cmd=sandbox-agent; else sandbox_agent_cmd='npx -y @sandbox-agent/cli@0.4.2'; fi; exec $sandbox_agent_cmd server --host 0.0.0.0 --port 2468 --no-token --no-telemetry"
     ],
     "claude_env": {
       "CLAUDE_CODE_NO_FLICKER": "1",
@@ -23,7 +23,8 @@
       "TANK_GLIMMUNG_ISSUE_REF": "",
       "TANK_GLIMMUNG_RUN_REF": "",
       "TANK_GLIMMUNG_TOUCHPOINT_REF": "",
-      "TANK_GLIMMUNG_VALIDATION_URL": ""
+      "TANK_GLIMMUNG_VALIDATION_URL": "",
+      "TANK_SESSION_MODE": "codex_gui"
     },
     "container_images": {
       "claude": "romainecr.azurecr.io/codex-container:latest",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9516,19 +9516,12 @@ function CliProcessTerminal({
 }
 
 function CliSession({ session, visible }: { session: Session; visible: boolean }) {
+  // The sidebar already shows the session title, mode badge, and status —
+  // a duplicate header inside the pane is wasted vertical space and made
+  // the un-sized provider icon render at intrinsic SVG dimensions
+  // (the giant cloud). Let the terminal fill the pane.
   return (
     <section className="run-panel">
-      <header className="run-header">
-        <div className="run-title-block">
-          <div className="run-title-row">
-            <span className="run-provider-mark">
-              <ProviderIcon provider={MODE_MENU_ICONS[session.mode]} className="run-provider-icon" />
-            </span>
-            <h2 className="run-title">{sessionDisplayName(session)}</h2>
-          </div>
-          <p className="run-subtitle">{MODE_LABELS[session.mode]}</p>
-        </div>
-      </header>
       <main className="run-main">
         <div className="run-shell">
           <CliProcessTerminal session={session} visible={visible} />

--- a/k8s/session-config/session-pod-bootstrap.sh
+++ b/k8s/session-config/session-pod-bootstrap.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Session-pod bootstrap. Runs once at pod boot, before sandbox-agent's HTTP
+# listener comes up, so any state the in-browser CLI shell (or a later
+# `codex` / `claude` / `pi` invocation) depends on is on disk before the
+# user can issue commands.
+#
+# Required env: TANK_SESSION_MODE (set on the claude container by the
+# orchestrator at pod creation; see sessionmodel.go).
+#
+# This is the migration target for the Python `tank-bootstrap.sh` that
+# 650c282 deleted as "dead" — it was not dead, it was the bootstrap.
+# The cli-process 400 it caused was patched in #637; this script
+# restores the per-mode seeding that broke at the same time.
+
+set -e
+
+mode="${TANK_SESSION_MODE:-}"
+if [ -z "$mode" ]; then
+  echo "session-pod-bootstrap: TANK_SESSION_MODE unset; nothing to seed" >&2
+  exit 0
+fi
+
+case "$mode" in
+  codex_config | codex_cli | codex_gui | codex_exec_gui | codex_app_server)
+    mkdir -p "$HOME/.codex"
+    # cli_auth_credentials_store=file forces the file-backed store.
+    # Codex defaults to the OS keychain, which doesn't exist in a
+    # Linux container — without this, `codex login` either fails or
+    # writes to a location codex can't read back. The save-credentials
+    # button reads $HOME/.codex/auth.json out of the pod, so this
+    # setting is load-bearing for the credentials wizard.
+    cat > "$HOME/.codex/config.toml" <<'TOML'
+cli_auth_credentials_store = "file"
+
+[projects."/workspace"]
+trust_level = "trusted"
+
+[tui]
+notifications = true
+notification_condition = "always"
+notification_method = "bel"
+TOML
+    ;;
+  config)
+    # Minimal seeds for the claude credentials-refresh wizard. The
+    # save-credentials button later reads $HOME/.claude/.credentials.json
+    # out of the pod — we deliberately do not pre-seed that file; the
+    # user must complete /login.
+    mkdir -p "$HOME/.claude"
+    cat > "$HOME/.claude/settings.json" <<'JSON'
+{"theme":"dark"}
+JSON
+    cat > "$HOME/.claude.json" <<'JSON'
+{"hasCompletedOnboarding": true}
+JSON
+    ;;
+  pi_config)
+    mkdir -p "$HOME/.pi/agent"
+    cat > "$HOME/.pi/agent/AGENTS.md" <<'MD'
+# Tank Pi Config Session
+
+Run `/login`, choose your provider, and complete the login flow. This mode is
+for manual Pi testing; Tank does not persist Pi's native auth.json.
+MD
+    ;;
+esac

--- a/k8s/templates/session-configmap.yaml
+++ b/k8s/templates/session-configmap.yaml
@@ -17,6 +17,8 @@ data:
 {{ .Files.Get "session-config/install-tank-docs.sh" | indent 4 }}
   install-tank-skills.sh: |
 {{ .Files.Get "session-config/install-tank-skills.sh" | indent 4 }}
+  session-pod-bootstrap.sh: |
+{{ .Files.Get "session-config/session-pod-bootstrap.sh" | indent 4 }}
   agent-runner-launch.sh: |
 {{ .Files.Get "session-config/agent-runner-launch.sh" | indent 4 }}
   codex-runner-launch.sh: |


### PR DESCRIPTION
## Summary

- **Per-mode auto-launch.** `codex_config` boots already running `codex login --device-auth`, `config` runs `claude /login`, `pi_config` drops into the `pi` REPL with a /login reminder. Drives off the session mode in `handleCLIProcess`; the reuse predicate uses the per-mode args so panel reopens reattach to the right shell.
- **Per-mode on-disk seeding.** New `k8s/session-config/session-pod-bootstrap.sh` runs at pod boot before sandbox-agent comes up. Writes `~/.codex/config.toml` (with `cli_auth_credentials_store = "file"` — codex defaults to the OS keychain, which doesn't exist in a Linux container), `~/.claude/settings.json` + `~/.claude.json` for the claude wizard, and `~/.pi/agent/AGENTS.md` for pi. Plumbed via `TANK_SESSION_MODE` env on the claude container.
- **CliSession header strip.** Removed the redundant title/subtitle that duplicated the sidebar; its container classes (`run-provider-mark`/`run-provider-icon`) had no CSS so the ProviderIcon SVG rendered at intrinsic size — the giant cloud in the bug report screenshot.

## Why this exists

[#650c282](https://github.com/nelsong6/tank-operator/commit/650c282) deleted the Python `tank-bootstrap.sh` as "dead session bootstrap script" the day before [#437](https://github.com/nelsong6/tank-operator/pull/437) rewrote the orchestrator in Go. It was not dead — it was the load-bearing per-mode bootstrap (auto-launch login + config.toml seeding + git identity + .mcp.json translation). [#637](https://github.com/nelsong6/tank-operator/pull/637) restored the cli-process endpoint but punted the wizard contents. This PR finishes the migration: every piece of the deleted script that's still relevant gets a current home (Go-side launch dispatcher + bash-side seeding script with its own regression test).

## Feature Contracts

Affected contracts:
- [x] None

No contracted feature names the credential-refresh wizards or the in-pod seeding surface. If a contract for "credential refresh round-trip" gets written later, the relevant invariants are: each wizard mode's terminal boots with the right login command on screen, the right on-disk files exist before sandbox-agent accepts connections, and panel reopens reattach to the same login shell (no duplicate device-auth flows fighting over the same `auth.json`). The tests in this PR encode those today.

Evidence:
- `TestCliProcessLaunchForMode_ConfigWizards` pins the three wizard launches (asserts the exact args strings).
- `TestCliProcessLaunchForMode_NonConfigDefault` keeps cli/gui/unknown modes on the plain `bash -l` from #637.
- `TestFindOrCreateSandboxCLIProcess_CreateMatchesLaunch` and `_ReuseMatchesPerModeLaunch` confirm the per-mode launch reaches sandbox-agent's wire body and that the reuse predicate matches the right shell.
- `TestSessionPodBootstrapScript_PerMode` exec's the bootstrap script against each mode in a temp HOME and asserts the right files appear — the regression guard #650c282's deletion didn't have. Skipped on Windows (POSIX-only), runs on Linux CI.
- Updated `manifest_fixture.json` covers the new claude_command and TANK_SESSION_MODE env.
- `go vet ./...` and `go test ./...` green; `npm run build` green; `helm template k8s/` renders the new ConfigMap key.

## Test plan

- [ ] Open a fresh `codex_config` session in tank.romaine.life. Terminal opens already prompting `codex login --device-auth` device-code URL — no manual typing required.
- [ ] Complete the device flow, hit **save**, verify Key Vault `codex-credentials` updated (e.g. `az keyvault secret show`).
- [ ] Open a `config` (claude) session, confirm `claude /login` runs automatically.
- [ ] Confirm the giant cloud icon is gone — terminal fills the pane.
- [ ] Close + reopen the run-shell panel on the codex_config session, confirm reattach to the same shell (no second `codex login` device prompt).
- [ ] `kubectl exec -c claude session-... -- cat ~/.codex/config.toml` — verify `cli_auth_credentials_store = "file"` is present at pod boot.

## Follow-ups (intentionally out of scope)

- The `.mcp.json` → codex `[mcp_servers.X]` TOML translation that the deleted bootstrap did for codex_cli / codex_gui. Those modes either use the codex-runner sidecar (own MCP wiring) or expose the gap when the user types `codex` interactively — not the wizard the user reported.
- Git identity configuration per mode. Not blocking the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)