### PR TITLE
hermes: deterministic bridge drain + Phase A/B test split

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_turns_test.go
+++ b/backend-go/cmd/tank-operator/handlers_turns_test.go
@@ -361,6 +361,29 @@ func TestCreateSessionInitialTurnFailureRollsBackCreatedPod(t *testing.T) {
 	}
 }
 
+// TestCreateHermesSessionInitialTurnSubmitsAtCreate asserts two
+// independent durability contracts on the hermes_gui create path:
+//
+// Phase A — the durable-before-202 contract. After handleCreateSession
+// returns the 201, the session's transcript already contains the
+// user_message.created + turn.submitted pair, even if Hermes itself
+// returns slowly. This is what the SPA needs to render the user
+// bubble immediately on submit.
+//
+// Phase B — the terminal-safety-net contract. The bridge spawns a
+// goroutine to tail Hermes' SSE event-stream. When the upstream stream
+// ends without an explicit terminal event (here, simulated by the
+// mock server returning 200 OK with an empty body), the bridge MUST
+// emit turn.command_failed with reason="hermes_stream_lost" itself so
+// the SPA's projection resolves to error rather than hanging in
+// "running" forever. This is durable-terminal-contract from
+// nelsong6/tank-operator#532 — load-bearing for hermes_gui sessions.
+//
+// The phases are awaited explicitly via Bridge.WaitForTurn so the
+// assertion below isn't racing the bridge's streaming goroutine, the
+// way the previous "len(upserts) == 2" assertion was (it flaked on
+// nelsong6/tank-operator#638's CI when the goroutine emitted its
+// safety-net upsert before the assertion ran).
 func TestCreateHermesSessionInitialTurnSubmitsAtCreate(t *testing.T) {
 	bus := &recordingSessionBus{}
 	app := testTurnsApp(t, bus)
@@ -375,6 +398,8 @@ func TestCreateHermesSessionInitialTurnSubmitsAtCreate(t *testing.T) {
 			}
 			writeJSON(w, http.StatusOK, hermes.CreateRunResponse{RunID: "run-1", Status: "started"})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run-1/events":
+			// Empty event-stream — intentionally triggers the bridge's
+			// hermes_stream_lost safety net (Phase B below).
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -414,13 +439,128 @@ func TestCreateHermesSessionInitialTurnSubmitsAtCreate(t *testing.T) {
 	if createRun.Input != "hello hermes" || createRun.SessionID != created.ID {
 		t.Fatalf("hermes create run request = %#v", createRun)
 	}
+
 	es := app.sessionEvents.(*recordingSessionEventStore)
-	if len(es.upserts) != 2 {
-		t.Fatalf("hermes upserts = %d, want 2", len(es.upserts))
+
+	// Phase A — durable-before-202 contract. The first two upserts
+	// are deterministic: handleCreateSession's hermes path calls
+	// b.store.Upsert for user_message.created + turn.submitted
+	// synchronously inside SubmitTurn, BEFORE spawning the streaming
+	// goroutine. The streaming goroutine's safety-net upsert may
+	// already have landed at index 2 (it races us); the count check
+	// is intentionally >= 2 to avoid re-introducing the prior flake.
+	if len(es.upserts) < 2 {
+		t.Fatalf("hermes upserts (Phase A) = %d, want >= 2", len(es.upserts))
 	}
 	for i, want := range []string{"user_message.created", "turn.submitted"} {
 		if got, _ := es.upserts[i]["type"].(string); got != want {
-			t.Fatalf("upsert[%d].type = %q, want %q", i, got, want)
+			t.Fatalf("Phase A upsert[%d].type = %q, want %q", i, got, want)
+		}
+	}
+
+	// Phase B — terminal-safety-net contract. Block until the bridge's
+	// streaming goroutine for this turn has returned (its done chan
+	// closed via runStream's defer). After this point the durable
+	// terminal event must be in the store: either a translated
+	// terminal from the upstream stream, or — for the empty-stream
+	// case this test simulates — a turn.command_failed with
+	// reason="hermes_stream_lost".
+	turnID, _ := es.upserts[1]["turn_id"].(string)
+	if turnID == "" {
+		t.Fatalf("turn.submitted has no turn_id; payload=%#v", es.upserts[1])
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := app.hermesBridge.WaitForTurn(waitCtx, created.ID, turnID); err != nil {
+		t.Fatalf("WaitForTurn: %v", err)
+	}
+	terminal := es.upserts[len(es.upserts)-1]
+	if got, _ := terminal["type"].(string); got != "turn.command_failed" {
+		t.Fatalf("Phase B terminal upsert type = %q, want turn.command_failed", got)
+	}
+	payload, _ := terminal["payload"].(map[string]any)
+	if reason, _ := payload["reason"].(string); reason != "hermes_stream_lost" {
+		t.Fatalf("Phase B terminal reason = %q, want hermes_stream_lost (the safety-net signature)", reason)
+	}
+}
+
+// TestCreateHermesSessionRealTerminalSuppressesSafetyNet asserts the
+// flip side of the safety-net contract: when Hermes' SSE stream DOES
+// carry a terminal event, the bridge translates it and the
+// hermes_stream_lost rescue MUST NOT fire on top. Otherwise every
+// successful turn would also produce a spurious command_failed and
+// the SPA would render two contradictory terminals.
+func TestCreateHermesSessionRealTerminalSuppressesSafetyNet(t *testing.T) {
+	bus := &recordingSessionBus{}
+	app := testTurnsApp(t, bus)
+	hermesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			writeJSON(w, http.StatusOK, hermes.CreateRunResponse{RunID: "run-1", Status: "started"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run-1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Errorf("test server writer is not a flusher")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			// Minimal SSE frame matching the Hermes translator's
+			// terminal contract — run.completed maps to
+			// EventTurnCompleted at translator.go:107, which
+			// suppresses the safety net.
+			if _, err := w.Write([]byte("event: run.completed\ndata: {}\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer hermesServer.Close()
+	app.hermesBridge = hermes.NewBridge(hermes.BridgeOptions{
+		Client: hermes.NewClient(hermes.Options{
+			BaseURL: hermesServer.URL,
+			Tokens:  staticHermesTokenSource{},
+			Timeout: time.Second,
+		}),
+		Store: app.sessionEvents.(*recordingSessionEventStore),
+		Scope: "default",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(`{
+		"mode":"hermes_gui",
+		"initial_turn":{"client_nonce":"turn-hermes_real","prompt":"hello"}
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedMainToken(t, "secret", "user@example.com"))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	app.handleCreateSession(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	var created sessions.Info
+	_ = json.NewDecoder(resp.Body).Decode(&created)
+	es := app.sessionEvents.(*recordingSessionEventStore)
+	turnID, _ := es.upserts[1]["turn_id"].(string)
+	waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := app.hermesBridge.WaitForTurn(waitCtx, created.ID, turnID); err != nil {
+		t.Fatalf("WaitForTurn: %v", err)
+	}
+	// Walk every upsert; no command_failed with reason=hermes_stream_lost
+	// must appear. (A translated terminal — turn.completed or sibling —
+	// is fine and expected; we don't constrain its exact type here
+	// because the translator's mapping is its own contract pinned
+	// elsewhere.)
+	for _, evt := range es.upserts {
+		if t1, _ := evt["type"].(string); t1 == "turn.command_failed" {
+			payload, _ := evt["payload"].(map[string]any)
+			if reason, _ := payload["reason"].(string); reason == "hermes_stream_lost" {
+				t.Fatalf("hermes_stream_lost fired on top of a real terminal; upserts=%#v", es.upserts)
+			}
 		}
 	}
 }

--- a/backend-go/internal/hermes/bridge.go
+++ b/backend-go/internal/hermes/bridge.go
@@ -65,6 +65,14 @@ type activeTurn struct {
 	cancel    context.CancelFunc
 	terminal  string // set on goroutine exit
 	startedAt time.Time
+	// done closes when the bridge's runStream goroutine for this turn
+	// returns — after the durable terminal event (translated terminal
+	// or the hermes_stream_lost safety net) has landed in
+	// session_events. WaitForTurn / WaitForActiveTurnsToSettle read
+	// from this channel; production callers use the latter as the
+	// graceful-shutdown drain, tests use the former to assert on the
+	// post-goroutine ledger state without timing-based sleeps.
+	done chan struct{}
 }
 
 // BridgeOptions configures NewBridge. Scope defaults to "default".
@@ -188,6 +196,7 @@ func (b *Bridge) SubmitTurn(ctx context.Context, args SubmitArgs) (SubmitResult,
 		runID:     runResp.RunID,
 		cancel:    cancel,
 		startedAt: time.Now(),
+		done:      make(chan struct{}),
 	}
 	b.mu.Lock()
 	b.activeTurns[args.SessionID+":"+turnID] = at
@@ -261,6 +270,15 @@ func (b *Bridge) runStream(ctx context.Context, args runStreamArgs, at *activeTu
 		if b.rows != nil {
 			b.rows.PublishCurrentRow(context.Background(), args.owner, args.sessionID)
 		}
+		// Signal completion AFTER the activeTurns delete + row publish
+		// so a caller awaiting on `done` sees a consistent post-state:
+		// the map no longer lists the turn, the row publisher has
+		// fired, and any durable terminal event the goroutine emitted
+		// (translated terminal or hermes_stream_lost safety net) has
+		// already landed via b.store.Upsert above. The close is the
+		// only operation that happens after publish so it's safe even
+		// if rows.PublishCurrentRow blocks briefly.
+		close(at.done)
 	}()
 
 	translator := NewTranslator(TranslatorConfig{
@@ -324,6 +342,81 @@ func (b *Bridge) runStream(ctx context.Context, args runStreamArgs, at *activeTu
 // agent-runner / codex-runner contract: the call is non-blocking — Hermes
 // returns {"status": "stopping"} immediately and the run's terminal SSE
 // event is what actually resolves the UI. If no active turn matches, a
+// WaitForTurn blocks until the streaming goroutine for (sessionID, turnID)
+// returns — which happens after the durable terminal event has landed
+// in session_events (translated terminal from the upstream Hermes
+// stream, or the hermes_stream_lost safety net the bridge emits when
+// no upstream terminal arrived). Returns immediately when the turn is
+// not (or no longer) active; returns ctx.Err() when the caller's
+// context completes before the goroutine.
+//
+// Used by tests to assert on the post-goroutine ledger state without
+// timing-based sleeps. The previous pattern — assert.Equal(len(upserts),
+// 2) right after SubmitTurn — was a race against this same goroutine
+// and was the cause of the intermittent TestCreateHermesSessionInitial
+// TurnSubmitsAtCreate flake on nelsong6/tank-operator#638.
+func (b *Bridge) WaitForTurn(ctx context.Context, sessionID, turnID string) error {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	at, ok := b.activeTurns[sessionID+":"+turnID]
+	b.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	select {
+	case <-at.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// WaitForActiveTurnsToSettle blocks until every in-flight bridge
+// goroutine returns. This is the graceful-shutdown drain — call it
+// from the orchestrator's shutdown hook with a bounded context (e.g.
+// 30s) so a rolling pod gives in-flight Hermes turns time to emit
+// their terminal events to session_events instead of getting killed
+// mid-emit and leaving the SPA's projection stuck on "running" until
+// the next stop/restart.
+//
+// Returns ctx.Err() when the deadline hits with turns still active.
+// Returns nil when every goroutine has signaled completion (the
+// activeTurns map will also be empty at that point, since the
+// goroutine's defer deletes its entry before closing done).
+func (b *Bridge) WaitForActiveTurnsToSettle(ctx context.Context) error {
+	if b == nil {
+		return nil
+	}
+	for {
+		b.mu.Lock()
+		// Snapshot the in-flight goroutines' done channels so we can
+		// wait without holding the bridge mutex (which a returning
+		// goroutine's defer needs to delete its activeTurns entry).
+		channels := make([]chan struct{}, 0, len(b.activeTurns))
+		for _, at := range b.activeTurns {
+			channels = append(channels, at.done)
+		}
+		b.mu.Unlock()
+		if len(channels) == 0 {
+			return nil
+		}
+		for _, ch := range channels {
+			select {
+			case <-ch:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		// Loop: a NEW turn may have started while we were waiting on
+		// the snapshot's channels. Drain those too. Steady-state
+		// shutdown has no new SubmitTurn callers (the HTTP server
+		// already stopped accepting), so this terminates after one
+		// or two iterations in practice.
+	}
+}
+
 // turn.command_failed is emitted directly so the UI's "stopping" state
 // still resolves (durable-terminal contract from #532).
 func (b *Bridge) StopTurn(ctx context.Context, sessionID, owner, turnID, clientNonce string) error {


### PR DESCRIPTION
## Summary

- **Bridge.WaitForTurn / WaitForActiveTurnsToSettle** ([internal/hermes/bridge.go](backend-go/internal/hermes/bridge.go)): activeTurn gains a `done chan struct{}` that closes after runStream's defer has cleaned the activeTurns map, published the sidebar row, and (importantly) AFTER any durable terminal event the goroutine emitted has landed in the store. WaitForTurn is the test API; WaitForActiveTurnsToSettle is the production graceful-shutdown drain for rolling pods.
- **Test split** ([cmd/tank-operator/handlers_turns_test.go](backend-go/cmd/tank-operator/handlers_turns_test.go)): TestCreateHermesSessionInitialTurnSubmitsAtCreate is now two named phases — Phase A (durable-before-202: user_message.created + turn.submitted) and Phase B (terminal-safety-net: WaitForTurn → last upsert is `turn.command_failed` with `reason="hermes_stream_lost"`). This is the **first explicit test of the safety net** — the prior `len(upserts) == 2` assertion was hiding it (and racing it; cause of the intermittent flake on #638's CI).
- **TestCreateHermesSessionRealTerminalSuppressesSafetyNet** is new — sends a real `event: run.completed` SSE frame and asserts the safety net does NOT fire on top. False-positive guard so a future refactor can't have the rescue duplicate every successful turn's terminal.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- **Transcript contract** (`docs/features/transcript/contract.md` — "Orchestrator rollout and runner-process restart must not lose already persisted transcript events"): the safety-net path that ensures every accepted hermes_gui turn produces a durable terminal event was previously implicit and untested. Phase B now pins it; the new positive-path test pins the inverse (no false-positive rescue when a real terminal arrives). The graceful-shutdown drain (WaitForActiveTurnsToSettle) is the rollout side of the same invariant — a rolling orchestrator pod can wait for in-flight bridges to emit their terminals before exiting, instead of stranding sessions on "running."

## Test plan

- [x] `go test -count=20 -run TestCreateHermesSession ./cmd/tank-operator/...` — 20 iterations, no flakes (compared to the previous shape that flaked once in two runs on #638).
- [x] `go test -count=1 ./...` — full backend suite green across all packages.

Why no -race: local env lacks gcc; CI will run with race detector.

Operational evidence to confirm post-deploy:
- [ ] Force the orchestrator to roll while a hermes_gui turn is mid-stream. Confirm the in-flight turn's terminal lands in `session_events` before the pod exits (the SPA on reconnect sees the terminal, projection resolves rather than hanging). Pre-PR behavior was the goroutine getting killed mid-emit and the SPA staying stuck on "running" until the user clicked Stop.

## Out of scope

- Wiring `WaitForActiveTurnsToSettle` into the orchestrator's shutdown hook in main.go. The primitive is in place; the shutdown-hook integration is a mechanical follow-up (one call site with a bounded context). Splitting it lets this PR ship the test-determinism fix without coupling to shutdown-hook policy decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)