### PR TITLE
Silent-stranding alert + retired-subject migration guards

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -49,6 +49,18 @@ func (s *appServer) persistBackendEvent(ctx context.Context, storageKey string, 
 		}
 		return err
 	}
+	// Silent-stranding observability: bump the lifecycle counter for the
+	// five bounding types after the durable write commits. The
+	// backend-direct path writes user_message.created + turn.submitted
+	// here at submit time, and the various turn.command_failed events on
+	// the interrupt / input-reply / stop-background paths. Pairs with
+	// the same call inside sessionbus.persistOneEvent so the signal
+	// works regardless of which path wrote the row. Filter on
+	// IsTurnLifecycleEvent at the call boundary so the helper just
+	// records. See docs/features/agent-runners/contract.md → Observability.
+	if eventType := stringMapField(event, "type"); conversation.IsTurnLifecycleEvent(conversation.EventType(eventType)) {
+		recordTurnLifecyclePersisted(eventType)
+	}
 	if s.sessionBus != nil && storageKey != "" {
 		if err := s.sessionBus.PublishSessionEventWake(ctx, storageKey); err != nil {
 			slog.Warn("session event wake publish failed",

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -215,6 +215,38 @@ var (
 		[]string{"event_type"},
 	)
 
+	// turnLifecycleTotal counts durable turn lifecycle events committed
+	// to session_events, partitioned by event type. The five types covered
+	// — turn.submitted plus the four terminal types (turn.completed,
+	// turn.failed, turn.command_failed, turn.interrupted) — bound a
+	// turn's open/close lifecycle. The TankTurnSilentStranding alert in
+	// k8s/templates/observability.yaml fires when sum(submitted) exceeds
+	// sum(terminal) over a window long enough to rule out a single long
+	// Codex turn.
+	//
+	// This is the silent-stranding observability surface named in the
+	// Agent Runners contract (docs/features/agent-runners/contract.md
+	// → Observability: "Silent strandings, where a requested action has
+	// no terminal event, are a counted bug class"). ea70777
+	// (nelsong6/tank-operator#652) — orchestrator deploy left every
+	// pre-existing runner subscribed to the OLD wire format, every
+	// submit_turn published to the new format was dropped, no terminal
+	// event ever fired — would have triggered this alert within minutes
+	// of deploy. Both the backend-direct path (handlers_turns.go
+	// persistBackendEvent) and the runner-side persister
+	// (sessionbus.RunEventPersister) increment this counter, so the
+	// signal works regardless of which path wrote the row.
+	//
+	// Label cardinality is bounded to 5 series; non-lifecycle event
+	// types are dropped at the recordTurnLifecyclePersisted call site.
+	turnLifecycleTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_turn_lifecycle_total",
+			Help: "Durable turn lifecycle events committed to session_events, labeled by event type (turn.submitted + four terminal types).",
+		},
+		[]string{"event_type"},
+	)
+
 	// turnInterruptRequestTotal counts stop requests posted to /interrupt,
 	// labeled by outcome at each exit point. Steady-state expectation:
 	// persisted dominates; persist_failed and publish_failed near zero.
@@ -951,6 +983,22 @@ func (promPersisterMetrics) RecordTransientFailure() {
 
 func (promPersisterMetrics) RecordTurnFailurePersisted(source string, reason string) {
 	transcriptTurnFailureTotal.WithLabelValues(source, reason).Inc()
+}
+
+func (promPersisterMetrics) RecordTurnLifecyclePersisted(eventType string) {
+	recordTurnLifecyclePersisted(eventType)
+}
+
+// recordTurnLifecyclePersisted bumps tank_turn_lifecycle_total for the
+// five lifecycle event types that bound a turn. Callers MUST filter
+// via conversation.IsTurnLifecycleEvent before invoking this helper —
+// the label set is bounded at 5 series, and the impl trusts the call
+// site rather than re-filtering. Both persistOneEvent (sessionbus) and
+// persistBackendEvent (handlers_turns.go) follow this pattern. Adding
+// a third writer is a regression unless that writer also lands rows in
+// session_events and applies the same call-site filter.
+func recordTurnLifecyclePersisted(eventType string) {
+	turnLifecycleTotal.WithLabelValues(eventType).Inc()
 }
 
 // promProviderHealthMetrics satisfies providerhealth.Metrics so the

--- a/backend-go/internal/conversation/types.go
+++ b/backend-go/internal/conversation/types.go
@@ -452,6 +452,30 @@ func validVisibility(visibility Visibility) bool {
 	return visibility == VisibilityDurable
 }
 
+// IsTurnLifecycleEvent reports whether eventType bounds a turn — i.e.,
+// it is the open boundary (turn.submitted) or one of the four terminal
+// types. The silent-stranding alert
+// (k8s/templates/observability.yaml → TankTurnSilentStranding) compares
+// the counts of these types, so the set must stay tight: turn.started
+// is intermediate (not a boundary); turn.interrupt_requested is a stop
+// request, not a stop completion; item.* / tool.* / session.* are not
+// turn boundaries. Both the runner-side persister
+// (sessionbus.persistOneEvent) and the backend-direct path
+// (cmd/tank-operator.persistBackendEvent) filter on this predicate
+// before incrementing tank_turn_lifecycle_total. See
+// docs/features/agent-runners/contract.md → Observability.
+func IsTurnLifecycleEvent(eventType EventType) bool {
+	switch eventType {
+	case EventTurnSubmitted,
+		EventTurnCompleted,
+		EventTurnFailed,
+		EventTurnCommandFailed,
+		EventTurnInterrupted:
+		return true
+	}
+	return false
+}
+
 func validEventType(eventType EventType) bool {
 	switch eventType {
 	case EventUserMessageCreated,

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -92,6 +92,21 @@ type PersisterMetrics interface {
 	// counter is how we notice "every session is failing" without browser
 	// devtools. Steady-state expectation: low and bursty.
 	RecordTurnFailurePersisted(source string, reason string)
+	// RecordTurnLifecyclePersisted increments for the five lifecycle
+	// event types that bound a turn — turn.submitted (the open boundary)
+	// plus the four terminal types (turn.completed / turn.failed /
+	// turn.command_failed / turn.interrupted). The submitted-vs-terminal
+	// divergence is the silent-stranding observability surface per
+	// docs/features/agent-runners/contract.md → Observability ("Silent
+	// strandings, where a requested action has no terminal event, are a
+	// counted bug class"). The TankTurnSilentStranding alert in
+	// k8s/templates/observability.yaml fires when submitted outruns
+	// terminal for a window long enough to rule out a single long Codex
+	// turn. ea70777 (nelsong6/tank-operator#652) was the prototypical
+	// silent-stranding incident; this counter would have caught it within
+	// minutes of deploy instead of a user bug report. Non-lifecycle event
+	// types are dropped at the implementation; the label set is bounded.
+	RecordTurnLifecyclePersisted(eventType string)
 }
 
 type noopPersisterMetrics struct{}
@@ -99,6 +114,7 @@ type noopPersisterMetrics struct{}
 func (noopPersisterMetrics) RecordSchemaRejected()                     {}
 func (noopPersisterMetrics) RecordTransientFailure()                   {}
 func (noopPersisterMetrics) RecordTurnFailurePersisted(string, string) {}
+func (noopPersisterMetrics) RecordTurnLifecyclePersisted(string)       {}
 
 // WakeMetrics receives counters for wake/event publish failures, the
 // success path, and the end-to-end persist→wake latency. The bus
@@ -543,6 +559,7 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, metrics Per
 	if err := store.Upsert(ctx, event); err != nil {
 		return err
 	}
+	eventType, _ := event["type"].(string)
 	// Record turn-failure persistence right after the durable write
 	// commits. This is the observability surface that replaced the SPA
 	// run-status pill: with the pill gone, "every codex_gui session is
@@ -551,7 +568,7 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, metrics Per
 	// from payload.reason so a Codex auth storm vs a generic
 	// provider_failure spike are distinguishable; the source label
 	// (claude/codex/tank) lets per-provider alerts fire independently.
-	if eventType, _ := event["type"].(string); eventType == string(conversation.EventTurnFailed) || eventType == string(conversation.EventTurnCommandFailed) {
+	if eventType == string(conversation.EventTurnFailed) || eventType == string(conversation.EventTurnCommandFailed) {
 		source, _ := event["source"].(string)
 		reason := ""
 		if payload, ok := event["payload"].(map[string]any); ok {
@@ -564,6 +581,15 @@ func (b *Bus) persistOneEvent(ctx context.Context, store EventStore, metrics Per
 			reason = "unknown"
 		}
 		metrics.RecordTurnFailurePersisted(source, reason)
+	}
+	// Silent-stranding surface: count the five lifecycle types that bound
+	// a turn (turn.submitted + the four terminal types). The
+	// TankTurnSilentStranding alert reads from the divergence between
+	// submitted and terminal counts. Filter at the call boundary so the
+	// interface contract is "this is a lifecycle event" — the impl just
+	// records.
+	if conversation.IsTurnLifecycleEvent(conversation.EventType(eventType)) {
+		metrics.RecordTurnLifecyclePersisted(eventType)
 	}
 	upsertedAt := time.Now()
 	storageKey, _ := event["tank_session_id"].(string)

--- a/backend-go/internal/sessionbus/bus_test.go
+++ b/backend-go/internal/sessionbus/bus_test.go
@@ -28,6 +28,7 @@ type recordingMetrics struct {
 	schemaRejected      int
 	transientFailure    int
 	turnFailureRecorded []turnFailureRecord
+	turnLifecycle       map[string]int
 }
 
 type turnFailureRecord struct {
@@ -39,6 +40,12 @@ func (m *recordingMetrics) RecordSchemaRejected()   { m.schemaRejected++ }
 func (m *recordingMetrics) RecordTransientFailure() { m.transientFailure++ }
 func (m *recordingMetrics) RecordTurnFailurePersisted(source string, reason string) {
 	m.turnFailureRecorded = append(m.turnFailureRecorded, turnFailureRecord{source: source, reason: reason})
+}
+func (m *recordingMetrics) RecordTurnLifecyclePersisted(eventType string) {
+	if m.turnLifecycle == nil {
+		m.turnLifecycle = map[string]int{}
+	}
+	m.turnLifecycle[eventType]++
 }
 
 type stubMsg struct {
@@ -286,6 +293,94 @@ func TestPersistMessageDoesNotRecordTurnFailureForSuccess(t *testing.T) {
 
 	if len(metrics.turnFailureRecorded) != 0 {
 		t.Fatalf("turn-failure counter fired on turn.completed (%d times); the counter is for failures only", len(metrics.turnFailureRecorded))
+	}
+}
+
+// TestPersistMessageRecordsTurnLifecycleCounter pins the silent-stranding
+// observability contract: each of the five lifecycle event types
+// (turn.submitted + the four terminal types) MUST bump
+// tank_turn_lifecycle_total{event_type=<type>} when the persister
+// commits a durable row, and non-lifecycle types MUST NOT contribute
+// (so the alert's expr stays comparing the right cardinalities). The
+// silent-stranding alert in k8s/templates/observability.yaml reads this
+// counter directly — a divergence here is the prototypical ea70777-
+// shape failure surface per docs/features/agent-runners/contract.md.
+func TestPersistMessageRecordsTurnLifecycleCounter(t *testing.T) {
+	lifecycleTypes := []string{
+		"turn.submitted",
+		"turn.completed",
+		"turn.failed",
+		"turn.command_failed",
+		"turn.interrupted",
+	}
+	for _, eventType := range lifecycleTypes {
+		t.Run(eventType, func(t *testing.T) {
+			bus := &Bus{scope: "default"}
+			store := &recordingStore{}
+			metrics := &recordingMetrics{}
+			raw, _ := json.Marshal(map[string]any{
+				"event_id":   "evt-" + eventType,
+				"session_id": "63",
+				"actor":      "runner",
+				"source":     "codex",
+				"type":       eventType,
+				"created_at": "2026-05-12T00:00:00.000Z",
+				"order_key":  "order-" + eventType,
+				"visibility": "durable",
+				"turn_id":    "turn-1",
+			})
+			msg := &stubMsg{subject: SessionEventSubject("63"), data: raw}
+
+			bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+			if metrics.turnLifecycle[eventType] != 1 {
+				t.Fatalf("lifecycle counter for %q = %d, want 1", eventType, metrics.turnLifecycle[eventType])
+			}
+		})
+	}
+}
+
+// TestPersistMessageOmitsNonLifecycleFromLifecycleCounter pins the bound
+// on tank_turn_lifecycle_total's label set: only the five lifecycle
+// types contribute. turn.started, item.*, tool.*, and session.* are
+// either intermediate or non-turn signals and must not skew the
+// submitted-vs-terminal divergence the silent-stranding alert reads.
+func TestPersistMessageOmitsNonLifecycleFromLifecycleCounter(t *testing.T) {
+	nonLifecycleTypes := []string{
+		"turn.started",
+		"turn.interrupt_requested",
+		"item.completed",
+		"tool.approval_requested",
+		"session.status",
+		"user_message.created",
+	}
+	for _, eventType := range nonLifecycleTypes {
+		t.Run(eventType, func(t *testing.T) {
+			bus := &Bus{scope: "default"}
+			store := &recordingStore{}
+			metrics := &recordingMetrics{}
+			raw, _ := json.Marshal(map[string]any{
+				"event_id":   "evt-" + eventType,
+				"session_id": "63",
+				"actor":      "runner",
+				"source":     "codex",
+				"type":       eventType,
+				"created_at": "2026-05-12T00:00:00.000Z",
+				"order_key":  "order-" + eventType,
+				"visibility": "durable",
+				"turn_id":    "turn-1",
+			})
+			msg := &stubMsg{subject: SessionEventSubject("63"), data: raw}
+
+			bus.handlePersistMessage(context.Background(), store, metrics, msg)
+
+			if got := metrics.turnLifecycle[eventType]; got != 0 {
+				t.Fatalf("lifecycle counter unexpectedly bumped for %q (= %d); only the five lifecycle types contribute", eventType, got)
+			}
+			if len(metrics.turnLifecycle) != 0 {
+				t.Fatalf("lifecycle counter has %d entries after non-lifecycle event %q; want 0", len(metrics.turnLifecycle), eventType)
+			}
+		})
 	}
 }
 

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -336,6 +336,74 @@ spec:
               reads can still work while live delivery never opens. Check
               Postgres connectivity and the stream_auth_tickets migration.
 
+        # Silent-stranding alert. Agent Runners contract names this as a
+        # counted bug class: "Silent strandings, where a requested action
+        # has no terminal event, are a counted bug class." The signal is
+        # divergence between turn.submitted (the open boundary, written by
+        # the backend's persistBackendEvent) and the four terminal types
+        # (turn.completed / turn.failed / turn.command_failed /
+        # turn.interrupted, written either by the runner-side persister or
+        # the backend-direct path). Both paths increment
+        # tank_turn_lifecycle_total at the same durable Upsert boundary, so
+        # the counter is path-independent.
+        #
+        # ea70777 (nelsong6/tank-operator#652) is the prototypical
+        # incident: the orchestrator deploy bumped the JetStream subject
+        # shape, every pre-existing runner kept subscribing on the OLD
+        # filter, every submit_turn published to the new subject was
+        # dropped, no terminal event ever fired. With this alert in place,
+        # silent strandings of that shape page within ~30 minutes of the
+        # deploy instead of waiting for a user bug report.
+        #
+        # Threshold tuning: window [15m], `> 2` divergence, `for: 20m`.
+        # A single legit Codex turn that runs 15 minutes contributes +1
+        # divergence inside the window; the `> 2` threshold and `for: 20m`
+        # together require the divergence to exceed two open turns
+        # sustained for 20+ minutes before firing. ea70777 would have
+        # produced +6 divergence within 30 minutes (six pre-deploy
+        # sessions, each emitting submit_turn with no terminal). False-
+        # positive shape would require 3+ simultaneous long turns lasting
+        # longer than the window, which is uncommon for this app's
+        # workload.
+        - alert: TankTurnSilentStranding
+          expr: |
+            sum(increase(tank_turn_lifecycle_total{event_type="turn.submitted"}[15m]))
+              - sum(increase(tank_turn_lifecycle_total{event_type=~"turn\\.(completed|failed|command_failed|interrupted)"}[15m]))
+              > 2
+          for: 20m
+          labels:
+            severity: warning
+          annotations:
+            summary: "turn.submitted is outrunning terminal events — silent stranding"
+            runbook: |
+              The backend is persisting turn.submitted events faster than
+              the runner is emitting turn.completed / turn.failed /
+              turn.command_failed / turn.interrupted. Agent Runners
+              contract names silent strandings (a submitted turn with no
+              terminal event) as a counted bug class — this counter is
+              the surface, this alert is the page.
+
+              Likely causes, in priority order:
+              (1) Runner JetStream consumer filter mismatch with the
+                  orchestrator's publish subject — the ea70777 (PR #652)
+                  failure shape. Verify via:
+                    nats consumer info TANK_SESSION_BUS <provider>_*
+                  against the wire shape in
+                  backend-go/internal/sessionbus/subjects.go and
+                  runner-shared/sessionBus.js. The CLAUDE.md migration
+                  audit checklist names this exact gate.
+              (2) Persister consumer dropping terminal events (compare
+                  tank_session_event_persist_schema_rejected_total and
+                  tank_session_event_persist_transient_failure_total).
+              (3) Provider hanging on a long turn (check
+                  tank_runner_provider_error_total per mode and runner
+                  pod logs).
+
+              Diagnose in Grafana with:
+                sum by (event_type) (rate(tank_turn_lifecycle_total[5m]))
+              The submitted line outpacing the terminal lines is the
+              direct signature.
+
     - name: tank-operator.session-list
       rules:
         # K8s-watch producer is leader-elected. The lease should be

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -57,6 +57,15 @@ const ignoredRelativePaths = new Set([
   // the migration guard doesn't fire on the deletion statement
   // itself.
   "backend-go/internal/pgstore/migrations.go",
+  // sessionBusSubjects.test.ts pins the post-ea70777 wire shape and
+  // asserts the legacy 3-token tank.session.<storage_token>.events
+  // form is NOT what eventSubject() returns. The legacy literal
+  // appears as a notEqual assertion fixture — it's the negative
+  // confirmation that the cutover held. Same exemption shape as
+  // backend-go/internal/sessionbus/subjects_test.go (which uses string
+  // concat and doesn't trip the guard) — TS string concat isn't as
+  // idiomatic, so the test pins the literal directly.
+  "agent-runner/src/sessionbus/sessionBusSubjects.test.ts",
 ]);
 
 const blocked = [
@@ -712,6 +721,36 @@ const blocked = [
     // which is the shape JetStream max_ack_pending=1 turns into a stuck
     // interrupt.
     pattern: /\.startCommandConsumer\(async\s*\(record\)[\s\S]{0,800}?isInterruptCommand\(record\)\s*\)\s*\{\s*(?:commandsConsumedTotal[\s\S]{0,200}?)?await\s+this\.acceptInterrupt/,
+  },
+  // ea70777 (nelsong6/tank-operator#652) retired the 4-token chat
+  // command/control subject shape and the 3-token chat event subject
+  // shape in favor of scope-partitioned 5-token / 4-token shapes that
+  // partition cleanly across (scope, session_id). The cutover gap left
+  // every pre-deploy session pod silently stranded on the OLD filter
+  // (see CLAUDE.md → "Migration audit checklist" for the durable-
+  // consumer wire-format gate). Block reintroduction of complete-
+  // literal OLD subjects on the wire so a future refactor can't quietly
+  // revert and silently re-strand chat. Test fixtures that construct
+  // the legacy shape via string concatenation (subjects_test.go's
+  // legacySlotSubject := "tank.session." + StorageToken(...) + ".events")
+  // do NOT contain a complete literal and don't trip the guard. The
+  // post-cutover shape is tank.session.<scope_token>.<session_token>.…
+  // (one more segment between tank.session and the boundary keyword).
+  {
+    name: "retired 4-token chat command subject literal",
+    pattern: /tank\.session\.[A-Za-z0-9_\-]+\.commands\.[a-z_]+\b/,
+  },
+  {
+    name: "retired 4-token chat control subject literal",
+    pattern: /tank\.session\.[A-Za-z0-9_\-]+\.control\.[a-z_]+\b/,
+  },
+  {
+    name: "retired 3-token chat event subject literal",
+    // tank.session.<token>.events is the pre-cutover shape; the
+    // post-cutover shape is tank.session.<scope>.<token>.events. The
+    // regex's [A-Za-z0-9_\-]+ stops at a dot, so the 4-token form
+    // (with an extra dot before .events) does not match this pattern.
+    pattern: /tank\.session\.[A-Za-z0-9_\-]+\.events\b/,
   },
 ];
 


### PR DESCRIPTION
## Summary

- New `tank_turn_lifecycle_total{event_type}` counter + `TankTurnSilentStranding` PrometheusRule alert covering the Agent Runners contract's "silent strandings are a counted bug class" invariant
- 3 new `scripts/check-removed-chat-runtime.mjs` patterns blocking reintroduction of the OLD 4-token chat command/control subjects and 3-token chat event subject (the wire shape retired by [ea70777](https://github.com/nelsong6/tank-operator/commit/ea70777) / PR #652)
- Implements the follow-up gap I named in PR #666's description

## Why

[`ea70777`](https://github.com/nelsong6/tank-operator/commit/ea70777) silently stranded chat for every pre-deploy session pod for ~6 hours before a user bug report surfaced it. With this change, the same regression would page within ~30 minutes of deploy via `TankTurnSilentStranding`, and a future PR can't reintroduce the OLD subject literals without `check-removed-chat-runtime.mjs` failing.

The metric is observable from outside the browser (the existing `tank_session_event_client_stream_silent_seconds` requires an open browser, so it didn't catch the `ea70777` incident where most stranded sessions had no browser open at deploy time).

## Design

**Counter shape.** `tank_turn_lifecycle_total{event_type}` with cardinality bounded at 5 series: the 5 lifecycle types that bound a turn (`turn.submitted` + the four terminal types `turn.completed` / `turn.failed` / `turn.command_failed` / `turn.interrupted`). The filter lives at the call boundary via `conversation.IsTurnLifecycleEvent` — the impl trusts the call site, and the test in [backend-go/internal/sessionbus/bus_test.go](backend-go/internal/sessionbus/bus_test.go) pins that the persister only calls `RecordTurnLifecyclePersisted` for the 5 types.

**Two writer paths instrumented.** Both end at `sessionEventsStore.Upsert`:
- [`backend-go/internal/sessionbus/bus.go`](backend-go/internal/sessionbus/bus.go) `persistOneEvent` — the runner-emitted path (NATS JetStream → persister → Postgres)
- [`backend-go/cmd/tank-operator/handlers_turns.go`](backend-go/cmd/tank-operator/handlers_turns.go) `persistBackendEvent` — the backend-direct path (`user_message.created` / `turn.submitted` / `turn.command_failed` written from HTTP handlers)

Without both, `ea70777` would have under-counted submits (the backend wrote `turn.submitted` even though the runner never received the command) and over-counted "silence" (no terminal events because the runner couldn't see commands).

**Alert tuning.** `sum(submitted) - sum(terminal) > 2` over a `[15m]` window, `for: 20m`, severity `warning`. A single 15-minute Codex turn contributes +1 inside the window — `> 2` keeps it from firing on legit long turns. `ea70777` would have produced +6 within 30 minutes; the alert would have fired in ~50 minutes wall-clock (15m for the rate to populate, 20m+ for the `for:` to satisfy).

**Migration-guard regex.** Matches only complete-literal occurrences of the OLD subject shapes (no `%s` placeholders, no string concatenation). Existing test fixtures that construct the legacy shape via concat (e.g. [subjects_test.go:89](backend-go/internal/sessionbus/subjects_test.go:89)) don't trip the guard. The TypeScript test at [sessionBusSubjects.test.ts:31](agent-runner/src/sessionbus/sessionBusSubjects.test.ts:31) pins the legacy literal as a `notEqual` assertion and is exempted, matching the pattern of other migration-pinning files in the script's exempt list.

## Test plan

- [x] `go test ./...` (backend-go) — all 19 packages pass, including new `TestPersistMessageRecordsTurnLifecycleCounter` (5 subtests, one per lifecycle type) and `TestPersistMessageOmitsNonLifecycleFromLifecycleCounter` (6 subtests covering `turn.started` / `turn.interrupt_requested` / `item.*` / `tool.*` / `session.*` / `user_message.created`)
- [x] `node scripts/check-removed-chat-runtime.mjs` — passes (no false positives on current tree)
- [x] `helm template k8s` — renders cleanly; new `TankTurnSilentStranding` alert appears in PrometheusRule output
- [ ] CI image builds (will gate this PR)

## Feature Contracts

Affected contracts:
- [x] Agent Runners
- [x] Observability

Evidence:
- **Agent Runners — Observability invariant**: `"Silent strandings, where a requested action has no terminal event, are a counted bug class"` ([docs/features/agent-runners/contract.md](docs/features/agent-runners/contract.md) → Observability). Before this PR there was no metric proving this invariant — `tank_transcript_turn_failure_total` covers only durable failures, not strandings. `tank_turn_lifecycle_total{event_type}` plus the alert is the direct surface; `ea70777` (the prototypical violation) would have produced +6 divergence within 30 minutes of deploy.
- **Agent Runners — Failure And Recovery invariant**: `"Browser disconnect and orchestrator rollout must not cancel runner work while the session pod and runner remain alive"`. The `ea70777` incident violated this. With `TankTurnSilentStranding` in place, the regression class becomes observable from outside the browser within ~50 minutes of deploy, instead of waiting for user report.
- **Observability — cardinality discipline**: The new counter respects [docs/observability.md](docs/observability.md)'s budget — 5 bounded series, no per-session / per-user labels. Pinned by the unit tests cited above.
- **Migration policy compliance**: This PR does NOT introduce a compat layer — the OLD subject shape has zero readers / writers in code; only the regex-guard against future reintroduction is added. Doctrine-clean per [docs/migration-policy.md](docs/migration-policy.md) ("no fallback defaults; no runtime reads whose purpose is to keep old behavior working").

🤖 Generated with [Claude Code](https://claude.com/claude-code)