### PR TITLE
Add Postgres connection-saturation observability

### DIFF
--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nelsong6/tank-operator/backend-go/internal/avataruploads"
 	"github.com/nelsong6/tank-operator/backend-go/internal/hermes"
 	"github.com/nelsong6/tank-operator/backend-go/internal/mcpgithub"
+	"github.com/nelsong6/tank-operator/backend-go/internal/pgstats"
 	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
 	"github.com/nelsong6/tank-operator/backend-go/internal/profiles"
 	"github.com/nelsong6/tank-operator/backend-go/internal/providerhealth"
@@ -432,6 +433,29 @@ func main() {
 				slog.Error("session controller k8s watch stopped", "error", err)
 			}
 		}()
+	}
+
+	// Postgres connection-saturation poller. Reuses the orchestrator's
+	// AAD-aware pool (no sidecar — the upstream pg_exporter image has
+	// no Entra ID workload-identity path) to read pg_stat_database and
+	// current_setting('max_connections') every 30s. Drives the
+	// TankPgConnectionSaturation alert that wasn't there to catch the
+	// 2026-05-25 SQLSTATE 53300 orchestrator crash-loop. Skipped when
+	// pgPool is nil — stub mode has no real server to poll.
+	if pgPool != nil {
+		poller, err := pgstats.New(pgstats.Config{
+			Pool:    pgPool,
+			Metrics: promPGStatsMetrics{},
+		})
+		if err != nil {
+			slog.Error("pgstats poller init failed", "error", err)
+		} else {
+			go func() {
+				if err := poller.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					slog.Error("pgstats poller stopped", "error", err)
+				}
+			}()
+		}
 	}
 
 	// Provider-credential health poller. Reads /health/<provider> on

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/nelsong6/tank-operator/backend-go/internal/pgstats"
 	"github.com/nelsong6/tank-operator/backend-go/internal/pgstore"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
 	"github.com/nelsong6/tank-operator/backend-go/internal/sessioncontroller"
@@ -1011,7 +1012,60 @@ var (
 		},
 		[]string{"operation"},
 	)
+
+	// Postgres server-side connection-saturation surface. The
+	// pgQueriesTotal counter above sees this orchestrator's own
+	// pool traffic; these gauges see the SERVER's total backend
+	// count and max_connections ceiling. The 2026-05-25 incident
+	// crash-looped the orchestrator on SQLSTATE 53300 with no
+	// advance signal at all — these gauges + the
+	// TankPgConnectionSaturation alert make the next saturation
+	// approach visible 13+ conns before the cap. Polled every 30s
+	// by internal/pgstats.Poller using the orchestrator's existing
+	// AAD-aware pgxpool; see that package for the auth/scale
+	// rationale.
+	//
+	// Both are unlabeled gauges — the server is a single shared
+	// instance; per-pod resolution would just multiply N identical
+	// series since every orchestrator pod sees the same server
+	// state. Alert PromQL uses max() across pods to dedupe.
+	pgBackendConnectionsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "tank_pg_backend_connections",
+		Help: "Total Postgres backend connections currently established on the shared Flex Server (sum across all databases). Read every 30s from pg_stat_database. Same value across orchestrator pods — aggregate with max() in PromQL.",
+	})
+	pgMaxConnectionsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "tank_pg_max_connections",
+		Help: "Postgres server's max_connections cap. Read every 30s from current_setting('max_connections') so an in-place SKU change updates the alert headroom without an orchestrator restart.",
+	})
+	pgStatsPollTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_pg_stats_poll_total",
+		Help: "Outcomes of the pgstats connection-saturation poller. Steady-state expectation: every increment lands on outcome=ok.",
+	}, []string{"outcome"})
 )
+
+// promPGStatsMetrics satisfies pgstats.Metrics so the poller can
+// emit gauges/counters without importing prometheus. Outcome label
+// is validated against the closed set the poller emits — anything
+// else collapses to "other" so a future poller change can't quietly
+// inflate the cardinality.
+type promPGStatsMetrics struct{}
+
+func (promPGStatsMetrics) RecordBackendConnections(count float64) {
+	pgBackendConnectionsGauge.Set(count)
+}
+
+func (promPGStatsMetrics) RecordMaxConnections(count float64) {
+	pgMaxConnectionsGauge.Set(count)
+}
+
+func (promPGStatsMetrics) RecordPollOutcome(outcome string) {
+	switch outcome {
+	case "ok", "query_failed":
+		pgStatsPollTotal.WithLabelValues(outcome).Inc()
+	default:
+		pgStatsPollTotal.WithLabelValues("other").Inc()
+	}
+}
 
 // --- NATS connection metrics ---
 
@@ -1322,6 +1376,7 @@ var (
 	_ sessionbus.WakeMetrics                    = promWakeMetrics{}
 	_ sessionbus.ConnectionMetrics              = promNATSConnectionMetrics{}
 	_ pgstore.SQLMetrics                        = promPGMetrics{}
+	_ pgstats.Metrics                           = promPGStatsMetrics{}
 	_ sessioncontroller.K8sWatchMetrics         = promK8sWatchMetrics{}
 	_ sessioncontroller.RowWriterMetrics        = promRowWriterMetrics{}
 	_ sessioncontroller.LifecycleEmitterMetrics = promLifecycleEmitterMetrics{}

--- a/backend-go/internal/pgstats/poller.go
+++ b/backend-go/internal/pgstats/poller.go
@@ -1,0 +1,143 @@
+// Package pgstats polls the Postgres server for connection-saturation
+// metrics that the orchestrator's existing query tracer cannot
+// observe — the tracer sees its own pool's traffic, not the server's
+// total backend count or the max_connections ceiling.
+//
+// The 2026-05-25 incident shape this package exists to surface in
+// advance: the B1ms Flex Server has max_connections=50; 12
+// orchestrator pods × pool.MaxConns each were exceeding the cap,
+// producing SQLSTATE 53300 "remaining connection slots are reserved
+// for roles with the SUPERUSER attribute" crash-loops on cold boot.
+// The only signal beforehand was the crash itself. After this
+// package lands, the TankPgConnectionSaturation alert fires at 70%
+// utilization so the SKU bump can be planned, not reactive.
+//
+// Auth: this poller reuses the orchestrator's AAD-aware pgxpool
+// instead of running a separate pg_exporter sidecar. The upstream
+// pg_exporter image expects username/password and has no native
+// Entra ID workload-identity path; building one would require a
+// wrapper container that fetches an AAD token and rewrites a DSN at
+// connection time. The orchestrator's pool already does that
+// correctly via pgstore.BeforeConnect, so the in-process poller is
+// the lower-complexity surface.
+package pgstats
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Metrics receives the per-poll connection counts. Wired to
+// prometheus in cmd/tank-operator/observability.go; tests can pass a
+// noop or recording implementation.
+//
+// Outcome labels are bounded at code: "ok" on a successful poll,
+// "query_failed" when a SQL call errors. The prometheus side
+// validates against the same closed set so a future poller change
+// can't quietly inflate the label space.
+type Metrics interface {
+	RecordBackendConnections(count float64)
+	RecordMaxConnections(count float64)
+	RecordPollOutcome(outcome string)
+}
+
+// noopMetrics is the default when Config.Metrics is nil. The poller
+// can still run usefully without a metrics implementation — the
+// gauges just don't update.
+type noopMetrics struct{}
+
+func (noopMetrics) RecordBackendConnections(float64) {}
+func (noopMetrics) RecordMaxConnections(float64)     {}
+func (noopMetrics) RecordPollOutcome(string)         {}
+
+// Config wires the poller's dependencies. Pool is required; the
+// other fields default sensibly.
+type Config struct {
+	Pool     *pgxpool.Pool
+	Metrics  Metrics
+	Interval time.Duration
+}
+
+// Poller queries pg_stat_database for the live backend count and
+// current_setting('max_connections') for the server cap on a fixed
+// interval. Run blocks until the context is canceled; transient query
+// failures are logged + counted but do not stop the loop.
+type Poller struct {
+	pool     *pgxpool.Pool
+	metrics  Metrics
+	interval time.Duration
+}
+
+// New builds a Poller with sensible defaults. Returns an error only
+// if Pool is nil — every other Config field is optional.
+func New(cfg Config) (*Poller, error) {
+	if cfg.Pool == nil {
+		return nil, fmt.Errorf("pgstats: pool is required")
+	}
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		// 30s gives operators a useful sample rate without making
+		// every orchestrator pod hammer the server: with N pods
+		// × 1 connection per poll × 1 poll / 30s, total poller load
+		// is N/30 conn-seconds/sec, negligible against a 50-conn cap.
+		interval = 30 * time.Second
+	}
+	return &Poller{pool: cfg.Pool, metrics: metrics, interval: interval}, nil
+}
+
+// Run blocks until ctx is canceled. The first poll fires
+// immediately so the gauges have a value before the first scrape
+// window elapses; subsequent polls fire on the interval ticker.
+func (p *Poller) Run(ctx context.Context) error {
+	p.pollOnce(ctx)
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			p.pollOnce(ctx)
+		}
+	}
+}
+
+// pollOnce reads both values inside a single 5s timeout. A failure
+// at either query records query_failed and returns without updating
+// the gauges, so a stale value never overwrites with a wrong one.
+func (p *Poller) pollOnce(ctx context.Context) {
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var backends int
+	if err := p.pool.QueryRow(
+		queryCtx,
+		`SELECT COALESCE(SUM(numbackends), 0)::int FROM pg_stat_database`,
+	).Scan(&backends); err != nil {
+		p.metrics.RecordPollOutcome("query_failed")
+		slog.Warn("pgstats backend connections poll failed", "error", err)
+		return
+	}
+
+	var maxConns int
+	if err := p.pool.QueryRow(
+		queryCtx,
+		`SELECT current_setting('max_connections')::int`,
+	).Scan(&maxConns); err != nil {
+		p.metrics.RecordPollOutcome("query_failed")
+		slog.Warn("pgstats max_connections poll failed", "error", err)
+		return
+	}
+
+	p.metrics.RecordBackendConnections(float64(backends))
+	p.metrics.RecordMaxConnections(float64(maxConns))
+	p.metrics.RecordPollOutcome("ok")
+}

--- a/backend-go/internal/pgstats/poller_test.go
+++ b/backend-go/internal/pgstats/poller_test.go
@@ -1,0 +1,70 @@
+package pgstats
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestNewRejectsNilPool: a missing pool is a configuration bug —
+// the alternative would be a runtime nil-deref inside pollOnce when
+// the loop fires.
+func TestNewRejectsNilPool(t *testing.T) {
+	if _, err := New(Config{}); err == nil {
+		t.Fatal("expected New to reject nil Pool")
+	}
+}
+
+// TestNewDefaultsIntervalAndMetrics: the package contract is that
+// only Pool is required. A caller passing just a pool should get a
+// runnable Poller without surprise.
+func TestNewDefaultsIntervalAndMetrics(t *testing.T) {
+	pool := &pgxpool.Pool{}
+	p, err := New(Config{Pool: pool})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.interval <= 0 {
+		t.Fatalf("interval = %v, want positive default", p.interval)
+	}
+	if p.metrics == nil {
+		t.Fatal("metrics is nil; New should install noopMetrics default")
+	}
+}
+
+// TestNoopMetricsSatisfiesInterface: a future Metrics method
+// addition must update noopMetrics in lockstep — this compile-time
+// check breaks the build if the two drift.
+func TestNoopMetricsSatisfiesInterface(t *testing.T) {
+	var _ Metrics = noopMetrics{}
+}
+
+// TestMetricsInterfaceContract: a recording impl proves the
+// interface methods are wired correctly; future code review sees the
+// concrete shape of each callback.
+func TestMetricsInterfaceContract(t *testing.T) {
+	r := &recordingMetrics{}
+	r.RecordBackendConnections(42)
+	r.RecordMaxConnections(100)
+	r.RecordPollOutcome("ok")
+
+	if r.backends != 42 {
+		t.Errorf("backends = %v, want 42", r.backends)
+	}
+	if r.max != 100 {
+		t.Errorf("max = %v, want 100", r.max)
+	}
+	if r.lastOutcome != "ok" {
+		t.Errorf("lastOutcome = %q, want %q", r.lastOutcome, "ok")
+	}
+}
+
+type recordingMetrics struct {
+	backends    float64
+	max         float64
+	lastOutcome string
+}
+
+func (r *recordingMetrics) RecordBackendConnections(v float64) { r.backends = v }
+func (r *recordingMetrics) RecordMaxConnections(v float64)     { r.max = v }
+func (r *recordingMetrics) RecordPollOutcome(outcome string)   { r.lastOutcome = outcome }

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -138,6 +138,77 @@ spec:
             summary: "tank-operator ran a Postgres query the operationFromSQL extractor did not recognize"
             runbook: "Add the new table to pgstore.knownTables and ship a follow-up; otherwise that query is invisible in latency dashboards."
 
+        # Postgres connection-cap saturation. The 2026-05-25 incident
+        # crash-looped the orchestrator on SQLSTATE 53300 ("remaining
+        # connection slots are reserved for roles with the SUPERUSER
+        # attribute") with no advance signal — the cap was hit and the
+        # crash was the first observation. With the pgstats poller in
+        # place, this alert fires at 70% utilization, leaving ~30% of
+        # the cap as headroom for the operator to act before the next
+        # crash. Both gauges are unlabeled aggregates of server-side
+        # state — max() across pods dedupes the N orchestrator pods'
+        # views of the same single shared server.
+        - alert: TankPgConnectionSaturation
+          expr: |
+            (max(tank_pg_backend_connections) / max(tank_pg_max_connections)) > 0.7
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Postgres backend connections at {{`{{ humanizePercentage $value }}`}} of max_connections for 5m"
+            runbook: |
+              The Flex Server connection cap is the next thing to
+              crash-loop the orchestrator (SQLSTATE 53300, the
+              2026-05-25 shape). Remediations in order of effort:
+
+              (1) Bump SKU in infra/postgres.tf. B1ms's cap is 50;
+                  B2s is 100, B2ms is 100 with more RAM, D2ds_v5 is
+                  859. In-place resize via tofu apply causes a
+                  ~60-90s connection drop on switchover.
+              (2) Add a PgBouncer sidecar to the orchestrator
+                  deployment so N pods × pgstore.MaxConns frontend
+                  connections funnel into ~5-10 backend connections.
+                  Decouples slot fleet size from the server cap
+                  entirely; doesn't help CPU/IO.
+              (3) Lower pgstore.MaxConns further (currently 4); only
+                  buys time against slot growth and increases
+                  per-pool contention.
+
+              Diagnose distribution: per-pod query rate is
+                sum by (pod) (rate(tank_pg_queries_total{outcome="ok"}[5m]))
+              from kube-state-metrics' pod labels — a single pod
+              dramatically over its share is a runaway query, not
+              cluster-wide pressure.
+
+        # Poller self-test. If this fires, tank_pg_backend_connections
+        # and tank_pg_max_connections are stale; the saturation alert
+        # above is silently disabled. Diagnostic-only — does not page.
+        - alert: TankPgConnectionPollFailing
+          expr: rate(tank_pg_stats_poll_total{outcome!="ok"}[10m]) > 0
+          for: 10m
+          labels:
+            severity: info
+          annotations:
+            summary: "pgstats poller is failing to read connection stats from Postgres"
+            runbook: |
+              The orchestrator's pgstats poller cannot query
+              pg_stat_database or current_setting('max_connections').
+              tank_pg_backend_connections / tank_pg_max_connections
+              are stale; TankPgConnectionSaturation can't fire.
+              Inspect orchestrator slog for "pgstats backend
+              connections poll failed" or "pgstats max_connections
+              poll failed". Likely causes:
+              (1) AAD token blip — the pool's BeforeConnect is
+                  rejecting the workload-identity token. Other pool
+                  traffic (tank_pg_queries_total) would also show
+                  outcome=failed.
+              (2) Postgres rejecting reads on the system views —
+                  permission regression on the orchestrator's
+                  managed-identity grants.
+              (3) Postgres down — the bigger problem here is every
+                  other tank_pg_* metric is also broken; this is
+                  collateral, not the root cause.
+
     - name: tank-operator.hermes
       rules:
         - alert: TankHermesCapabilityProbeFailing


### PR DESCRIPTION
## Summary

- 2026-05-25-adjacent: orchestrator crash-looped on `SQLSTATE 53300` ("remaining connection slots are reserved for roles with the SUPERUSER attribute") because 12 orchestrator pods' pgxpools collectively exceeded B1ms's `max_connections=50` cap. There was no advance signal — the crash was the first observation. Sister PR [#676](https://github.com/nelsong6/tank-operator/pull/676) lowered `MaxConns: 10 → 4` to fit under the cap, but the *next* approach to saturation (slot growth, larger pool, SKU change with smaller cap) still has no signal.
- This PR adds an in-process pgxpool-reusing poller that exposes `tank_pg_backend_connections` and `tank_pg_max_connections` gauges, plus a `TankPgConnectionSaturation` alert that fires at 70% utilization. Headroom of ~30% gives operator time to bump the SKU before the next crash-loop.

## Feature Contracts

Affected contracts:
- [x] Observability
- [ ] None

Evidence:

**Observability contract** — § Acceptance Checks:
- *Counter / gauge respects cardinality rules; help string explains what + which failure mode.* Both gauges are unlabeled (single shared server, identical view across pods); the poll counter has one bounded label (`outcome` ∈ {ok, query_failed, other}). Help strings explain why max() dedupes across pods.
- *Alert distinguishes specific candidates.* `TankPgConnectionSaturation` runbook enumerates SKU bump, PgBouncer sidecar, and `MaxConns` reduction in order of effort with the specific PromQL drill-down for distinguishing cluster-wide pressure from a single-pod runaway.
- *Operator can diagnose without devtools / `kubectl exec`.* New gauges feed the existing orchestrator `/metrics` endpoint scraped by the prod ServiceMonitor. Self-test alert `TankPgConnectionPollFailing` tells on the observability surface itself.
- *`helm template` and tests pass.* `go build ./...`, `go test ./internal/pgstats/... ./cmd/tank-operator/...`, `helm template k8s` all green.

## Design notes

**Why in-process, not pg_exporter sidecar:**
The upstream `quay.io/prometheuscommunity/postgres-exporter` image expects username/password authentication. The Flex Server is configured AAD-only (per CLAUDE.md: "no password auth in steady state; admin password lives in KV for break-glass only"); the orchestrator authenticates via workload-identity through `pgstore.BeforeConnect`. Building a sidecar wrapper that fetches an AAD token, rewrites a DSN, and refreshes before expiry is more complexity than reusing the orchestrator's existing AAD-aware pgxpool. The in-process poller adds ~5ms / 30s of pool traffic per pod — negligible.

**Why unlabeled gauges:**
Every orchestrator pod polls the same single server and reports the same value. Per-pod resolution would just multiply N identical series. PromQL `max()` aggregates across pods cleanly. Per docs/observability.md cardinality rules.

**Why 70% threshold for 5m:**
B1ms cap is 50 → alert fires at 35 backend conns, leaving ~13-conn headroom. With sister PR's `MaxConns: 4 × 12 pods = 48` max possible, the alert fires before the orchestrator hits the cap. 5m `for:` window survives a single scrape gap and rules out a brief burst (e.g. boot-time pool warmup).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pgstats/... ./cmd/tank-operator/...` (4 new unit tests + existing suite)
- [x] `helm template k8s` renders both new alerts cleanly
- [x] All migration guard scripts pass (`check-removed-chat-runtime`, `check-askuserquestion-migration`, `check-session-pod-hot-swap-migration` 38/38)
- [ ] **Post-merge live verification:** after ArgoCD sync, `kubectl exec -n tank-operator <orch-pod> -- wget -qO- localhost:8080/metrics | grep tank_pg_backend_connections` shows a number > 0; the new alert appears in `https://grafana.romaine.life/alerting/list`

## Out of scope (named, not hidden)

- **Doesn't fix Postgres CPU/IO ceiling.** B1ms's single burst-credit vCPU + 32 IOPS is the next ceiling after `max_connections`. This PR makes the connection cap visible; it doesn't add visibility for CPU credits or IOPS exhaustion. Those would need additional gauges (`pg_stat_database` tup_returned rate, IO timing extensions) — defer until the connection alert fires and the SKU bump exposes whether compute is the next bind.
- **No PgBouncer prep.** The runbook lists PgBouncer as remediation step 2, but no chart-side work is included here. If the alert fires, the SKU bump is the 1-line tofu change to try first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)