### PR TITLE
Wire diagnostic-discipline to firing alerts via Grafana

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,8 @@ Microsoft sign-in is delegated to **auth.romaine.life** (Better Auth + Microsoft
 
 **Break-glass CLI auth (admin only).** When tank's UI is broken and an admin needs to reach the API from a curl: load `https://auth.romaine.life/admin` -> click **Mint bot token** -> copy the 24h JWT -> `curl -H "Authorization: Bearer <jwt>" https://tank.romaine.life/api/sessions/8/events`. The bot token carries `role=admin` + `purpose=bot` and goes through the same auth.romaine.life JWKS verifier; admin cross-user reads (below) accept it for any session. Revoke before natural expiry with `az keyvault key rotate auth-jwt-signing`, which rolls the auth-side signing key and invalidates every outstanding JWT. See `nelsong6/auth/README.md -> "Admin bot tokens"`.
 
+**Grafana scripted access (same bot token).** The same auth.romaine.life bot token authenticates against `https://grafana.romaine.life` directly — Grafana's `[auth.jwt]` block validates the same JWKS, so there is no separate Grafana SA token to mint. Hit firing alerts with `curl -H "Authorization: Bearer <jwt>" https://grafana.romaine.life/api/datasources/proxy/uid/prometheus/api/v1/alerts`. This is the canonical scripted-diagnosis path that [docs/diagnostic-discipline.md](docs/diagnostic-discipline.md) step 3 invokes; full recipes (PromQL queries, Alertmanager view) live in [docs/observability.md](docs/observability.md) → "Scripted access via Grafana".
+
 ## In-cluster MCP servers
 
 The HTTP MCP servers live in standalone repos. Each MCP repo owns its Python

--- a/docs/diagnostic-discipline.md
+++ b/docs/diagnostic-discipline.md
@@ -41,9 +41,28 @@ When a user reports "X didn't work":
    evidence you write down should be from Postgres (or the equivalent durable
    surface for the area), not from logs or metrics.
 
-3. **Then live signals.** Metrics, logs, JetStream consumer info,
-   `kubectl describe`. These are how you explain *why* the durable ledger
-   shows what it shows.
+3. **Then live signals — firing alerts first.** Before code-walking,
+   query Grafana for what's already firing in the subsystem. Alert
+   names mirror the candidate failure classes in `observability.md`
+   (e.g. `TankSessionEventBrowserStreamSilent` → candidate B "zombie
+   SSE"; `TankSessionEventClientEmitDivergence` → candidate C "reducer
+   drop"). A firing alert whose subsystem matches the symptom *is*
+   the diagnosis surface — its `runbook` field names the code path.
+   Only after exhausting firing alerts do you reach for raw metrics,
+   structured logs, JetStream consumer info, or `kubectl describe`.
+
+   ```
+   curl -H "Authorization: Bearer $JWT" \
+     https://grafana.romaine.life/api/datasources/proxy/uid/prometheus/api/v1/alerts \
+     | jq '.data.alerts[] | select(.state=="firing") | .labels.alertname' \
+     | sort -u
+   ```
+
+   `$JWT` is the auth.romaine.life admin bot token from the break-glass
+   flow in `CLAUDE.md`. Grafana's `[auth.jwt]` block validates the same
+   JWKS, so one token covers both `tank.romaine.life` and
+   `grafana.romaine.life`. Full scripted-diagnosis recipes live in
+   `observability.md → "Scripted access via Grafana"`.
 
 4. **Map evidence to the claim, not the other way around.** If the loudest
    signal (log spam, alert firing) doesn't directly contradict the user's
@@ -52,7 +71,7 @@ When a user reports "X didn't work":
 
 ## When you find a likely cause
 
-5. **Walk the three policy docs as a checklist.** Specifically:
+5. **Walk the policy docs as a checklist.** Specifically:
    - `product-inspirations.md` — "A control such as Stop is only complete when
      the durable terminal event arrives." If the proposed cause involves a
      user-visible state that doesn't have a corresponding durable terminal,
@@ -63,6 +82,11 @@ When a user reports "X didn't work":
      it" or "Missing counters for user-trust failures."
    - `migration-policy.md` — If the proposed fix preserves an old behavior
      "for safety," it is not a fix.
+   - `observability.md` — the named-alert taxonomy. If a firing alert's
+     `runbook` already names the candidate, don't reconstruct the cause
+     from code; cite the alert. A new fix that adds a metric or alert
+     must respect the cardinality rules and pair with a runbook entry,
+     not be added "just to see."
 
 6. **Read the closed `session-log` issues for the area.** Stop / interrupt /
    refresh / rollout / auth — each has a small library of post-mortems with

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -106,6 +106,38 @@ All metric names are prefixed `tank_`. The full namespace:
 - `tank_mcp_auth_proxy_*` — sidecar counters/histograms. Label
   `mcp_server` is bounded by the LISTENERS table in `server.py`.
 
+## Scripted access via Grafana
+
+Grafana's `[auth.jwt]` block validates the `auth.romaine.life` JWKS,
+so any auth.romaine.life bearer token (including the admin bot-token
+from `CLAUDE.md` → "Break-glass CLI auth") works directly as an
+`Authorization` header on Grafana's REST API. The datasource proxy
+exposes the kube-prometheus-stack's Prometheus and Alertmanager
+without `kubectl port-forward`:
+
+```
+# firing alerts (the canonical first stop in diagnostic-discipline.md step 3)
+curl -H "Authorization: Bearer $JWT" \
+  https://grafana.romaine.life/api/datasources/proxy/uid/prometheus/api/v1/alerts
+
+# arbitrary PromQL
+curl -H "Authorization: Bearer $JWT" \
+  "https://grafana.romaine.life/api/datasources/proxy/uid/prometheus/api/v1/query?query=tank_session_event_client_events_total"
+
+# Alertmanager-side view (silences, groupings)
+curl -H "Authorization: Bearer $JWT" \
+  https://grafana.romaine.life/api/datasources/proxy/uid/alertmanager/api/v2/alerts
+```
+
+This is the default scripted-access path; `kubectl exec` +
+`wget /metrics` is reserved for the operator-only failure mode where
+Grafana itself is down, per
+`features/observability/contract.md → "Migration Rules"`. The single
+auth surface means an agent investigating a runtime bug does not need
+a separate Grafana SA token, KV secret, or device-flow handshake —
+the same bot token that curls `tank.romaine.life/api/sessions/...`
+curls `grafana.romaine.life/api/datasources/...`.
+
 ## Per-stream debug surface
 
 `GET /api/debug/session-event-streams` (admin-only) returns the


### PR DESCRIPTION
## Summary

- `docs/diagnostic-discipline.md` step 3 now opens with a literal `curl` against `grafana.romaine.life`'s datasource proxy (auth.romaine.life bot token) and names the candidate-B/C alert mapping, so an investigator following the doc reaches firing alerts *before* code-walking.
- `docs/diagnostic-discipline.md` step 5 adds `observability.md` to the policy-doc checklist and pins the rule: a firing alert's `runbook` is the canonical writeup, don't reconstruct from code.
- `docs/observability.md` adds a "Scripted access via Grafana" section explaining that the same auth.romaine.life JWT covers Grafana via `[auth.jwt]`/JWKS — no Grafana SA token to mint, no KV secret to maintain.
- `CLAUDE.md` break-glass paragraph adds a sibling line for Grafana scripted access pointing at the recipes.

Context: A Stop-failed UI investigation on session 172 ran for several turns of code-walking before the investigator (me) queried Prometheus — at which point three alerts (`TankSessionEventBrowserStreamSilent`, `TankSessionEventClientEmitDivergence`, `TankSessionEventWakeDeliveryGap`) were already firing and named the candidate failure class. The diagnostic doc didn't tell the investigator to look there first; this PR fixes that.

No new metrics, alerts, debug endpoints, code, or memory entries. Pure doctrine wiring.

## Feature Contracts

Affected contracts:
- [x] Observability

Evidence:
- Reinforces `docs/features/observability/contract.md` → "Migration Rules" rule that `kubectl exec` + `wget /metrics` is not a supported workflow when Grafana exposes the same data — the new `diagnostic-discipline.md` step 3 makes that rule operational by naming the Grafana curl as the first move.
- Reinforces the contract's "Sources Of Truth" entry that browser devtools are not a supported diagnostic surface — by giving an investigator a curl-able alternative for the alerts question that previously could have driven them to devtools.
- Does not add, rename, or remove any metric, alert, dashboard panel, admin debug endpoint, or scrape target, so the contract's "Failure And Recovery" rule about pairing metric/alert changes with dashboard updates does not apply.
- Verified end-to-end before the doc edits: `curl -H "Authorization: Bearer <auth.romaine bot jwt>" https://grafana.romaine.life/api/datasources/proxy/uid/prometheus/api/v1/alerts` returned 59 firing alerts including the user-trust-critical `TankStreamAuthTicketStoreFailures` and `TankSessionEventWakeDeliveryGap`.

## Test plan

- [ ] `helm template k8s/` succeeds (no chart changes, but cheap sanity check)
- [ ] An investigator following `diagnostic-discipline.md` step 3 verbatim reaches a list of firing alert names without leaving the terminal and without `kubectl exec`
- [ ] The `curl` recipe in step 3 succeeds against `https://grafana.romaine.life` with a freshly-minted auth.romaine.life admin bot token
- [ ] No links broken in `CLAUDE.md`, `docs/diagnostic-discipline.md`, or `docs/observability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)