### PR TITLE
Add agent <-> system avatar kind reassignment

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_avatars.go
+++ b/backend-go/cmd/tank-operator/handlers_avatars.go
@@ -333,6 +333,56 @@ func (s *appServer) handleCreateAvatar(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, resp)
 }
 
+func (s *appServer) handleUpdateAvatarKind(w http.ResponseWriter, r *http.Request) {
+	_, ok := s.requireAdmin(w, r, "update_kind")
+	if !ok {
+		return
+	}
+	if s.avatars == nil {
+		recordAvatarAssetRequest("update_kind", "", "store_unavailable")
+		writeError(w, http.StatusServiceUnavailable, "avatar store not configured")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("avatar_id"))
+	if id == "" {
+		recordAvatarAssetRequest("update_kind", "", "bad_request")
+		writeError(w, http.StatusBadRequest, "missing avatar id")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1024)
+	var body struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		recordAvatarAssetRequest("update_kind", "", "bad_request")
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	newKind, ok := avatarassets.NormalizeKind(body.Kind)
+	if !ok {
+		recordAvatarAssetRequest("update_kind", "", "bad_request")
+		writeError(w, http.StatusBadRequest, "kind must be agent or system")
+		return
+	}
+	meta, err := s.avatars.UpdateKind(r.Context(), id, newKind)
+	if err != nil {
+		switch {
+		case errors.Is(err, avatarassets.ErrNotFound):
+			recordAvatarAssetRequest("update_kind", "", "not_found")
+			writeError(w, http.StatusNotFound, "avatar not found")
+		case errors.Is(err, avatarassets.ErrKindUnchanged):
+			recordAvatarAssetRequest("update_kind", newKind, "bad_request")
+			writeError(w, http.StatusConflict, "avatar already has the requested kind")
+		default:
+			recordAvatarAssetRequest("update_kind", newKind, "store_error")
+			writeError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+	recordAvatarAssetRequest("update_kind", meta.Kind, "ok")
+	writeJSON(w, http.StatusOK, avatarAssetResponseFromMeta(meta))
+}
+
 func (s *appServer) handleDeleteAvatar(w http.ResponseWriter, r *http.Request) {
 	_, ok := s.requireAdmin(w, r, "delete")
 	if !ok {

--- a/backend-go/cmd/tank-operator/handlers_avatars_test.go
+++ b/backend-go/cmd/tank-operator/handlers_avatars_test.go
@@ -195,6 +195,143 @@ func TestDefaultAvatarImageFallsBackToBundledStatic(t *testing.T) {
 	}
 }
 
+func TestAvatarUpdateKindFlipsBetweenAgentAndSystem(t *testing.T) {
+	app := newAvatarTestServer(t)
+	createReq := avatarCreateRequest(t, map[string]string{
+		"kind": "agent",
+		"name": "Ada",
+	})
+	createReq.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	createResp := httptest.NewRecorder()
+	app.handleCreateAvatar(createResp, createReq)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", createResp.Code, createResp.Body.String())
+	}
+	var created avatarAssetResponse
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	flipReq := httptest.NewRequest(http.MethodPatch, "/api/admin/avatars/"+created.ID+"/kind", strings.NewReader(`{"kind":"system"}`))
+	flipReq.SetPathValue("avatar_id", created.ID)
+	flipReq.Header.Set("Content-Type", "application/json")
+	flipReq.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	flipResp := httptest.NewRecorder()
+	app.handleUpdateAvatarKind(flipResp, flipReq)
+	if flipResp.Code != http.StatusOK {
+		t.Fatalf("flip status = %d body = %s", flipResp.Code, flipResp.Body.String())
+	}
+	var flipped avatarAssetResponse
+	if err := json.Unmarshal(flipResp.Body.Bytes(), &flipped); err != nil {
+		t.Fatal(err)
+	}
+	if flipped.Kind != "system" || flipped.ID != created.ID {
+		t.Fatalf("flipped = %#v", flipped)
+	}
+
+	backReq := httptest.NewRequest(http.MethodPatch, "/api/admin/avatars/"+created.ID+"/kind", strings.NewReader(`{"kind":"agent"}`))
+	backReq.SetPathValue("avatar_id", created.ID)
+	backReq.Header.Set("Content-Type", "application/json")
+	backReq.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	backResp := httptest.NewRecorder()
+	app.handleUpdateAvatarKind(backResp, backReq)
+	if backResp.Code != http.StatusOK {
+		t.Fatalf("back status = %d body = %s", backResp.Code, backResp.Body.String())
+	}
+	var roundTripped avatarAssetResponse
+	if err := json.Unmarshal(backResp.Body.Bytes(), &roundTripped); err != nil {
+		t.Fatal(err)
+	}
+	if roundTripped.Kind != "agent" {
+		t.Fatalf("round-trip = %#v", roundTripped)
+	}
+}
+
+func TestAvatarUpdateKindRejectsNonAdmin(t *testing.T) {
+	app := newAvatarTestServer(t)
+	createReq := avatarCreateRequest(t, map[string]string{
+		"kind": "agent",
+		"name": "Ada",
+	})
+	createReq.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	createResp := httptest.NewRecorder()
+	app.handleCreateAvatar(createResp, createReq)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", createResp.Code, createResp.Body.String())
+	}
+	var created avatarAssetResponse
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/admin/avatars/"+created.ID+"/kind", strings.NewReader(`{"kind":"system"}`))
+	req.SetPathValue("avatar_id", created.ID)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, otherUser, auth.RoleUser))
+	resp := httptest.NewRecorder()
+	app.handleUpdateAvatarKind(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestAvatarUpdateKindRejectsInvalidKind(t *testing.T) {
+	app := newAvatarTestServer(t)
+	req := httptest.NewRequest(http.MethodPatch, "/api/admin/avatars/av_missing/kind", strings.NewReader(`{"kind":"personal"}`))
+	req.SetPathValue("avatar_id", "av_missing")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+	app.handleUpdateAvatarKind(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "kind must be agent or system") {
+		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestAvatarUpdateKindReturnsConflictWhenUnchanged(t *testing.T) {
+	app := newAvatarTestServer(t)
+	createReq := avatarCreateRequest(t, map[string]string{
+		"kind": "agent",
+		"name": "Ada",
+	})
+	createReq.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	createResp := httptest.NewRecorder()
+	app.handleCreateAvatar(createResp, createReq)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", createResp.Code, createResp.Body.String())
+	}
+	var created avatarAssetResponse
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/admin/avatars/"+created.ID+"/kind", strings.NewReader(`{"kind":"agent"}`))
+	req.SetPathValue("avatar_id", created.ID)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+	app.handleUpdateAvatarKind(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestAvatarUpdateKindReturnsNotFoundForUnknownID(t *testing.T) {
+	app := newAvatarTestServer(t)
+	req := httptest.NewRequest(http.MethodPatch, "/api/admin/avatars/av_missing/kind", strings.NewReader(`{"kind":"system"}`))
+	req.SetPathValue("avatar_id", "av_missing")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	resp := httptest.NewRecorder()
+	app.handleUpdateAvatarKind(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
+	}
+}
+
 func TestAvatarCreateRejectsInvalidKind(t *testing.T) {
 	app := newAvatarTestServer(t)
 	req := avatarCreateRequest(t, map[string]string{

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -391,7 +391,7 @@ func recordAvatarUploadAttempt(stage, result string) {
 
 func avatarAssetOperationLabel(operation string) string {
 	switch operation {
-	case "list", "read_image", "create", "delete":
+	case "list", "read_image", "create", "delete", "update_kind":
 		return operation
 	default:
 		return "unknown"

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -133,6 +133,7 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/avatars/{avatar_id}/backing", s.handleGetAvatarBacking)
 	mux.HandleFunc("GET /api/admin/avatar-decks", s.handleGetAvatarDecks)
 	mux.HandleFunc("POST /api/admin/avatars", s.handleCreateAvatar)
+	mux.HandleFunc("PATCH /api/admin/avatars/{avatar_id}/kind", s.handleUpdateAvatarKind)
 	mux.HandleFunc("DELETE /api/admin/avatars/{avatar_id}", s.handleDeleteAvatar)
 	// Admin-only durable support surface for avatar upload failures. The
 	// form error returns attempt_id; this endpoint turns that reference into

--- a/backend-go/internal/avatarassets/avatarassets.go
+++ b/backend-go/internal/avatarassets/avatarassets.go
@@ -18,6 +18,7 @@ const (
 var (
 	ErrNotFound       = errors.New("avatar asset not found")
 	ErrInvalidVariant = errors.New("invalid avatar image variant")
+	ErrKindUnchanged  = errors.New("avatar kind already matches")
 )
 
 type Crop struct {
@@ -65,6 +66,13 @@ type Store interface {
 	Create(ctx context.Context, asset NewAsset) (Metadata, error)
 	Ensure(ctx context.Context, asset NewAsset) error
 	Delete(ctx context.Context, id string) (Metadata, error)
+	// UpdateKind flips an avatar's kind between "agent" and "system".
+	// Implementations that own a per-owner shuffled deck (pgstore) MUST
+	// also remove the avatar's *unused* entries from the OLD kind's deck
+	// cycles in the same transaction — used entries are historical and
+	// stay. The new kind picks the avatar up on its next cycle by the
+	// same "new additions wait" rule that applies to fresh uploads.
+	UpdateKind(ctx context.Context, id, newKind string) (Metadata, error)
 }
 
 type ImageStore interface {
@@ -167,6 +175,26 @@ func (s *MemoryStore) Delete(_ context.Context, id string) (Metadata, error) {
 		return Metadata{}, ErrNotFound
 	}
 	delete(s.records, id)
+	return meta, nil
+}
+
+func (s *MemoryStore) UpdateKind(_ context.Context, id, newKind string) (Metadata, error) {
+	normalized, ok := NormalizeKind(newKind)
+	if !ok {
+		return Metadata{}, errors.New("kind must be agent or system")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	meta, ok := s.records[id]
+	if !ok {
+		return Metadata{}, ErrNotFound
+	}
+	if meta.Kind == normalized {
+		return Metadata{}, ErrKindUnchanged
+	}
+	meta.Kind = normalized
+	meta.UpdatedAt = time.Now().UTC()
+	s.records[id] = meta
 	return meta, nil
 }
 

--- a/backend-go/internal/pgstore/avatar_assets.go
+++ b/backend-go/internal/pgstore/avatar_assets.go
@@ -122,6 +122,66 @@ func (s *AvatarAssetStore) Ensure(ctx context.Context, asset avatarassets.NewAss
 	return err
 }
 
+// UpdateKind flips an avatar's kind and atomically removes the avatar's
+// unused entries from the OLD kind's deck cycles. Used deck entries stay
+// as historical record of which avatar was drawn for which session. The
+// new kind picks the avatar up on its next cycle — adding it mid-cycle
+// would violate the "new additions wait until next cycle" rule that
+// covers fresh uploads (see migrations.go on avatar_deck_entries).
+func (s *AvatarAssetStore) UpdateKind(ctx context.Context, id, newKind string) (avatarassets.Metadata, error) {
+	normalized, ok := avatarassets.NormalizeKind(newKind)
+	if !ok {
+		return avatarassets.Metadata{}, errors.New("kind must be agent or system")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return avatarassets.Metadata{}, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	const selectQ = `
+		SELECT kind FROM avatar_assets
+		WHERE id = $1 AND deleted_at IS NULL
+		FOR UPDATE
+	`
+	var currentKind string
+	if err := tx.QueryRow(ctx, selectQ, id).Scan(&currentKind); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return avatarassets.Metadata{}, avatarassets.ErrNotFound
+		}
+		return avatarassets.Metadata{}, err
+	}
+	if currentKind == normalized {
+		return avatarassets.Metadata{}, avatarassets.ErrKindUnchanged
+	}
+
+	const updateQ = `
+		UPDATE avatar_assets
+		SET kind = $2, updated_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, kind, name, crop, created_by, created_at, updated_at,
+			avatar_mime, coalesce(avatar_blob_key, ''),
+			backing_mime, coalesce(backing_blob_key, '')
+	`
+	meta, err := scanAvatarMetadata(tx.QueryRow(ctx, updateQ, id, normalized))
+	if err != nil {
+		return avatarassets.Metadata{}, err
+	}
+
+	const cleanupDeckQ = `
+		DELETE FROM avatar_deck_entries
+		WHERE kind = $1 AND avatar_id = $2 AND used_session_id IS NULL
+	`
+	if _, err := tx.Exec(ctx, cleanupDeckQ, currentKind, id); err != nil {
+		return avatarassets.Metadata{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return avatarassets.Metadata{}, err
+	}
+	return meta, nil
+}
+
 func (s *AvatarAssetStore) Delete(ctx context.Context, id string) (avatarassets.Metadata, error) {
 	const q = `
 		UPDATE avatar_assets

--- a/backend-go/internal/pgstore/avatar_assets_integration_test.go
+++ b/backend-go/internal/pgstore/avatar_assets_integration_test.go
@@ -1,0 +1,171 @@
+package pgstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/avatarassets"
+)
+
+func TestPostgresAvatarAssetUpdateKindClearsUnusedDeckEntries(t *testing.T) {
+	dsn := os.Getenv("TANK_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TANK_TEST_POSTGRES_DSN is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	adminPool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect admin pool: %v", err)
+	}
+	schema := fmt.Sprintf("tank_avatar_kind_%d", time.Now().UnixNano())
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schemaIdent); err != nil {
+		adminPool.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(context.Background(), "DROP SCHEMA IF EXISTS "+schemaIdent+" CASCADE")
+		adminPool.Close()
+	})
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse test dsn: %v", err)
+	}
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect schema pool: %v", err)
+	}
+	defer pool.Close()
+
+	if err := RunMigrations(ctx, pool); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	store := NewAvatarAssetStore(pool)
+	if _, err := store.Create(ctx, avatarassets.NewAsset{
+		ID:             "av_kind_flip",
+		Kind:           "system",
+		Name:           "Flippable",
+		Crop:           avatarassets.Crop{CenterX: 0.5, CenterY: 0.5, Size: 1},
+		AvatarMIME:     "image/png",
+		AvatarBlobKey:  "avatars/av_kind_flip/avatar.png",
+		BackingMIME:    "image/png",
+		BackingBlobKey: "avatars/av_kind_flip/backing.png",
+		CreatedBy:      "tester@example.com",
+	}); err != nil {
+		t.Fatalf("create avatar: %v", err)
+	}
+
+	insertEntry := `
+		INSERT INTO avatar_deck_entries (
+			email, session_scope, kind, cycle, position, avatar_id, used_session_id, used_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`
+	// Two owners, one with an unused entry (must be cleaned), the other
+	// with a used entry (historical, must stay).
+	if _, err := pool.Exec(ctx, insertEntry, "alpha@example.com", "default", "system", 1, 1, "av_kind_flip", nil, nil); err != nil {
+		t.Fatalf("insert unused system entry: %v", err)
+	}
+	usedAt := time.Now().UTC()
+	if _, err := pool.Exec(ctx, insertEntry, "bravo@example.com", "default", "system", 1, 1, "av_kind_flip", "session-7", usedAt); err != nil {
+		t.Fatalf("insert used system entry: %v", err)
+	}
+	// An agent-kind unused entry pointing at a different avatar should
+	// survive the flip — only the OLD kind's unused entries for THIS
+	// avatar should be removed.
+	if _, err := store.Create(ctx, avatarassets.NewAsset{
+		ID:             "av_other",
+		Kind:           "agent",
+		Name:           "Other",
+		Crop:           avatarassets.Crop{CenterX: 0.5, CenterY: 0.5, Size: 1},
+		AvatarMIME:     "image/png",
+		AvatarBlobKey:  "avatars/av_other/avatar.png",
+		BackingMIME:    "image/png",
+		BackingBlobKey: "avatars/av_other/backing.png",
+		CreatedBy:      "tester@example.com",
+	}); err != nil {
+		t.Fatalf("create other avatar: %v", err)
+	}
+	if _, err := pool.Exec(ctx, insertEntry, "alpha@example.com", "default", "agent", 1, 1, "av_other", nil, nil); err != nil {
+		t.Fatalf("insert agent entry: %v", err)
+	}
+
+	meta, err := store.UpdateKind(ctx, "av_kind_flip", "agent")
+	if err != nil {
+		t.Fatalf("update kind: %v", err)
+	}
+	if meta.Kind != "agent" {
+		t.Fatalf("meta.Kind = %q, want agent", meta.Kind)
+	}
+
+	var unusedRemaining int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM avatar_deck_entries
+		WHERE avatar_id = $1 AND kind = 'system' AND used_session_id IS NULL
+	`, "av_kind_flip").Scan(&unusedRemaining); err != nil {
+		t.Fatalf("count unused system entries: %v", err)
+	}
+	if unusedRemaining != 0 {
+		t.Fatalf("expected unused system entries cleaned, got %d", unusedRemaining)
+	}
+
+	var usedRemaining int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM avatar_deck_entries
+		WHERE avatar_id = $1 AND kind = 'system' AND used_session_id IS NOT NULL
+	`, "av_kind_flip").Scan(&usedRemaining); err != nil {
+		t.Fatalf("count used system entries: %v", err)
+	}
+	if usedRemaining != 1 {
+		t.Fatalf("expected used system entry preserved, got %d", usedRemaining)
+	}
+
+	var otherRemaining int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM avatar_deck_entries
+		WHERE avatar_id = 'av_other'
+	`).Scan(&otherRemaining); err != nil {
+		t.Fatalf("count other agent entries: %v", err)
+	}
+	if otherRemaining != 1 {
+		t.Fatalf("expected unrelated avatar entry preserved, got %d", otherRemaining)
+	}
+
+	// Round-trip the kind back to system; the previously cleaned unused
+	// entry should not magically reappear (cycle won't refill mid-life).
+	if _, err := store.UpdateKind(ctx, "av_kind_flip", "system"); err != nil {
+		t.Fatalf("flip back: %v", err)
+	}
+	var systemUnused int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM avatar_deck_entries
+		WHERE avatar_id = $1 AND kind = 'system' AND used_session_id IS NULL
+	`, "av_kind_flip").Scan(&systemUnused); err != nil {
+		t.Fatalf("count system unused after round-trip: %v", err)
+	}
+	if systemUnused != 0 {
+		t.Fatalf("expected no unused system entries after round-trip, got %d", systemUnused)
+	}
+
+	if _, err := store.UpdateKind(ctx, "av_kind_flip", "system"); !errors.Is(err, avatarassets.ErrKindUnchanged) {
+		t.Fatalf("expected ErrKindUnchanged on no-op flip, got %v", err)
+	}
+
+	if _, err := store.UpdateKind(ctx, "av_missing", "agent"); !errors.Is(err, avatarassets.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing id, got %v", err)
+	}
+}

--- a/docs/features/app-chrome/capabilities.md
+++ b/docs/features/app-chrome/capabilities.md
@@ -102,16 +102,22 @@ Affected contracts:
 - Observability, because admin mutations affect user-visible identity surfaces
 
 Contract impact:
-- Avatar additions and deletions are confirmed by the backend durable store.
+- Avatar additions, deletions, and kind reassignments (agent <-> system) are
+  confirmed by the backend durable store.
 - Uploaded backing photos are not exposed as unauthenticated static assets.
 - Non-admin callers can read the active catalog for rendering but cannot mutate
   it.
-- Failure states for auth, upload validation, image reads, and deletes are
-  visible in the Settings -> Admin avatar pane.
+- A kind reassignment is atomic with cleanup of the avatar's unused entries in
+  the old kind's per-owner deck cycles; used entries stay as a historical
+  record of which avatar was drawn for which session.
+- Failure states for auth, upload validation, image reads, deletes, and kind
+  reassignments are visible in the Settings -> Admin avatar pane.
 
 Evidence:
 - PRs changing avatar admin behavior should verify the Settings -> Admin pane,
   admin-only writes, authenticated image reads, and reload-safe catalog
   rendering.
 - PRs changing avatar storage should cite the migration and bounded metric
-  evidence for avatar create/read/delete outcomes.
+  evidence for avatar create/read/delete/update_kind outcomes.
+- PRs touching kind reassignment should prove the unused-deck-entry cleanup
+  is atomic with the kind flip and that used entries are preserved.

--- a/frontend/src/AdminAvatarManager.tsx
+++ b/frontend/src/AdminAvatarManager.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import {
+  ArrowLeftRightIcon,
   ImagePlusIcon,
   Loader2Icon,
   Trash2Icon,
@@ -185,6 +186,29 @@ export function avatarSaveErrorMessage(status: number, body: AvatarUploadErrorBo
     ? body.attempt_id.trim()
     : "";
   return attemptID ? `${detail} Reference ${attemptID}.` : detail;
+}
+
+export type AvatarKindChangeResult =
+  | { ok: true }
+  | { ok: false; detail: string };
+
+export async function requestAvatarKindChange(
+  id: string,
+  nextKind: AvatarKind,
+): Promise<AvatarKindChangeResult> {
+  const res = await authedFetch(`/api/admin/avatars/${encodeURIComponent(id)}/kind`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind: nextKind }),
+  });
+  if (res.ok) {
+    return { ok: true };
+  }
+  const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
+  const detail = typeof body.detail === "string" && body.detail.trim()
+    ? body.detail.trim()
+    : `kind change failed: ${res.status}`;
+  return { ok: false, detail };
 }
 
 async function fetchAvatarDecks(): Promise<AvatarDeckKind[]> {
@@ -578,6 +602,18 @@ export function AdminAvatarManager({ onCatalogChanged }: AdminAvatarManagerProps
     await notifyCatalogChanged(setListError, "Avatar deleted");
   }
 
+  async function swapAvatarKind(entry: AvatarView) {
+    const nextKind: AvatarKind = entry.kind === "agent" ? "system" : "agent";
+    const result = await requestAvatarKindChange(entry.id, nextKind);
+    if (!result.ok) {
+      setListError(result.detail);
+      return;
+    }
+    await reloadEntries();
+    await reloadDecks();
+    await notifyCatalogChanged(setListError, "Avatar kind changed");
+  }
+
   const visibleDeck = decks.find((deck) => deck.kind === kind);
   const deckEntries = visibleDeck?.entries ?? [];
   const entriesById = new Map(entries.map((entry) => [entry.id, entry]));
@@ -784,6 +820,18 @@ export function AdminAvatarManager({ onCatalogChanged }: AdminAvatarManagerProps
                           {entry.imageError ? "image unavailable" : entry.created_by}
                         </span>
                       </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="admin-avatar-swap"
+                      title={`Move to ${entry.kind === "agent" ? "system" : "agent"} avatars`}
+                      aria-label={`Move ${entry.name} to ${entry.kind === "agent" ? "system" : "agent"} avatars`}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void swapAvatarKind(entry);
+                      }}
+                    >
+                      <ArrowLeftRightIcon size={15} aria-hidden="true" />
                     </button>
                     <button
                       type="button"

--- a/frontend/src/adminAvatarManager.test.ts
+++ b/frontend/src/adminAvatarManager.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { avatarSaveErrorMessage, fetchAvatarViews } from "./AdminAvatarManager";
+import {
+  avatarSaveErrorMessage,
+  fetchAvatarViews,
+  requestAvatarKindChange,
+} from "./AdminAvatarManager";
 
 test("avatar save errors include server attempt references", () => {
   assert.equal(
@@ -97,6 +101,136 @@ test("avatar admin keeps usable entries when another avatar image is missing", a
     globalThis.fetch = originalFetch;
     (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;
     URL.createObjectURL = originalCreateObjectURL;
+  }
+});
+
+test("requestAvatarKindChange PATCHes /api/admin/avatars/{id}/kind with the requested kind", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const storage = new Map<string, string>([["auth-romaine-jwt", "jwt"]]);
+
+  (globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => storage.clear(),
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+
+  let observedMethod = "";
+  let observedURL = "";
+  let observedBody = "";
+  let observedAuth = "";
+  let observedContentType = "";
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    observedURL = String(input);
+    observedMethod = String(init?.method ?? "GET");
+    observedBody = typeof init?.body === "string" ? init.body : "";
+    const headers = new Headers(init?.headers);
+    observedAuth = headers.get("Authorization") ?? "";
+    observedContentType = headers.get("Content-Type") ?? "";
+    return new Response(
+      JSON.stringify({
+        id: "av_1",
+        kind: "system",
+        name: "Ada",
+        avatar_url: "/api/avatars/av_1/image",
+        backing_url: "/api/avatars/av_1/backing",
+        crop: { center_x: 0.5, center_y: 0.5, size: 1 },
+        created_by: "admin@example.test",
+        created_at: "2026-05-25T00:00:00Z",
+        updated_at: "2026-05-25T00:01:00Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as typeof fetch;
+
+  try {
+    const result = await requestAvatarKindChange("av_1", "system");
+
+    assert.deepEqual(result, { ok: true });
+    assert.equal(observedMethod, "PATCH");
+    assert.equal(observedURL, "/api/admin/avatars/av_1/kind");
+    assert.equal(observedBody, JSON.stringify({ kind: "system" }));
+    assert.equal(observedAuth, "Bearer jwt");
+    assert.equal(observedContentType, "application/json");
+  } finally {
+    globalThis.fetch = originalFetch;
+    (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;
+  }
+});
+
+test("requestAvatarKindChange surfaces backend detail on failure", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const storage = new Map<string, string>([["auth-romaine-jwt", "jwt"]]);
+
+  (globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => storage.clear(),
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ detail: "avatar already has the requested kind" }), {
+      status: 409,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+  try {
+    const result = await requestAvatarKindChange("av_1", "agent");
+    assert.deepEqual(result, { ok: false, detail: "avatar already has the requested kind" });
+  } finally {
+    globalThis.fetch = originalFetch;
+    (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;
+  }
+});
+
+test("requestAvatarKindChange falls back to status when body has no detail", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const storage = new Map<string, string>([["auth-romaine-jwt", "jwt"]]);
+
+  (globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => storage.clear(),
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+
+  globalThis.fetch = (async () =>
+    new Response("not json", { status: 500 })) as typeof fetch;
+
+  try {
+    const result = await requestAvatarKindChange("av_1", "agent");
+    assert.deepEqual(result, { ok: false, detail: "kind change failed: 500" });
+  } finally {
+    globalThis.fetch = originalFetch;
+    (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;
   }
 });
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -717,10 +717,10 @@ button:disabled {
   font-size: var(--text-xs);
 }
 
+.admin-avatar-swap,
 .admin-avatar-delete {
   position: absolute;
   top: 0.45rem;
-  right: 0.45rem;
   width: 1.7rem;
   height: 1.7rem;
   border-radius: 6px;
@@ -728,6 +728,19 @@ button:disabled {
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
+}
+
+.admin-avatar-delete {
+  right: 0.45rem;
+}
+
+.admin-avatar-swap {
+  right: 2.3rem;
+}
+
+.admin-avatar-swap:hover {
+  color: var(--text-bright);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .admin-avatar-delete:hover {


### PR DESCRIPTION
## Summary

- New `PATCH /api/admin/avatars/{id}/kind` admin route flips an avatar between the `agent` and `system` catalogs.
- The Postgres implementation flips the kind and atomically deletes the avatar's *unused* `avatar_deck_entries` rows in the OLD kind, so the next draw from that owner's old-kind deck cycle does not return an avatar whose kind no longer matches. Used entries stay as historical record of which avatar was drawn for which session; the new kind picks the avatar up on its next cycle.
- The admin avatar pane shows a small left/right-arrow button next to the existing delete affordance on each card; errors surface through the same listError as delete.

## Feature Contracts

Affected contracts:
- [x] App Chrome
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [x] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **App Chrome / Avatar Admin Console** (`docs/features/app-chrome/capabilities.md`): the capability ledger was updated to name kind reassignment as a confirmed durable-store mutation and to require atomic cleanup of unused old-kind deck entries. Frontend coverage: `requestAvatarKindChange` is exercised by `frontend/src/adminAvatarManager.test.ts` (happy path, backend-detail surfacing, status fallback). Handler-level admin gating and bad-request shapes are covered by `TestAvatarUpdateKindRejectsNonAdmin`, `TestAvatarUpdateKindRejectsInvalidKind`, `TestAvatarUpdateKindReturnsNotFoundForUnknownID`, and `TestAvatarUpdateKindReturnsConflictWhenUnchanged`.
- **Auth And Streams**: route is `requireAdmin`-gated like the existing create / delete; non-admin caller returns 403 (`TestAvatarUpdateKindRejectsNonAdmin`). No new auth surface; same JWT verifier path.
- **Observability**: the bounded label set on `tank_avatar_asset_requests_total` was widened to include `operation="update_kind"`, with `result` reusing the existing closed set (`ok | bad_request | forbidden | not_found | store_unavailable | store_error`). Cardinality stays bounded (5 ops × 3 kinds × 6 results = 90 series ceiling, in line with the existing budget).
- **Deck cleanup atomicity**: `backend-go/internal/pgstore/avatar_assets_integration_test.go::TestPostgresAvatarAssetUpdateKindClearsUnusedDeckEntries` boots a fresh schema, plants an unused entry + a used entry + an unrelated-avatar entry, runs `UpdateKind`, and asserts: (a) unused old-kind entry for this avatar is gone, (b) used old-kind entry survives, (c) unrelated avatar's entry untouched, (d) round-trip flip does not resurrect cleaned entries, (e) `ErrKindUnchanged` on no-op, (f) `ErrNotFound` for unknown id. This test runs whenever `TANK_TEST_POSTGRES_DSN` is set in CI; same skip shape as the other pgstore integration tests.
- **No new migration required**: `avatar_assets.kind` already exists with the `agent | system` CHECK constraint; the change only adds a new write path against the existing column and an existing DELETE pattern against `avatar_deck_entries`.

## Test plan

- [x] `go test ./...` (handler unit tests pass; pgstore integration test skipped locally without DSN, runs in CI)
- [x] `npm test` in `frontend/` (214 tests pass)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: click swap button on an avatar card in the admin pane and confirm it relocates to the other section + the runtime catalog updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)