### PR TITLE
Surface sustained provider-credential failures via session.status:failed

### DIFF
--- a/api-proxy/src/tank_api_proxy/__main__.py
+++ b/api-proxy/src/tank_api_proxy/__main__.py
@@ -21,8 +21,8 @@ def main() -> None:
 async def _run() -> None:
     port = int(os.environ.get("EXT_PROC_PORT", "9000"))
     metrics_port = int(os.environ.get("METRICS_PORT", "9100"))
-    server = await serve(port)
-    metrics_runner = await start_metrics_server(metrics_port)
+    server, injector = await serve(port)
+    metrics_runner = await start_metrics_server(metrics_port, injector.health_snapshot)
     stop = asyncio.Event()
 
     def _shutdown(*_: object) -> None:

--- a/api-proxy/src/tank_api_proxy/metrics.py
+++ b/api-proxy/src/tank_api_proxy/metrics.py
@@ -16,8 +16,10 @@ without colliding with the ext_proc port.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+from typing import Any, Callable
 
 from aiohttp import web
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
@@ -126,10 +128,53 @@ async def _handle_healthz(_: web.Request) -> web.Response:
     return web.Response(text="ok")
 
 
-async def start_metrics_server(port: int) -> web.AppRunner:
+HealthSnapshotProvider = Callable[[], dict[str, Any]]
+
+
+def _make_health_handler(snapshot: HealthSnapshotProvider) -> Callable[[web.Request], web.Response]:
+    """Wrap a health-snapshot callable as an aiohttp handler.
+
+    The orchestrator polls this endpoint every 30s. Schema:
+        {
+          "provider": "codex" | "claude",
+          "result": "success" | "http_error" | "request_failed" | ...,
+          "reason": "refresh_token_reused" | "" | ...,
+          "text": "Sign-in expired. ...",
+          "last_attempted_at": <unix-seconds float | null>,
+          "last_succeeded_at": <unix-seconds float | null>,
+          "attempt_id": <int>
+        }
+    Snapshot exceptions degrade to 503 — the orchestrator treats
+    503s as "skip this poll cycle" so a momentary proxy issue doesn't
+    flip the transcript banner.
+    """
+    def handler(_: web.Request) -> web.Response:
+        try:
+            payload = snapshot()
+        except Exception:
+            log.exception("health snapshot failed")
+            return web.Response(status=503, text="snapshot unavailable")
+        return web.Response(
+            body=json.dumps(payload),
+            content_type="application/json",
+        )
+    return handler
+
+
+async def start_metrics_server(
+    port: int,
+    health_snapshot: HealthSnapshotProvider | None = None,
+) -> web.AppRunner:
     app = web.Application()
     app.router.add_get("/metrics", _handle_metrics)
     app.router.add_get("/healthz", _handle_healthz)
+    if health_snapshot is not None:
+        # Route is /health/<provider> so a Grafana dashboard or a
+        # multi-provider orchestrator can disambiguate which deployment
+        # answered without parsing the body. The shape matches the
+        # transcript-surfaced banner contract documented on tank-operator's
+        # side (docs/features/transcript/contract.md).
+        app.router.add_get(f"/health/{PROVIDER}", _make_health_handler(health_snapshot))
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, host="0.0.0.0", port=port)

--- a/api-proxy/src/tank_api_proxy/server.py
+++ b/api-proxy/src/tank_api_proxy/server.py
@@ -250,6 +250,62 @@ def _iso_ms(value: str | None) -> int | None:
         return None
 
 
+# User-facing copy for known OAuth refresh-failure reasons. The /health
+# endpoint surfaces these strings directly; the orchestrator's
+# session.status:failed banner copies them verbatim into the transcript.
+# Keep the strings actionable — every entry should answer "what does the
+# user do next" since the action affordance ("Re-sign-in to ...") is
+# generic.
+_REFRESH_FAILURE_TEXT = {
+    "refresh_token_reused": "Sign-in expired. The refresh token has already been used; re-authenticate to restore service.",
+    "invalid_grant": "Sign-in expired. Re-authenticate to restore service.",
+    "invalid_request": "Sign-in could not be refreshed. Re-authenticate to restore service.",
+    "unauthorized_client": "Sign-in is not authorized to refresh. Re-authenticate to restore service.",
+}
+
+
+def _classify_refresh_failure(resp: httpx.Response) -> tuple[str, str]:
+    """Extract a (reason, text) tuple from an OAuth /token error response.
+
+    The upstream body shape is the standard OAuth error envelope:
+        {"error": {"code": "refresh_token_reused", "message": "..."}}
+    For non-JSON bodies (rare; upstream proxies misbehaving), fall back
+    to the HTTP status as the reason. The reason field is what feeds
+    the orchestrator's metric label and Layer 1 row; text is what shows
+    in the transcript banner.
+    """
+    reason = ""
+    text = ""
+    try:
+        body = resp.json()
+    except Exception:
+        body = None
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict):
+            code = err.get("code")
+            message = err.get("message")
+            if isinstance(code, str) and code:
+                reason = code
+            if isinstance(message, str) and message:
+                text = message
+        elif isinstance(err, str) and err:
+            reason = err
+    if not reason:
+        reason = f"http_{resp.status_code}"
+    if not text:
+        text = _REFRESH_FAILURE_TEXT.get(reason, "Sign-in could not be refreshed. Re-authenticate to restore service.")
+    else:
+        # If we got an upstream message AND the reason is one we have
+        # canonical copy for, prefer the canonical copy — the upstream
+        # message is often referrer-style ("Please try signing in again.")
+        # and lands awkwardly in the SPA's banner.
+        canonical = _REFRESH_FAILURE_TEXT.get(reason)
+        if canonical:
+            text = canonical
+    return reason, text
+
+
 class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
     def __init__(self, config: ProxyConfig | None = None) -> None:
         self._config = config or _config_from_env()
@@ -274,6 +330,20 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
         # of five+ successful rotations in two seconds.
         self._refresh_task: asyncio.Task[None] | None = None
         self._kv_url = os.environ.get("AZURE_KEYVAULT_URL", "")
+        # Health snapshot — the durable provider-credential health surface
+        # consumed by tank-operator's poller. The orchestrator polls
+        # /health/<provider> on a 30s interval, debounces sustained
+        # failures, and writes provider_credential_health rows + fans
+        # session.status:failed events into every affected session's
+        # transcript. See docs/features/transcript/contract.md for the
+        # surface. The proxy is a stateless monitor; durability lives in
+        # Postgres on the orchestrator side.
+        self._health_last_attempted_at: float | None = None
+        self._health_last_succeeded_at: float | None = None
+        self._health_last_result: str = "unknown"
+        self._health_last_reason: str = ""
+        self._health_last_text: str = ""
+        self._health_attempt_id: int = 0
         log.info(
             "starting %s auth injector (credentials=%s, kv_secret=%s)",
             self._config.provider,
@@ -545,9 +615,12 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
             if self._cached_refresh is None:
                 log.error("no refresh token available; cannot rotate")
                 record_refresh("no_refresh_token")
+                self._record_health_result("no_refresh_token", "no_refresh_token", "No refresh token available; the OAuth blob is missing or unreadable.")
                 return
             log.info("calling %s to rotate %s token", self._config.token_url, self._config.provider)
             refresh_start = time.monotonic()
+            self._health_last_attempted_at = time.time()
+            self._health_attempt_id += 1
             try:
                 async with httpx.AsyncClient(timeout=30.0) as http:
                     resp = await http.post(
@@ -562,10 +635,13 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
             except Exception:
                 log.exception("refresh request crashed; keeping existing tokens")
                 record_refresh("request_failed", time.monotonic() - refresh_start)
+                self._record_health_result("request_failed", "request_failed", "Upstream OAuth token endpoint unreachable.")
                 return
             if resp.status_code != 200:
                 log.error("refresh failed: status=%s body=%s", resp.status_code, resp.text[:500])
                 record_refresh("http_error", time.monotonic() - refresh_start)
+                reason, text = _classify_refresh_failure(resp)
+                self._record_health_result("http_error", reason, text)
                 return
             data = resp.json()
             new_access = data["access_token"]
@@ -595,7 +671,38 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
                 expires_in,
             )
             record_refresh("success", time.monotonic() - refresh_start)
+            self._health_last_succeeded_at = time.time()
+            self._record_health_result("success", "", "")
             await self._persist_to_kv(expires_in)
+
+    def _record_health_result(self, result: str, reason: str, text: str) -> None:
+        """Record the outcome of a refresh attempt for the /health endpoint.
+
+        result is the high-level outcome ("success" / "http_error" /
+        "request_failed" / "no_refresh_token"); reason is the
+        fine-grained label (e.g. "refresh_token_reused"); text is the
+        user-facing string the orchestrator copies into a
+        session.status:failed banner.
+        """
+        self._health_last_result = result
+        self._health_last_reason = reason
+        self._health_last_text = text
+
+    def health_snapshot(self) -> dict[str, Any]:
+        """Return the current refresh-health snapshot for the /health
+        endpoint. The orchestrator's poller reads this every 30s,
+        debounces sustained failures, and writes Layer 1 rows. Times
+        are unix-seconds floats (or None when no attempt yet).
+        """
+        return {
+            "provider": self._config.provider,
+            "result": self._health_last_result,
+            "reason": self._health_last_reason,
+            "text": self._health_last_text,
+            "last_attempted_at": self._health_last_attempted_at,
+            "last_succeeded_at": self._health_last_succeeded_at,
+            "attempt_id": self._health_attempt_id,
+        }
 
     async def _persist_to_kv(self, expires_in: int) -> None:
         """Best-effort write of the rotated blob back to KV.
@@ -652,14 +759,21 @@ def _peek_status(msg: ext_proc_pb2.HttpHeaders) -> int | None:
     return None
 
 
-async def serve(port: int) -> grpc.aio.Server:
+async def serve(port: int) -> tuple[grpc.aio.Server, AuthInjector]:
+    """Boot the ext_proc grpc server and return both the server and the
+    AuthInjector instance. The injector is returned so __main__ can wire
+    its health_snapshot() into the metrics-server's /health endpoint —
+    the orchestrator's poller reads that snapshot to drive the
+    transcript-surfaced provider-credential banner.
+    """
     config = _config_from_env()
     server = grpc.aio.server()
-    ext_proc_grpc.add_ExternalProcessorServicer_to_server(AuthInjector(config), server)
+    injector = AuthInjector(config)
+    ext_proc_grpc.add_ExternalProcessorServicer_to_server(injector, server)
     server.add_insecure_port(f"0.0.0.0:{port}")
     await server.start()
     log.info("%s ext_proc listening on 0.0.0.0:%d", config.provider, port)
-    return server
+    return server, injector
 
 
 # Suppress unused-import warning: the http_status import is kept so that

--- a/api-proxy/tests/test_server.py
+++ b/api-proxy/tests/test_server.py
@@ -49,7 +49,12 @@ def install_proto_stubs() -> None:
 
 install_proto_stubs()
 
-from tank_api_proxy.server import AuthInjector, ProxyConfig, _patch_blob
+from tank_api_proxy.server import (
+    AuthInjector,
+    ProxyConfig,
+    _classify_refresh_failure,
+    _patch_blob,
+)
 
 
 def jwt_with_claims(claims: dict) -> str:
@@ -163,6 +168,116 @@ class ServerTests(unittest.TestCase):
 
             self.assertEqual(injector._cached_access, "new-access")
             self.assertEqual(injector._cached_refresh, "new-refresh")
+
+
+class HealthSnapshotTests(unittest.TestCase):
+    """Pins the contract the orchestrator's provider-health poller depends on.
+
+    See docs/features/transcript/contract.md (the session.status surface
+    that consumes this snapshot) and the orchestrator's poller in
+    backend-go/internal/providerhealth/. The poller reads /health/<provider>
+    every 30s, debounces sustained failures, and writes
+    provider_credential_health rows that drive the transcript banner.
+    A regression in the snapshot fields would silently break the banner.
+    """
+
+    def _fresh_injector(self) -> AuthInjector:
+        with tempfile.TemporaryDirectory() as tmp:
+            return AuthInjector(codex_config(str(Path(tmp) / "auth.json")))
+
+    def test_snapshot_default_state_is_unknown(self) -> None:
+        # Before any refresh attempt, the snapshot's result is "unknown"
+        # — the orchestrator treats this as "no data yet, do not flip
+        # Layer 1." The proxy intentionally does not infer healthy from
+        # the bare absence of a failure; the cached blob may still be
+        # serving a long-lived access token whose refresh has never been
+        # exercised.
+        injector = self._fresh_injector()
+        snapshot = injector.health_snapshot()
+        self.assertEqual(snapshot["provider"], "codex")
+        self.assertEqual(snapshot["result"], "unknown")
+        self.assertEqual(snapshot["reason"], "")
+        self.assertEqual(snapshot["text"], "")
+        self.assertIsNone(snapshot["last_attempted_at"])
+        self.assertIsNone(snapshot["last_succeeded_at"])
+        self.assertEqual(snapshot["attempt_id"], 0)
+
+    def test_snapshot_after_success_records_success_state(self) -> None:
+        injector = self._fresh_injector()
+        injector._record_health_result("success", "", "")
+        injector._health_attempt_id = 1
+        injector._health_last_succeeded_at = 1700000000.0
+        injector._health_last_attempted_at = 1700000000.0
+        snapshot = injector.health_snapshot()
+        self.assertEqual(snapshot["result"], "success")
+        self.assertEqual(snapshot["last_succeeded_at"], 1700000000.0)
+
+    def test_snapshot_after_failure_carries_reason_and_text(self) -> None:
+        injector = self._fresh_injector()
+        injector._record_health_result(
+            "http_error",
+            "refresh_token_reused",
+            "Sign-in expired. The refresh token has already been used; re-authenticate to restore service.",
+        )
+        injector._health_attempt_id = 2
+        injector._health_last_attempted_at = 1700000100.0
+        snapshot = injector.health_snapshot()
+        self.assertEqual(snapshot["result"], "http_error")
+        self.assertEqual(snapshot["reason"], "refresh_token_reused")
+        self.assertIn("Re-authenticate", snapshot["text"])
+        # last_succeeded_at must remain None — a later failure does not
+        # invalidate a never-observed success.
+        self.assertIsNone(snapshot["last_succeeded_at"])
+
+
+class ClassifyRefreshFailureTests(unittest.TestCase):
+    """Pins how upstream OAuth /token error bodies become (reason, text).
+
+    The refresh_token_reused incident that motivated the transcript
+    banner: upstream returns {"error":{"code":"refresh_token_reused",
+    "message":"Your refresh token has already been used..."}} and the
+    SPA sees a banner explaining what to do. If this classifier drifts,
+    the banner becomes content-free again.
+    """
+
+    class _StubResponse:
+        def __init__(self, status_code: int, body: object) -> None:
+            self.status_code = status_code
+            self._body = body
+            self.text = json.dumps(body) if isinstance(body, dict) else str(body)
+
+        def json(self) -> object:
+            if isinstance(self._body, dict):
+                return self._body
+            raise ValueError("non-json body")
+
+    def test_classify_refresh_token_reused_returns_canonical_text(self) -> None:
+        resp = self._StubResponse(
+            401,
+            {
+                "error": {
+                    "code": "refresh_token_reused",
+                    "message": "Your refresh token has already been used to generate a new access token. Please try signing in again.",
+                }
+            },
+        )
+        reason, text = _classify_refresh_failure(resp)  # type: ignore[arg-type]
+        self.assertEqual(reason, "refresh_token_reused")
+        # Canonical copy preferred over the upstream message — the
+        # upstream "Please try signing in again." reads awkwardly in
+        # the SPA banner.
+        self.assertIn("re-authenticate", text.lower())
+
+    def test_classify_unknown_code_falls_back_to_status(self) -> None:
+        resp = self._StubResponse(401, {"error": "bad_things"})
+        reason, _ = _classify_refresh_failure(resp)  # type: ignore[arg-type]
+        self.assertEqual(reason, "bad_things")
+
+    def test_classify_non_json_body_uses_http_status(self) -> None:
+        resp = self._StubResponse(500, "Internal Server Error")
+        reason, text = _classify_refresh_failure(resp)  # type: ignore[arg-type]
+        self.assertEqual(reason, "http_500")
+        self.assertTrue(text)
 
 
 if __name__ == "__main__":

--- a/backend-go/cmd/tank-operator/handlers_sessions.go
+++ b/backend-go/cmd/tank-operator/handlers_sessions.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nelsong6/tank-operator/backend-go/internal/conversation"
 	"github.com/nelsong6/tank-operator/backend-go/internal/kubeexec"
+	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
 )
@@ -206,8 +207,49 @@ func (s *appServer) handleCreateSession(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 	}
+	// Provider-credential backfill: when a new session's mode requires a
+	// provider whose Layer 1 row is currently in a failed state, emit a
+	// session.status:failed banner into the freshly-created session's
+	// transcript ledger so the SPA renders the same "<provider> sign-in
+	// expired" line that already-active sessions see. The ordering rule
+	// from docs/features/transcript/contract.md is satisfied: this fires
+	// AFTER the initial-turn block above writes user_message.created (or
+	// the deferred persistInitialTurnUserMessage) and AFTER manager.Create
+	// inserts the sessions row whose trigger emits session.status:ready —
+	// never before user_message. A best-effort error here (Postgres
+	// blip, NATS not yet healthy) is logged but does not roll back the
+	// session create; the next poll cycle will fan out and pick it up.
+	s.backfillProviderHealthBanner(r.Context(), owner, info)
 	sessionReposSelectedTotal.WithLabelValues(repoSelectionBucket(len(repos))).Inc()
 	writeJSON(w, http.StatusCreated, info)
+}
+
+// backfillProviderHealthBanner is the session-create-time read-side of
+// the provider-credential-banner pipeline. The poll loop is the steady-
+// state writer; this method covers the gap for sessions created during
+// a sustained outage. Skipped silently when the mode's provider has no
+// Layer 1 entry yet (nothing to backfill) or when the row is healthy.
+func (s *appServer) backfillProviderHealthBanner(ctx context.Context, owner string, info sessions.Info) {
+	if s == nil || s.providerHealth == nil {
+		return
+	}
+	provider, ok := sdkProviderForMode(info.Mode)
+	if !ok {
+		return
+	}
+	row, present, err := s.providerHealth.CurrentHealth(ctx, provider)
+	if err != nil {
+		slog.Warn("providerhealth current-health lookup failed on session create",
+			"provider", provider, "session_id", info.ID, "error", err)
+		return
+	}
+	if !present || row.Status != pgstore.ProviderHealthStatusFailed {
+		return
+	}
+	if err := s.providerHealth.EmitForSession(ctx, provider, info.ID, owner, row); err != nil {
+		slog.Warn("providerhealth session-create backfill emit failed",
+			"provider", provider, "session_id", info.ID, "error", err)
+	}
 }
 
 func (s *appServer) persistInitialTurnUserMessage(ctx context.Context, owner, sessionID string, turn createSessionInitialTurnRequest, createdAt time.Time) (int, string) {
@@ -831,6 +873,7 @@ func (s *appServer) handleCreateSessionWithContext(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	s.backfillProviderHealthBanner(r.Context(), email, info)
 	sessionReposSelectedTotal.WithLabelValues(repoSelectionBucket(len(repos))).Inc()
 	writeJSON(w, http.StatusCreated, info)
 }

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/mcpgithub"
 	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
 	"github.com/nelsong6/tank-operator/backend-go/internal/profiles"
+	"github.com/nelsong6/tank-operator/backend-go/internal/providerhealth"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessioncontroller"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
@@ -115,6 +116,53 @@ func buildMCPGitHubClient() *mcpgithub.Client {
 		MCPGitHubURL: envDefault("MCP_GITHUB_URL", mcpgithub.DefaultMCPGitHubURL),
 		SATokenPath:  saPath,
 	})
+}
+
+// providerHealthEmitter adapts the session-events store + bus to the
+// narrow EventEmitter interface providerhealth.Manager calls when
+// fanning out session.status:failed banner events. Upsert lands the
+// durable row; Wake nudges every open SSE stream on the session.
+type providerHealthEmitter struct {
+	events store.SessionEventStore
+	bus    *sessionbus.Bus
+}
+
+func (e providerHealthEmitter) Upsert(ctx context.Context, event map[string]any) error {
+	if e.events == nil {
+		return nil
+	}
+	return e.events.Upsert(ctx, event)
+}
+
+func (e providerHealthEmitter) Wake(ctx context.Context, storageKey string) {
+	if e.bus == nil || storageKey == "" {
+		return
+	}
+	if err := e.bus.PublishSessionEventWake(ctx, storageKey); err != nil {
+		slog.Warn("providerhealth wake publish failed",
+			"storage_key", storageKey, "error", err)
+	}
+}
+
+// buildProviderHealthConfigs reads CODEX_PROXY_HEALTH_URL (and, when it
+// lands, CLAUDE_PROXY_HEALTH_URL) and returns one ProviderConfig per
+// configured provider. An empty env var disables that provider's
+// banner — useful in tests and local dev where the proxy isn't
+// running. The Action target URL is the canonical re-sign-in flow on
+// auth.romaine.life; the SPA opens it as a top-level navigation.
+func buildProviderHealthConfigs() []providerhealth.ProviderConfig {
+	var configs []providerhealth.ProviderConfig
+	if url := strings.TrimSpace(os.Getenv("CODEX_PROXY_HEALTH_URL")); url != "" {
+		configs = append(configs, providerhealth.ProviderConfig{
+			Provider: "codex",
+			Source:   providerhealth.NewHTTPSource("codex", url, nil),
+			Action: providerhealth.Action{
+				Label: "Re-sign-in to Codex",
+				Href:  envDefault("CODEX_REAUTH_URL", "https://auth.romaine.life/codex"),
+			},
+		})
+	}
+	return configs
 }
 
 func main() {
@@ -313,6 +361,36 @@ func main() {
 		}()
 	}
 
+	// Provider-credential health poller. Reads /health/<provider> on
+	// the in-cluster api-proxy services, debounces sustained failures,
+	// writes provider_credential_health rows, and fans session.status
+	// banner events into every active session whose mode requires the
+	// affected provider. The poller is the durable source of the
+	// transcript-surfaced "Codex sign-in expired" banner (the
+	// designed-and-visible failure surface replacing the deleted SPA
+	// pill). Skipped when pgPool is nil — stub mode has no place to
+	// write the Layer 1 row.
+	var providerHealthManager *providerhealth.Manager
+	if pgPool != nil && sessionEventsStore != nil {
+		providerHealthStore := pgstore.NewProviderCredentialHealthStore(pgPool)
+		providerConfigs := buildProviderHealthConfigs()
+		providerHealthManager = providerhealth.NewManager(providerhealth.ManagerConfig{
+			Store:     providerHealthStore,
+			Pool:      pgPool,
+			Emitter:   providerHealthEmitter{events: sessionEventsStore, bus: sessionBus},
+			Providers: providerConfigs,
+			Scope:     sessionScope,
+			Metrics:   promProviderHealthMetrics{},
+		})
+		if len(providerConfigs) > 0 {
+			go func() {
+				if err := providerHealthManager.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					slog.Error("providerhealth manager stopped", "error", err)
+				}
+			}()
+		}
+	}
+
 	// 12. Register all routes. Internal session handlers authenticate via
 	// the auth.romaine.life service-principal JWT path (#486 Stage 4); the
 	// pre-migration (ns, sa) allowlist env was retired with that change.
@@ -337,6 +415,7 @@ func main() {
 		spawnQuota:               NewSpawnQuotaTracker(),
 		hermesBridge:             buildHermesBridge(sessionEventsStore, sessionScope),
 		mcpGitHub:                buildMCPGitHubClient(),
+		providerHealth:           providerHealthManager,
 	}
 	srv.registerRoutes(mux)
 

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -136,6 +136,35 @@ var (
 		Help: "Durable turn.failed / turn.command_failed events persisted to session_events, partitioned by producer source and payload reason.",
 	}, []string{"source", "reason"})
 
+	// Provider-credential health: the durable Layer 1 surface for
+	// "Codex / Claude sign-in expired" banners. Replaces the SPA pill
+	// as the user-trust observability surface for sustained
+	// provider-auth failures. Steady-state expectation: poll counters
+	// climb at one tick per provider per interval; status gauge stays
+	// 1 on healthy and flips to 0 only during an actual outage;
+	// transition counter and failure-duration histogram are quiet.
+	providerHealthPollTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_provider_credential_poll_total",
+		Help: "Provider-health poll attempts, partitioned by provider and outcome.",
+	}, []string{"provider", "outcome"})
+	providerHealthStatusGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tank_provider_credential_health_status",
+		Help: "Current provider credential health (1 when status == label, else 0).",
+	}, []string{"provider", "scope", "status"})
+	providerHealthTransitionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_provider_credential_transitions_total",
+		Help: "Provider credential health transitions (healthy↔failed etc), partitioned by provider, scope, from, to, reason.",
+	}, []string{"provider", "scope", "from", "to", "reason"})
+	providerHealthFailureDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "tank_provider_credential_failure_duration_seconds",
+		Help:    "How long a provider's credential was in the failed state, observed on recovery.",
+		Buckets: []float64{30, 60, 300, 900, 3600, 14400, 86400},
+	}, []string{"provider", "scope"})
+	providerHealthFanoutSessionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_provider_credential_fanout_sessions_total",
+		Help: "Sessions that received a session.status banner event on a provider-credential transition.",
+	}, []string{"provider", "scope"})
+
 	// Wake-publish failures. The bus records here before returning the
 	// error to the caller. Per-session wakes drive the chat-window SSE;
 	// per-owner session-list events drive the sidebar SSE (replaced
@@ -846,6 +875,49 @@ func (promPersisterMetrics) RecordTransientFailure() {
 
 func (promPersisterMetrics) RecordTurnFailurePersisted(source string, reason string) {
 	transcriptTurnFailureTotal.WithLabelValues(source, reason).Inc()
+}
+
+// promProviderHealthMetrics satisfies providerhealth.Metrics so the
+// transcript-banner poller can increment counters without importing
+// prometheus directly. The gauge flips between status labels rather
+// than zero/one to match the multi-status enum (healthy/degraded/failed)
+// without making PromQL queries guess at the "off" state.
+type promProviderHealthMetrics struct{}
+
+func (promProviderHealthMetrics) RecordPoll(provider string, ok bool) {
+	outcome := "ok"
+	if !ok {
+		outcome = "error"
+	}
+	providerHealthPollTotal.WithLabelValues(provider, outcome).Inc()
+}
+
+func (promProviderHealthMetrics) RecordHealthStatus(provider, scope, status string) {
+	for _, candidate := range []string{"healthy", "degraded", "failed"} {
+		value := 0.0
+		if candidate == status {
+			value = 1.0
+		}
+		providerHealthStatusGauge.WithLabelValues(provider, scope, candidate).Set(value)
+	}
+}
+
+func (promProviderHealthMetrics) RecordTransition(provider, scope, from, to, reason string) {
+	if reason == "" {
+		reason = "unknown"
+	}
+	providerHealthTransitionsTotal.WithLabelValues(provider, scope, from, to, reason).Inc()
+}
+
+func (promProviderHealthMetrics) RecordFailureDuration(provider, scope string, seconds float64) {
+	providerHealthFailureDurationSeconds.WithLabelValues(provider, scope).Observe(seconds)
+}
+
+func (promProviderHealthMetrics) RecordFanout(provider, scope string, sessions int) {
+	if sessions <= 0 {
+		return
+	}
+	providerHealthFanoutSessionsTotal.WithLabelValues(provider, scope).Add(float64(sessions))
 }
 
 // promWakeMetrics satisfies sessionbus.WakeMetrics so the bus can increment

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -125,6 +125,17 @@ var (
 		Help: "Persister failures the persister chose to NAK for retry (infrastructure-side, retryable).",
 	})
 
+	// Durable per-turn failure surface (turn.failed / turn.command_failed).
+	// Replaces the SPA run-status pill as the "every session is failing"
+	// observability surface: with the pill removed, this counter is how
+	// Grafana / alert rules detect provider-credential storms and other
+	// session-affecting failures. Labels: source (claude/codex/tank) and
+	// reason from payload.reason (e.g. provider_failure, command_failed).
+	transcriptTurnFailureTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_transcript_turn_failure_total",
+		Help: "Durable turn.failed / turn.command_failed events persisted to session_events, partitioned by producer source and payload reason.",
+	}, []string{"source", "reason"})
+
 	// Wake-publish failures. The bus records here before returning the
 	// error to the caller. Per-session wakes drive the chat-window SSE;
 	// per-owner session-list events drive the sidebar SSE (replaced
@@ -831,6 +842,10 @@ func (promPersisterMetrics) RecordSchemaRejected() {
 
 func (promPersisterMetrics) RecordTransientFailure() {
 	recordSessionEventPersistTransientFailure()
+}
+
+func (promPersisterMetrics) RecordTurnFailurePersisted(source string, reason string) {
+	transcriptTurnFailureTotal.WithLabelValues(source, reason).Inc()
 }
 
 // promWakeMetrics satisfies sessionbus.WakeMetrics so the bus can increment

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
 	"github.com/nelsong6/tank-operator/backend-go/internal/hermes"
 	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
+	"github.com/nelsong6/tank-operator/backend-go/internal/providerhealth"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessions"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionstream"
@@ -77,6 +78,14 @@ type appServer struct {
 	// auth.romaine.life-audience projected SA token — the endpoint
 	// then 503s loudly rather than mis-routing the request.
 	mcpGitHub AppServerMCPGitHub
+
+	// providerHealth drives the transcript-surfaced "<provider>
+	// sign-in expired" banner. The poll loop owns Layer 1 and the
+	// post-transition fan-out; this handle is used by handleCreateSession
+	// to backfill a session.status:failed banner on a freshly-created
+	// session whose mode's provider is currently in a failed state.
+	// nil when pgPool is unset (stub mode).
+	providerHealth *providerhealth.Manager
 }
 
 type sessionCommandBus interface {

--- a/backend-go/internal/conversation/contract_test.go
+++ b/backend-go/internal/conversation/contract_test.go
@@ -237,6 +237,131 @@ func TestValidateEventMapAcceptsSessionStatus(t *testing.T) {
 	}
 }
 
+func TestValidateEventMapAcceptsSessionStatusFailedExtension(t *testing.T) {
+	event := map[string]any{
+		"event_id":    "session:63:provider:codex:status",
+		"order_key":   "1768179848000-00000003-session:63:provider:codex:status",
+		"session_id":  "63",
+		"timeline_id": "session:63:provider:codex:status",
+		"actor":       "system",
+		"source":      "tank",
+		"type":        "session.status",
+		"created_at":  "2026-05-24T18:48:30.000Z",
+		"visibility":  "durable",
+		"payload": map[string]any{
+			"status":           "failed",
+			"text":             "Codex sign-in expired. Re-authenticate to continue.",
+			"failure_scope":    "provider",
+			"failure_subject":  "codex",
+			"failure_reason":   "refresh_token_reused",
+			"action": map[string]any{
+				"label": "Re-sign-in to Codex",
+				"href":  "/api/auth/codex/login",
+			},
+		},
+	}
+	if err := ValidateEventMap(event); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateEventMapRejectsContentFreeSessionStatusFailed(t *testing.T) {
+	// failure_scope is set so the extension shape kicks in, but no
+	// subject is provided. A future writer could not produce a
+	// content-free banner: the contract forces (subject + (reason OR
+	// action)) once any extension field is set. This pins the
+	// "designed and visible" line from docs/quality-timeframes.md.
+	tests := []struct {
+		name  string
+		edit  func(payload map[string]any)
+		error string
+	}{
+		{
+			name: "missing failure_subject",
+			edit: func(p map[string]any) {
+				p["failure_scope"] = "provider"
+			},
+			error: "failure_subject is required",
+		},
+		{
+			name: "invalid failure_scope",
+			edit: func(p map[string]any) {
+				p["failure_scope"] = "everything"
+				p["failure_subject"] = "codex"
+				p["failure_reason"] = "broken"
+			},
+			error: "failure_scope must be provider, session, or pod",
+		},
+		{
+			name: "no reason and no action",
+			edit: func(p map[string]any) {
+				p["failure_scope"] = "provider"
+				p["failure_subject"] = "codex"
+			},
+			error: "failure_reason or payload.action is required",
+		},
+		{
+			name: "action missing href",
+			edit: func(p map[string]any) {
+				p["failure_scope"] = "provider"
+				p["failure_subject"] = "codex"
+				p["action"] = map[string]any{"label": "Re-sign-in"}
+			},
+			error: "action.label and payload.action.href are required",
+		},
+	}
+	base := map[string]any{
+		"event_id":    "session:63:provider:codex:status",
+		"order_key":   "k",
+		"session_id":  "63",
+		"timeline_id": "session:63:provider:codex:status",
+		"actor":       "system",
+		"source":      "tank",
+		"type":        "session.status",
+		"created_at":  "2026-05-24T18:48:30.000Z",
+		"visibility":  "durable",
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := map[string]any{"status": "failed", "text": "broken"}
+			tt.edit(payload)
+			event := cloneMap(base)
+			event["payload"] = payload
+			err := ValidateEventMap(event)
+			if err == nil {
+				t.Fatalf("ValidateEventMap succeeded, want error containing %q", tt.error)
+			}
+			if !strings.Contains(err.Error(), tt.error) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.error)
+			}
+		})
+	}
+}
+
+func TestValidateEventMapAcceptsBareSessionStatusFailed(t *testing.T) {
+	// Legacy bare failed (no extension fields). Pod-lifecycle writers
+	// may emit this shape; only when extension fields are present does
+	// the stricter contract kick in.
+	event := map[string]any{
+		"event_id":    "session:63:status:failed",
+		"order_key":   "k",
+		"session_id":  "63",
+		"timeline_id": "session:63:status:failed",
+		"actor":       "system",
+		"source":      "tank",
+		"type":        "session.status",
+		"created_at":  "2026-05-24T18:48:30.000Z",
+		"visibility":  "durable",
+		"payload": map[string]any{
+			"status": "failed",
+			"text":   "Session failed.",
+		},
+	}
+	if err := ValidateEventMap(event); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateEventMapRejectsUnknownSessionStatus(t *testing.T) {
 	event := map[string]any{
 		"event_id":    "session:63:status:booting",

--- a/backend-go/internal/conversation/types.go
+++ b/backend-go/internal/conversation/types.go
@@ -307,6 +307,66 @@ func validateSessionStatusPayload(event map[string]any) error {
 	if stringField(payload, "text") == "" {
 		return fmt.Errorf("payload.text is required for %s", stringField(event, "type"))
 	}
+	if status == "failed" {
+		if err := validateSessionStatusFailedExtension(event, payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateSessionStatusFailedExtension enforces the contract for the
+// extended payload that ships alongside a session.status:failed event.
+// The extension lets the SPA render an actionable banner in the
+// transcript (e.g. "Codex sign-in expired — Re-sign-in to Codex"). The
+// contract intentionally rejects content-free failed banners: every
+// failed event must name what's broken (failure_scope + failure_subject)
+// and provide either an action affordance OR a non-trivial reason — see
+// docs/quality-timeframes.md's "Failure ... states are designed and
+// visible". The extension is optional only when no extension fields are
+// set at all, which is the legacy boot-status path (pod failure surfaces
+// as a bare failed status). Once any extension field is set, the full
+// shape is required so future writers can't half-populate.
+func validateSessionStatusFailedExtension(event map[string]any, payload map[string]any) error {
+	scope := stringField(payload, "failure_scope")
+	subject := stringField(payload, "failure_subject")
+	reason := stringField(payload, "failure_reason")
+	actionRaw, hasAction := payload["action"]
+	hasExtension := scope != "" || subject != "" || reason != "" || hasAction
+
+	if !hasExtension {
+		// Legacy bare failed status (pod lifecycle) — no extension required.
+		return nil
+	}
+
+	switch scope {
+	case "provider", "session", "pod":
+	default:
+		return fmt.Errorf("payload.failure_scope must be provider, session, or pod for %s when extension fields are present", stringField(event, "type"))
+	}
+	if subject == "" {
+		return fmt.Errorf("payload.failure_subject is required for %s when failure_scope is set", stringField(event, "type"))
+	}
+
+	if hasAction {
+		action, ok := actionRaw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("payload.action must be an object for %s", stringField(event, "type"))
+		}
+		label := stringField(action, "label")
+		href := stringField(action, "href")
+		if label == "" || href == "" {
+			return fmt.Errorf("payload.action.label and payload.action.href are required for %s", stringField(event, "type"))
+		}
+	}
+
+	// Reject content-free banners: the user-facing line must explain
+	// either WHY (reason) or WHAT TO DO (action). Both is fine; neither
+	// is not — that would be a regression to the "Error" pill we just
+	// retired.
+	if reason == "" && !hasAction {
+		return fmt.Errorf("payload.failure_reason or payload.action is required for %s when failure_scope is set", stringField(event, "type"))
+	}
 	return nil
 }
 

--- a/backend-go/internal/pgstore/migrations.go
+++ b/backend-go/internal/pgstore/migrations.go
@@ -554,6 +554,45 @@ var schemaMigrations = []string{
 	// fresh database has nothing to drop; an upgraded database loses
 	// the table on the first migrations pass after this PR rolls.
 	`DROP TABLE IF EXISTS session_lifecycle_events`,
+
+	// provider_credential_health — Layer 1 durable model for the
+	// transcript-surfaced "Codex / Claude sign-in expired" banner.
+	// Source of truth for whether a provider's host-wide OAuth blob
+	// (or, when per-user OAuth lands, a per-user blob) is currently
+	// usable. Multi-provider and multi-scope from day one so the
+	// claude/codex follow-up and the per-user OAuth follow-up don't
+	// need schema migrations.
+	//
+	// status enum: "healthy" | "degraded" | "failed". "degraded" is a
+	// reserved seat for a future "transient retries succeeding but
+	// concerning" intermediate state — today the orchestrator's
+	// debouncer flips healthy↔failed directly.
+	//
+	// action_label / action_href carry the user-facing affordance
+	// (e.g. "Re-sign-in to Codex" → "/api/auth/codex/login"). Either
+	// both are populated or both are NULL; a contract test on the
+	// session.status emitter rejects content-free "failed" banners.
+	//
+	// row_version is the optimistic-concurrency counter the
+	// orchestrator subscriber UPSERTs against so two replicas racing
+	// on the same transition don't double-fan-out: only the writer
+	// that wins the version bump publishes the session.status events.
+	`CREATE TABLE IF NOT EXISTS provider_credential_health (
+		provider          text NOT NULL,
+		owner_scope       text NOT NULL,
+		status            text NOT NULL,
+		reason            text NOT NULL DEFAULT '',
+		text              text NOT NULL DEFAULT '',
+		action_label      text NOT NULL DEFAULT '',
+		action_href       text NOT NULL DEFAULT '',
+		detected_at       timestamptz NOT NULL,
+		last_attempted_at timestamptz NOT NULL,
+		last_succeeded_at timestamptz,
+		row_version       bigint NOT NULL DEFAULT 0,
+		PRIMARY KEY (provider, owner_scope)
+	)`,
+	`CREATE INDEX IF NOT EXISTS provider_credential_health_status
+		ON provider_credential_health (status, provider)`,
 }
 
 // migrationsAdvisoryLockKey is an arbitrary stable 64-bit value used to

--- a/backend-go/internal/pgstore/provider_credential_health.go
+++ b/backend-go/internal/pgstore/provider_credential_health.go
@@ -1,0 +1,191 @@
+package pgstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ProviderCredentialHealth is the durable Layer 1 model for whether a
+// provider's OAuth blob (host-wide today, per-user when that lands) is
+// currently usable. It's the source of truth the orchestrator reads
+// when deciding whether to emit a session.status:failed banner into a
+// session's durable transcript ledger; the SPA renders that banner
+// through the existing session.status rendering path. See
+// docs/features/transcript/contract.md ("session.status events own
+// startup notices") for the surface and docs/quality-timeframes.md
+// ("durable state over process memory") for why the row drives both
+// detection and rendering rather than an in-process flag.
+type ProviderCredentialHealth struct {
+	Provider        string
+	OwnerScope      string
+	Status          string
+	Reason          string
+	Text            string
+	ActionLabel     string
+	ActionHref      string
+	DetectedAt      time.Time
+	LastAttemptedAt time.Time
+	LastSucceededAt *time.Time
+	RowVersion      int64
+}
+
+const (
+	ProviderHealthStatusHealthy  = "healthy"
+	ProviderHealthStatusDegraded = "degraded"
+	ProviderHealthStatusFailed   = "failed"
+
+	// OwnerScopeHost is the per-deployment OAuth blob scope. The
+	// schema is multi-scope so a future per-user OAuth path can use
+	// "user:<email>" without a migration; today every row is "host".
+	OwnerScopeHost = "host"
+)
+
+var (
+	ErrProviderCredentialHealthNotFound = errors.New("provider credential health row not found")
+	ErrProviderCredentialHealthStale    = errors.New("provider credential health row_version stale")
+)
+
+type ProviderCredentialHealthStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewProviderCredentialHealthStore(pool *pgxpool.Pool) *ProviderCredentialHealthStore {
+	return &ProviderCredentialHealthStore{pool: pool}
+}
+
+// Get returns the row for (provider, scope) or ErrProviderCredentialHealthNotFound
+// when nothing has been written yet. A missing row is treated by callers
+// as "healthy unknown" — the orchestrator does not fan out a banner
+// from absence; only an explicit "failed" row triggers events.
+func (s *ProviderCredentialHealthStore) Get(ctx context.Context, provider, scope string) (ProviderCredentialHealth, error) {
+	if s == nil || s.pool == nil {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health store not configured")
+	}
+	provider = normalizeProviderHealthKey(provider)
+	scope = normalizeProviderHealthKey(scope)
+	if provider == "" || scope == "" {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: provider and scope are required")
+	}
+	row := ProviderCredentialHealth{Provider: provider, OwnerScope: scope}
+	err := s.pool.QueryRow(ctx, `
+		SELECT status, reason, text, action_label, action_href,
+		       detected_at, last_attempted_at, last_succeeded_at, row_version
+		FROM provider_credential_health
+		WHERE provider = $1 AND owner_scope = $2
+	`, provider, scope).Scan(
+		&row.Status, &row.Reason, &row.Text, &row.ActionLabel, &row.ActionHref,
+		&row.DetectedAt, &row.LastAttemptedAt, &row.LastSucceededAt, &row.RowVersion,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ProviderCredentialHealth{}, ErrProviderCredentialHealthNotFound
+		}
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: get: %w", err)
+	}
+	return row, nil
+}
+
+// UpsertTransition writes the row for (provider, scope) and returns the
+// post-write row (with row_version incremented when the persisted row
+// changed). The expectedVersion parameter is the row_version the caller
+// believed it was overwriting; pass -1 to skip the optimistic-concurrency
+// check (first-write path). When expectedVersion >= 0 and disagrees with
+// the persisted row, returns ErrProviderCredentialHealthStale — the
+// caller should re-read and decide whether to retry.
+//
+// The orchestrator's debouncer uses the optimistic check so two replicas
+// observing the same proxy transition only fan out session.status events
+// once: whichever wins the version bump publishes, the loser sees Stale
+// and drops the fan-out.
+func (s *ProviderCredentialHealthStore) UpsertTransition(ctx context.Context, row ProviderCredentialHealth, expectedVersion int64) (ProviderCredentialHealth, error) {
+	if s == nil || s.pool == nil {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health store not configured")
+	}
+	row.Provider = normalizeProviderHealthKey(row.Provider)
+	row.OwnerScope = normalizeProviderHealthKey(row.OwnerScope)
+	if row.Provider == "" || row.OwnerScope == "" {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: provider and scope are required")
+	}
+	if !isProviderHealthStatus(row.Status) {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: status %q must be one of healthy/degraded/failed", row.Status)
+	}
+	if row.DetectedAt.IsZero() {
+		row.DetectedAt = time.Now().UTC()
+	}
+	if row.LastAttemptedAt.IsZero() {
+		row.LastAttemptedAt = row.DetectedAt
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: begin upsert: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var currentVersion int64 = -1
+	err = tx.QueryRow(ctx, `
+		SELECT row_version FROM provider_credential_health
+		WHERE provider = $1 AND owner_scope = $2
+		FOR UPDATE
+	`, row.Provider, row.OwnerScope).Scan(&currentVersion)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: select for update: %w", err)
+	}
+	if expectedVersion >= 0 && currentVersion >= 0 && currentVersion != expectedVersion {
+		return ProviderCredentialHealth{}, ErrProviderCredentialHealthStale
+	}
+	nextVersion := currentVersion + 1
+	if currentVersion < 0 {
+		nextVersion = 1
+	}
+	row.RowVersion = nextVersion
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO provider_credential_health (
+			provider, owner_scope, status, reason, text,
+			action_label, action_href,
+			detected_at, last_attempted_at, last_succeeded_at, row_version
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+		ON CONFLICT (provider, owner_scope) DO UPDATE SET
+			status            = EXCLUDED.status,
+			reason            = EXCLUDED.reason,
+			text              = EXCLUDED.text,
+			action_label      = EXCLUDED.action_label,
+			action_href       = EXCLUDED.action_href,
+			detected_at       = EXCLUDED.detected_at,
+			last_attempted_at = EXCLUDED.last_attempted_at,
+			last_succeeded_at = EXCLUDED.last_succeeded_at,
+			row_version       = EXCLUDED.row_version
+	`,
+		row.Provider, row.OwnerScope, row.Status, row.Reason, row.Text,
+		row.ActionLabel, row.ActionHref,
+		row.DetectedAt, row.LastAttemptedAt, row.LastSucceededAt, row.RowVersion,
+	); err != nil {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: upsert: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return ProviderCredentialHealth{}, fmt.Errorf("provider credential health: commit: %w", err)
+	}
+	return row, nil
+}
+
+func normalizeProviderHealthKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func isProviderHealthStatus(value string) bool {
+	switch value {
+	case ProviderHealthStatusHealthy,
+		ProviderHealthStatusDegraded,
+		ProviderHealthStatusFailed:
+		return true
+	}
+	return false
+}

--- a/backend-go/internal/providerhealth/providerhealth.go
+++ b/backend-go/internal/providerhealth/providerhealth.go
@@ -1,0 +1,581 @@
+// Package providerhealth drives the transcript-surfaced
+// "<provider> sign-in expired" banner.
+//
+// The pipeline is two layers per the design at docs/features/transcript/contract.md:
+//
+//  1. A durable Postgres row in `provider_credential_health` (one per
+//     provider, owner_scope) is the source of truth for whether a
+//     provider's OAuth blob is currently usable. The orchestrator's
+//     poller writes this row when the api-proxy reports a sustained
+//     refresh failure (debounced over 30s so a single transient failure
+//     does not flap the banner).
+//
+//  2. On every transition (healthy→failed, failed→healthy), the poller
+//     fans out a session.status event into every active session whose
+//     mode requires the affected provider. The events use the extended
+//     session.status payload (failure_scope, failure_subject, action)
+//     that the SPA's existing session.status renderer surfaces in the
+//     transcript. See backend-go/internal/conversation/types.go for
+//     the contract.
+//
+// What this package replaces: the previous SPA-side "Error" pill that
+// hid the upstream cause (a String() coercion at the runner produced
+// "[object Object]" in the durable payload). The pill was retired in
+// PR #638; this package is the heavy version of "make sustained
+// provider failures legible in the transcript" — the surface where the
+// existing session.status events already render.
+package providerhealth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/conversation"
+	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
+)
+
+// Snapshot is the wire shape the proxy's /health/<provider> endpoint
+// returns. Mirror of tank_api_proxy.server.AuthInjector.health_snapshot()
+// in Python — keep field tags aligned with that endpoint's JSON output.
+type Snapshot struct {
+	Provider        string   `json:"provider"`
+	Result          string   `json:"result"`
+	Reason          string   `json:"reason"`
+	Text            string   `json:"text"`
+	LastAttemptedAt *float64 `json:"last_attempted_at"`
+	LastSucceededAt *float64 `json:"last_succeeded_at"`
+	AttemptID       int64    `json:"attempt_id"`
+}
+
+// Source is the per-provider health probe. The HTTP implementation
+// targets the proxy's /health endpoint; tests use a stub.
+type Source interface {
+	Provider() string
+	Fetch(ctx context.Context) (Snapshot, error)
+}
+
+// EventEmitter is the narrow interface the poller uses to write the
+// per-session session.status:failed (or matching ready) banner events
+// into the durable transcript ledger and wake any open SSE streams.
+type EventEmitter interface {
+	Upsert(ctx context.Context, event map[string]any) error
+	Wake(ctx context.Context, storageKey string)
+}
+
+// ProviderModes maps provider names to the session modes that require
+// the provider's auth blob. Updating this map is how a new provider's
+// banner becomes session-scoped (claude → claude_gui / claude_cli;
+// codex → codex_gui / codex_app_server). Today only codex is wired.
+var ProviderModes = map[string][]string{
+	"codex":  {"codex_gui", "codex_app_server"},
+	"claude": {"claude_gui", "claude_cli"},
+}
+
+// Action carries the optional user-facing affordance copied into a
+// session.status:failed event's payload.action. The SPA renders this
+// as a button next to the system-role banner text. Empty Label/Href
+// means "no action available" — the contract test rejects content-free
+// banners (reason must be non-empty when no action is given).
+type Action struct {
+	Label string
+	Href  string
+}
+
+// ProviderConfig binds a provider name to its detection source and the
+// optional re-sign-in affordance. The poller iterates configs at
+// startup so adding claude is mechanical (one config struct, no
+// architecture change).
+type ProviderConfig struct {
+	Provider string
+	Source   Source
+	Action   Action // optional; empty Label disables the SPA button
+}
+
+// ManagerConfig wires the package's runtime dependencies. Owned by
+// cmd/tank-operator/main.go.
+type ManagerConfig struct {
+	Store     *pgstore.ProviderCredentialHealthStore
+	Pool      *pgxpool.Pool
+	Emitter   EventEmitter
+	Providers []ProviderConfig
+	Scope     string
+	// PollInterval defaults to 30s. Smaller values cost more proxy
+	// requests; larger values delay the transcript banner appearing
+	// after a refresh storm starts. Per the cost story documented in
+	// docs/quality-timeframes.md, 30s is the negotiated minimum.
+	PollInterval time.Duration
+	// DebounceCycles is how many consecutive failed polls must occur
+	// before the manager transitions Layer 1 to "failed". Default 1
+	// (single-cycle): a single failed poll, given the 30s interval,
+	// already represents 30s of sustained failure. Tests override
+	// this to 0 to make transitions immediate.
+	DebounceCycles int
+	// Metrics is optional; nil uses a no-op recorder.
+	Metrics Metrics
+}
+
+// Metrics is the prometheus-shaped sink the manager calls on every
+// poll + transition. See cmd/tank-operator/observability.go for the
+// promauto-backed implementation.
+type Metrics interface {
+	RecordPoll(provider string, ok bool)
+	RecordHealthStatus(provider, scope, status string)
+	RecordTransition(provider, scope, from, to, reason string)
+	RecordFailureDuration(provider, scope string, seconds float64)
+	RecordFanout(provider, scope string, sessions int)
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) RecordPoll(string, bool)                  {}
+func (noopMetrics) RecordHealthStatus(string, string, string) {}
+func (noopMetrics) RecordTransition(string, string, string, string, string) {}
+func (noopMetrics) RecordFailureDuration(string, string, float64) {}
+func (noopMetrics) RecordFanout(string, string, int)          {}
+
+// Manager runs the per-provider polling loop and writes Layer 1 + the
+// per-session fan-out. Use NewManager to construct one.
+type Manager struct {
+	cfg              ManagerConfig
+	failedCycles     map[string]int
+	failureStartedAt map[string]time.Time
+}
+
+func NewManager(cfg ManagerConfig) *Manager {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 30 * time.Second
+	}
+	if cfg.DebounceCycles < 0 {
+		cfg.DebounceCycles = 0
+	}
+	if cfg.Metrics == nil {
+		cfg.Metrics = noopMetrics{}
+	}
+	return &Manager{
+		cfg:              cfg,
+		failedCycles:     map[string]int{},
+		failureStartedAt: map[string]time.Time{},
+	}
+}
+
+// Run starts the polling loop. Returns when ctx is cancelled. The
+// manager is configured for multiple providers; today only "codex" is
+// wired, but the loop handles any number.
+func (m *Manager) Run(ctx context.Context) error {
+	if m == nil || m.cfg.Store == nil {
+		return errors.New("providerhealth: store is required")
+	}
+	if len(m.cfg.Providers) == 0 {
+		slog.Info("providerhealth manager started with no providers configured; idle")
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	ticker := time.NewTicker(m.cfg.PollInterval)
+	defer ticker.Stop()
+	// Run an initial poll immediately so a freshly-booted orchestrator
+	// reflects the proxy's current state without waiting for the first
+	// tick. The 30s interval is for sustained observation, not first
+	// detection.
+	for _, p := range m.cfg.Providers {
+		m.pollOnce(ctx, p)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			for _, p := range m.cfg.Providers {
+				m.pollOnce(ctx, p)
+			}
+		}
+	}
+}
+
+// pollOnce runs one poll cycle for one provider. Public for tests.
+func (m *Manager) PollOnce(ctx context.Context, provider ProviderConfig) {
+	m.pollOnce(ctx, provider)
+}
+
+func (m *Manager) pollOnce(ctx context.Context, p ProviderConfig) {
+	snapshot, err := p.Source.Fetch(ctx)
+	if err != nil {
+		// A transient proxy fetch failure (e.g. proxy pod restarting)
+		// must not flip the banner. Skip this cycle.
+		m.cfg.Metrics.RecordPoll(p.Provider, false)
+		slog.Warn("providerhealth poll failed; skipping cycle",
+			"provider", p.Provider, "error", err)
+		return
+	}
+	m.cfg.Metrics.RecordPoll(p.Provider, true)
+	desired := classifySnapshot(snapshot)
+	current, err := m.cfg.Store.Get(ctx, p.Provider, pgstore.OwnerScopeHost)
+	if err != nil && !errors.Is(err, pgstore.ErrProviderCredentialHealthNotFound) {
+		slog.Warn("providerhealth layer-1 read failed",
+			"provider", p.Provider, "error", err)
+		return
+	}
+	previousStatus := current.Status
+	if previousStatus == "" {
+		previousStatus = pgstore.ProviderHealthStatusHealthy
+	}
+	if desired == pgstore.ProviderHealthStatusFailed {
+		m.failedCycles[p.Provider]++
+		if _, ok := m.failureStartedAt[p.Provider]; !ok {
+			m.failureStartedAt[p.Provider] = time.Now().UTC()
+		}
+		if m.failedCycles[p.Provider] <= m.cfg.DebounceCycles {
+			// Still inside the debounce window; do not transition yet.
+			return
+		}
+	} else {
+		m.failedCycles[p.Provider] = 0
+	}
+	if previousStatus == desired {
+		// No transition; just refresh the gauge.
+		m.cfg.Metrics.RecordHealthStatus(p.Provider, pgstore.OwnerScopeHost, desired)
+		return
+	}
+	now := time.Now().UTC()
+	row := pgstore.ProviderCredentialHealth{
+		Provider:        p.Provider,
+		OwnerScope:      pgstore.OwnerScopeHost,
+		Status:          desired,
+		Reason:          snapshot.Reason,
+		Text:            bannerText(p, desired, snapshot),
+		ActionLabel:     "",
+		ActionHref:      "",
+		DetectedAt:      now,
+		LastAttemptedAt: unixToTime(snapshot.LastAttemptedAt, now),
+		LastSucceededAt: unixToTimePtr(snapshot.LastSucceededAt),
+	}
+	if desired == pgstore.ProviderHealthStatusFailed {
+		row.ActionLabel = p.Action.Label
+		row.ActionHref = p.Action.Href
+	}
+	expectedVersion := current.RowVersion
+	if errors.Is(err, pgstore.ErrProviderCredentialHealthNotFound) {
+		expectedVersion = -1
+	}
+	persisted, err := m.cfg.Store.UpsertTransition(ctx, row, expectedVersion)
+	if err != nil {
+		if errors.Is(err, pgstore.ErrProviderCredentialHealthStale) {
+			// Another replica raced us; back off and try next cycle.
+			slog.Info("providerhealth transition lost race; another replica wrote first",
+				"provider", p.Provider)
+			return
+		}
+		slog.Error("providerhealth layer-1 upsert failed",
+			"provider", p.Provider, "error", err)
+		return
+	}
+	m.cfg.Metrics.RecordHealthStatus(p.Provider, pgstore.OwnerScopeHost, persisted.Status)
+	m.cfg.Metrics.RecordTransition(p.Provider, pgstore.OwnerScopeHost, previousStatus, persisted.Status, persisted.Reason)
+	if previousStatus == pgstore.ProviderHealthStatusFailed && persisted.Status == pgstore.ProviderHealthStatusHealthy {
+		if started, ok := m.failureStartedAt[p.Provider]; ok {
+			m.cfg.Metrics.RecordFailureDuration(p.Provider, pgstore.OwnerScopeHost, time.Since(started).Seconds())
+			delete(m.failureStartedAt, p.Provider)
+		}
+	}
+	if err := m.FanOut(ctx, p.Provider, persisted); err != nil {
+		slog.Error("providerhealth fan-out failed",
+			"provider", p.Provider, "error", err)
+	}
+}
+
+// FanOut emits a session.status event for every active session whose
+// mode requires the provider. Public for the session-create backfill
+// path: when a session is created while Layer 1 is in a failed state,
+// the create handler reads the row and calls FanOut for the single
+// new session id.
+//
+// The transcript contract demands ordering: the failed banner must NOT
+// pre-empt the user's first message; this function only emits to
+// sessions whose user_message + boot events already exist. The poll
+// path satisfies this implicitly (the sessions are already alive); the
+// create-backfill path is responsible for sequencing the call AFTER
+// the boot events land.
+func (m *Manager) FanOut(ctx context.Context, provider string, row pgstore.ProviderCredentialHealth) error {
+	if m == nil || m.cfg.Emitter == nil || m.cfg.Pool == nil {
+		return nil
+	}
+	modes := ProviderModes[provider]
+	if len(modes) == 0 {
+		return nil
+	}
+	sessions, err := m.listActiveSessions(ctx, modes)
+	if err != nil {
+		return fmt.Errorf("list sessions for %s fan-out: %w", provider, err)
+	}
+	count := 0
+	for _, sess := range sessions {
+		if err := m.emitForSession(ctx, provider, sess, row); err != nil {
+			slog.Warn("providerhealth fan-out emit failed",
+				"provider", provider,
+				"session_id", sess.SessionID,
+				"email", sess.Email,
+				"error", err)
+			continue
+		}
+		count++
+	}
+	m.cfg.Metrics.RecordFanout(provider, pgstore.OwnerScopeHost, count)
+	return nil
+}
+
+// EmitForSession emits a single session.status event for one session
+// based on the current Layer 1 row. Used by the session-create backfill
+// path. The event respects the transcript contract — caller is
+// responsible for ordering it after the session's boot events.
+func (m *Manager) EmitForSession(ctx context.Context, provider, sessionID, email string, row pgstore.ProviderCredentialHealth) error {
+	if m == nil || m.cfg.Emitter == nil {
+		return nil
+	}
+	return m.emitForSession(ctx, provider, activeSession{SessionID: sessionID, Email: email, Scope: m.cfg.Scope}, row)
+}
+
+type activeSession struct {
+	SessionID string
+	Email     string
+	Scope     string
+}
+
+func (m *Manager) listActiveSessions(ctx context.Context, modes []string) ([]activeSession, error) {
+	// Active for provider-banner fan-out = (Pending|Active) AND mode
+	// requires this provider. Scope is bound to the orchestrator's
+	// scope so test slots don't fan out into prod. Visibility is
+	// filtered Go-side per docs/session-list-redesign.md Phase 2 (the
+	// SQL returns every matching row; the Visible column is read into
+	// the struct and consulted by the caller). Soft-deleted sessions
+	// (visible=false) are skipped — a banner emitted into a
+	// just-deleted session would be cosmetic noise.
+	rows, err := m.cfg.Pool.Query(ctx, `
+		SELECT email, session_id, visible
+		FROM sessions
+		WHERE session_scope = $1
+		  AND status IN ('Pending', 'Active')
+		  AND mode = ANY($2::text[])
+	`, m.cfg.Scope, modes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []activeSession
+	for rows.Next() {
+		var email, sessionID string
+		var visible bool
+		if err := rows.Scan(&email, &sessionID, &visible); err != nil {
+			return nil, err
+		}
+		if !visible {
+			continue
+		}
+		out = append(out, activeSession{
+			SessionID: sessionID,
+			Email:     email,
+			Scope:     m.cfg.Scope,
+		})
+	}
+	return out, rows.Err()
+}
+
+func (m *Manager) emitForSession(ctx context.Context, provider string, sess activeSession, row pgstore.ProviderCredentialHealth) error {
+	storageKey := sessionmodel.SessionStorageKey(sess.Scope, sess.SessionID)
+	timelineID := fmt.Sprintf("session:%s:provider:%s:status", sess.SessionID, provider)
+	statusKey := row.Status
+	// The schema only emits transcript events for the failed and ready
+	// values; degraded does not produce a banner (intermediate state).
+	if statusKey != pgstore.ProviderHealthStatusFailed && statusKey != pgstore.ProviderHealthStatusHealthy {
+		return nil
+	}
+	mappedStatus := "ready"
+	text := fmt.Sprintf("%s sign-in is back online.", capitalize(provider))
+	payload := map[string]any{
+		"status": mappedStatus,
+		"text":   text,
+	}
+	if statusKey == pgstore.ProviderHealthStatusFailed {
+		mappedStatus = "failed"
+		text = row.Text
+		if text == "" {
+			text = fmt.Sprintf("%s sign-in is unavailable. Re-authenticate to restore service.", capitalize(provider))
+		}
+		payload = map[string]any{
+			"status":           mappedStatus,
+			"text":             text,
+			"failure_scope":    "provider",
+			"failure_subject":  provider,
+			"failure_reason":   firstNonEmpty(row.Reason, "unknown"),
+		}
+		if row.ActionLabel != "" && row.ActionHref != "" {
+			payload["action"] = map[string]any{
+				"label": row.ActionLabel,
+				"href":  row.ActionHref,
+			}
+		}
+	}
+	// order_key matches the session.status convention used by the
+	// existing pgstore migration trigger so a fresh banner inserted
+	// alongside boot events sorts deterministically. status_sequence
+	// 00000003 keeps provider-status events after loading (0) and
+	// ready (1) boot events.
+	now := time.Now().UTC()
+	orderKey := fmt.Sprintf("%013d-00000003-%s",
+		now.UnixMilli(),
+		timelineID,
+	)
+	event := map[string]any{
+		"event_id":        timelineID,
+		"uuid":            timelineID,
+		"id":              timelineID,
+		"order_key":       orderKey,
+		"conversation_id": sess.SessionID,
+		"session_id":      sess.SessionID,
+		"tank_session_id": storageKey,
+		"timeline_id":     timelineID,
+		"actor":           string(conversation.ActorSystem),
+		"source":          string(conversation.SourceTank),
+		"type":            string(conversation.EventSessionStatus),
+		"created_at":      now.Format("2006-01-02T15:04:05.000Z"),
+		"written_at":      now.Format("2006-01-02T15:04:05.000Z"),
+		"visibility":      "durable",
+		"producer": map[string]any{
+			"name": "tank-operator",
+		},
+		"payload": payload,
+	}
+	if sess.Email != "" {
+		event["email"] = sess.Email
+	}
+	if err := m.cfg.Emitter.Upsert(ctx, event); err != nil {
+		return fmt.Errorf("upsert session.status event: %w", err)
+	}
+	m.cfg.Emitter.Wake(ctx, storageKey)
+	return nil
+}
+
+// CurrentHealth returns the Layer 1 row for the given provider, or a
+// healthy zero-value row when no entry exists yet. Used by the
+// session-create backfill path: a brand-new codex_gui session reads
+// this and emits a session.status:failed when needed.
+func (m *Manager) CurrentHealth(ctx context.Context, provider string) (pgstore.ProviderCredentialHealth, bool, error) {
+	if m == nil || m.cfg.Store == nil {
+		return pgstore.ProviderCredentialHealth{}, false, nil
+	}
+	row, err := m.cfg.Store.Get(ctx, provider, pgstore.OwnerScopeHost)
+	if errors.Is(err, pgstore.ErrProviderCredentialHealthNotFound) {
+		return pgstore.ProviderCredentialHealth{
+			Provider:   provider,
+			OwnerScope: pgstore.OwnerScopeHost,
+			Status:     pgstore.ProviderHealthStatusHealthy,
+		}, false, nil
+	}
+	if err != nil {
+		return pgstore.ProviderCredentialHealth{}, false, err
+	}
+	return row, true, nil
+}
+
+// HTTPSource is the real Source: GETs /health/<provider> on the proxy.
+type HTTPSource struct {
+	provider string
+	url      string
+	client   *http.Client
+}
+
+func NewHTTPSource(provider, url string, client *http.Client) *HTTPSource {
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &HTTPSource{provider: provider, url: url, client: client}
+}
+
+func (h *HTTPSource) Provider() string { return h.provider }
+
+func (h *HTTPSource) Fetch(ctx context.Context) (Snapshot, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.url, nil)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return Snapshot{}, fmt.Errorf("provider health %s: status %d", h.url, resp.StatusCode)
+	}
+	var snap Snapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		return Snapshot{}, fmt.Errorf("decode provider health %s: %w", h.url, err)
+	}
+	if snap.Provider == "" {
+		snap.Provider = h.provider
+	}
+	return snap, nil
+}
+
+// classifySnapshot maps a proxy snapshot to a Layer 1 status.
+// - success → healthy
+// - http_error / request_failed / no_refresh_token → failed
+// - unknown (no refresh attempted yet) → healthy (cached blob still serving)
+func classifySnapshot(s Snapshot) string {
+	switch s.Result {
+	case "success", "unknown":
+		return pgstore.ProviderHealthStatusHealthy
+	case "http_error", "request_failed", "no_refresh_token":
+		return pgstore.ProviderHealthStatusFailed
+	}
+	return pgstore.ProviderHealthStatusHealthy
+}
+
+func bannerText(p ProviderConfig, status string, snap Snapshot) string {
+	if status != pgstore.ProviderHealthStatusFailed {
+		return ""
+	}
+	if snap.Text != "" {
+		return snap.Text
+	}
+	return fmt.Sprintf("%s sign-in is unavailable. Re-authenticate to restore service.", capitalize(p.Provider))
+}
+
+func unixToTime(value *float64, fallback time.Time) time.Time {
+	if value == nil {
+		return fallback
+	}
+	sec := int64(*value)
+	nsec := int64((*value - float64(sec)) * 1e9)
+	return time.Unix(sec, nsec).UTC()
+}
+
+func unixToTimePtr(value *float64) *time.Time {
+	if value == nil {
+		return nil
+	}
+	t := unixToTime(value, time.Time{})
+	return &t
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/backend-go/internal/providerhealth/providerhealth_test.go
+++ b/backend-go/internal/providerhealth/providerhealth_test.go
@@ -1,0 +1,123 @@
+package providerhealth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClassifySnapshotMapsResultToLayer1Status(t *testing.T) {
+	cases := []struct {
+		name   string
+		result string
+		want   string
+	}{
+		{"success → healthy", "success", "healthy"},
+		// "unknown" is the pre-first-refresh state — the cached blob
+		// may still be serving a long-lived token. Do not flip to
+		// failed on absence of data.
+		{"unknown → healthy", "unknown", "healthy"},
+		{"http_error → failed", "http_error", "failed"},
+		{"request_failed → failed", "request_failed", "failed"},
+		{"no_refresh_token → failed", "no_refresh_token", "failed"},
+		{"unrecognized → healthy (defensive default)", "weird", "healthy"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifySnapshot(Snapshot{Result: tt.result})
+			if got != tt.want {
+				t.Fatalf("classifySnapshot(%q) = %q, want %q", tt.result, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPSourceParsesProxySnapshotShape(t *testing.T) {
+	// Pins the wire contract between the api-proxy's /health/<provider>
+	// endpoint and this poller. A drift here would silently break the
+	// transcript banner — the poller is the only consumer.
+	body := map[string]any{
+		"provider":          "codex",
+		"result":            "http_error",
+		"reason":            "refresh_token_reused",
+		"text":              "Codex sign-in expired. Re-authenticate to restore service.",
+		"last_attempted_at": 1700000100.0,
+		"last_succeeded_at": nil,
+		"attempt_id":        7,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	src := NewHTTPSource("codex", srv.URL, srv.Client())
+	got, err := src.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got.Provider != "codex" || got.Result != "http_error" {
+		t.Fatalf("snapshot = %#v", got)
+	}
+	if got.Reason != "refresh_token_reused" {
+		t.Fatalf("reason = %q, want refresh_token_reused", got.Reason)
+	}
+	if got.LastAttemptedAt == nil || *got.LastAttemptedAt != 1700000100.0 {
+		t.Fatalf("last_attempted_at = %v", got.LastAttemptedAt)
+	}
+	if got.LastSucceededAt != nil {
+		t.Fatalf("last_succeeded_at should be nil; got %v", got.LastSucceededAt)
+	}
+}
+
+func TestHTTPSourceTreatsNon2xxAsError(t *testing.T) {
+	// A proxy that returns 503 (snapshot temporarily unavailable, per
+	// the metrics.py contract) must NOT flip Layer 1 — the Source
+	// errors out, the poller's RecordPoll(false) increments, no
+	// transition is attempted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("snapshot unavailable"))
+	}))
+	defer srv.Close()
+
+	src := NewHTTPSource("codex", srv.URL, srv.Client())
+	_, err := src.Fetch(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 503; got nil")
+	}
+}
+
+func TestBannerTextPrefersProxyText(t *testing.T) {
+	cfg := ProviderConfig{Provider: "codex"}
+	snap := Snapshot{
+		Result: "http_error",
+		Reason: "refresh_token_reused",
+		Text:   "Sign-in expired. Re-authenticate to restore service.",
+	}
+	got := bannerText(cfg, "failed", snap)
+	if got != snap.Text {
+		t.Fatalf("bannerText = %q, want proxy text", got)
+	}
+}
+
+func TestBannerTextFallsBackWhenProxyTextIsEmpty(t *testing.T) {
+	cfg := ProviderConfig{Provider: "codex"}
+	got := bannerText(cfg, "failed", Snapshot{Result: "http_error"})
+	if got == "" {
+		t.Fatal("bannerText must not be empty on failed status — would emit a content-free banner")
+	}
+}
+
+func TestBannerTextIsEmptyForHealthy(t *testing.T) {
+	// Recovery emits a session.status:ready event (status="ready" on
+	// the same timeline_id). That event carries its own canonical text
+	// from emitForSession; bannerText is only used to populate Layer 1
+	// for failed transitions.
+	got := bannerText(ProviderConfig{Provider: "codex"}, "healthy", Snapshot{})
+	if got != "" {
+		t.Fatalf("bannerText(healthy) = %q, want empty", got)
+	}
+}

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -83,12 +83,22 @@ func (noopLifecycleEmitter) EmitChatActivityDelta(_ context.Context, _ map[strin
 type PersisterMetrics interface {
 	RecordSchemaRejected()
 	RecordTransientFailure()
+	// RecordTurnFailurePersisted increments when a durable turn-terminal
+	// failure event (turn.failed / turn.command_failed) lands in the
+	// session_events ledger. Labels carry the producer source ("claude",
+	// "codex", "tank") and the failure reason from payload.reason (e.g.
+	// "provider_failure", "command_failed"). Replaces the SPA pill as the
+	// user-trust-failure observability surface: with the pill gone, this
+	// counter is how we notice "every session is failing" without browser
+	// devtools. Steady-state expectation: low and bursty.
+	RecordTurnFailurePersisted(source string, reason string)
 }
 
 type noopPersisterMetrics struct{}
 
-func (noopPersisterMetrics) RecordSchemaRejected()   {}
-func (noopPersisterMetrics) RecordTransientFailure() {}
+func (noopPersisterMetrics) RecordSchemaRejected()                      {}
+func (noopPersisterMetrics) RecordTransientFailure()                    {}
+func (noopPersisterMetrics) RecordTurnFailurePersisted(string, string)  {}
 
 // WakeMetrics receives counters for wake/event publish failures, the
 // success path, and the end-to-end persist→wake latency. The bus
@@ -465,7 +475,7 @@ type persistableMessage interface {
 // handlePersistMessage routes one bus message through the store and acks /
 // NAKs / terminates based on the outcome.
 func (b *Bus) handlePersistMessage(ctx context.Context, store EventStore, metrics PersisterMetrics, msg persistableMessage) {
-	err := b.persistOneEvent(ctx, store, msg)
+	err := b.persistOneEvent(ctx, store, metrics, msg)
 	if err == nil {
 		if ackErr := msg.Ack(); ackErr != nil {
 			slog.Warn("session bus event ack failed", "subject", msg.Subject(), "error", ackErr)
@@ -505,7 +515,7 @@ func (b *Bus) handlePersistMessage(ctx context.Context, store EventStore, metric
 // does not cause the persister to NAK — the chat event is already
 // durable, and the sidebar will catch up via cursor-resume on the next
 // SSE reconnect.
-func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, msg persistableMessage) error {
+func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, metrics PersisterMetrics, msg persistableMessage) error {
 	var event map[string]any
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
 		// Invalid JSON is a producer-side bug that can never succeed on
@@ -520,6 +530,28 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, msg persist
 	}
 	if err := store.Upsert(ctx, event); err != nil {
 		return err
+	}
+	// Record turn-failure persistence right after the durable write
+	// commits. This is the observability surface that replaced the SPA
+	// run-status pill: with the pill gone, "every codex_gui session is
+	// failing" must be visible from outside the browser (Grafana / alert
+	// rules), not by looking at the pill turn red. The reason label comes
+	// from payload.reason so a Codex auth storm vs a generic
+	// provider_failure spike are distinguishable; the source label
+	// (claude/codex/tank) lets per-provider alerts fire independently.
+	if eventType, _ := event["type"].(string); eventType == string(conversation.EventTurnFailed) || eventType == string(conversation.EventTurnCommandFailed) {
+		source, _ := event["source"].(string)
+		reason := ""
+		if payload, ok := event["payload"].(map[string]any); ok {
+			reason, _ = payload["reason"].(string)
+		}
+		if source == "" {
+			source = "unknown"
+		}
+		if reason == "" {
+			reason = "unknown"
+		}
+		metrics.RecordTurnFailurePersisted(source, reason)
 	}
 	upsertedAt := time.Now()
 	storageKey, _ := event["tank_session_id"].(string)

--- a/backend-go/internal/sessionbus/bus_test.go
+++ b/backend-go/internal/sessionbus/bus_test.go
@@ -25,12 +25,21 @@ func (r *recordingStore) Upsert(_ context.Context, event map[string]any) error {
 }
 
 type recordingMetrics struct {
-	schemaRejected   int
-	transientFailure int
+	schemaRejected      int
+	transientFailure    int
+	turnFailureRecorded []turnFailureRecord
+}
+
+type turnFailureRecord struct {
+	source string
+	reason string
 }
 
 func (m *recordingMetrics) RecordSchemaRejected()   { m.schemaRejected++ }
 func (m *recordingMetrics) RecordTransientFailure() { m.transientFailure++ }
+func (m *recordingMetrics) RecordTurnFailurePersisted(source string, reason string) {
+	m.turnFailureRecorded = append(m.turnFailureRecorded, turnFailureRecord{source: source, reason: reason})
+}
 
 type stubMsg struct {
 	subject  string
@@ -177,6 +186,106 @@ func TestPersistMessageTerminatesInvalidJSON(t *testing.T) {
 	if metrics.transientFailure != 0 {
 		t.Fatalf("transient counter = %d, want 0 — invalid JSON is permanent not transient",
 			metrics.transientFailure)
+	}
+}
+
+// TestPersistMessageRecordsTurnFailureCounter pins the user-trust observability
+// surface that replaced the SPA run-status pill. With the pill removed, the
+// tank_transcript_turn_failure_total counter is how Grafana / alert rules
+// detect "every codex_gui session is failing" (e.g. the Codex auth
+// refresh_token_reused storm that motivated the pill removal). The counter
+// must label by source (claude/codex/tank) and reason (payload.reason) so
+// per-provider alerts fire independently.
+func TestPersistMessageRecordsTurnFailureCounter(t *testing.T) {
+	bus := &Bus{scope: "default"}
+	store := &recordingStore{}
+	metrics := &recordingMetrics{}
+	raw, _ := json.Marshal(map[string]any{
+		"event_id":   "evt-fail-1",
+		"session_id": "63",
+		"actor":      "runner",
+		"source":     "codex",
+		"type":       "turn.failed",
+		"created_at": "2026-05-12T00:00:00.000Z",
+		"order_key":  "order-fail-1",
+		"visibility": "durable",
+		"turn_id":    "turn-1",
+		"payload": map[string]any{
+			"reason": "provider_failure",
+			"error":  "rate limit exceeded",
+		},
+	})
+	msg := &stubMsg{subject: "tank.session.63.events", data: raw}
+
+	bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+	if msg.acked != 1 {
+		t.Fatalf("acked = %d, want 1", msg.acked)
+	}
+	if len(metrics.turnFailureRecorded) != 1 {
+		t.Fatalf("turn-failure counter recorded %d times, want 1", len(metrics.turnFailureRecorded))
+	}
+	got := metrics.turnFailureRecorded[0]
+	if got.source != "codex" {
+		t.Fatalf("source label = %q, want %q", got.source, "codex")
+	}
+	if got.reason != "provider_failure" {
+		t.Fatalf("reason label = %q, want %q", got.reason, "provider_failure")
+	}
+}
+
+func TestPersistMessageRecordsCommandFailedCounter(t *testing.T) {
+	bus := &Bus{scope: "default"}
+	store := &recordingStore{}
+	metrics := &recordingMetrics{}
+	raw, _ := json.Marshal(map[string]any{
+		"event_id":   "evt-cmdfail-1",
+		"session_id": "63",
+		"actor":      "system",
+		"source":     "tank",
+		"type":       "turn.command_failed",
+		"created_at": "2026-05-12T00:00:00.000Z",
+		"order_key":  "order-cmdfail-1",
+		"visibility": "durable",
+		"turn_id":    "turn-1",
+		"payload": map[string]any{
+			"reason": "command_failed",
+		},
+	})
+	msg := &stubMsg{subject: "tank.session.63.events", data: raw}
+
+	bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+	if len(metrics.turnFailureRecorded) != 1 {
+		t.Fatalf("turn-failure counter recorded %d times, want 1 for turn.command_failed", len(metrics.turnFailureRecorded))
+	}
+	got := metrics.turnFailureRecorded[0]
+	if got.source != "tank" || got.reason != "command_failed" {
+		t.Fatalf("label tuple = (%q, %q), want (tank, command_failed)", got.source, got.reason)
+	}
+}
+
+func TestPersistMessageDoesNotRecordTurnFailureForSuccess(t *testing.T) {
+	bus := &Bus{scope: "default"}
+	store := &recordingStore{}
+	metrics := &recordingMetrics{}
+	raw, _ := json.Marshal(map[string]any{
+		"event_id":   "evt-ok-1",
+		"session_id": "63",
+		"actor":      "runner",
+		"source":     "codex",
+		"type":       "turn.completed",
+		"created_at": "2026-05-12T00:00:00.000Z",
+		"order_key":  "order-ok-1",
+		"visibility": "durable",
+		"turn_id":    "turn-1",
+	})
+	msg := &stubMsg{subject: "tank.session.63.events", data: raw}
+
+	bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+	if len(metrics.turnFailureRecorded) != 0 {
+		t.Fatalf("turn-failure counter fired on turn.completed (%d times); the counter is for failures only", len(metrics.turnFailureRecorded))
 	}
 }
 

--- a/codex-runner/src/appServerTransport.ts
+++ b/codex-runner/src/appServerTransport.ts
@@ -55,6 +55,25 @@ function abortError(message = "turn interrupted"): Error {
   return err;
 }
 
+// Unwrap a Codex app-server JSONRPC `error` notification's params into a
+// readable string. params?.error is often a structured `{code, type, message,
+// param}` object (e.g. token_expired); coercing it with String() yielded
+// "[object Object]" in the durable turn.failed payload, hiding the real cause.
+function codexErrorMessage(params: JsonRecord | undefined): string {
+  const candidate = params?.error ?? params?.message;
+  if (typeof candidate === "string" && candidate.length > 0) return candidate;
+  if (candidate && typeof candidate === "object") {
+    const message = (candidate as { message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+    try {
+      return JSON.stringify(candidate);
+    } catch {
+      // fall through to generic
+    }
+  }
+  return "codex app-server error";
+}
+
 class AsyncEventQueue {
   private readonly items: QueuedEvent[] = [];
   private readonly waiters: Array<(item: QueuedEvent | null) => void> = [];
@@ -400,7 +419,7 @@ export class CodexAppServerTransport {
     if (method === "error") {
       queue.push({
         kind: "event",
-        event: { type: "error", message: String(params?.message ?? params?.error ?? "codex app-server error") },
+        event: { type: "error", message: codexErrorMessage(params) },
       });
     }
   }

--- a/frontend/public/assets/avatars/ATTRIBUTION.md
+++ b/frontend/public/assets/avatars/ATTRIBUTION.md
@@ -16,11 +16,11 @@ Asset notes:
 - Subject-centred crop per `HINTS` in the normalize script — wide scene
   stills (e.g. Muldoon's "clever girl" or Nedry on the dock) get a
   positional hint so the focal point survives the square crop.
-- Rendered through `.session-avatar` / `.run-msg-ai-icon` /
-  `.run-status-avatar` (see `frontend/src/index.css`) at 22–42px,
-  `object-fit: contain`, circle-clipped, no backdrop or padding — the
-  source PNG itself is the visible shape, so subjects that don't fill
-  the square frame read as floating silhouettes at the small sizes.
+- Rendered through `.session-avatar` and `.run-msg-ai-icon` (see
+  `frontend/src/index.css`) at 42px, `object-fit: contain`, circle-clipped,
+  no backdrop or padding — the source PNG itself is the visible shape, so
+  subjects that don't fill the square frame read as floating silhouettes at
+  the small sizes.
 
 Reproducing the asset set:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3755,6 +3755,25 @@ function RunMessageBubble({
   const { user } = useContext(RunContext);
   const text = entry.text ?? "";
   const messageKind = (entry as Record<string, unknown>).messageKind;
+  // session.status:failed transcripts events carry severity="error" and
+  // an optional action (e.g. "Re-sign-in to Codex"). The renderer
+  // surfaces both: data-severity drives error-bubble styling; action
+  // becomes a button next to the text.
+  const messageSeverity =
+    typeof (entry as Record<string, unknown>).severity === "string"
+      ? ((entry as Record<string, unknown>).severity as "info" | "error")
+      : undefined;
+  const messageAction = (entry as Record<string, unknown>).action as
+    | { label?: unknown; href?: unknown }
+    | undefined;
+  const messageActionLabel =
+    messageAction && typeof messageAction.label === "string" && messageAction.label.length > 0
+      ? messageAction.label
+      : undefined;
+  const messageActionHref =
+    messageAction && typeof messageAction.href === "string" && messageAction.href.length > 0
+      ? messageAction.href
+      : undefined;
   const isSkillAction = messageKind === "skill-action";
   const skillName = (entry as Record<string, unknown>).skillName;
   const skillSupplementalText =
@@ -3779,6 +3798,7 @@ function RunMessageBubble({
       data-role={variant}
       data-kind={isSkillAction ? "skill-action" : "message"}
       data-skill={isSkillAction && typeof skillName === "string" ? skillName : undefined}
+      data-severity={variant === "system" ? messageSeverity : undefined}
       data-message-id={entry.id}
       data-highlight={highlighted ? "true" : undefined}
     >
@@ -3811,6 +3831,16 @@ function RunMessageBubble({
             </span>
           ) : (
             <RunMarkdown>{text}</RunMarkdown>
+          )}
+          {variant === "system" && messageActionLabel && messageActionHref && (
+            <a
+              className="run-msg-system-action"
+              href={messageActionHref}
+              target="_self"
+              rel="noopener"
+            >
+              {messageActionLabel}
+            </a>
           )}
         </div>
         <div

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2469,26 +2469,6 @@ function isImagePath(path: string): boolean {
 // Verbs cycled by the streaming status pill. Matches cloudcli's
 // ClaudeStatus rotation so the user sees motion even when the model
 // hasn't sent any text deltas yet.
-const STREAM_VERBS = [
-  "Thinking",
-  "Processing",
-  "Analyzing",
-  "Working",
-  "Computing",
-  "Reasoning",
-] as const;
-
-// Format a Claude tool name for display in the status pill.
-// "Bash" → "Bash"
-// "mcp__github__create_pull_request" → "github · create pull request"
-function formatToolLabel(toolName: string): string {
-  const stripped = toolName.replace(/^mcp__/, "");
-  const [server, ...rest] = stripped.split("__");
-  if (rest.length === 0) return server;
-  const action = rest.join("__").replace(/_/g, " ");
-  return `${server} · ${action}`;
-}
-
 // Context-window sizes per model. Used for the usage % ring. The 1M
 // variant of Opus is a separate id; for everything else, 200k is the
 // shipping default.
@@ -2522,14 +2502,6 @@ function totalContextTokens(u: ClaudeUsage | undefined): number {
     (u.cache_creation_input_tokens ?? 0) +
     (u.cache_read_input_tokens ?? 0)
   );
-}
-
-function formatStreamElapsed(ms: number): string {
-  const sec = Math.floor(ms / 1000);
-  if (sec < 60) return `${sec}s`;
-  const m = Math.floor(sec / 60);
-  const s = sec % 60;
-  return `${m}m ${s}s`;
 }
 
 interface SlashCommand {
@@ -5896,13 +5868,8 @@ function ChatPane({
     onAutoRenameConsumed();
   }, [autoRename, session.id, session.name, onAutoRenameConsumed]);
   const [runStatus, setRunStatus] = useState<LocalRunStatus>("idle");
-  const [activeToolName, setActiveToolName] = useState<string | null>(null);
-  const activeToolNameRef = useRef<string | null>(null);
   const activeToolUseIdRef = useRef<string | null>(null);
   const scheduledWakeupRef = useRef(false);
-  // Mirrors cloudcli's ClaudeStatus idle state: persists last status text
-  // after the run ends (amber/static pill) instead of vanishing.
-  const [lastStatusText, setLastStatusText] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<RunTab>("chat");
   const [backgroundView, setBackgroundView] = useState<BackgroundView>("shells");
   const [selectedBackgroundId, setSelectedBackgroundId] = useState<string | null>(null);
@@ -5956,11 +5923,6 @@ function ChatPane({
     : (effortOptions.some((opt) => opt.id === preferredEffortId) ? preferredEffortId : fallbackEffortId);
   const [selectedModelId] = useState<string>(initialModelId);
   const [selectedEffortId] = useState<string>(initialEffortId);
-  // Run timing — drives the streaming status pill's elapsed counter and the
-  // rotating action verb / animated dots. Both refresh on a single 250ms
-  // interval while running so the bar updates without a per-element timer.
-  const [runStartedAt, setRunStartedAt] = useState<number | null>(null);
-  const [now, setNow] = useState<number>(() => Date.now());
   // Context tokens used in the most recent assistant turn.
   const [tokensUsed, setTokensUsed] = useState(0);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
@@ -6232,18 +6194,14 @@ function ChatPane({
     if (sdkActive) {
       setRunStatus(projection.runStatus === "stopping" ? "stopping" : "running");
       setRunning(true);
-      setRunStartedAt((startedAt) => startedAt ?? Date.now());
-      setNow(Date.now());
       return;
     }
 
     setRunning(false);
     if (projection.runStatus === "error") {
       setRunStatus("error");
-      setLastStatusText("Error");
     } else if (projection.runStatus === "stopped") {
       setRunStatus("done");
-      setLastStatusText("Stopped");
     } else {
       setRunStatus((prev) => (prev === "running" ? "done" : prev));
     }
@@ -6563,14 +6521,6 @@ function ChatPane({
     return () => window.clearInterval(interval);
   }, [session.id, session.status, visible]);
 
-  // Tick `now` every 250ms while running. 250 is the LCM-ish for the dot
-  // animation (500ms cycle) and the elapsed counter (1s display step) —
-  // one timer drives both without per-element setIntervals.
-  useEffect(() => {
-    if (!running) return;
-    const id = window.setInterval(() => setNow(Date.now()), 250);
-    return () => window.clearInterval(id);
-  }, [running]);
 
   // Auto-send the next queued message once the current run finishes.
   useEffect(() => {
@@ -7665,9 +7615,7 @@ function ChatPane({
     if (isScheduleWakeupToolName(toolName ?? undefined)) {
       scheduledWakeupRef.current = true;
     }
-    activeToolNameRef.current = toolName;
     activeToolUseIdRef.current = toolName ? toolUseId : null;
-    setActiveToolName(toolName);
   }
 
   function openSlashCommandMenu() {
@@ -7718,7 +7666,6 @@ function ChatPane({
     try {
       await interruptSdkTurn(turnID);
     } catch (err) {
-      setLastStatusText("Stop failed");
       const id = nextEntryId("sdk-interrupt-error");
       appendSdkRealtimeEntries(
         markLocalEntries(
@@ -7782,7 +7729,6 @@ function ChatPane({
     try {
       await stopBackgroundTask(entry);
     } catch (err) {
-      setLastStatusText("Stop failed");
       const id = nextEntryId("background-stop-error");
       appendSdkRealtimeEntries(
         markLocalEntries(
@@ -8005,9 +7951,6 @@ function ChatPane({
     setRunStatus("running");
     setRunning(true);
     setActiveTool(null);
-    setLastStatusText(null);
-    setRunStartedAt(Date.now());
-    setNow(Date.now());
     // The form clears the textarea internally on submit but doesn't
     // always fire an input event in time, so my mirror lingers and the
     // X-clear button stays visible. Force the mirror clean.
@@ -8024,7 +7967,6 @@ function ChatPane({
         setRunning(false);
         setRunStatus("error");
         setSdkConnectionState("idle");
-        setLastStatusText("Error");
         const id = nextEntryId("sdk-submit-error");
         appendSdkRealtimeEntries(
           markLocalEntries(
@@ -8050,13 +7992,6 @@ function ChatPane({
     const durationMs = Date.now() - run.turnStart;
     updateSdkLastAssistantDuration(durationMs);
     if (terminal.status === "done") {
-      setLastStatusText(
-        scheduledWakeupRef.current
-          ? "Wakeup scheduled"
-          : activeToolNameRef.current
-            ? `Used ${formatToolLabel(activeToolNameRef.current)}`
-            : "Done",
-      );
       setRunStatus("done");
       // Turn-complete sound is fired by the App-level SSE consumer
       // on the always-on /api/sessions/events stream, NOT here. Per
@@ -8067,10 +8002,8 @@ function ChatPane({
       // listener covers this same transition for both visible and
       // background sessions.
     } else if (terminal.status === "stopped") {
-      setLastStatusText("Stopped");
       setRunStatus("done");
     } else {
-      setLastStatusText(activeToolNameRef.current ? `Used ${formatToolLabel(activeToolNameRef.current)}` : "Error");
       setRunStatus("error");
     }
     scheduledWakeupRef.current = false;
@@ -8389,20 +8322,6 @@ function ChatPane({
     return () => window.removeEventListener("keydown", onKey, true);
   }, [activeTab, focusComposerTextarea, visible]);
 
-  // Streaming-pill computeds — only meaningful while running.
-  const elapsedMs = runStartedAt != null ? Math.max(0, now - runStartedAt) : 0;
-  const elapsedLabel = formatStreamElapsed(elapsedMs);
-  const dotPhase = Math.floor(now / 500) % 3; // 0..2
-  const dots = ".".repeat(dotPhase + 1);
-  const isStopping = runStatus === "stopping";
-  // When a tool call is in flight, show its name. Otherwise cycle the
-  // generic verbs every 3s (matches cloudcli's ClaudeStatus pattern).
-  const verbIndex = Math.floor(now / 3000) % STREAM_VERBS.length;
-  const verb = isStopping
-    ? "Stopping"
-    : activeToolName
-    ? `Using ${formatToolLabel(activeToolName)}`
-    : STREAM_VERBS[verbIndex];
   const connectionLabel = sdkConnectionLabel(sdkConnectionState);
 
   async function sendInputReply(
@@ -9009,47 +8928,20 @@ function ChatPane({
         )}
       </>)}
       floatingBetweenBodyAndComposer={(<>
-      {/* Streaming status pill — pinned between transcript and composer
-          while the run is in flight. Provider icon, rotating verb +
-          animated dots, elapsed counter, Stop button with ESC hint. */}
-      {activeTab === "chat" && (running || lastStatusText !== null) && (
+      {/* Connectivity banner — only renders when the SSE stream is degraded
+          (connecting / connection_lost / resyncing). Healthy stream → no
+          banner. Replaces the connection label that used to ride on the
+          run-status pill. Run status itself (streaming / stopping / error)
+          now lives on the composer's Submit↔Stop button, and per-turn
+          errors land as durable transcript meta lines via the reducer +
+          projection path. */}
+      {activeTab === "chat" && connectionLabel && (
         <div
-          className={`run-status-bar${!running ? " run-status-bar-idle" : ""}`}
+          className="run-connection-banner"
           role="status"
           aria-live="polite"
         >
-          <span className="run-status-icon">
-            <AgentAvatarIcon avatar={sessionAvatar} className="run-status-avatar" />
-          </span>
-          <span className="run-status-text">
-            <span className="run-status-verb">{running ? verb : lastStatusText}</span>
-            {running && (
-              <span className="run-status-dots" aria-hidden="true">
-                {dots}
-              </span>
-            )}
-          </span>
-          {connectionLabel && (
-            <span className="run-status-connection">{connectionLabel}</span>
-          )}
-          {running && (
-            <>
-              <span className="run-status-elapsed" title="elapsed">
-                {elapsedLabel}
-              </span>
-              <button
-                type="button"
-                className="run-status-stop"
-                onClick={cancelRun}
-                disabled={isStopping}
-                aria-label={isStopping ? "Stopping generation" : "Stop generating"}
-              >
-                <SquareIcon className="run-status-stop-icon" aria-hidden="true" />
-                <span>{isStopping ? "Stopping" : "Stop"}</span>
-                {!isStopping && <kbd className="run-status-kbd">ESC</kbd>}
-              </button>
-            </>
-          )}
+          <span className="run-connection-label">{connectionLabel}</span>
         </div>
       )}
 

--- a/frontend/src/conversationProjection.test.ts
+++ b/frontend/src/conversationProjection.test.ts
@@ -171,6 +171,82 @@ test("turn.completed produces no meta entry — success speaks through the bubbl
   assert.equal(metas.length, 0);
 });
 
+test("session.status:failed with provider extension carries severity + action onto the system message", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("session:63:provider:codex:status", "session.status", {
+        actor: "system",
+        timeline_id: "session:63:provider:codex:status",
+        created_at: "2026-05-24T18:48:30.000Z",
+        payload: {
+          status: "failed",
+          text: "Codex sign-in expired. Re-authenticate to continue.",
+          failure_scope: "provider",
+          failure_subject: "codex",
+          failure_reason: "refresh_token_reused",
+          action: {
+            label: "Re-sign-in to Codex",
+            href: "https://auth.romaine.life/codex",
+          },
+        },
+      }),
+    ]),
+  );
+  const msg = projection.entries.find((entry) => entry.kind === "message");
+  assert.ok(msg, "session.status:failed should produce a message entry");
+  if (msg?.kind === "message") {
+    assert.equal(msg.role, "system");
+    assert.equal(msg.severity, "error");
+    assert.deepEqual(msg.action, {
+      label: "Re-sign-in to Codex",
+      href: "https://auth.romaine.life/codex",
+    });
+  }
+});
+
+test("session.status:ready replaces a prior failed banner with the same timeline_id", () => {
+  // Recovery contract: when a provider's auth comes back online, the
+  // poller writes a session.status event with status="ready" on the
+  // SAME timeline_id as the prior failed banner. The reducer must
+  // replace the failed entry rather than appending a second message
+  // — otherwise scrollback shows the stale error indefinitely.
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("session:63:provider:codex:status", "session.status", {
+        actor: "system",
+        timeline_id: "session:63:provider:codex:status",
+        created_at: "2026-05-24T18:48:30.000Z",
+        payload: {
+          status: "failed",
+          text: "Codex sign-in expired.",
+          failure_scope: "provider",
+          failure_subject: "codex",
+          failure_reason: "refresh_token_reused",
+        },
+      }),
+      ev("session:63:provider:codex:status:ready", "session.status", {
+        actor: "system",
+        timeline_id: "session:63:provider:codex:status",
+        created_at: "2026-05-24T19:10:00.000Z",
+        payload: {
+          status: "ready",
+          text: "Codex sign-in is back online.",
+        },
+      }),
+    ]),
+  );
+  const messages = projection.entries.filter(
+    (entry) => entry.kind === "message" && entry.role === "system",
+  );
+  assert.equal(messages.length, 1, "recovery must replace, not append");
+  const msg = messages[0];
+  if (msg.kind === "message") {
+    assert.equal(msg.text, "Codex sign-in is back online.");
+    assert.equal(msg.severity, "info");
+    assert.equal(msg.action, undefined);
+  }
+});
+
 test("session.status projects as a system transcript message", () => {
   const projection = projectConversationState(
     reduceConversationEvents([

--- a/frontend/src/conversationProjection.test.ts
+++ b/frontend/src/conversationProjection.test.ts
@@ -70,6 +70,107 @@ test("turn.interrupt_requested renders a 'Stop requested' meta chip at its order
   }
 });
 
+test("turn.failed projects as an error meta line at its order_key", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "hi" },
+      }),
+      ev("2", "turn.submitted", { client_nonce: "run-1" }),
+      ev("3", "turn.started", { source: "codex" }),
+      ev("4", "turn.failed", {
+        source: "codex",
+        payload: { reason: "provider_failure", error: "rate limit exceeded" },
+      }),
+    ]),
+  );
+
+  assert.equal(projection.runStatus, "error");
+  assert.equal(projection.failed, true);
+  const metas = projection.entries.filter((entry) => entry.kind === "meta");
+  assert.equal(metas.length, 1, "turn.failed should produce one meta entry");
+  const meta = metas[0];
+  if (meta.kind === "meta") {
+    assert.equal(meta.meta.title, "Turn failed");
+    assert.equal(meta.meta.detail, "rate limit exceeded");
+    assert.equal(meta.meta.severity, "error");
+    assert.equal(meta.turnId, "turn-1");
+    assert.equal(meta.orderKey, "0004");
+  }
+});
+
+test("turn.failed with structured-error object unwraps .message into the meta detail", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "hi" },
+      }),
+      ev("2", "turn.failed", {
+        source: "codex",
+        payload: {
+          reason: "provider_failure",
+          error: { code: "token_expired", message: "auth token expired" },
+        },
+      }),
+    ]),
+  );
+
+  const meta = projection.entries.find((entry) => entry.kind === "meta");
+  assert.ok(meta, "turn.failed should produce a meta entry");
+  if (meta?.kind === "meta") {
+    assert.equal(meta.meta.detail, "auth token expired");
+  }
+});
+
+test("turn.interrupted projects as an info 'Stopped' meta line; not 'failed'", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "long task" },
+      }),
+      ev("2", "turn.submitted", { client_nonce: "run-1" }),
+      ev("3", "turn.started", { source: "codex" }),
+      ev("4", "turn.interrupted", {
+        source: "codex",
+        payload: { reason: "client_interrupt" },
+      }),
+    ]),
+  );
+
+  assert.equal(projection.failed, false);
+  const metas = projection.entries.filter((entry) => entry.kind === "meta");
+  assert.equal(metas.length, 1);
+  const meta = metas[0];
+  if (meta.kind === "meta") {
+    assert.equal(meta.meta.title, "Stopped");
+    assert.equal(meta.meta.severity, "info");
+  }
+});
+
+test("turn.completed produces no meta entry — success speaks through the bubble", () => {
+  const projection = projectConversationState(
+    reduceConversationEvents([
+      ev("1", "user_message.created", {
+        actor: "user",
+        client_nonce: "run-1",
+        payload: { text: "hi" },
+      }),
+      ev("2", "turn.submitted", { client_nonce: "run-1" }),
+      ev("3", "turn.started", { source: "codex" }),
+      ev("4", "turn.completed", { source: "codex" }),
+    ]),
+  );
+
+  const metas = projection.entries.filter((entry) => entry.kind === "meta");
+  assert.equal(metas.length, 0);
+});
+
 test("session.status projects as a system transcript message", () => {
   const projection = projectConversationState(
     reduceConversationEvents([
@@ -442,7 +543,13 @@ test("canonical duplicate delivery converges before projection", () => {
     reduceConversationEvents([...events, ...events]),
   );
 
-  assert.equal(projection.entries.length, 1);
+  // Two entries: the user message + the "Stopped" transcript meta line
+  // derived from turn.interrupted. Duplicate delivery must not double either.
+  assert.equal(projection.entries.length, 2);
+  const messageEntries = projection.entries.filter((e) => e.kind === "message");
+  const metaEntries = projection.entries.filter((e) => e.kind === "meta");
+  assert.equal(messageEntries.length, 1);
+  assert.equal(metaEntries.length, 1);
   assert.equal(projection.stopped, true);
   assert.equal(projection.failed, false);
 });

--- a/frontend/src/conversationProjection.ts
+++ b/frontend/src/conversationProjection.ts
@@ -192,6 +192,11 @@ export function projectConversationState(
         orderKey: request.orderKey,
       },
     })),
+    // Per-turn terminal failures and interruptions become durable transcript
+    // meta lines, replacing the floating run-status pill. turn.completed
+    // emits no meta entry — successful completion speaks through the
+    // assistant bubble itself.
+    ...turnTerminalMetaEntries(state),
   ]), state.turnTerminals);
 
   const activeItem = activeToolItem(state);
@@ -360,6 +365,46 @@ function annotateTurnTerminals(
       turnTerminalEventId: terminal.sourceEventId,
     };
   });
+}
+
+function turnTerminalMetaEntries(
+  state: ConversationReducerState,
+): Array<{ index: number; orderKey: string | undefined; entry: ConversationViewEntry }> {
+  const baseIndex =
+    state.messages.length +
+    state.items.length +
+    state.backgroundTasks.length +
+    state.interruptRequests.length;
+  const out: Array<{ index: number; orderKey: string | undefined; entry: ConversationViewEntry }> = [];
+  let offset = 0;
+  for (const terminal of Object.values(state.turnTerminals)) {
+    if (terminal.status === "completed") continue;
+    const isFailed = terminal.status === "failed";
+    const title = isFailed ? "Turn failed" : "Stopped";
+    const detail = isFailed
+      ? terminal.detail ?? "The provider returned an error."
+      : "Turn stopped by user.";
+    out.push({
+      index: baseIndex + offset,
+      orderKey: terminal.orderKey,
+      entry: {
+        id: `turn-terminal:${terminal.sourceEventId}`,
+        kind: "meta",
+        meta: {
+          title,
+          detail,
+          severity: isFailed ? "error" : "info",
+        },
+        turnId: terminal.turnId,
+        clientNonce: terminal.clientNonce,
+        time: terminal.time,
+        sourceEventId: terminal.sourceEventId,
+        orderKey: terminal.orderKey,
+      },
+    });
+    offset += 1;
+  }
+  return out;
 }
 
 function compareNullableString(a: string | undefined, b: string | undefined): number {

--- a/frontend/src/conversationProjection.ts
+++ b/frontend/src/conversationProjection.ts
@@ -26,6 +26,14 @@ export interface ConversationMessageEntry extends ConversationEntryBase {
   // this to pick the parent session's avatar instead of the human
   // owner's Gravatar. See conversationReducer.applyUserMessage.
   originSessionId?: string;
+  // Severity tag for system-role messages — drives the renderer's
+  // styling. Set on session.status:failed banners; absent on neutral
+  // loading/ready notices. user/assistant messages ignore it.
+  severity?: "info" | "error";
+  // Optional actionable affordance ("Re-sign-in to Codex"). Present on
+  // session.status banners that carry a payload.action; the renderer
+  // surfaces it as a button on the system bubble.
+  action?: { label: string; href: string };
 }
 
 export interface AskUserQuestionAnswer {
@@ -147,6 +155,8 @@ export function projectConversationState(
             sourceEventId: message.sourceEventId,
             orderKey: message.orderKey,
             ...(message.originSessionId ? { originSessionId: message.originSessionId } : {}),
+            ...(message.severity ? { severity: message.severity } : {}),
+            ...(message.action ? { action: message.action } : {}),
           },
         },
       ];

--- a/frontend/src/conversationReducer.ts
+++ b/frontend/src/conversationReducer.ts
@@ -70,6 +70,10 @@ export interface ConversationTurnTerminal {
   orderKey?: string;
   time: string;
   sourceEventId: string;
+  // Unwrapped error text for failed/command_failed turns. Drives the
+  // transcript meta line that renders at the turn's terminal order_key.
+  // Undefined on completed/interrupted turns.
+  detail?: string;
 }
 
 export interface ConversationBackgroundTask {
@@ -281,6 +285,7 @@ function applyTurnTerminal(
   status: ConversationTurnTerminalStatus,
 ): ConversationReducerState {
   if (!event.turn_id) return state;
+  const detail = status === "failed" ? errorText(event) ?? undefined : undefined;
   return {
     ...state,
     turnTerminals: {
@@ -292,6 +297,7 @@ function applyTurnTerminal(
         orderKey: event.order_key,
         time: event.created_at,
         sourceEventId: event.event_id,
+        ...(detail ? { detail } : {}),
       },
     },
   };

--- a/frontend/src/conversationReducer.ts
+++ b/frontend/src/conversationReducer.ts
@@ -35,6 +35,17 @@ export interface ConversationMessage {
   // replaces the human owner's Gravatar so the handoff reads as
   // agent-authored. Absent for normal human-typed turns.
   originSessionId?: string;
+  // Severity tag for system-role messages. session.status:failed events
+  // with the extended payload (failure_scope=provider) carry this so
+  // the renderer can style the bubble as an error rather than a
+  // neutral system notice (e.g. "Session is ready."). undefined means
+  // "info" — the default.
+  severity?: "info" | "error";
+  // Optional actionable affordance ("Re-sign-in to Codex" → /...).
+  // Present on session.status:failed events that include an action in
+  // their durable payload; the renderer surfaces it as a button on the
+  // system-role message bubble.
+  action?: { label: string; href: string };
 }
 
 export interface ConversationItem {
@@ -366,6 +377,9 @@ function applySessionStatusMessage(
 ): ConversationReducerState {
   const text = stringPayload(event, "text") ?? "";
   if (!event.timeline_id || !text) return state;
+  const status = stringPayload(event, "status");
+  const severity: "info" | "error" = status === "failed" ? "error" : "info";
+  const action = sessionStatusAction(event);
   const message: ConversationMessage = {
     id: event.timeline_id,
     role: "system",
@@ -373,11 +387,41 @@ function applySessionStatusMessage(
     orderKey: event.order_key,
     sourceEventId: event.event_id,
     createdAt: event.created_at,
+    severity,
+    ...(action ? { action } : {}),
   };
+  // session.status:failed banners share their timeline_id across
+  // transitions (e.g. failed -> ready on Codex auth recovery). Replace
+  // the prior entry rather than appending so a recovery doesn't leave
+  // the stale failed banner in the rendered transcript. Other
+  // session.status messages (loading / ready boot notices) keep their
+  // own unique timeline_ids and never collide here.
+  const existingIndex = state.messages.findIndex((m) => m.id === event.timeline_id);
+  if (existingIndex >= 0) {
+    const next = [...state.messages];
+    next[existingIndex] = message;
+    return { ...state, messages: next };
+  }
   return {
     ...state,
     messages: [...state.messages, message],
   };
+}
+
+function sessionStatusAction(
+  event: TankConversationEvent,
+): { label: string; href: string } | undefined {
+  const payload = event.payload;
+  if (!payload || typeof payload !== "object") return undefined;
+  const raw = (payload as Record<string, unknown>).action;
+  if (!raw || typeof raw !== "object") return undefined;
+  const label = (raw as { label?: unknown }).label;
+  const href = (raw as { href?: unknown }).href;
+  if (typeof label === "string" && label.length > 0 &&
+      typeof href === "string" && href.length > 0) {
+    return { label, href };
+  }
+  return undefined;
 }
 
 function upsertItem(

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4490,24 +4490,28 @@ textarea.run-files-viewer-editor:focus {
   cursor: default;
 }
 
-/* Streaming status bar — sits between transcript and composer while the
-   run is in flight. Matches cloudcli's ClaudeStatus shape: provider icon
-   on the left, rotating action verb + animated dots, elapsed counter on
-   the right, destructive Stop pill with ESC kbd hint. Hidden when idle. */
-.run-status-bar {
+/* SSE connectivity banner — only renders when the live event stream is
+   degraded (connecting / connection_lost / resyncing). Healthy stream:
+   no banner. Replaces the old run-status pill's connectionLabel slot;
+   run status now lives on the composer's Submit↔Stop button and per-turn
+   errors are durable transcript meta lines. */
+.run-connection-banner {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  justify-content: center;
   margin: 0 var(--space-5) var(--space-2);
-  padding: 0.55rem 0.75rem 0.55rem 0.85rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgba(52, 211, 153, 0.22);
-  background: linear-gradient(180deg, rgba(52, 211, 153, 0.08), rgba(52, 211, 153, 0.03));
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  background: linear-gradient(180deg, rgba(251, 191, 36, 0.08), rgba(251, 191, 36, 0.03));
   font-family: var(--font-primary);
-  font-size: var(--text-sm);
-  box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.04);
-  animation: run-status-pulse 2.4s ease-in-out infinite;
+  font-size: var(--text-xs);
+}
+
+.run-connection-label {
+  color: rgba(251, 191, 36, 0.85);
+  letter-spacing: 0.02em;
 }
 
 /* "Load earlier messages" pill — sits at the top of the transcript when
@@ -4547,130 +4551,6 @@ textarea.run-files-viewer-editor:focus {
   margin: var(--space-3) auto var(--space-2);
   color: var(--danger, #f87171);
   font-size: var(--text-xs);
-}
-
-@keyframes run-status-pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.04); }
-  50%      { box-shadow: 0 0 0 6px rgba(52, 211, 153, 0.10); }
-}
-
-/* Idle/done state — amber static pill, no pulse. Mirrors cloudcli's
-   ClaudeStatus amber indicator when isLoading=false but status is set. */
-.run-status-bar-idle {
-  animation: none;
-  border-color: rgba(251, 191, 36, 0.25);
-  background: linear-gradient(180deg, rgba(251, 191, 36, 0.07), rgba(251, 191, 36, 0.03));
-  box-shadow: none;
-}
-
-.run-status-bar-idle .run-status-verb {
-  color: rgba(251, 191, 36, 0.85);
-}
-
-.run-status-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.4rem;
-  height: 1.4rem;
-  border-radius: 999px;
-}
-
-.run-status-avatar {
-  width: 1.4rem;
-  height: 1.4rem;
-  border-radius: 999px;
-  object-fit: contain;
-}
-
-.run-status-text {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.05rem;
-  color: var(--text-primary);
-  font-weight: 500;
-  white-space: nowrap;
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.run-status-verb {
-  letter-spacing: 0.01em;
-}
-
-.run-status-dots {
-  display: inline-block;
-  width: 1.5em;
-  text-align: left;
-  color: rgba(255, 255, 255, 0.6);
-  font-variant-numeric: tabular-nums;
-}
-
-.run-status-connection {
-  flex: 0 0 auto;
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  white-space: nowrap;
-}
-
-.run-status-elapsed {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-  padding: 0 0.25rem;
-}
-
-.run-status-stop {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.55rem 0.3rem 0.5rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(239, 68, 68, 0.38);
-  background: rgba(239, 68, 68, 0.12);
-  color: #fecaca;
-  font-family: var(--font-primary);
-  font-size: 0.78rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition:
-    background var(--motion-fast, 120ms) ease,
-    border-color var(--motion-fast, 120ms) ease,
-    color var(--motion-fast, 120ms) ease;
-}
-
-.run-status-stop:hover {
-  background: rgba(239, 68, 68, 0.2);
-  border-color: rgba(239, 68, 68, 0.55);
-  color: #fee2e2;
-}
-
-.run-status-stop:disabled {
-  cursor: progress;
-  opacity: 0.75;
-}
-
-.run-status-stop-icon {
-  width: 0.85rem;
-  height: 0.85rem;
-  fill: currentColor;
-}
-
-.run-status-kbd {
-  display: inline-block;
-  padding: 0.05rem 0.35rem;
-  margin-left: 0.15rem;
-  border-radius: 0.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(0, 0, 0, 0.25);
-  color: rgba(255, 255, 255, 0.7);
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  letter-spacing: 0.04em;
-  line-height: 1.4;
 }
 
 /* Per-message footer — timestamp + message actions, hover-revealed. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5848,6 +5848,47 @@ textarea.run-files-viewer-editor:focus {
   border: 1px solid rgba(255, 255, 255, 0.09);
 }
 
+/* Error-severity system messages — used by session.status:failed banners
+   (provider credential failures, sustained session-level conditions).
+   The bubble reads as a transcript-native error notice, NOT as a
+   floating toast — by design, per docs/features/transcript/contract.md.
+   The avatar takes a danger-tinted variant so the eye lands on the
+   banner without scanning the body. */
+.run-transcript-message[data-variant="system"][data-severity="error"] .run-msg-system-avatar {
+  color: rgba(252, 165, 165, 0.95);
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.32);
+}
+
+.run-transcript-message[data-variant="system"][data-severity="error"] .run-transcript-message-text {
+  color: rgba(254, 226, 226, 0.96);
+}
+
+.run-msg-system-action {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.55rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  background: rgba(239, 68, 68, 0.16);
+  color: #fee2e2;
+  font-family: var(--font-primary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  text-decoration: none;
+  transition:
+    background var(--motion-fast, 120ms) ease,
+    border-color var(--motion-fast, 120ms) ease,
+    color var(--motion-fast, 120ms) ease;
+}
+
+.run-msg-system-action:hover {
+  background: rgba(239, 68, 68, 0.24);
+  border-color: rgba(239, 68, 68, 0.6);
+  color: #ffffff;
+}
+
 .run-msg-ai-icon {
   width: 2.625rem;
   height: 2.625rem;

--- a/frontend/src/sessionAvatars.tsx
+++ b/frontend/src/sessionAvatars.tsx
@@ -12,11 +12,10 @@ export type AgentAvatar = {
 // frontend/public/assets/avatars/ and are served at /assets/avatars/<file>.
 // See ATTRIBUTION.md in that directory for sourcing/licensing notes.
 //
-// Render contract (see index.css .session-avatar / .run-status-avatar /
-// .run-msg-ai-icon): square frame, object-fit: contain, 22-42px display
-// size. All three surfaces are circle-cropped and run edge-to-edge with
-// no backdrop or padding, so the source image itself is the visible
-// shape. The JP1 sources are scene stills (not transparent silhouettes),
+// Render contract (see index.css .session-avatar / .run-msg-ai-icon):
+// square frame, object-fit: contain, 42px display size. Both surfaces are
+// circle-cropped and run edge-to-edge with no backdrop or padding, so the
+// source image itself is the visible shape. The JP1 sources are scene stills (not transparent silhouettes),
 // so the per-slug CROPS in scripts/normalize-jp1-avatars.py are tuned to
 // put the dark subject in the circle and push bright sky / clothing out
 // of frame — anything brighter than the sidebar bg reads as a filled

--- a/frontend/src/styleguide/avatars.tsx
+++ b/frontend/src/styleguide/avatars.tsx
@@ -7,9 +7,8 @@
 // Contract (see also docs/styleguide-contract.md in the glimmung repo):
 // when you change AGENT_AVATARS, the .session-avatar render contract,
 // or how avatars get assigned to sessions, update this page in the same
-// PR. The avatar pool's other render contexts (.run-msg-ai-icon,
-// .run-status-avatar) live here too because the picker drives all three
-// at once.
+// PR. The avatar pool's other render context (.run-msg-ai-icon) lives
+// here too because the picker drives both at once.
 
 import { useState } from "react";
 import { ProviderIcon } from "../providerIcons";
@@ -57,13 +56,11 @@ export function StyleguideAvatars() {
           (<code>getSessionAvatar</code>). Sources live under{" "}
           <code>frontend/public/assets/avatars/jp1-*.png</code>. Three
           render contexts ship: <code>.session-avatar</code> in the sidebar
-          (42px, circle-cropped, edge-to-edge — no backdrop or padding),{" "}
+          (42px, circle-cropped, edge-to-edge — no backdrop or padding) and{" "}
           <code>.run-msg-ai-icon</code> on transcript messages (also 42px,
           matching the sidebar so the avatar reads the same in both
-          surfaces), <code>.run-status-avatar</code> in the run-status pill
-          (~22px, circle-cropped, edge-to-edge). All three are the source
-          PNG clipped to a circle with no chrome, so the picker drives
-          every surface at once.
+          surfaces). Both are the source PNG clipped to a circle with no
+          chrome, so the picker drives every surface at once.
         </p>
 
         {selectedAvatar && (
@@ -261,33 +258,6 @@ export function StyleguideAvatars() {
                 </div>
               </div>
 
-              {/* run-status pill — square */}
-              <div style={{ flex: "0 0 auto" }}>
-                <div
-                  style={{
-                    fontSize: "var(--text-xs)",
-                    color: "var(--text-muted)",
-                    marginBottom: 6,
-                  }}
-                >
-                  status pill · <code>.run-status-avatar</code> · ~22px · circle
-                </div>
-                <div
-                  className="run-status-bar run-status-bar-idle"
-                  role="status"
-                  style={{ display: "inline-flex", alignItems: "center" }}
-                >
-                  <span className="run-status-icon">
-                    <AgentAvatarIcon
-                      avatar={selectedAvatar}
-                      className="run-status-avatar"
-                    />
-                  </span>
-                  <span className="run-status-text">
-                    <span className="run-status-verb">Done</span>
-                  </span>
-                </div>
-              </div>
             </div>
           </section>
         )}

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -190,6 +190,18 @@ spec:
               value: {{ .Values.hermes.authRomaineExchangeURL | quote }}
             - name: HERMES_AUTH_ROMAINE_SA_TOKEN_PATH
               value: "/var/run/secrets/auth.romaine.life/token"
+            # Provider-credential health poller — reads the codex-api-proxy
+            # /health/codex endpoint to drive the transcript-surfaced
+            # "Codex sign-in expired" banner. The poll loop is conditional
+            # on this env var being set; empty disables the banner
+            # surface entirely (useful in test environments). The
+            # re-auth URL is the user-facing affordance the SPA renders
+            # as a button on the system message — point it at the
+            # canonical Codex sign-in flow.
+            - name: CODEX_PROXY_HEALTH_URL
+              value: {{ .Values.providerHealth.codexProxyHealthURL | default "" | quote }}
+            - name: CODEX_REAUTH_URL
+              value: {{ .Values.providerHealth.codexReauthURL | default "https://auth.romaine.life" | quote }}
           envFrom:
             - secretRef:
                 name: {{ include "tank-operator.credentialRefresherConfigSecret" . }}

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -424,6 +424,41 @@ spec:
             summary: "api-proxy ({{`{{ $labels.provider }}`}}) cannot rotate its OAuth refresh chain"
             runbook: "All inbound requests will eventually 401. Inspect ext-proc logs for `refresh failed` / `refresh request crashed`."
 
+    - name: tank-operator.provider-credential-health
+      rules:
+        # Layer 1 has been "failed" for >5m. The transcript banner is
+        # already surfacing the failure to every active session in the
+        # affected mode; this alert is for the on-call to act on the
+        # operational side (re-sign-in flow, KV rotation, etc.). Steady-
+        # state expectation is zero. Sibling to
+        # TankApiProxyRefreshFailures: the proxy alert fires on raw
+        # refresh-rate; this alert fires on the orchestrator's debounced
+        # Layer 1 status (which is what the user actually sees).
+        - alert: TankProviderCredentialFailed
+          expr: tank_provider_credential_health_status{status="failed"} == 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "provider credential {{`{{ $labels.provider }}`}} ({{`{{ $labels.scope }}`}}) in failed state for 5m"
+            runbook: "Every active session whose mode requires this provider is currently rendering a session.status:failed banner in its transcript. Inspect tank_api_proxy_token_refresh_total{result!=\"success\"} to confirm the proxy-side cause, then run the re-sign-in flow / rotate the KV refresh blob."
+
+        # The poller itself is broken — we're not getting fresh data
+        # from the proxy. The transcript banner state is therefore
+        # frozen at whatever it last observed. Sub-alerts on
+        # TankApiProxyRefreshFailures cover proxy-internal issues; this
+        # alert covers the orchestrator-side wire (DNS, TCP, JSON
+        # decode, etc.).
+        - alert: TankProviderHealthPollerStuck
+          expr: rate(tank_provider_credential_poll_total{outcome="ok"}[10m]) == 0
+            and rate(tank_provider_credential_poll_total{outcome="error"}[10m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "providerhealth poller ({{`{{ $labels.provider }}`}}) is erroring on every poll for 10m"
+            runbook: "Layer 1 row is stale and the transcript banner state cannot update. Inspect orchestrator slog for `providerhealth poll failed` and the proxy's /health/<provider> response."
+
     - name: tank-operator.mcp-auth-proxy
       rules:
         - alert: TankMCPAuthProxySATokenReadFailures

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -233,6 +233,20 @@ hermes:
   # downstream API target — they could conceivably move independently.
   authRomaineExchangeURL: "https://auth.romaine.life/api/auth/exchange/k8s"
 
+# Provider-credential health poller — drives the transcript-surfaced
+# "<provider> sign-in expired" banner. The orchestrator polls
+# codexProxyHealthURL every 30s, debounces sustained failures, writes
+# Layer 1 rows (provider_credential_health), and fans session.status
+# banner events into every active codex_gui session whose transcript
+# would otherwise show only a cryptic "Error" line. Leave
+# codexProxyHealthURL empty to disable the banner — useful in test
+# environments that lack a real Codex sign-in. The re-auth URL is the
+# affordance the SPA renders as a button on the banner; point at the
+# canonical Codex sign-in flow on auth.romaine.life.
+providerHealth:
+  codexProxyHealthURL: "http://codex-api-proxy.tank-operator.svc.cluster.local:9100/health/codex"
+  codexReauthURL: "https://auth.romaine.life"
+
 externalSecret:
   storeName: romaine-kv
   storeKind: ClusterSecretStore

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -643,6 +643,40 @@ const blocked = [
   // (cutover hygiene for in-flight stragglers); the pattern below
   // matches only the dispatch-to-acceptInterrupt shape, not the
   // defensive drop.
+  // Run-status pill retired in favor of routing per-turn status through
+  // the durable transcript + composer (docs/features/transcript/contract.md
+  // names session_events as the source of truth; quality-timeframes.md's
+  // review heuristic "local UI state that can contradict durable state"
+  // describes the pill exactly). Per-turn failures now produce
+  // ConversationViewEntry meta entries from the reducer's turn.failed /
+  // turn.command_failed / turn.interrupted cases; the composer's
+  // PromptInputSubmit handles Submit↔Stop. Block reintroduction of the
+  // pill JSX, its state machinery, and the helper functions that only
+  // existed to fill the pill's rotating verb / elapsed counter slots.
+  {
+    name: "removed run-status-bar CSS class",
+    pattern: /\brun-status-bar\b/,
+  },
+  {
+    name: "removed run-status-avatar CSS class",
+    pattern: /\brun-status-avatar\b/,
+  },
+  {
+    name: "removed lastStatusText pill mirror state",
+    pattern: /\b(?:setLastStatusText|lastStatusText)\b/,
+  },
+  {
+    name: "removed STREAM_VERBS pill verb cycle",
+    pattern: /\bSTREAM_VERBS\b/,
+  },
+  {
+    name: "removed formatStreamElapsed pill elapsed helper",
+    pattern: /\bformatStreamElapsed\b/,
+  },
+  {
+    name: "removed formatToolLabel pill verb helper",
+    pattern: /\bformatToolLabel\b/,
+  },
   {
     name: "retired interrupt-on-data-plane dispatch",
     // Anchored on `.startCommandConsumer(...)` so the control-plane

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -643,6 +643,31 @@ const blocked = [
   // (cutover hygiene for in-flight stragglers); the pattern below
   // matches only the dispatch-to-acceptInterrupt shape, not the
   // defensive drop.
+  // Provider-credential health surface — the durable session.status:failed
+  // banner pipeline replaces every prior "infer codex auth state from
+  // turn outcomes" path the SPA might have grown. The Layer 1 row
+  // (provider_credential_health) is the source of truth; the orchestrator
+  // poller writes it; the SPA reads it through session.status events.
+  //
+  // The guards below catch the most likely regression shape: a future
+  // refactor that adds an SPA-side fetch of the proxy's /health endpoint
+  // (which would bypass the durable transcript surface and the debouncer)
+  // or a frontend.tsx file referencing Layer 1 row state by name. We
+  // intentionally do NOT block the unqualified "provider_credential_health"
+  // string because legitimate backend code references the table name in
+  // SQL, struct names, and counter help strings.
+  {
+    name: "in-SPA proxy /health/codex polling (must go via session.status banner)",
+    // Block fetch("/health/codex") / new EventSource("/health/codex") /
+    // similar from anywhere — the path is internal to the cluster and
+    // not exposed at the orchestrator HTTP boundary anyway, but a
+    // regression where a developer wires the SPA at it directly would
+    // bypass the debouncer. /health/codex appears nowhere in legitimate
+    // tank-operator frontend code today; the proxy and orchestrator
+    // reference it as a path literal in their own internal client.
+    pattern: /fetch\([\s\S]{0,80}["'`]\/health\/codex\b/,
+  },
+
   // Run-status pill retired in favor of routing per-turn status through
   // the durable transcript + composer (docs/features/transcript/contract.md
   // names session_events as the source of truth; quality-timeframes.md's


### PR DESCRIPTION
## Summary

- **Layer 1**: new `provider_credential_health` Postgres table is the source of truth for whether a provider's OAuth blob is currently usable. Multi-provider, multi-scope from day one. (provider, owner_scope) PK, status enum (healthy|degraded|failed), optimistic-concurrency `row_version` so two orchestrator replicas don't double-fan-out.
- **Layer 2**: `session.status` payload validator extended to accept `failure_scope`/`failure_subject`/`failure_reason`/`action` when `status="failed"`. Contract test rejects content-free banners; legacy bare-failed still validates so pod-lifecycle writers keep working.
- **Detection signal**: `codex-api-proxy` exposes `/health/codex` on the metrics port. AuthInjector tracks refresh outcomes; `_classify_refresh_failure` parses OAuth `{"error":{"code":"refresh_token_reused",...}}` bodies into `(reason, text)` with canonical user-facing copy.
- **Orchestrator poller** (`backend-go/internal/providerhealth`): polls `/health/<provider>` every 30s, debounces sustained failures, UPSERTs Layer 1, fans out `session.status` events to every active session whose mode requires the provider. `ProviderModes` maps `codex` → `{codex_gui, codex_app_server}`; only codex is wired today.
- **Session-create backfill**: a freshly-created codex_gui session whose provider is in a `failed` Layer 1 state gets the banner appended after the boot events (never before `user_message.created` per the transcript contract's ordering rule).
- **SPA**: `session.status:failed` carries `severity="error"` + optional `action` onto the system message. Renderer styles the bubble as an error and shows an inline `Re-sign-in to Codex` button when present. The reducer collapses by `timeline_id` so a recovery event (`status="ready"` on the same id) replaces the failed banner in scrollback.
- **Observability**: 5 new metrics (`tank_provider_credential_*`) + a `tank-operator.provider-credential-health` PrometheusRule group (`TankProviderCredentialFailed` critical >5m, `TankProviderHealthPollerStuck` warning >10m).
- **Migration guard** blocks SPA code from fetching `/health/codex` directly — the durable `session.status` channel is the only consumer the frontend should know about.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Transcript contract** (`docs/features/transcript/contract.md`): `session_events` remains the source of truth. The fan-out and backfill paths write `session.status` events through the existing persister + wake fabric — no new transcript surface, no client-only placeholder. Ordering rule satisfied: provider banner is emitted only after `session.status:ready` on session create, and only against already-Active sessions on the poll path (never pre-empts `user_message.created`). Reducer test pins `failed → ready` collapse by `timeline_id` so recovery doesn't leave a stale banner in scrollback.
- **Observability**: 5 new metrics on the standard `promauto` registry surface through the existing `/metrics` endpoint. New PrometheusRule alerts route through the existing kube-prometheus-stack. PromQL queries reference exact metric names defined in `backend-go/cmd/tank-operator/observability.go`. The poller exposes its own poll-attempt counter so a stuck poller (proxy unreachable, JSON-decode regression) is observable independently of the api-proxy's existing refresh counters.

## Test plan

Local verification:
- [x] `go test -count=1 ./...` — all backend packages green; new `internal/providerhealth` package (4 tests pinning classifier mapping, HTTP source wire shape, 503 handling, banner text fallback).
- [x] `npm test` (frontend): 183/183 pass. 2 new tests cover (a) `session.status:failed` carries `severity` + `action` onto the system message and (b) recovery collapses by `timeline_id`.
- [x] api-proxy unittests added for `health_snapshot()` (default state + post-success + post-failure) and `_classify_refresh_failure` (canonical-copy preference, unknown-code fallback, non-JSON-body fallback). Run in the api-proxy image build via the existing Dockerfile path.
- [x] `helm template k8s --values k8s/values.yaml` clean.
- [x] `node scripts/check-removed-chat-runtime.mjs` clean (now includes the new guard against in-SPA `/health/codex` polling).
- [x] `node scripts/check-tank-conversation-contract.mjs` clean.

Operational evidence to confirm post-deploy (cannot run from this PR's session):
- [ ] Force `codex-api-proxy` to return a `refresh_token_reused` (simulate by pointing it at a 401-returning stub, or wait for the next natural occurrence) and confirm:
  - `tank_provider_credential_poll_total{outcome="ok"}` advances.
  - After 30s, `tank_provider_credential_transitions_total{from="healthy",to="failed"}` increments.
  - `tank_provider_credential_health_status{provider="codex",status="failed"}` flips to 1.
  - A `session.status:failed` event lands in every active codex_gui session's `session_events` (queryable: `SELECT timeline_id, payload FROM session_events WHERE event_type = 'session.status' AND payload->>'failure_subject' = 'codex'`).
  - SPA renders the banner with the Re-sign-in button in every open codex_gui transcript without reload.
- [ ] Rotate the Codex OAuth blob (re-sign-in) and confirm recovery: transition counter increments `failed → healthy`, banner flips to "Codex sign-in is back online." in every open session, scrollback shows only the recovery line (failed entry replaced).
- [ ] Create a new codex_gui session while Layer 1 is `failed` and confirm the banner appears AFTER `Session is ready.` (ordering invariant).

## Out of scope (named follow-ups)

- **Claude provider**: schema and code path are multi-provider from day one; wiring is one entry in `buildProviderHealthConfigs()` once `claude-api-proxy` gains its own `/health/claude` endpoint. Mechanical follow-up.
- **Per-user OAuth scope**: schema's `owner_scope` is a free column; today every row is `host`. When per-user OAuth lands, the proxy publishes user-scoped snapshots and `ProviderModes` / fan-out picks them up.
- **Auto-recovery**: Tank doesn't mint new refresh tokens from a dead chain. This PR makes the failure mode legible — the operational rotation flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)