### PR TITLE
Add admin debug surface for session-event ledger

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_debug_session_event_ledger.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_event_ledger.go
@@ -1,0 +1,205 @@
+// Admin-only debug surface for the durable session_events ledger.
+// Returns event rows by tank session id without going through the
+// registry visibility gate, so an operator (or the AI support agent)
+// can audit a deleted session's chat history through curl without
+// flipping `sessions.visible=true` first.
+//
+// The user-facing per-session timeline (`GET /api/sessions/{id}/timeline`)
+// intentionally 404s once a session row is soft-deleted (visible=false)
+// — the SPA should tombstone it and never render it again. The
+// `session_events` rows themselves are durable (no FK, no cascade) so
+// the chat is recoverable in principle, just not through the public
+// surface. This endpoint closes that observability gap so admin
+// pickup-the-prior-codex-pod workflows don't require a one-off psql
+// pod or an un-soft-delete write.
+//
+// Pair with `/api/debug/session-list-state` to find an invisible
+// session's id, then call this endpoint with that id. Pair with
+// `tank_admin_debug_session_event_ledger_reads_total{result}` at
+// /metrics to monitor usage volume.
+//
+// Auth: Tank admin power required. Counts as an admin cross-user
+// read; emits a structured slog audit line per call.
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionmodel"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+// debugSessionEventLedgerMaxLimit caps a single page so a runaway
+// request can't pull a giant ledger into one response. The underlying
+// store also normalizes via normalizeSessionEventLimit (1000 hard cap
+// inside the store), but we cap lower at the surface for predictability.
+const debugSessionEventLedgerMaxLimit = 500
+
+// debugSessionEventLedgerDefaultLimit is the page size when the caller
+// does not pass `?limit=`. Matches the store's default of 200.
+const debugSessionEventLedgerDefaultLimit = 200
+
+func (s *appServer) handleDebugSessionEventLedger(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	if !hasAdminPower(user) {
+		recordDebugSessionEventLedgerRead("forbidden")
+		writeError(w, http.StatusForbidden, "admin access required")
+		return
+	}
+
+	sessionID := strings.TrimSpace(r.URL.Query().Get("session_id"))
+	if sessionID == "" {
+		recordDebugSessionEventLedgerRead("bad_request")
+		writeError(w, http.StatusBadRequest, "session_id is required")
+		return
+	}
+
+	scope, status, scopeErr := s.resolveSessionScopeFromRequest(user, r)
+	if scopeErr != nil {
+		recordDebugSessionEventLedgerRead("forbidden")
+		writeError(w, status, scopeErr.Error())
+		return
+	}
+
+	limit := debugSessionEventLedgerDefaultLimit
+	if rawLimit := strings.TrimSpace(r.URL.Query().Get("limit")); rawLimit != "" {
+		parsed, err := strconv.Atoi(rawLimit)
+		if err != nil || parsed <= 0 {
+			recordDebugSessionEventLedgerRead("bad_request")
+			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		limit = parsed
+	}
+	if limit > debugSessionEventLedgerMaxLimit {
+		limit = debugSessionEventLedgerMaxLimit
+	}
+
+	direction := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("direction")))
+	if direction != "" && direction != "asc" && direction != "desc" {
+		recordDebugSessionEventLedgerRead("bad_request")
+		writeError(w, http.StatusBadRequest, "direction must be asc or desc")
+		return
+	}
+
+	cursor := store.SessionEventCursor{
+		AfterOrderKey:  strings.TrimSpace(r.URL.Query().Get("after_order_key")),
+		BeforeOrderKey: strings.TrimSpace(r.URL.Query().Get("before_order_key")),
+		Direction:      direction,
+	}
+	if cursor.AfterOrderKey != "" && cursor.BeforeOrderKey != "" {
+		recordDebugSessionEventLedgerRead("bad_request")
+		writeError(w, http.StatusBadRequest, "specify at most one of after_order_key / before_order_key")
+		return
+	}
+
+	eventStore := s.sessionEventStoreForScope(scope)
+	if eventStore == nil {
+		recordDebugSessionEventLedgerRead("not_configured")
+		writeError(w, http.StatusServiceUnavailable, "session event store not configured")
+		return
+	}
+	if _, ok := eventStore.(store.StubSessionEventStore); ok {
+		recordDebugSessionEventLedgerRead("not_configured")
+		writeError(w, http.StatusServiceUnavailable, "session event store running in stub mode")
+		return
+	}
+
+	page, err := eventStore.ListBySession(r.Context(), sessionID, cursor, limit)
+	if err != nil {
+		recordDebugSessionEventLedgerRead("store_error")
+		slog.Error("debug session-event ledger read failed",
+			"caller_email", user.Email,
+			"session_id", sessionID,
+			"session_scope", scope,
+			"limit", limit,
+			"after_order_key", cursor.AfterOrderKey,
+			"before_order_key", cursor.BeforeOrderKey,
+			"direction", cursor.Direction,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	result := "ok"
+	if len(page.Events) == 0 {
+		result = "empty"
+	}
+	recordDebugSessionEventLedgerRead(result)
+	slog.Info("debug session-event ledger read",
+		"caller_email", user.Email,
+		"session_id", sessionID,
+		"session_scope", scope,
+		"limit", limit,
+		"after_order_key", cursor.AfterOrderKey,
+		"before_order_key", cursor.BeforeOrderKey,
+		"direction", cursor.Direction,
+		"count", len(page.Events),
+		"has_more", page.HasMore,
+		"result", result,
+	)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"description":      debugSessionEventLedgerDescription,
+		"session_id":       sessionID,
+		"session_scope":    scope,
+		"storage_key":      sessionmodel.SessionStorageKey(scope, sessionID),
+		"count":            len(page.Events),
+		"events":           page.Events,
+		"has_more":         page.HasMore,
+		"next_order_key":   page.NextOrderKey,
+		"prev_order_key":   page.PrevOrderKey,
+		"found_oldest":     page.FoundOldest,
+		"found_newest":     page.FoundNewest,
+		"fetched_at":       time.Now().UTC().Format(time.RFC3339Nano),
+	})
+}
+
+// errDebugSessionEventLedgerNotConfigured surfaces the stub-store case
+// to tests without coupling them to the string body. Kept package-level
+// so the test file can assert against it.
+var errDebugSessionEventLedgerNotConfigured = errors.New("session event store not configured")
+
+// debugSessionEventLedgerDescription is rendered into the JSON response
+// so an operator running `curl | jq` sees the meaning of each field
+// without leaving the terminal. Per docs/quality-timeframes.md
+// "Observability exists for the bugs a user would otherwise have to
+// guess about." Pair with docs/observability.md → "Session Event Ledger
+// Debug Surface" for the playbook.
+const debugSessionEventLedgerDescription = `Durable session_events ledger for one tank session, bypassing the visibility gate.
+
+Use this when you need to audit chat events for a session whose
+sessions.visible row is false (the user deleted it through the SPA)
+and whose pod is gone. The user-facing GET /api/sessions/{id}/timeline
+returns 404 in that case by design — this endpoint is the operator
+counterpart for "I deleted the session, but the codex agent's chat is
+the input I need to pick up the work."
+
+Query params:
+  session_id        Required. Public session id (e.g., "203").
+  session_scope     Optional. Defaults to this orchestrator's scope.
+  limit             Optional. Default 200, max 500.
+  after_order_key   Optional. Forward-paginate ASC strictly after this key.
+  before_order_key  Optional. Backward-paginate DESC strictly before this key.
+  direction         Optional. "asc" (default) or "desc"; "desc" with no cursor
+                    returns the tail (latest events). Specify at most one of
+                    after_order_key / before_order_key.
+
+Response: events[] is always returned ASC by order_key. has_more / found_oldest
+/ found_newest let the caller decide whether to paginate further. storage_key
+is the underlying partition key (scope:session_id) for cross-referencing the
+raw session_events table.
+
+Counts as an admin cross-user audit read. Emits a structured slog line per
+call (caller_email, session_id, session_scope, limit, cursor, result, count)
+and increments tank_admin_debug_session_event_ledger_reads_total{result} at
+/metrics.`

--- a/backend-go/cmd/tank-operator/handlers_debug_session_event_ledger_test.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_event_ledger_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+	"github.com/nelsong6/tank-operator/backend-go/internal/store"
+)
+
+// fakeDebugSessionEventLedgerStore is a tiny in-test implementation of
+// store.SessionEventStore that the ledger handler tests can drive
+// directly. The real Postgres-backed store is exercised by
+// session_events_test.go; here we just need to assert handler shape
+// (auth, query parsing, response envelope, metric labels).
+type fakeDebugSessionEventLedgerStore struct {
+	lastSessionID string
+	lastCursor    store.SessionEventCursor
+	lastLimit     int
+	page          store.SessionEventPage
+	err           error
+	calls         int
+}
+
+func (f *fakeDebugSessionEventLedgerStore) Upsert(context.Context, map[string]any) error {
+	return nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) ListBySession(_ context.Context, sessionID string, cursor store.SessionEventCursor, limit int) (store.SessionEventPage, error) {
+	f.calls++
+	f.lastSessionID = sessionID
+	f.lastCursor = cursor
+	f.lastLimit = limit
+	if f.err != nil {
+		return store.SessionEventPage{}, f.err
+	}
+	return f.page, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) HasOrderKey(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) OrderKeyForTimelineID(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) LatestEvents(context.Context, string, int) (store.SessionEventPage, error) {
+	return store.SessionEventPage{}, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) EventsAround(context.Context, string, string, int, int) (store.SessionEventPage, error) {
+	return store.SessionEventPage{}, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) EventsForTurn(context.Context, string, string, int) (store.SessionEventPage, error) {
+	return store.SessionEventPage{}, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) FindTurnTerminal(context.Context, string, string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) LatestLifecycleEvents(context.Context, string, int) ([]map[string]any, error) {
+	return nil, nil
+}
+
+func (f *fakeDebugSessionEventLedgerStore) UnreadOutputCount(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+
+func newLedgerTestServer(t *testing.T) (*appServer, *fakeDebugSessionEventLedgerStore) {
+	t.Helper()
+	app := adminTestServer(t)
+	app.sessionScope = "default"
+	fake := &fakeDebugSessionEventLedgerStore{}
+	app.sessionEvents = fake
+	return app, fake
+}
+
+func TestDebugSessionEventLedgerNonAdmin403(t *testing.T) {
+	app, _ := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, otherUser, auth.RoleUser))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerMissingSessionID400(t *testing.T) {
+	app, _ := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "session_id is required") {
+		t.Fatalf("error body should explain missing session_id; got %s", resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerInvalidLimit400(t *testing.T) {
+	app, _ := newLedgerTestServer(t)
+	for _, raw := range []string{"abc", "0", "-1"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&limit="+raw, nil)
+		req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+		resp := httptest.NewRecorder()
+
+		app.handleDebugSessionEventLedger(resp, req)
+
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("limit=%q expected 400, got %d; body=%s", raw, resp.Code, resp.Body.String())
+		}
+	}
+}
+
+func TestDebugSessionEventLedgerInvalidDirection400(t *testing.T) {
+	app, _ := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&direction=sideways", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerBothCursors400(t *testing.T) {
+	app, _ := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&after_order_key=a&before_order_key=b", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerStubMode503(t *testing.T) {
+	app := adminTestServer(t)
+	app.sessionScope = "default"
+	// Keep the stub sessionEvents that adminTestServer wires up; the
+	// handler should refuse to pretend a stub-mode ledger is real data.
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body = %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stub mode") {
+		t.Fatalf("stub-mode response should name stub mode; got %s", resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerStoreError500(t *testing.T) {
+	app, fake := newLedgerTestServer(t)
+	fake.err = errors.New("boom")
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerHappyPath200(t *testing.T) {
+	app, fake := newLedgerTestServer(t)
+	fake.page = store.SessionEventPage{
+		Events: []map[string]any{
+			{"id": "evt-1", "order_key": "01", "type": "user_message.created"},
+			{"id": "evt-2", "order_key": "02", "type": "turn.submitted"},
+		},
+		NextOrderKey: "02",
+		PrevOrderKey: "01",
+		HasMore:      true,
+		FoundOldest:  true,
+		FoundNewest:  false,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&limit=2", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if fake.lastSessionID != "203" {
+		t.Fatalf("store called with session_id=%q, want 203", fake.lastSessionID)
+	}
+	if fake.lastLimit != 2 {
+		t.Fatalf("store called with limit=%d, want 2", fake.lastLimit)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	for _, field := range []string{"description", "session_id", "session_scope", "storage_key", "count", "events", "has_more", "next_order_key", "prev_order_key", "found_oldest", "found_newest", "fetched_at"} {
+		if _, ok := body[field]; !ok {
+			t.Errorf("response missing field %q; body=%s", field, resp.Body.String())
+		}
+	}
+	if count, ok := body["count"].(float64); !ok || int(count) != 2 {
+		t.Errorf("count=%v, want 2", body["count"])
+	}
+	if storageKey, _ := body["storage_key"].(string); storageKey == "" {
+		t.Errorf("storage_key should be set; body=%s", resp.Body.String())
+	}
+}
+
+func TestDebugSessionEventLedgerEmptyResultIs200(t *testing.T) {
+	app, fake := newLedgerTestServer(t)
+	fake.page = store.SessionEventPage{Events: []map[string]any{}, FoundOldest: true, FoundNewest: true}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=999999", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if count, _ := body["count"].(float64); int(count) != 0 {
+		t.Errorf("count=%v, want 0", body["count"])
+	}
+}
+
+func TestDebugSessionEventLedgerClampsLimitAtMax(t *testing.T) {
+	app, fake := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&limit=9999", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if fake.lastLimit != debugSessionEventLedgerMaxLimit {
+		t.Errorf("limit=%d, want clamp to %d", fake.lastLimit, debugSessionEventLedgerMaxLimit)
+	}
+}
+
+func TestDebugSessionEventLedgerForwardCursor(t *testing.T) {
+	app, fake := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&after_order_key=05", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if fake.lastCursor.AfterOrderKey != "05" {
+		t.Errorf("cursor.AfterOrderKey=%q, want 05", fake.lastCursor.AfterOrderKey)
+	}
+	if fake.lastCursor.BeforeOrderKey != "" {
+		t.Errorf("cursor.BeforeOrderKey=%q, want empty", fake.lastCursor.BeforeOrderKey)
+	}
+}
+
+func TestDebugSessionEventLedgerBackwardCursor(t *testing.T) {
+	app, fake := newLedgerTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/session-event-ledger?session_id=203&before_order_key=20&direction=desc", nil)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+
+	app.handleDebugSessionEventLedger(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if fake.lastCursor.BeforeOrderKey != "20" {
+		t.Errorf("cursor.BeforeOrderKey=%q, want 20", fake.lastCursor.BeforeOrderKey)
+	}
+	if fake.lastCursor.Direction != "desc" {
+		t.Errorf("cursor.Direction=%q, want desc", fake.lastCursor.Direction)
+	}
+}

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -709,7 +709,38 @@ var (
 		Name: "tank_admin_cross_user_session_lists_total",
 		Help: "Times a Tank admin-power caller passed `?owner=<email>` to list sessions or session-list events for another user.",
 	})
+
+	// debugSessionEventLedgerReadsTotal is the volume signal for the
+	// admin-only `GET /api/debug/session-event-ledger` surface.
+	// `result` labels: ok, empty, bad_request, forbidden, store_error,
+	// not_configured. Pair with the audit slog line per call; the
+	// counter answers "is this being used at scale", the slog line
+	// answers "who read what, and when". `result=empty` is its own
+	// label so a wave of misdirected lookups (wrong scope, wrong id)
+	// is visible without grepping logs.
+	debugSessionEventLedgerReadsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_admin_debug_session_event_ledger_reads_total",
+			Help: "Admin reads of /api/debug/session-event-ledger, labeled by bounded result.",
+		},
+		[]string{"result"},
+	)
 )
+
+func recordDebugSessionEventLedgerRead(result string) {
+	debugSessionEventLedgerReadsTotal.WithLabelValues(
+		debugSessionEventLedgerResultLabel(result),
+	).Inc()
+}
+
+func debugSessionEventLedgerResultLabel(result string) string {
+	switch result {
+	case "ok", "empty", "bad_request", "forbidden", "store_error", "not_configured":
+		return result
+	default:
+		return "other"
+	}
+}
 
 func recordAdminCrossUserRead() {
 	adminCrossUserReadsTotal.Inc()

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -181,6 +181,15 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	// reducer-drop without browser devtools. Per
 	// memory/feedback_no_devtools_build_surfaces_instead.md.
 	mux.HandleFunc("GET /api/debug/session-event-streams", s.handleDebugSessionEventStreams)
+	// Admin-only audit surface for the durable session_events ledger.
+	// Bypasses the registry visibility gate so a deleted session's
+	// chat is reachable via curl + bot token — closes the gap that
+	// would otherwise force an un-soft-delete write or a one-off psql
+	// pod just to pick up a codex agent's prior conversation. Pairs
+	// with /api/debug/session-list-state for invisible-session lookup
+	// and with the avatar-upload-attempts surface as the existing
+	// "admin debug counterpart to a user-facing read" template.
+	mux.HandleFunc("GET /api/debug/session-event-ledger", s.handleDebugSessionEventLedger)
 	mux.HandleFunc("PUT /api/sessions/order", s.handleReorderSessions)
 	mux.HandleFunc("DELETE /api/sessions/{session_id}", s.handleDeleteSession)
 	mux.HandleFunc("GET /api/sessions/{session_id}", s.handleGetSession)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,6 +51,13 @@ All metric names are prefixed `tank_`. The full namespace:
   (`validate_*`), image field failures (`read_avatar` / `read_backing`),
   blob-storage failures (`store_*`), and metadata-write failures
   (`create_metadata`) without using browser devtools.
+- `tank_admin_debug_session_event_ledger_reads_total{result}` — admin
+  reads of `GET /api/debug/session-event-ledger` (the durable
+  `session_events` audit surface that bypasses the registry visibility
+  gate). Bounded `result` labels: `ok`, `empty`, `bad_request`,
+  `forbidden`, `store_error`, `not_configured`. `empty` is its own
+  label so a wave of misdirected lookups (wrong scope, wrong id) is
+  visible without grepping the audit slog line.
 - `tank_chat_scroll_client_*` - browser-reported transcript scroll
   diagnostics ingested through `POST /api/client-metrics/chat-scroll`.
   Labels are server-bucketed only: `event`, `surface`, `session_mode`,
@@ -189,6 +196,53 @@ failures point at blob storage or Postgres.
 For browser-independent reproduction, `scripts/debug-avatar-upload.sh`
 posts the same multipart contract with `curl -F` and prints the raw
 API response, including `attempt_id` on success or failure.
+
+## Session Event Ledger Debug Surface
+
+`GET /api/debug/session-event-ledger` (admin-only) returns events from
+the durable `session_events` Postgres table for one tank session,
+bypassing the registry visibility gate. Use this when picking up work
+from a session whose `sessions.visible` row is `false` (the user
+deleted it through the SPA) and whose pod is gone — the user-facing
+`GET /api/sessions/{id}/timeline` returns 404 in that case by design,
+but the underlying `session_events` rows are durable (no FK, no
+cascade) and recoverable through this surface.
+
+Query params:
+
+- `session_id` (required) — public session id (e.g., `203`).
+- `session_scope` — defaults to this orchestrator's scope (`default`
+  in prod). Admin power can target a different scope.
+- `limit` — page size, default 200, max 500.
+- `after_order_key` — forward-paginate ASC strictly after this key.
+- `before_order_key` — backward-paginate DESC strictly before this
+  key. At most one of `after_order_key` / `before_order_key`.
+- `direction` — `asc` (default) or `desc`. `desc` with no cursor
+  returns the tail (latest events).
+
+Response: `events[]` is always ASC by `order_key`. `has_more`,
+`found_oldest`, and `found_newest` let the caller decide when to stop
+paginating. `storage_key` is the underlying partition key (`scope:
+session_id`) for cross-referencing the raw `session_events` table.
+
+Standard workflow for "pick up a deleted session":
+
+1. `GET /api/debug/session-list-state?owner=<email>` to locate the
+   `visible=false` row and confirm the session id.
+2. `GET /api/debug/session-event-ledger?session_id=<id>` to read the
+   chat. Page with `after_order_key=<next_order_key>` if needed.
+
+This is the admin counterpart to the deliberate visibility gate on the
+user-facing timeline (the SPA tombstones soft-deleted sessions; an
+admin pickup-the-prior-codex-pod workflow shouldn't have to
+un-soft-delete or open a one-off `psql` pod to recover the chat).
+
+Counts as an admin cross-user audit read. Emits a structured `slog`
+line per call (`caller_email`, `session_id`, `session_scope`,
+`limit`, cursor fields, `result`, `count`) and increments
+`tank_admin_debug_session_event_ledger_reads_total{result}` at
+`/metrics`. `result` labels: `ok`, `empty`, `bad_request`,
+`forbidden`, `store_error`, `not_configured`.
 
 ## Cardinality rules
 


### PR DESCRIPTION
## Summary

- Add `GET /api/debug/session-event-ledger` admin-only endpoint that reads `session_events` directly by storage key, bypassing the `sessions.visible` filter the user-facing timeline applies. Closes the gap that made deleted-session chat unreachable through the admin API surface.
- Reuses the existing `store.SessionEventStore.ListBySession` reader (no new store method needed — the registry visibility check lives in the HTTP auth path, not the store).
- Counter `tank_admin_debug_session_event_ledger_reads_total{result}` + structured slog audit line per call.

## Why

Picking up a tank session's work after the user has soft-deleted it (the normal pod-cleanup workflow once a codex agent has pushed its commits) requires reading the agent's chat. Today admin-bot-token callers can find the row via `/api/debug/session-list-state` but cannot read the chat without either:

- un-soft-deleting the row (a write, no admin endpoint exists)
- exec'ing `psql` from a one-off pod with workload identity

The `session_events` table has no FK and no cascade — events are deliberately durable across deletion. This PR adds the admin counterpart to the user-facing timeline gate, matching the existing pattern set by `/api/debug/session-list-state` and `/api/debug/avatar-upload-attempts`.

## Tests

- `go test ./cmd/tank-operator/ -run TestDebugSessionEventLedger -v` — 12 new tests pass (admin gate, missing session_id, invalid limit, invalid direction, both cursors set, stub-mode 503, store error 500, happy path 200, empty result 200, limit clamp at max, forward cursor, backward cursor).
- `go test ./cmd/tank-operator/` — full package tests pass.
- `go build ./...` — full backend builds.
- `node scripts/check-removed-chat-runtime.mjs` — clean.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [x] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Auth And Streams**: Admin-only gate is asserted by `TestDebugSessionEventLedgerNonAdmin403` (role=user gets 403). Per-call structured slog line with `caller_email`, `session_id`, `session_scope`, cursor fields, `result`, and `count` provides admin cross-user audit accounting. Write paths are unaffected — this is a read-only endpoint and the registry visibility filter on the user-facing `GET /api/sessions/{id}/timeline` is preserved.
- **Observability**: New counter `tank_admin_debug_session_event_ledger_reads_total{result}` with bounded labels (`ok`, `empty`, `bad_request`, `forbidden`, `store_error`, `not_configured`) — bounded-label rule honored, no per-session / per-email cardinality. Documented in `docs/observability.md` under "Session Event Ledger Debug Surface" and listed in the `tank_*` metric catalog. The `result=empty` label is its own series so misdirected lookups are visible without grepping the audit slog.

## Notes

- No migration. Schema unchanged (already-durable `session_events` rows).
- No frontend changes. No SPA visibility-gate change — the soft-delete tombstoning behavior is preserved by design.
- No slot smoke included: the change is server-only Go code, the existing Docker Build Check workflow will validate the image, and pre-deploy verification will come through the standard PR CI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)