### PR TITLE
Add browser long-task observability

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_client_metrics_long_tasks.go
+++ b/backend-go/cmd/tank-operator/handlers_client_metrics_long_tasks.go
@@ -1,0 +1,172 @@
+// Client-side ingest for browser long-task entries. Pairs with
+// frontend/src/longTaskTelemetry.ts; the SPA ships raw durations and
+// correlation deltas (since last tank-event / session-switch / scroll)
+// and this handler buckets each entry into a single bounded
+// `correlation` label plus the duration histogram, so the client
+// cannot blow the active-series budget regardless of what it sends.
+//
+// The probe exists because the SPA user can't reach for devtools'
+// Performance panel (memory/feedback_no_devtools_build_surfaces_instead),
+// and click-unresponsiveness at low memory + low CPU is the classic
+// shape of bursty main-thread blocking that this counter is built to
+// surface.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+)
+
+const (
+	longTaskMetricsMaxBodyBytes = 64 * 1024
+	longTaskMetricsMaxEvents    = 40
+	// Lower bound mirrors the client-side filter. A value below 50 ms
+	// is not a longtask per the spec and indicates either a future
+	// PerformanceObserver entry type slipping through or a misbehaving
+	// caller; bucket it to keep the metric honest.
+	longTaskMinDurationMs = 50
+	// Above this, attribution is "stale" — the long task happened long
+	// enough after the correlation signal that calling it caused-by is
+	// noise. Mirrors a reasonable upper bound on "render fallout from
+	// the user action that triggered it." Server-side check; the client
+	// passes the raw delta and lets the server decide.
+	longTaskCorrelationWindowMs = 1500
+)
+
+type longTaskMetricsRequest struct {
+	Events []longTaskMetricEvent `json:"events"`
+}
+
+type longTaskMetricEvent struct {
+	DurationMs           *float64 `json:"durationMs"`
+	StartMs              *float64 `json:"startMs,omitempty"`
+	SessionMode          string   `json:"sessionMode"`
+	SinceTankEventMs     *float64 `json:"sinceTankEventMs,omitempty"`
+	SinceSessionSwitchMs *float64 `json:"sinceSessionSwitchMs,omitempty"`
+	SinceScrollMs        *float64 `json:"sinceScrollMs,omitempty"`
+	Attribution          string   `json:"attribution,omitempty"`
+	PagePath             string   `json:"pagePath,omitempty"`
+}
+
+func (s *appServer) handleLongTaskMetrics(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	if !user.IsHuman() {
+		recordLongTaskClientReport("denied_role")
+		writeError(w, http.StatusForbidden, "human user required")
+		return
+	}
+
+	var body longTaskMetricsRequest
+	limited := http.MaxBytesReader(w, r.Body, longTaskMetricsMaxBodyBytes)
+	decoder := json.NewDecoder(limited)
+	if err := decoder.Decode(&body); err != nil {
+		recordLongTaskClientReport("invalid_json")
+		writeError(w, http.StatusBadRequest, "invalid long-task metrics payload")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		recordLongTaskClientReport("invalid_json")
+		writeError(w, http.StatusBadRequest, "invalid long-task metrics payload")
+		return
+	}
+	if len(body.Events) > longTaskMetricsMaxEvents {
+		recordLongTaskClientReport("too_many_events")
+		writeError(w, http.StatusBadRequest, "too many long-task metric events")
+		return
+	}
+	for _, event := range body.Events {
+		if !validLongTaskMetricNumbers(event) {
+			recordLongTaskClientReport("invalid_value")
+			writeError(w, http.StatusBadRequest, "invalid long-task metric value")
+			return
+		}
+	}
+	for _, event := range body.Events {
+		recordLongTaskClientEvent(event)
+	}
+	recordLongTaskClientReport("ok")
+	writeJSON(w, http.StatusAccepted, map[string]any{"accepted": len(body.Events)})
+}
+
+func validLongTaskMetricNumbers(event longTaskMetricEvent) bool {
+	for _, value := range []*float64{
+		event.DurationMs,
+		event.StartMs,
+		event.SinceTankEventMs,
+		event.SinceSessionSwitchMs,
+		event.SinceScrollMs,
+	} {
+		if value == nil {
+			continue
+		}
+		if math.IsNaN(*value) || math.IsInf(*value, 0) {
+			return false
+		}
+		if *value < 0 {
+			return false
+		}
+	}
+	if event.DurationMs == nil {
+		return false
+	}
+	return true
+}
+
+// longTaskCorrelationLabel buckets each entry into a single attribution
+// by picking the most-recent correlation signal that fired inside the
+// 1.5s window. The order — tank-event > session-switch > scroll — matches
+// the expected diagnostic priority: an event burst that lands during a
+// fresh session switch is most usefully labeled as the burst, since the
+// switch is a known one-time cost.
+func longTaskCorrelationLabel(event longTaskMetricEvent) string {
+	type candidate struct {
+		label string
+		since *float64
+	}
+	candidates := []candidate{
+		{"event_burst", event.SinceTankEventMs},
+		{"session_switch", event.SinceSessionSwitchMs},
+		{"scroll", event.SinceScrollMs},
+	}
+	bestLabel := "idle"
+	bestSince := math.Inf(1)
+	for _, c := range candidates {
+		if c.since == nil {
+			continue
+		}
+		if *c.since < 0 || *c.since > longTaskCorrelationWindowMs {
+			continue
+		}
+		if *c.since < bestSince {
+			bestSince = *c.since
+			bestLabel = c.label
+		}
+	}
+	return bestLabel
+}
+
+func longTaskAttributionLabel(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "self":
+		return "self"
+	case "":
+		return "unknown"
+	default:
+		return "other"
+	}
+}
+
+// longTaskSessionModeLabel reuses the chat-scroll mode allowlist so all
+// browser-ingested metrics share a single bounded mode label set. Drift
+// between the two would fragment dashboards; keeping one source of
+// truth means any new mode added to chat scroll automatically flows
+// here too.
+func longTaskSessionModeLabel(raw string) string {
+	return chatScrollSessionModeLabel(raw)
+}

--- a/backend-go/cmd/tank-operator/handlers_client_metrics_long_tasks_test.go
+++ b/backend-go/cmd/tank-operator/handlers_client_metrics_long_tasks_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/auth"
+)
+
+func TestHandleLongTaskMetricsRecordsPrometheus(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/long-tasks", strings.NewReader(`{
+		"events": [{
+			"durationMs": 180,
+			"startMs": 600,
+			"sessionMode": "claude_gui",
+			"sinceTankEventMs": 90,
+			"sinceSessionSwitchMs": 1200,
+			"sinceScrollMs": 800,
+			"attribution": "self",
+			"pagePath": "/sessions/188"
+		}]
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	res := httptest.NewRecorder()
+
+	app.handleLongTaskMetrics(res, req)
+
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("metrics status = %d body=%s, want 202", res.Code, res.Body.String())
+	}
+	metrics := scrapePrometheus(t)
+	for _, want := range []string{
+		`tank_client_long_task_reports_total{result="ok"}`,
+		// Correlation should be event_burst because sinceTankEventMs=90
+		// is the closest in-window signal (session_switch=1200 is still
+		// inside the 1500ms window but later than the tank-event).
+		`tank_client_long_task_total{attribution="self",correlation="event_burst",session_mode="claude_gui"} 1`,
+		`tank_client_long_task_duration_seconds_bucket{correlation="event_burst",session_mode="claude_gui",le="0.25"}`,
+	} {
+		if !strings.Contains(metrics, want) {
+			t.Fatalf("scrape missing %s\n%s", want, metrics)
+		}
+	}
+}
+
+func TestHandleLongTaskMetricsBucketsCorrelationToIdleOutsideWindow(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/long-tasks", strings.NewReader(`{
+		"events": [{
+			"durationMs": 120,
+			"sessionMode": "codex_gui",
+			"sinceTankEventMs": 5000,
+			"sinceSessionSwitchMs": 9000,
+			"attribution": "self"
+		}]
+	}`))
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	res := httptest.NewRecorder()
+
+	app.handleLongTaskMetrics(res, req)
+
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("metrics status = %d body=%s, want 202", res.Code, res.Body.String())
+	}
+	metrics := scrapePrometheus(t)
+	if !strings.Contains(metrics, `tank_client_long_task_total{attribution="self",correlation="idle",session_mode="codex_gui"}`) {
+		t.Fatalf("expected correlation=idle when all signals are outside the 1.5s window; got:\n%s", metrics)
+	}
+}
+
+func TestHandleLongTaskMetricsRejectsTooManyEvents(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	var body bytes.Buffer
+	body.WriteString(`{"events":[`)
+	for i := 0; i < longTaskMetricsMaxEvents+1; i++ {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteString(`{"durationMs":100,"sessionMode":"claude_gui"}`)
+	}
+	body.WriteString(`]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/long-tasks", &body)
+	req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+	res := httptest.NewRecorder()
+
+	app.handleLongTaskMetrics(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("metrics status = %d body=%s, want 400", res.Code, res.Body.String())
+	}
+}
+
+func TestHandleLongTaskMetricsRejectsNegativeAndNaN(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	cases := []string{
+		`{"events":[{"durationMs":-1,"sessionMode":"claude_gui"}]}`,
+		`{"events":[{"sessionMode":"claude_gui"}]}`,
+	}
+	for _, payload := range cases {
+		req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/long-tasks", strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+signedTokenWithRole(t, adminEmail, auth.RoleAdmin))
+		res := httptest.NewRecorder()
+		app.handleLongTaskMetrics(res, req)
+		if res.Code != http.StatusBadRequest {
+			t.Fatalf("payload %q got status %d, want 400", payload, res.Code)
+		}
+	}
+}
+
+func TestLongTaskMetricsAttributionLabelsAreBounded(t *testing.T) {
+	durationMs := 200.0
+	sinceTankEventMs := 50.0
+	event := longTaskMetricEvent{
+		DurationMs:       &durationMs,
+		SessionMode:      "mode-for-user-123",
+		Attribution:      "user-controlled-attribution-value",
+		SinceTankEventMs: &sinceTankEventMs,
+	}
+	recordLongTaskClientEvent(event)
+
+	metrics := scrapePrometheus(t)
+	for _, want := range []string{
+		`tank_client_long_task_total{attribution="other",correlation="event_burst",session_mode="unknown"}`,
+	} {
+		if !strings.Contains(metrics, want) {
+			t.Fatalf("scrape missing %s\n%s", want, metrics)
+		}
+	}
+	if strings.Contains(metrics, "user-controlled-attribution-value") ||
+		strings.Contains(metrics, "mode-for-user-123") {
+		t.Fatalf("scrape leaked unbounded labels:\n%s", metrics)
+	}
+}
+
+func TestHandleLongTaskMetricsRejectsServiceCallers(t *testing.T) {
+	app := &appServer{verifier: auth.NewVerifier(testJWT(t))}
+	req := httptest.NewRequest(http.MethodPost, "/api/client-metrics/long-tasks", strings.NewReader(`{"events":[]}`))
+	req.Header.Set("Authorization", "Bearer "+signedServiceToken(t, "pod-77", adminEmail))
+	res := httptest.NewRecorder()
+
+	app.handleLongTaskMetrics(res, req)
+
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("service caller got status %d, want 403", res.Code)
+	}
+}

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -723,6 +723,58 @@ func boolMetricLabel(value *bool) string {
 	return "false"
 }
 
+// --- Browser long-task metrics ---
+//
+// Surfaces main-thread blocks ≥50 ms reported by the SPA via
+// PerformanceObserver({type: "longtask"}). The SPA passes raw
+// durations and correlation deltas; the server picks a single bounded
+// `correlation` label so cardinality stays predictable. The SPA user
+// can't open devtools' Performance panel, so this counter and its
+// duration histogram are the operational replacement.
+var (
+	longTaskClientReportsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_client_long_task_reports_total",
+			Help: "Browser long-task metric report requests, labeled by bounded result.",
+		},
+		[]string{"result"},
+	)
+	longTaskClientTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tank_client_long_task_total",
+			Help: "Browser main-thread long tasks (≥50 ms) reported by the SPA, labeled by session mode, attribution, and correlation.",
+		},
+		[]string{"session_mode", "attribution", "correlation"},
+	)
+	longTaskClientDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "tank_client_long_task_duration_seconds",
+			Help: "Duration of browser main-thread long tasks (≥50 ms) reported by the SPA.",
+			// Buckets target the input-responsiveness range. 0.05 is the
+			// spec floor for a longtask; >2 s is the "page feels frozen"
+			// threshold past which finer resolution doesn't change the
+			// diagnosis ("it's stuck").
+			Buckets: []float64{0.05, 0.075, 0.1, 0.15, 0.25, 0.5, 1, 2, 5},
+		},
+		[]string{"session_mode", "correlation"},
+	)
+)
+
+func recordLongTaskClientReport(result string) {
+	longTaskClientReportsTotal.WithLabelValues(result).Inc()
+}
+
+func recordLongTaskClientEvent(event longTaskMetricEvent) {
+	if event.DurationMs == nil || *event.DurationMs < longTaskMinDurationMs {
+		return
+	}
+	mode := longTaskSessionModeLabel(event.SessionMode)
+	attribution := longTaskAttributionLabel(event.Attribution)
+	correlation := longTaskCorrelationLabel(event)
+	longTaskClientTotal.WithLabelValues(mode, attribution, correlation).Inc()
+	longTaskClientDurationSeconds.WithLabelValues(mode, correlation).Observe(*event.DurationMs / 1000.0)
+}
+
 // GET /api/github/repos counters. The endpoint proxies through to
 // mcp-github via an on-behalf-of token mint; both legs can fail
 // independently, so we surface a simple ok|error outcome label plus

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -127,6 +127,11 @@ func (s *appServer) registerRoutes(mux *http.ServeMux) {
 	// (zombie SSE) and candidate-C (reducer drop) stethoscope on the
 	// client side. Pairs with server-side counters in observability.go.
 	mux.HandleFunc("POST /api/client-metrics/session-events-stream", s.handleSessionEventStreamMetrics)
+	// Browser-side main-thread long-task probe. Surfaces input-
+	// blocking ≥50 ms blocks (the failure mode behind "clicks aren't
+	// responding") with a correlation label tying each block to the
+	// most-recent tank-event / session-switch / scroll the SPA saw.
+	mux.HandleFunc("POST /api/client-metrics/long-tasks", s.handleLongTaskMetrics)
 
 	// Avatar assets. Reads are authenticated so uploaded backing photos
 	// are not exposed as static public files; writes are admin-only.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -95,6 +95,22 @@ All metric names are prefixed `tank_`. The full namespace:
   candidate-B zombie-SSE detector: the browser's silence watchdog
   observes the idle interval whenever a connected stream has gone
   >30 s without emitting events while a turn is in flight.
+- `tank_client_long_task_*` — browser-reported main-thread long-task
+  diagnostics ingested through `POST /api/client-metrics/long-tasks`.
+  The SPA installs a `PerformanceObserver({type: "longtask"})` probe
+  at boot (`frontend/src/longTaskTelemetry.ts`) and reports every
+  ≥50 ms main-thread block along with three correlation deltas: time
+  since the last tank-event SSE delivery, since the last session
+  switch, and since the last user scroll. Server-bucketed labels:
+  `session_mode` (the chat-scroll mode allowlist), `attribution`
+  (`self` / `other` / `unknown`, bucketed from
+  `PerformanceLongTaskTiming.name`), and `correlation` (`event_burst`
+  / `session_switch` / `scroll` / `idle`, picked from the most-recent
+  in-window signal). The duration histogram buckets target the
+  input-responsiveness band (50 ms - 5 s); anything past 2 s is the
+  "page feels frozen" zone. This is the operational replacement for
+  devtools' Performance panel — the SPA user can't open devtools, so
+  the click-unresponsiveness failure mode otherwise has no surface.
 - `tank_turn_terminal_missing_client_nonce_total{source,event_type}` —
   durable turn terminal rows (`turn.completed`, `turn.failed`,
   `turn.command_failed`, `turn.interrupted`) persisted without

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9179,10 +9179,6 @@ function ChatPane({
         sessionMode: session.mode,
         eventType,
       });
-      // Long-task correlation: a tank-event triggers JSON.parse +
-      // reducer fold + projection rebuild + render. If those produce
-      // a >50 ms main-thread block, the longtask probe will attribute
-      // it via the sinceTankEventMs delta.
       noteTankEvent();
       silenceWatchdogRef.current?.reset();
       applySdkDurableEvent(parsed);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -136,6 +136,11 @@ import {
   logChatScrollEvent,
 } from "./chatScrollTelemetry";
 import {
+  noteSessionSwitch,
+  noteTankEvent,
+  setActiveSessionMode,
+} from "./longTaskTelemetry";
+import {
   clusterHealthHeadline,
   clusterHealthIssueText,
   clusterHealthNatsLoadLabel,
@@ -9174,6 +9179,11 @@ function ChatPane({
         sessionMode: session.mode,
         eventType,
       });
+      // Long-task correlation: a tank-event triggers JSON.parse +
+      // reducer fold + projection rebuild + render. If those produce
+      // a >50 ms main-thread block, the longtask probe will attribute
+      // it via the sinceTankEventMs delta.
+      noteTankEvent();
       silenceWatchdogRef.current?.reset();
       applySdkDurableEvent(parsed);
     });
@@ -9209,6 +9219,12 @@ function ChatPane({
 
   useEffect(() => {
     if (!visible || !CHAT_MODES.has(session.mode) || !historyBootstrapped) return;
+    // Long-task correlation: switching active sessions triggers a
+    // reducer reset + transcript bootstrap + scroll rewire. Attribute
+    // any block in that window to the switch via sinceSessionSwitchMs,
+    // and label any block that fires now by the session's mode.
+    setActiveSessionMode(session.mode);
+    noteSessionSwitch();
     sdkEventSourceRef.current?.close();
     sdkEventSourceRef.current = null;
     void openSdkEventStream();

--- a/frontend/src/longTaskTelemetry.test.ts
+++ b/frontend/src/longTaskTelemetry.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  flushLongTaskMetricsForTest,
+  ingestLongTaskEntryForTest,
+  isLongTaskDebugEnabled,
+  noteSessionSwitch,
+  noteTankEvent,
+  noteUserScroll,
+  setActiveSessionMode,
+  stopLongTaskObserverForTest,
+} from "./longTaskTelemetry";
+
+let fakeStorage: Record<string, string>;
+let consoleLogs: Array<[string, unknown[]]>;
+let origConsoleLog: typeof console.log;
+let fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }>;
+let origFetch: typeof fetch;
+let fakeNow: number;
+let origPerformance: typeof performance | undefined;
+
+function setupBrowserEnv(): void {
+  fakeStorage = {};
+  consoleLogs = [];
+  fetchCalls = [];
+  fakeNow = 1_000;
+
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(fakeStorage, key)
+        ? fakeStorage[key]
+        : null;
+    },
+    setItem(key: string, value: string) {
+      fakeStorage[key] = value;
+    },
+    removeItem(key: string) {
+      delete fakeStorage[key];
+    },
+    clear() {
+      fakeStorage = {};
+    },
+    length: 0,
+    key() {
+      return null;
+    },
+  };
+
+  origPerformance = globalThis.performance;
+  (globalThis as { performance: { now: () => number } }).performance = {
+    now: () => fakeNow,
+  };
+
+  origConsoleLog = console.log;
+  console.log = (message: string, ...args: unknown[]) => {
+    consoleLogs.push([message, args]);
+  };
+  origFetch = fetch;
+  (globalThis as { fetch: typeof fetch }).fetch = (async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response("{}", { status: 202 });
+  }) as typeof fetch;
+
+  (globalThis as { window?: unknown }).window = {
+    location: { pathname: "/sessions/188", search: "?session=188" },
+    setTimeout: (() => 1) as typeof window.setTimeout,
+    clearTimeout: () => undefined,
+    addEventListener: () => undefined,
+  };
+}
+
+beforeEach(() => {
+  setupBrowserEnv();
+});
+
+afterEach(() => {
+  stopLongTaskObserverForTest();
+  console.log = origConsoleLog;
+  (globalThis as { fetch: typeof fetch }).fetch = origFetch;
+  delete (globalThis as { localStorage?: unknown }).localStorage;
+  delete (globalThis as { window?: unknown }).window;
+  if (origPerformance) {
+    (globalThis as { performance: typeof performance }).performance = origPerformance;
+  } else {
+    delete (globalThis as { performance?: unknown }).performance;
+  }
+});
+
+function fakeLongTaskEntry(
+  duration: number,
+  startTime: number,
+  name = "self",
+): PerformanceEntry {
+  return {
+    duration,
+    startTime,
+    name,
+    entryType: "longtask",
+    toJSON: () => ({ duration, startTime, name }),
+  } as unknown as PerformanceEntry;
+}
+
+test("long-task debug logs are off by default", () => {
+  assert.equal(isLongTaskDebugEnabled(), false);
+  ingestLongTaskEntryForTest(fakeLongTaskEntry(120, 500));
+  assert.equal(consoleLogs.length, 0);
+});
+
+test("long-task debug logs fire when tankDebug includes long-tasks", () => {
+  fakeStorage.tankDebug = "session-list,long-tasks";
+  assert.equal(isLongTaskDebugEnabled(), true);
+  ingestLongTaskEntryForTest(fakeLongTaskEntry(120, 500));
+  assert.equal(consoleLogs.length, 1);
+  assert.equal(consoleLogs[0]?.[0], "[tank/long-tasks] long-task");
+});
+
+test("entries below the 50ms threshold are dropped", () => {
+  fakeStorage["auth-romaine-jwt"] = "token-123";
+  ingestLongTaskEntryForTest(fakeLongTaskEntry(40, 500));
+  flushLongTaskMetricsForTest();
+  assert.equal(fetchCalls.length, 0);
+});
+
+test("entries are batched to the Prometheus ingestion endpoint", () => {
+  fakeStorage["auth-romaine-jwt"] = "token-123";
+  setActiveSessionMode("claude_gui");
+  ingestLongTaskEntryForTest(fakeLongTaskEntry(180, 600, "self"));
+  flushLongTaskMetricsForTest();
+
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0]?.input, "/api/client-metrics/long-tasks");
+  assert.equal(fetchCalls[0]?.init?.method, "POST");
+  assert.equal(
+    new Headers(fetchCalls[0]?.init?.headers).get("Authorization"),
+    "Bearer token-123",
+  );
+  const payload = JSON.parse(String(fetchCalls[0]?.init?.body)) as {
+    events: Array<Record<string, unknown>>;
+  };
+  const event = payload.events[0]!;
+  assert.equal(event.durationMs, 180);
+  assert.equal(event.startMs, 600);
+  assert.equal(event.sessionMode, "claude_gui");
+  assert.equal(event.attribution, "self");
+  assert.equal(event.pagePath, "/sessions/188");
+});
+
+test("correlation hints record deltas to recent tank-event / session-switch / scroll", () => {
+  fakeStorage["auth-romaine-jwt"] = "token-123";
+  setActiveSessionMode("claude_gui");
+
+  fakeNow = 1_000;
+  noteTankEvent();
+  fakeNow = 1_050;
+  noteSessionSwitch();
+  fakeNow = 1_080;
+  noteUserScroll();
+  // Long task starts at t=1100ms, runs 250ms.
+  ingestLongTaskEntryForTest(fakeLongTaskEntry(250, 1_100));
+  flushLongTaskMetricsForTest();
+
+  const payload = JSON.parse(String(fetchCalls[0]?.init?.body)) as {
+    events: Array<Record<string, unknown>>;
+  };
+  const event = payload.events[0]!;
+  assert.equal(event.sinceTankEventMs, 100);
+  assert.equal(event.sinceSessionSwitchMs, 50);
+  assert.equal(event.sinceScrollMs, 20);
+});
+
+test("correlation deltas are null when the signal hasn't fired yet", () => {
+  fakeStorage["auth-romaine-jwt"] = "token-123";
+  setActiveSessionMode("claude_gui");
+  ingestLongTaskEntryForTest(fakeLongTaskEntry(150, 500));
+  flushLongTaskMetricsForTest();
+
+  const payload = JSON.parse(String(fetchCalls[0]?.init?.body)) as {
+    events: Array<Record<string, unknown>>;
+  };
+  const event = payload.events[0]!;
+  assert.equal(event.sinceTankEventMs, null);
+  assert.equal(event.sinceSessionSwitchMs, null);
+  assert.equal(event.sinceScrollMs, null);
+});
+
+test("batched entries flush when they hit the batch cap without waiting for the timer", () => {
+  fakeStorage["auth-romaine-jwt"] = "token-123";
+  setActiveSessionMode("claude_gui");
+  for (let i = 0; i < 40; i += 1) {
+    ingestLongTaskEntryForTest(fakeLongTaskEntry(60, 100 + i));
+  }
+  // No explicit flush call; the 40th entry should have tripped the cap.
+  assert.equal(fetchCalls.length, 1);
+  const payload = JSON.parse(String(fetchCalls[0]?.init?.body)) as {
+    events: Array<Record<string, unknown>>;
+  };
+  assert.equal(payload.events.length, 40);
+});

--- a/frontend/src/longTaskTelemetry.ts
+++ b/frontend/src/longTaskTelemetry.ts
@@ -1,0 +1,234 @@
+import { authedFetch } from "./auth";
+
+// Browser long-task probe. Wraps PerformanceObserver({ type: "longtask" })
+// to surface main-thread blocks ≥50 ms — the input-blocking failure mode
+// that produces "clicks aren't responding" without burning sustained CPU
+// or memory. Pairs with server-bucketed Prometheus labels in
+// backend-go/cmd/tank-operator/handlers_client_metrics_long_tasks.go so
+// the SPA never controls cardinality directly.
+//
+// Correlation hints (last tank-event, last session-switch, last scroll)
+// let the server bucket each long task into a single attribution label
+// without leaking high-cardinality context. Without correlation a
+// duration histogram only tells us "things are slow"; with correlation
+// it tells us "things are slow specifically when an SSE event burst
+// lands," which is the actionable signal.
+//
+// Console logging is opt-in via `localStorage.tankDebug = "long-tasks"`
+// (comma-separated list including that token), mirroring the
+// chat-scroll and session-events probes.
+
+const DEBUG_STORAGE_KEY = "tankDebug";
+const DEBUG_TOKEN = "long-tasks";
+const CONSOLE_PREFIX = "[tank/long-tasks]";
+const METRICS_ENDPOINT = "/api/client-metrics/long-tasks";
+const MAX_BATCH_EVENTS = 40;
+const FLUSH_DELAY_MS = 1_000;
+// Drop entries below this threshold so an upstream PerformanceObserver
+// change (the spec is moving toward "long-animation-frame" which
+// surfaces shorter blocks) doesn't accidentally widen the metric
+// surface beyond what we agreed to ingest.
+const MIN_REPORTED_DURATION_MS = 50;
+
+interface LongTaskMetricPayload {
+  durationMs: number;
+  startMs: number;
+  sessionMode: string;
+  // Milliseconds since the most recent of each correlation signal.
+  // null means "never observed in this pageload."
+  sinceTankEventMs: number | null;
+  sinceSessionSwitchMs: number | null;
+  sinceScrollMs: number | null;
+  // PerformanceLongTaskTiming.name is one of a closed enum
+  // ("self" / "same-origin-ancestor" / "same-origin-descendant" /
+  // "same-origin" / "cross-origin-ancestor" / "cross-origin-descendant"
+  // / "cross-origin-unreachable" / "multiple-contexts" / "unknown").
+  // We pass it through; the server buckets to "self" / "other".
+  attribution: string;
+  pagePath: string;
+}
+
+let pendingMetrics: LongTaskMetricPayload[] = [];
+let flushTimer: number | null = null;
+let observer: PerformanceObserver | null = null;
+let currentSessionMode = "unknown";
+
+// Module-level correlation timestamps. Updated by note*() hooks called
+// from the SSE handler, session-switch effect, and scroll listener.
+// performance.now() to share a clock with PerformanceObserver entries.
+let lastTankEventMs: number | null = null;
+let lastSessionSwitchMs: number | null = null;
+let lastScrollMs: number | null = null;
+
+export function noteTankEvent(): void {
+  if (typeof performance === "undefined") return;
+  lastTankEventMs = performance.now();
+}
+
+export function noteSessionSwitch(): void {
+  if (typeof performance === "undefined") return;
+  lastSessionSwitchMs = performance.now();
+}
+
+export function noteUserScroll(): void {
+  if (typeof performance === "undefined") return;
+  lastScrollMs = performance.now();
+}
+
+// setActiveSessionMode lets the app shell push the currently-visible
+// session's mode so correlation-attributed long tasks land under the
+// right bucket. Called whenever the active pane changes; cleared back
+// to "unknown" when no session pane is visible.
+export function setActiveSessionMode(mode: string): void {
+  currentSessionMode = clampString(mode) || "unknown";
+}
+
+export function isLongTaskDebugEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(DEBUG_STORAGE_KEY) ?? "";
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .includes(DEBUG_TOKEN);
+  } catch {
+    return false;
+  }
+}
+
+export function startLongTaskObserver(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof PerformanceObserver === "undefined") return false;
+  if (observer) return true;
+  // PerformanceObserver.supportedEntryTypes is the right capability
+  // probe; Firefox doesn't ship longtask. The probe degrades silently
+  // there — the server just won't see any data from that browser.
+  const supported = (PerformanceObserver as unknown as {
+    supportedEntryTypes?: ReadonlyArray<string>;
+  }).supportedEntryTypes;
+  if (Array.isArray(supported) && !supported.includes("longtask")) {
+    return false;
+  }
+  try {
+    observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        ingestLongTaskEntry(entry);
+      }
+    });
+    observer.observe({ type: "longtask", buffered: true });
+  } catch {
+    observer = null;
+    return false;
+  }
+  return true;
+}
+
+export function stopLongTaskObserverForTest(): void {
+  if (observer) {
+    try {
+      observer.disconnect();
+    } catch {
+      // best-effort
+    }
+    observer = null;
+  }
+  currentSessionMode = "unknown";
+  pendingMetrics = [];
+  if (flushTimer !== null && typeof window !== "undefined") {
+    if (typeof window.clearTimeout === "function") {
+      window.clearTimeout(flushTimer);
+    }
+    flushTimer = null;
+  }
+  lastTankEventMs = null;
+  lastSessionSwitchMs = null;
+  lastScrollMs = null;
+}
+
+export function flushLongTaskMetricsForTest(): void {
+  if (flushTimer !== null && typeof window !== "undefined") {
+    if (typeof window.clearTimeout === "function") {
+      window.clearTimeout(flushTimer);
+    }
+    flushTimer = null;
+  }
+  flushLongTaskMetrics();
+}
+
+// Exposed for tests so the observer-side path can be exercised
+// without depending on the browser actually scheduling a long task.
+export function ingestLongTaskEntryForTest(entry: PerformanceEntry): void {
+  ingestLongTaskEntry(entry);
+}
+
+function ingestLongTaskEntry(entry: PerformanceEntry): void {
+  const duration = Math.round(entry.duration);
+  if (!Number.isFinite(duration) || duration < MIN_REPORTED_DURATION_MS) {
+    return;
+  }
+  const startMs = Math.round(entry.startTime);
+  const attribution =
+    typeof entry.name === "string" && entry.name ? entry.name : "unknown";
+  const payload: LongTaskMetricPayload = {
+    durationMs: duration,
+    startMs,
+    sessionMode: currentSessionMode,
+    sinceTankEventMs: deltaSince(lastTankEventMs, entry.startTime),
+    sinceSessionSwitchMs: deltaSince(lastSessionSwitchMs, entry.startTime),
+    sinceScrollMs: deltaSince(lastScrollMs, entry.startTime),
+    attribution: clampString(attribution) || "unknown",
+    pagePath: currentPagePath(),
+  };
+  pendingMetrics.push(payload);
+  if (isLongTaskDebugEnabled()) {
+    console.log(`${CONSOLE_PREFIX} long-task`, payload);
+  }
+  if (pendingMetrics.length >= MAX_BATCH_EVENTS) {
+    flushLongTaskMetrics();
+    return;
+  }
+  scheduleFlush();
+}
+
+function scheduleFlush(): void {
+  if (typeof window === "undefined" || flushTimer !== null) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    flushLongTaskMetrics();
+  }, FLUSH_DELAY_MS);
+}
+
+function flushLongTaskMetrics(): void {
+  if (typeof window === "undefined" || pendingMetrics.length === 0) return;
+  const events = pendingMetrics.splice(0, MAX_BATCH_EVENTS);
+  if (typeof fetch !== "function") return;
+  authedFetch(METRICS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ events }),
+    keepalive: true,
+  }).catch(() => undefined);
+  if (pendingMetrics.length > 0) scheduleFlush();
+}
+
+function deltaSince(eventMs: number | null, atMs: number): number | null {
+  if (eventMs === null) return null;
+  const delta = Math.round(atMs - eventMs);
+  if (!Number.isFinite(delta) || delta < 0) return null;
+  return delta;
+}
+
+function clampString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, 80);
+}
+
+function currentPagePath(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.pathname.slice(0, 160);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", flushLongTaskMetrics);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { App } from "./App";
 import { LongChatDebugPage } from "./LongChatDebugPage";
 import { SessionListDebugPage } from "./SessionListDebugPage";
 import { AvatarPreviewHost } from "./avatarPreview";
+import { noteUserScroll, startLongTaskObserver } from "./longTaskTelemetry";
 import { StyleguideAvatars } from "./styleguide/avatars";
 import { StyleguideBootState } from "./styleguide/boot-state";
 import { StyleguideButtons } from "./styleguide/buttons";
@@ -111,6 +112,19 @@ function Root() {
     if (render) return render();
   }
   return <App />;
+}
+
+// Install the main-thread long-task observer before React mounts so the
+// initial-paint chunk is also counted. The probe degrades silently on
+// browsers without PerformanceObserver longtask support (Firefox).
+startLongTaskObserver();
+// Passive document-level scroll listener feeds the long-task probe's
+// scroll-correlation signal. Capture=true catches scroll events on
+// any scrollable container (chat transcript, sidebar) without each one
+// needing its own listener. Passive so the listener can never block
+// the input being measured.
+if (typeof document !== "undefined") {
+  document.addEventListener("scroll", noteUserScroll, { capture: true, passive: true });
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary

- Installs a `PerformanceObserver({type: "longtask"})` probe at SPA boot
  (`frontend/src/longTaskTelemetry.ts`) that ships every ≥50 ms
  main-thread block to a new `POST /api/client-metrics/long-tasks`
  endpoint. The orchestrator server-buckets each entry into bounded
  `session_mode` / `attribution` / `correlation` labels.
- New metrics: `tank_client_long_task_total{session_mode,attribution,correlation}`,
  `tank_client_long_task_duration_seconds{session_mode,correlation}` (50 ms–5 s
  buckets), and `tank_client_long_task_reports_total{result}`.
- Correlation hooks (`noteTankEvent` from the SSE `tank-event` handler,
  `noteSessionSwitch` + `setActiveSessionMode` from the pane-visible
  effect, document-level passive scroll listener) let the server pick a
  single attribution label per entry (`event_burst` / `session_switch` /
  `scroll` / `idle`) without ever taking a per-session or per-pod label.

This is the diagnostic probe for the "clicks aren't responding" symptom
when memory and CPU snapshots both look fine — the bursty main-thread
blocking failure mode that devtools' Performance panel would normally
surface. The Observability contract excludes devtools as a supported
diagnostic surface, so the equivalent has to ride a server-bucketed
Prometheus endpoint instead.

## Feature Contracts

Affected contracts:
- [x] Observability
- [ ] None

Evidence:
- Observability contract — "Live Behavior" requires that client-side
  telemetry bearing on user-trust failures Prom-routes through
  `POST /api/client-metrics/*` with orchestrator-bucketed labels and that
  the SPA never sets metric labels directly. This PR adds
  `/api/client-metrics/long-tasks` matching that pattern; the SPA passes
  raw durations + correlation deltas only, and the orchestrator buckets
  to a closed enum for every label
  (`backend-go/cmd/tank-operator/handlers_client_metrics_long_tasks.go`
  → `longTaskCorrelationLabel` / `longTaskAttributionLabel` /
  `longTaskSessionModeLabel`).
- New series respect the cardinality budget in `docs/observability.md`:
  `session_mode` reuses the existing 13-value `chatScrollSessionModeLabel`
  allowlist; `attribution` is bounded to `self` / `other` / `unknown`;
  `correlation` is bounded to `event_burst` / `session_switch` / `scroll`
  / `idle`. Total active series cap: 13 × 3 × 4 = 156 for the counter,
  13 × 4 × 9 = 468 buckets for the histogram. No per-session, per-pod,
  per-URL, or per-user label.
- Failure mode named in the contract this distinguishes: "An operator
  can diagnose a contracted-feature failure mode without browser
  devtools" (Live Behavior § + Sources Of Truth §). Without this probe,
  the click-unresponsiveness failure shape is invisible to Prom because
  the existing `tank_http_*` / `tank_pg_*` request-path metrics
  cover server-side latency only — a fully-blocked browser tab still
  emits clean 2xx responses. The new histogram lets PromQL ask
  `histogram_quantile(0.95, sum by (le, correlation) (rate(tank_client_long_task_duration_seconds_bucket[5m])))`
  and immediately separate event-burst-induced blocks from
  session-switch-induced blocks from idle GC pauses.
- Cardinality-validator test:
  `TestLongTaskMetricsAttributionLabelsAreBounded` asserts that
  user-controlled `Attribution` and `SessionMode` strings collapse to
  `other` / `unknown` rather than leaking through as labels. Service
  callers are rejected with 403
  (`TestHandleLongTaskMetricsRejectsServiceCallers`) — the probe is
  human-user-only since browsers are the only producers.
- Documented under `docs/observability.md` → metric taxonomy.

## Test plan

- [x] `npm test` in `frontend/`: 7/7 new + existing pass
- [x] `npm run build` in `frontend/`: tsc + vite both clean
- [x] `go test ./cmd/tank-operator/`: full package suite green including
      the 6 new tests
- [ ] Post-merge: confirm the probe lands data once deployed
      (`tank_client_long_task_reports_total{result="ok"}` ticking),
      then run the diagnostic PromQL queries against the user's
      reported click-unresponsiveness symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
