### PR TITLE
Harden NATS JetStream contract after 2026-05-25 publish-failure incident

### DIFF
--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -180,6 +180,22 @@ var (
 		Name: "tank_session_list_event_publish_failure_total",
 		Help: "Per-owner typed session-list event publishes that failed against NATS.",
 	})
+	// sessionBusCommandPublishFailureTotal covers the JetStream Publish
+	// path for runner commands (submit_turn / interrupt_turn /
+	// input_reply / stop_background_task). The two counters above
+	// cover the raw nc.Publish wake fabric; this counter covers the
+	// js.Publish command fabric. Both are needed: the 2026-05-25
+	// incident produced a sustained js.Publish failure (JetStream
+	// quorum loss → `nats: no response from stream`) while the wake
+	// counters above stayed quiet, because raw nc.Publish does not
+	// wait for a stream ack. Labels: kind from the closed Command.Type
+	// set (4 series), reason from classifyPublishError (5 series) =
+	// 20 series total. The TankSessionBusPublishFailing alert in
+	// k8s/templates/observability.yaml pages on any non-zero rate.
+	sessionBusCommandPublishFailureTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_session_bus_command_publish_failure_total",
+		Help: "Session-bus JetStream command publishes (submit_turn/interrupt_turn/input_reply/stop_background_task) that failed, labeled by kind and classified reason.",
+	}, []string{"kind", "reason"})
 	// Wake success counters + persist→wake latency. The published vs
 	// received delta is the candidate-A stethoscope (see
 	// docs/quality-timeframes.md observability requirement and the
@@ -1103,6 +1119,39 @@ func (promWakeMetrics) RecordSessionEventPersistToWakeDuration(seconds float64) 
 		seconds = 0
 	}
 	sessionEventPersistToWakeSeconds.Observe(seconds)
+}
+
+func (promWakeMetrics) RecordCommandPublishFailed(kind string, reason string) {
+	sessionBusCommandPublishFailureTotal.WithLabelValues(
+		sessionBusCommandKindLabel(kind),
+		sessionBusCommandReasonLabel(reason),
+	).Inc()
+}
+
+// sessionBusCommandKindLabel is the prom-side validator for the kind
+// label. The bus already buckets via commandKindLabel; this guard
+// catches a future schema drift where a new Command.Type slips through
+// without a matching bucket update, so cardinality stays bounded.
+func sessionBusCommandKindLabel(kind string) string {
+	switch kind {
+	case "submit_turn", "interrupt_turn", "input_reply", "stop_background_task", "other":
+		return kind
+	default:
+		return "other"
+	}
+}
+
+// sessionBusCommandReasonLabel mirrors classifyPublishError's bounded
+// output. Validation is intentionally redundant with the bus's own
+// classifier so a future bus change can't silently widen this label
+// set without touching the prom layer too.
+func sessionBusCommandReasonLabel(reason string) string {
+	switch reason {
+	case "no_response_from_stream", "connection", "timeout", "canceled", "other":
+		return reason
+	default:
+		return "other"
+	}
 }
 
 // recordSessionEventStreamEmittedByType is the per-event-type bump that

--- a/backend-go/internal/pgstore/client.go
+++ b/backend-go/internal/pgstore/client.go
@@ -78,7 +78,15 @@ func NewPool(ctx context.Context, cfg Config) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("pgstore: parse DSN: %w", err)
 	}
 	poolConfig.MaxConnLifetime = MaxConnLifetime
-	poolConfig.MaxConns = 10
+	// MaxConns is bounded against the shared Azure Postgres Flex Server's
+	// `max_connections` ceiling. B1ms's default cap is 50. The orchestrator
+	// runs as prod×2 replicas + up to 5 test slots×2 replicas = 12 pods
+	// sharing one DB, each with its own pool; 12×4 = 48 fits the cap with
+	// 2-conn headroom. Raising MaxConns or growing the slot fleet without
+	// matching B-tier upgrade reintroduces the SQLSTATE 53300 crash-loop
+	// observed on 2026-05-25 ("remaining connection slots are reserved
+	// for roles with the SUPERUSER attribute").
+	poolConfig.MaxConns = 4
 	poolConfig.MinConns = 1
 	if cfg.QueryMetrics != nil {
 		poolConfig.ConnConfig.Tracer = NewQueryTracer(cfg.QueryMetrics)

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -137,6 +137,19 @@ type WakeMetrics interface {
 	RecordSessionEventWakePublished()
 	RecordSessionEventWakeReceived()
 	RecordSessionEventPersistToWakeDuration(seconds float64)
+	// RecordCommandPublishFailed increments when js.Publish on a
+	// session-bus command subject returns an error — submit_turn,
+	// interrupt_turn, or input_reply commands that the orchestrator
+	// could not hand to the runner because JetStream itself failed.
+	// Steady-state expectation is zero. The 2026-05-25 NATS quorum
+	// incident produced sustained `reason="no_response_from_stream"`
+	// across `kind="submit_turn"` — every chat submission failed
+	// silently until the SPA rendered the durable turn.command_failed
+	// event the orchestrator wrote at handlers_turns.go:798. The
+	// TankSessionBusPublishFailing alert pages on any non-zero rate;
+	// `kind` and `reason` labels are bounded by the bus's own
+	// classifyPublishError + the closed Command.Type set.
+	RecordCommandPublishFailed(kind string, reason string)
 }
 
 type noopWakeMetrics struct{}
@@ -146,6 +159,7 @@ func (noopWakeMetrics) RecordSessionListEventPublishFailed()            {}
 func (noopWakeMetrics) RecordSessionEventWakePublished()                {}
 func (noopWakeMetrics) RecordSessionEventWakeReceived()                 {}
 func (noopWakeMetrics) RecordSessionEventPersistToWakeDuration(float64) {}
+func (noopWakeMetrics) RecordCommandPublishFailed(string, string)       {}
 
 // WakeRecorder is the optional per-stream hook SubscribeWakes calls
 // from the NATS message callback. The SSE handler passes its
@@ -240,7 +254,14 @@ func Connect(ctx context.Context, cfg Config) (*Bus, error) {
 		b.scope = "default"
 	}
 	if b.replicas <= 0 {
-		b.replicas = 2
+		// JetStream Raft requires R ∈ {1, 3, 5}; R=2 has no tiebreaker
+		// and halts on a single slow member. The production chart sets
+		// sessionBus.streamReplicas: 3 and exports it as
+		// NATS_STREAM_REPLICAS; this default is a defense-in-depth
+		// safety net only — if the env is unset for any reason, the
+		// stream is still created with a sane quorum size rather than
+		// regressing to the 2026-05-25 incident shape.
+		b.replicas = 3
 	}
 	if b.wakeMetrics == nil {
 		b.wakeMetrics = noopWakeMetrics{}
@@ -289,7 +310,62 @@ func (b *Bus) PublishCommand(ctx context.Context, command Command) error {
 	// single decision point so the routing rule is unit-testable without
 	// touching JetStream.
 	_, err = b.js.Publish(ctx, SubjectForCommand(command), raw, jetstream.WithMsgID(command.CommandID))
+	if err != nil {
+		// The 2026-05-25 incident shape: JetStream lost quorum and
+		// returned `nats: no response from stream`, every submit_turn
+		// failed, and the only signal was the per-session
+		// turn.command_failed event the handler writes below. The
+		// counter here is the observability surface the
+		// TankSessionBusPublishFailing alert reads — without it,
+		// re-occurrence stays invisible to Grafana until a user
+		// screenshots the failure.
+		b.wakeMetrics.RecordCommandPublishFailed(
+			commandKindLabel(command.Type),
+			classifyPublishError(err),
+		)
+	}
 	return err
+}
+
+// classifyPublishError maps a js.Publish error into a bounded reason
+// label for the publish-failure counter. The jetstream package exports
+// the two transport-layer sentinels that map cleanly to operational
+// causes; context errors are stdlib; everything else collapses to
+// "other" so a future nats.go release can't quietly inflate the
+// label cardinality.
+func classifyPublishError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, jetstream.ErrNoStreamResponse):
+		return "no_response_from_stream"
+	case errors.Is(err, jetstream.ErrConnectionClosed),
+		errors.Is(err, nats.ErrConnectionClosed):
+		return "connection"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	default:
+		return "other"
+	}
+}
+
+// commandKindLabel buckets Command.Type against the closed set of
+// commands this bus publishes today. The set is enumerated at
+// internal/sessionbus/commands.go; any addition there should mirror
+// here so the metric stays path-independent. Unknown types collapse
+// to "other".
+func commandKindLabel(commandType string) string {
+	switch commandType {
+	case CommandSubmitTurn,
+		CommandInterrupt,
+		CommandInputReply,
+		CommandStopBackgroundTask:
+		return commandType
+	default:
+		return "other"
+	}
 }
 
 // PublishSessionEventWake signals SSE subscribers on

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -510,6 +510,113 @@ spec:
             summary: "tank-operator's NATS client is reconnecting faster than 6/min"
             runbook: "JetStream session bus is unstable. Check the nats namespace's pod health and ServerCertificate."
 
+        # Per-command publish-failure observability. The wake/event-list
+        # publish counters above cover the raw nc.Publish path; this
+        # alert covers the js.Publish command path the orchestrator uses
+        # for submit_turn / interrupt_turn / input_reply /
+        # stop_background_task. The 2026-05-25 NATS quorum incident
+        # produced sustained reason="no_response_from_stream" on
+        # kind="submit_turn" — every chat submission failed silently,
+        # the user only learned via the durable turn.command_failed
+        # event the SPA rendered. Pages on any non-zero rate because
+        # each failure is a user-visible "Submit failed" banner.
+        - alert: TankSessionBusPublishFailing
+          expr: sum(rate(tank_session_bus_command_publish_failure_total[5m])) by (kind, reason) > 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "session-bus js.Publish failing kind={{`{{ $labels.kind }}`}} reason={{`{{ $labels.reason }}`}}"
+            runbook: |
+              Every failed publish here is a stranded user submission:
+              the backend persisted user_message.created + turn.submitted
+              to the durable ledger, then could not publish the runner
+              command. kind=submit_turn failures surface as
+              turn.command_failed in the transcript and "Submit failed" /
+              "Turn failed" banners to the user. kind=interrupt_turn
+              failures surface as Stop not landing.
+
+              reason="no_response_from_stream" — JetStream cluster has
+              lost quorum or the stream is overloaded. Pair with
+              TankJetStreamRaftAtRisk below and the NATS server-side
+              "NO quorum, stalled" warnings in the `nats` namespace.
+
+              reason="connection" — tank-operator's NATS client is
+              unable to reach tank-nats. Pair with TankNATSReconnectStorm.
+
+              reason="timeout" / "canceled" — the publish context
+              expired before the stream ack arrived. Usually a
+              symptom of upstream pressure, not a transport bug.
+
+        # JetStream consumer stalled: pending messages with no delivery
+        # progress. Catches the per-session consumer regression shape
+        # where a runner consumer exists but is not draining work — the
+        # orchestrator keeps publishing submit_turn commands that the
+        # runner never receives. Compare with the prior 2026-05-25
+        # incident: the cluster-level "NO quorum" warnings appear at
+        # the producer side (TankSessionBusPublishFailing above), but a
+        # post-quorum-recovery world can still have individual
+        # consumers stuck due to redelivery storms, orphaned
+        # consumers, etc.
+        - alert: TankJetStreamConsumerStalled
+          expr: |
+            sum by (stream_name, consumer_name) (nats_consumer_num_pending{stream_name="TANK_SESSION_BUS"})
+              > 0
+              unless on(stream_name, consumer_name)
+                (changes(nats_consumer_delivered_consumer_seq{stream_name="TANK_SESSION_BUS"}[5m]) > 0)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "JetStream consumer {{`{{ $labels.consumer_name }}`}} on {{`{{ $labels.stream_name }}`}} has pending messages with no delivery progress for 5m"
+            runbook: |
+              Either the consuming runner pod is gone (a session was
+              deleted but the durable consumer was orphaned), or the
+              cluster lost write quorum and acks cannot land. Check NATS
+              server logs in the nats namespace for "has NO quorum,
+              stalled" warnings. If quorum is healthy, enumerate active
+              session pods and remove orphan consumers via the nats CLI
+              in nats-box. The consumer naming convention is
+              "{provider}_{storage_key}" for data-plane and
+              "{provider}_control_{storage_key}" for control-plane —
+              see backend-go/internal/sessionbus/subjects.go.
+
+        # JetStream Raft at risk: cluster-level signals that quorum is
+        # in danger BEFORE consumers actually stall. The 2026-05-25
+        # incident's early warning was that one NATS pod's readloop
+        # processing time climbed to 2-3s under host CPU pressure;
+        # the per-server prom exporter does not expose readloop
+        # processing time directly, but two adjacent signals do:
+        # meta_pending climbs when Raft replication falls behind, and
+        # slow_consumers > 0 indicates the server is struggling to
+        # drain subscribers (which under enough pressure produces the
+        # same Raft-stall outcome).
+        - alert: TankJetStreamRaftAtRisk
+          expr: |
+            max(nats_varz_jetstream_meta_pending) > 50
+              or max(nats_varz_slow_consumers) > 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NATS JetStream Raft is backlogged (meta_pending > 50 or slow_consumers > 0)"
+            runbook: |
+              The 2026-05-25 chat-submission outage started here: a
+              single NATS replica got starved of CPU on a saturated
+              node, its Raft readloop fell behind, the R=2 cluster
+              lost quorum, every TANK_SESSION_BUS command publish
+              failed for ~10 minutes. The infra-bootstrap chart now
+              runs cluster.replicas: 3 with required-hostname
+              podAntiAffinity and Burstable QoS to prevent the
+              co-tenancy + CPU-starvation shape, but this alert is
+              the early warning: by the time
+              TankJetStreamConsumerStalled or TankSessionBusPublishFailing
+              fires, users are already seeing "Submit failed".
+              Check `kubectl top nodes` for the node hosting the
+              affected tank-nats pod and verify each NATS replica is
+              on its own node (anti-affinity guarantees this but a
+              drain/upgrade window can temporarily violate it).
+
     - name: tank-operator.api-proxy
       rules:
         - alert: TankApiProxyRefreshStorm

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -190,7 +190,14 @@ avatarAssets:
 
 sessionBus:
   stream: TANK_SESSION_BUS
-  streamReplicas: 2
+  # JetStream Raft tolerates {1, 3, 5} replicas. R=2 needs both replicas
+  # to ack to make progress (write quorum = 2 of 2) and has no tiebreaker,
+  # so a single slow member halts writes — the 2026-05-25 incident shape
+  # (one NATS pod slowed under host CPU pressure → entire TANK_SESSION_BUS
+  # lost quorum → every submit_turn failed with `nats: no response from
+  # stream`). R=3 requires the infra-bootstrap NATS chart to also run
+  # cluster.replicas: 3; both must move together.
+  streamReplicas: 3
   authSecret: tank-nats-auth
   tokenKvKey: tank-nats-token
   # NATS lives in its own namespace, deployed by infra-bootstrap's nats


### PR DESCRIPTION
## Summary

- Sustained `nats: no response from stream` on every submit_turn for ~10 min on 2026-05-25; visible only as durable `turn.command_failed` events because the bus had no publish-failure counter. Root cause was a JetStream R=2 cluster losing quorum when both NATS pods (co-tenanted on a CPU-saturated node, BestEffort QoS) slowed simultaneously.
- This PR closes the orchestrator-side half of the remediation: stream R=3 to match the new R=3 cluster, defense-in-depth code default, new `tank_session_bus_command_publish_failure_total{kind,reason}` counter, three new PrometheusRule alerts, plus `pgstore.MaxConns` lowered to fit B1ms's `max_connections` ceiling (orchestrator crash-looped on SQLSTATE 53300 during the same window).
- Pairs with an infra-bootstrap PR that updates the NATS chart to R=3 + required-hostname `podAntiAffinity` + Burstable QoS, plus a tofu min-count bump to keep R=3 schedulable.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:

**Observability contract** — § Acceptance Checks:
- *New metric respects cardinality rules; help string explains what + which failure mode.* `tank_session_bus_command_publish_failure_total{kind, reason}` is bounded at 4 × 5 = 20 series (closed `Command.Type` set × `classifyPublishError` enum). Help string names the 2026-05-25 incident as the prototypical failure shape.
- *New alert names durable source of truth + distinguishes specific candidates.* All three new alerts in `tank-operator.nats`:
  - `TankSessionBusPublishFailing` runbook distinguishes `no_response_from_stream` (quorum loss) from `connection` (client-side reach) from `timeout`/`canceled` (context expiry).
  - `TankJetStreamConsumerStalled` runbook names orphan consumers vs cluster quorum loss as the two candidate causes and points at `backend-go/internal/sessionbus/subjects.go` for consumer naming.
  - `TankJetStreamRaftAtRisk` runbook names the 2026-05-25 incident as the prototypical signature and the new chart-side mitigations as the structural fix.
- *Operator can diagnose without browser devtools / `kubectl exec`.* The new counter is scraped via the existing `ServiceMonitor`; consumer/Raft metrics are scraped from the `promExporter` sidecar the NATS chart already enables. End-to-end PromQL path.
- *`helm template` and tests pass.* `go test ./internal/sessionbus/... ./cmd/tank-operator/...` passes; `helm template k8s` renders 3961 lines cleanly with the new env var and alerts present.

**Agent Runners contract** — § Observability ("Metrics must distinguish command published, consumed, acked, redelivered, failed, and terminal-event-emitted outcomes"):
- The new counter covers the **failed** axis for every command kind (`submit_turn`, `interrupt_turn`, `input_reply`, `stop_background_task`). Previously a publish failure was only visible as the durable `turn.command_failed` event the orchestrator wrote at [`handlers_turns.go:798`](backend-go/cmd/tank-operator/handlers_turns.go:798), and only for `submit_turn` — `interrupt_turn` publish failures had no observability surface.
- Pairs with the existing `tank_turn_lifecycle_total{event_type}` (turn-terminal axis) and `TankTurnSilentStranding` alert to close the publish→consume→terminal observability loop.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/sessionbus/... ./cmd/tank-operator/...` passes (1.3s + 1.9s)
- [x] `helm template k8s` renders cleanly (3961 lines); new env var + all 3 alerts present in output
- [x] `scripts/check-removed-chat-runtime.mjs`, `check-askuserquestion-migration.mjs`, `check-session-pod-hot-swap-migration.mjs` (38/38) all pass
- [ ] **Blocked by infra-bootstrap PR landing first:** can't merge this PR until the NATS chart is R=3 — orchestrator would create an R=3 stream against an R=2 cluster, which fails. Tag waits for chart-side PR.
- [ ] Post-merge live verification: confirm `nats stream info TANK_SESSION_BUS` reports `Replicas: 3` after orchestrator rollout

## Out of scope (named, not hidden)

- **Session pod CPU bursting.** Codex GUI sessions can burn 700m+ with only 35m CPU request and no limit. NATS is now protected by Burstable QoS via the chart change, but other co-tenants (`auth-db`, `mcp-*`) remain exposed to noisy-neighbor degradation. Fixing this requires either honest session-pod CPU requests/limits + raising the AKS autoscaler `max_count` (new bursty cost when triggered), or a dedicated platform node pool ($45/mo steady state). Deferred per user direction.
- **B1ms Postgres CPU ceiling.** Lowering `MaxConns` fixes connection-slot exhaustion but doesn't solve the single-vCPU Flex Server serving every orchestrator + slot + persister. If query p99 degrades, the next step is a B-tier upgrade or PgBouncer; not on the table now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)