### PR TITLE
Document JetStream durable-consumer wire-format gates in migration checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,35 @@ needs a blocker report per `docs/migration-policy.md`.
   a completion requirement, not a follow-up.
 - Confirm the cutover is atomic: no fallback layer, no parallel path that
   "works for now," no read-side silent skip on old data shapes.
+- For wire-format changes affecting **durable JetStream consumers**
+  (`filter_subject`, `filter_subjects`, consumer name, or any other
+  server-immutable `ConsumerConfig` field), confirm the cutover includes
+  an explicit remediation for existing consumers — a deploy alone cannot
+  repair them. The runner's `ensureConsumer` at
+  `runner-shared/sessionBus.js` only mutates `ack_wait`, `max_deliver`,
+  `max_ack_pending`, `inactive_threshold` on existing durables, and
+  pre-existing session pods do not auto-recreate per the session
+  lifecycle contract. Cutover options: (a) ship an orchestrator-startup
+  step that updates each existing durable to the new shape, or (b)
+  delete the OLD session pods before the new producer publishes a
+  single message in the new shape. Verify by enumerating durables on a
+  staging deploy and confirming filter/name parity with the new code.
+- Validation MUST exercise a **pre-deploy session pod**, not only a
+  freshly-created one. "Live new-session SSE smoke" passes when only the
+  producer side of the new wire format is exercised; it cannot detect a
+  regression where existing pods still emit on the OLD subject shape or
+  subscribe on the OLD filter. Both the SDK migration cutover and
+  nelsong6/tank-operator#652 (the `ea70777` "Fix sidebar activity
+  readiness indicators" change) shipped with new-session-only validation
+  and silently broke chat for every pre-deploy session — the exact
+  Agent Runners contract violation ("orchestrator rollout must not
+  cancel runner work while the session pod and runner remain alive" /
+  "silent strandings are a counted bug class").
 
 Skipping this checklist is the failure mode that left dual-path debt in
-the SDK migration. The checklist takes ~10 minutes and runs *before*
-ExitPlanMode, not after merge.
+the SDK migration and that broke chat delivery for every pre-`ea70777`
+session pod in 2026-05-25. The checklist takes ~10 minutes and runs
+*before* ExitPlanMode, not after merge.
 
 ## Agentic flows ship as multi-stage LLM splits
 


### PR DESCRIPTION
## Summary

- Add two bullets to the **Migration audit checklist (procedural)** section of CLAUDE.md that name the failure shape behind the SDK migration cutover and [`ea70777`](https://github.com/nelsong6/tank-operator/commit/ea70777) (PR #652, "Fix sidebar activity readiness indicators")
- Wire-format changes affecting durable JetStream consumers MUST include explicit existing-consumer remediation — a deploy alone cannot repair them, because the runner's `ensureConsumer` deliberately limits `update()` to 4 fields and pre-deploy session pods don't auto-recreate
- Validation MUST exercise a pre-deploy session pod, not only a freshly-created one — "live new-session SSE smoke" cannot detect the regression class that broke chat for every pre-`ea70777` pod

## Why now

`ea70777` changed the JetStream subject format from `tank.session.{base64(storageKey)}.…` (4 tokens) to `tank.session.{base64(scope)}.{base64(sessionID)}.…` (5 tokens). Both the backend Go orchestrator and `runner-shared/sessionBus.js` were updated in lockstep at the code level, but:

- The orchestrator deploy could not repair the durable consumers inside existing session pods — `ensureConsumer` at [`runner-shared/sessionBus.js:265`](https://github.com/nelsong6/tank-operator/blob/main/runner-shared/sessionBus.js#L265) only mutates `ack_wait`, `max_deliver`, `max_ack_pending`, `inactive_threshold` on an existing durable, never `filter_subject`.
- Session pods are an explicit non-goal for messaging durability per CLAUDE.md's Sessions section, but they're also not auto-recreated. So existing pods kept their pre-cutover consumer filters and silently dropped every `submit_turn` published in the new shape.
- PR #652's validation was "live new-session SSE smoke in slot 1" — which only exercised the producer side of the new wire format on a brand-new pod, so it couldn't see the regression.

This was the second time a migration of this exact shape shipped (the SDK migration was the first). The audit checklist is the doctrine-compliant gate per `docs/migration-policy.md` — no code-level compat layer, no runtime read for legacy shape.

## Test plan

- [x] CLAUDE.md renders cleanly (Markdown verified locally)
- [x] PR number reference (#652) verified via `gh search prs --merge-commit ea70777`
- [x] Quoted invariants verified against `docs/features/agent-runners/contract.md` ("orchestrator rollout must not cancel runner work…", "silent strandings are a counted bug class")
- [x] Four pre-`ea70777` session pods that exposed the gap were manually deleted as part of completing the migration, per `docs/migration-policy.md` line 24–26 ("If removal exposes another dependency on the old system, delete that dependency too")

## Feature Contracts

Affected contracts:
- [x] Agent Runners
- [x] Session Lifecycle

Evidence:
- **Agent Runners — Failure And Recovery**: contract invariant `"Browser disconnect and orchestrator rollout must not cancel runner work while the session pod and runner remain alive"` was violated by `ea70777` for all pre-deploy pods. This PR adds the procedural gate that would have caught the cutover gap before merge, restoring the contract for the next migration of this shape.
- **Agent Runners — Observability**: contract invariant `"Silent strandings, where a requested action has no terminal event, are a counted bug class"` was the user-visible failure mode (POST `/api/sessions/{id}/turns` returned 202 → no terminal event → infinite "stopping" UI). The audit-checklist bullets reference this invariant by name so future cutovers must consider whether existing consumers can still produce terminal events.
- **Session Lifecycle**: the new bullets cite `"pre-existing session pods do not auto-recreate per the session lifecycle contract"` as the structural reason the deploy can't self-repair. This pins the cross-contract dependency that PR #652 didn't notice.
- This PR is docs-only — no test changes. The contract evidence is the procedural improvement itself, verified by the deletion of the four exposing pods (the doctrinal completion of `ea70777`'s migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)