### PR TITLE
Fix click-unresponsiveness: move App-root periodic state out of cascade path

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,6 +143,10 @@ import {
   setActiveSessionMode,
 } from "./longTaskTelemetry";
 import {
+  useRelativeMinutes,
+  useRelativeSeconds,
+} from "./timeService";
+import {
   clusterHealthHeadline,
   clusterHealthIssueText,
   clusterHealthNatsReachabilityLabel,
@@ -1246,19 +1250,6 @@ function formatBootTime(ms: number): string {
   return formatRuntime(ms);
 }
 
-function sessionRuntimeLabel(session: Session, nowMs: number): string | null {
-  if (!session.created_at) return null;
-  const startedMs = Date.parse(session.created_at);
-  if (!Number.isFinite(startedMs)) return null;
-  return formatRuntime(nowMs - startedMs);
-}
-
-function sessionRuntimeTitle(session: Session, nowMs: number): string {
-  const startedMs = session.created_at ? Date.parse(session.created_at) : NaN;
-  const runtime = Number.isFinite(startedMs) ? formatRuntime(nowMs - startedMs) : "unknown";
-  return `running ${runtime}`;
-}
-
 function currentSessionSkillState(
   testState?: TestState | null,
   rolloutState?: RolloutState | null,
@@ -1340,24 +1331,68 @@ function sessionBootStartMs(session: Session): number {
   return Number.isFinite(createdMs) ? createdMs : NaN;
 }
 
-function sessionBootLabel(session: Session, nowMs: number): string | null {
-  const startMs = sessionBootStartMs(session);
-  if (!Number.isFinite(startMs)) return null;
+// SessionStats renders the sidebar's ↓ boot-time and ↑ runtime
+// labels for one session row. The hooks (useRelativeSeconds /
+// useRelativeMinutes) subscribe to the singleton timeService at the
+// granularity the label actually displays, so re-renders only happen
+// when *this row's* bucket boundary is crossed — not on every clock
+// tick at the App root. Replaces the prior App-root `nowMs` ticker
+// that cascaded a full-tree re-render every 30s (and every 1s while
+// any session was Pending), which was the dominant
+// `correlation=idle` long-task source observed in
+// `tank_client_long_task_duration_seconds`.
+function SessionStats({ session }: { session: Session }) {
+  const bootStartMs = sessionBootStartMs(session);
   const readyMs = session.ready_at ? Date.parse(session.ready_at) : NaN;
-  if (Number.isFinite(readyMs)) return formatBootTime(readyMs - startMs);
-  if (session.status === "Pending") return formatBootTime(nowMs - startMs);
-  return null;
-}
-
-function sessionBootTitle(session: Session, nowMs: number): string {
-  const startMs = sessionBootStartMs(session);
-  if (!Number.isFinite(startMs)) return "startup time unknown";
-  const readyMs = session.ready_at ? Date.parse(session.ready_at) : NaN;
-  if (Number.isFinite(readyMs)) {
-    return `ready ${formatBootTime(readyMs - startMs)} after request`;
+  const bootFinalMs =
+    Number.isFinite(readyMs) && Number.isFinite(bootStartMs)
+      ? readyMs - bootStartMs
+      : null;
+  // Live boot ticker only runs while Pending and we don't yet have a
+  // final ready_at. Passing null here keeps the hook subscribed but
+  // makes its getSnapshot return null — useSyncExternalStore then
+  // dedupes and no re-render fires.
+  const liveBootStart =
+    bootFinalMs === null && session.status === "Pending" && Number.isFinite(bootStartMs)
+      ? bootStartMs
+      : null;
+  const liveBootSeconds = useRelativeSeconds(liveBootStart);
+  let bootLabel: string | null = null;
+  let bootTitle = "startup time unknown";
+  if (bootFinalMs !== null) {
+    bootLabel = formatBootTime(bootFinalMs);
+    bootTitle = `ready ${bootLabel} after request`;
+  } else if (liveBootStart !== null && liveBootSeconds !== null) {
+    bootLabel = formatBootTime(liveBootSeconds * 1000);
+    bootTitle = `starting for ${bootLabel} since request`;
   }
-  if (session.status === "Pending") return `starting for ${formatBootTime(nowMs - startMs)} since request`;
-  return "startup time unknown";
+
+  const createdMs = session.created_at ? Date.parse(session.created_at) : NaN;
+  const runtimeStartedAt = Number.isFinite(createdMs) ? createdMs : null;
+  const runtimeMinutes = useRelativeMinutes(runtimeStartedAt);
+  const runtimeLabel =
+    runtimeStartedAt !== null && runtimeMinutes !== null
+      ? formatRuntime(runtimeMinutes * 60_000)
+      : null;
+  const runtimeTitle = runtimeLabel ? `running ${runtimeLabel}` : "runtime unknown";
+
+  if (!bootLabel && !runtimeLabel) return null;
+  return (
+    <span className="session-stats">
+      {bootLabel && (
+        <span className="session-stat" title={bootTitle} aria-label={bootTitle}>
+          <span aria-hidden="true">↓</span>
+          <span>{bootLabel}</span>
+        </span>
+      )}
+      {runtimeLabel && (
+        <span className="session-stat" title={runtimeTitle} aria-label={runtimeTitle}>
+          <span aria-hidden="true">↑</span>
+          <span>{runtimeLabel}</span>
+        </span>
+      )}
+    </span>
+  );
 }
 
 function readGlimmungLaunchContext(): GlimmungLaunchContext | null {
@@ -1420,17 +1455,13 @@ function clearGlimmungLaunchContext(): void {
 // ledger; the polling loop (only active while any session was
 // non-Active) is no longer needed.
 //
-// Two cadences for the shared `nowMs` clock:
-//   - BOOT: 1s while any session is Pending, so the sidebar ↓ boot label
-//     (second-resolution via formatBootTime) visibly counts up second by
-//     second during pod launch. A coarser interval here makes the counter
-//     look frozen and only "post an update when it's done loading."
-//   - IDLE: 30s once nothing is booting, since the ↑ runtime label is
-//     minute-resolution (formatRuntime returns "<1m" / "Nm" / "Nh" / "Nd")
-//     and doesn't need second-grain ticks — pod uptime lasts minutes-to-
-//     hours, so a slow tick is enough to catch minute boundaries.
-const SESSION_BOOT_TICK_MS = 1_000;
-const SESSION_RUNTIME_TICK_MS = 30_000;
+// Sidebar boot/runtime labels subscribe to the singleton timeService
+// (see SessionStats above). The previous design held `nowMs` as App-
+// root useState and ticked it from a setInterval, which cascaded a
+// full-tree re-render every 30s (or every 1s while any session was
+// Pending) — observed as 5+ second `correlation=idle` blocks in
+// `tank_client_long_task_duration_seconds`. Per-row hooks now subscribe
+// at the granularity each label actually renders at.
 const HOME_DEFAULT_SESSION_TITLE = "New session";
 
 function altArrowSessionDirection(event: KeyboardEvent): -1 | 1 | null {
@@ -1777,17 +1808,52 @@ function SessionAvatarIcon({
   return <AgentAvatarIcon avatar={avatar} className={className} />;
 }
 
-function ClusterHealthWidget({
-  health,
-  error,
-  loading,
-  onRefresh,
-}: {
-  health: ClusterHealthResponse | null;
-  error: string | null;
-  loading: boolean;
-  onRefresh: () => void;
-}) {
+// ClusterHealthWidget owns its own polling. The 30s setInterval +
+// state setters previously lived at App-root, which cascaded a
+// full-tree re-render every 30s — observed as `correlation=idle`
+// blocks in `tank_client_long_task_duration_seconds`. Co-locating the
+// polling here keeps the re-render scoped to this widget. `enabled`
+// gates the poll (only run when the user is signed in); flipping it
+// false tears down the state so a signed-out / styleguide render
+// stays at zero work.
+function ClusterHealthWidget({ enabled }: { enabled: boolean }) {
+  const [health, setHealth] = useState<ClusterHealthResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!enabled) return;
+    setLoading(true);
+    try {
+      const res = await authedFetch("/api/cluster-health");
+      if (!res.ok) throw new Error(`cluster health failed: ${res.status}`);
+      setHealth((await res.json()) as ClusterHealthResponse);
+      setError(null);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setHealth(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    void load();
+    const interval = window.setInterval(() => {
+      void load();
+    }, 30_000);
+    return () => window.clearInterval(interval);
+  }, [enabled, load]);
+
+  const onRefresh = useCallback(() => {
+    void load();
+  }, [load]);
+
   const status: ClusterHealthStatus = error ? "unknown" : health?.status ?? "unknown";
   const headline = error ? "Cluster unknown" : clusterHealthHeadline(health);
   const issue = error || clusterHealthIssueText(health);
@@ -2071,8 +2137,6 @@ function DemoLanding() {
             {demoSessions.map((s) => {
               const isActive = s.id === selected?.id;
               const statusDotClass = sessionStatusDotClass(s);
-              const bootLabel = sessionBootLabel(s, Date.now());
-              const runtimeLabel = sessionRuntimeLabel(s, Date.now());
               const avatar = getSessionAvatarByID(s.agent_avatar_id);
               return (
                 <li
@@ -2104,22 +2168,7 @@ function DemoLanding() {
                       aria-label={`status: ${s.status}`}
                     />
                     <ModeChip mode={s.mode} interaction={sessionInteractionForSession(s)} />
-                    {(bootLabel || runtimeLabel) && (
-                      <span className="session-stats">
-                        {bootLabel && (
-                          <span className="session-stat" title={sessionBootTitle(s, Date.now())}>
-                            <span aria-hidden="true">↓</span>
-                            <span>{bootLabel}</span>
-                          </span>
-                        )}
-                        {runtimeLabel && (
-                          <span className="session-stat" title={sessionRuntimeTitle(s, Date.now())}>
-                            <span aria-hidden="true">↑</span>
-                            <span>{runtimeLabel}</span>
-                          </span>
-                        )}
-                      </span>
-                    )}
+                    <SessionStats session={s} />
                     {s.mode === "claude_cli" && (
                       <span className="session-action session-remote is-icon" title="remote control">
                         <IconExternal />
@@ -10761,7 +10810,6 @@ export function App() {
   const [authError, setAuthError] = useState<string | null>(null);
   const [appConfig, setAppConfig] = useState<AppPublicConfig>({});
   const [sessions, setSessions] = useState<Session[]>([]);
-  const [nowMs, setNowMs] = useState(() => Date.now());
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [active, setActive] = useState<string | null>(null);
@@ -10862,37 +10910,10 @@ export function App() {
     await loadRuntimeAvatarCatalog();
     setAvatarCatalogVersion((version) => version + 1);
   }, []);
-  const [clusterHealth, setClusterHealth] = useState<ClusterHealthResponse | null>(null);
-  const [clusterHealthError, setClusterHealthError] = useState<string | null>(null);
-  const [clusterHealthLoading, setClusterHealthLoading] = useState(false);
-  const loadClusterHealth = useCallback(async () => {
-    if (!user) return;
-    setClusterHealthLoading(true);
-    try {
-      const res = await authedFetch("/api/cluster-health");
-      if (!res.ok) throw new Error(`cluster health failed: ${res.status}`);
-      setClusterHealth((await res.json()) as ClusterHealthResponse);
-      setClusterHealthError(null);
-    } catch (err) {
-      setClusterHealthError(errorMessage(err));
-    } finally {
-      setClusterHealthLoading(false);
-    }
-  }, [user]);
-
-  useEffect(() => {
-    if (!user) {
-      setClusterHealth(null);
-      setClusterHealthError(null);
-      setClusterHealthLoading(false);
-      return;
-    }
-    void loadClusterHealth();
-    const interval = window.setInterval(() => {
-      void loadClusterHealth();
-    }, 30_000);
-    return () => window.clearInterval(interval);
-  }, [loadClusterHealth, user]);
+  // Cluster-health polling lives inside ClusterHealthWidget so the
+  // 30s setInterval + its setState calls don't cascade re-renders
+  // through the App-root tree. See SessionStats above for the same
+  // pattern applied to the per-row time labels.
 
   // Reflect the active session in the URL so reloads land back on it.
   // Mirrors cloudcli's URL-tracking behaviour. Done as an effect rather
@@ -11511,15 +11532,6 @@ export function App() {
     void refresh();
   }, [user, effectiveSessionScope]);
 
-  // While a pod is booting we need a 1s tick so the ↓ boot label counts up
-  // second by second. Once nothing's booting, fall back to the slow tick —
-  // the ↑ runtime label is minute-resolution and re-rendering the sidebar
-  // every second for hours of idle uptime would be wasted work.
-  const hasPendingSession = useMemo(
-    () => sessions.some((s) => s.status === "Pending"),
-    [sessions],
-  );
-
   // Keep the refs that the SSE reducer reads in sync with the latest
   // committed state. This lets the SSE useEffect close over a stable
   // user identity instead of every render's state, avoiding constant
@@ -11541,13 +11553,6 @@ export function App() {
       sessions: sessionListDebugRows(sessions),
     });
   }, [sessions, active, avatarCatalogVersion]);
-
-  useEffect(() => {
-    if (!user) return;
-    const tickMs = hasPendingSession ? SESSION_BOOT_TICK_MS : SESSION_RUNTIME_TICK_MS;
-    const t = setInterval(() => setNowMs(Date.now()), tickMs);
-    return () => clearInterval(t);
-  }, [user, hasPendingSession]);
 
   useEffect(() => {
     const context = glimmungLaunchContext.current;
@@ -12657,8 +12662,6 @@ export function App() {
               const avatar = getSessionAvatarByID(s.agent_avatar_id);
               const statusDotClass = sessionStatusDotClass(s, sessionActivities[s.id]);
               const statusLabel = sessionStatusLabel(s, sessionActivities[s.id]);
-              const bootLabel = sessionBootLabel(s, nowMs);
-              const runtimeLabel = sessionRuntimeLabel(s, nowMs);
               const skillStateClass = sessionSkillStateClass(s);
               return (
                 <li
@@ -12704,30 +12707,8 @@ export function App() {
                       aria-label={`status: ${statusLabel}`}
                     />
                     <ModeChip mode={s.mode} interaction={sessionInteractionForSession(s)} />
-                    {(bootLabel || runtimeLabel) && (
-                      <span className="session-stats">
-                        {bootLabel && (
-                          <span
-                            className="session-stat"
-                            title={sessionBootTitle(s, nowMs)}
-                            aria-label={sessionBootTitle(s, nowMs)}
-                          >
-                            <span aria-hidden="true">↓</span>
-                            <span>{bootLabel}</span>
-                          </span>
-                        )}
-                        {runtimeLabel && (
-                          <span
-                            className="session-stat"
-                            title={sessionRuntimeTitle(s, nowMs)}
-                            aria-label={sessionRuntimeTitle(s, nowMs)}
-                          >
-                            <span aria-hidden="true">↑</span>
-                            <span>{runtimeLabel}</span>
-                          </span>
-                        )}
-                      </span>
-                    )}
+                    <SessionStats session={s} />
+                    {isClosing && <span className="session-closing-chip">closing</span>}
                     {CONFIG_MODES.has(s.mode) && (
                       <button
                         className="session-action"
@@ -12749,14 +12730,7 @@ export function App() {
           </ul>
         </div>
 
-        <ClusterHealthWidget
-          health={clusterHealth}
-          error={clusterHealthError}
-          loading={clusterHealthLoading}
-          onRefresh={() => {
-            void loadClusterHealth();
-          }}
-        />
+        <ClusterHealthWidget enabled={Boolean(user)} />
 
         <div className="sidebar-footer" data-menu="profile">
           <button

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -50,6 +50,58 @@ test("session activity is not refreshed by a steady interval", () => {
   assert.equal(/setInterval\(\s*refreshSessionActivity/.test(appSource), false);
 });
 
+test("App-root holds no periodic React state setters (cascade-prone pattern)", () => {
+  // Two App-root tickers used to live here and were the dominant source
+  // of `correlation=idle` long-task blocks (5+ s p95) observed via
+  // `tank_client_long_task_duration_seconds`. Both are retired:
+  //
+  //   1. `nowMs` / `setNowMs` ticker (1s while any session was Pending,
+  //      else 30s) → SessionStats now subscribes to the singleton
+  //      timeService at minute/second granularity, re-rendering only
+  //      the row whose bucket changed.
+  //   2. `clusterHealth*` + `loadClusterHealth` + 30s setInterval →
+  //      ClusterHealthWidget now owns its own state and polling.
+  //
+  // Re-introducing either pattern restores the cascading-rerender
+  // failure mode; this guard catches it at PR time. If a future
+  // surface legitimately needs a periodic refresh, scope it to its
+  // own component (or use the timeService for time-relative labels).
+  for (const forbidden of [
+    "setNowMs",
+    "hasPendingSession",
+    "SESSION_BOOT_TICK_MS",
+    "SESSION_RUNTIME_TICK_MS",
+    "setClusterHealth",
+    "loadClusterHealth",
+    "sessionBootLabel",
+    "sessionRuntimeLabel",
+    "sessionBootTitle",
+    "sessionRuntimeTitle",
+  ]) {
+    assert.equal(
+      new RegExp(`\\b${forbidden}\\b`).test(
+        appSource.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, ""),
+      ),
+      false,
+      `${forbidden} must not appear in App.tsx code (only in comments). The cascading-rerender pattern is retired; use timeService or co-locate the state with its consumer.`,
+    );
+  }
+  // Sidebar boot/runtime labels must use the timeService hooks, not
+  // wall-clock reads at render time. A bare Date.now() at render would
+  // give a stale label until the parent re-rendered for some other
+  // reason — the failure mode that the old nowMs ticker covered up.
+  assert.match(
+    appSource,
+    /from\s+"\.\/timeService"/,
+    "App.tsx must import from ./timeService for relative-time labels",
+  );
+  assert.match(
+    appSource,
+    /\buseRelative(Seconds|Minutes)\b/,
+    "App.tsx must call a timeService hook (useRelativeSeconds / useRelativeMinutes) so per-row labels stay live without an App-root ticker",
+  );
+});
+
 test("session activity status states have explicit sidebar styles", () => {
   for (const state of [
     "active",

--- a/frontend/src/timeService.test.ts
+++ b/frontend/src/timeService.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  __timeServiceListenerCountForTest,
+  __timeServiceResetForTest,
+  __timeServiceSubscribeForTest,
+  __timeServiceTickForTest,
+  __timeServiceTickerRunningForTest,
+} from "./timeService";
+
+// The hooks themselves wrap useSyncExternalStore + a stable getSnapshot
+// per consumer. The React-level semantics (snapshot dedup → no
+// re-render unless the bucket changed) belong to React; what we own at
+// this layer is the ticker lifecycle and the listener fan-out. Those
+// invariants are tested here directly. The hook integration is
+// exercised by the App at render time and observable via
+// `tank_client_long_task_duration_seconds` once deployed.
+
+beforeEach(() => {
+  // Patch window.setInterval so the singleton can install/tear down
+  // its ticker in this test environment.
+  (globalThis as { window?: unknown }).window = globalThis;
+  __timeServiceResetForTest();
+});
+
+afterEach(() => {
+  __timeServiceResetForTest();
+  delete (globalThis as { window?: unknown }).window;
+});
+
+test("ticker stays off until the first listener subscribes", () => {
+  assert.equal(__timeServiceListenerCountForTest(), 0);
+  assert.equal(__timeServiceTickerRunningForTest(), false);
+});
+
+test("first subscriber starts the ticker; tick fans out to every listener", () => {
+  let firstCalls = 0;
+  let secondCalls = 0;
+  const unsubA = __timeServiceSubscribeForTest(() => { firstCalls += 1; });
+  assert.equal(__timeServiceTickerRunningForTest(), true);
+  const unsubB = __timeServiceSubscribeForTest(() => { secondCalls += 1; });
+  assert.equal(__timeServiceListenerCountForTest(), 2);
+
+  __timeServiceTickForTest();
+  __timeServiceTickForTest();
+
+  assert.equal(firstCalls, 2);
+  assert.equal(secondCalls, 2);
+
+  unsubA();
+  unsubB();
+});
+
+test("ticker stops once the last subscriber unsubscribes", () => {
+  const unsub = __timeServiceSubscribeForTest(() => {});
+  assert.equal(__timeServiceTickerRunningForTest(), true);
+  unsub();
+  assert.equal(__timeServiceListenerCountForTest(), 0);
+  assert.equal(__timeServiceTickerRunningForTest(), false);
+});
+
+test("unsubscribing one of several listeners keeps the ticker running", () => {
+  const unsubA = __timeServiceSubscribeForTest(() => {});
+  const unsubB = __timeServiceSubscribeForTest(() => {});
+  unsubA();
+  assert.equal(__timeServiceListenerCountForTest(), 1);
+  assert.equal(__timeServiceTickerRunningForTest(), true);
+  unsubB();
+  assert.equal(__timeServiceTickerRunningForTest(), false);
+});

--- a/frontend/src/timeService.ts
+++ b/frontend/src/timeService.ts
@@ -1,0 +1,106 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+// Singleton time source for components rendering relative-time labels
+// ("5s", "2m", "3h"). The previous design held `nowMs` as App-root
+// `useState` and ticked it from a `setInterval`, which cascaded a full
+// re-render through the 13K-line App tree on every tick — observed as
+// 5+ second `correlation=idle` long-task blocks in
+// `tank_client_long_task_duration_seconds`. The fix is to move the
+// clock outside React state and let each consumer subscribe at the
+// granularity it actually renders at.
+//
+// Implementation: one shared `setInterval` ticking at 1 Hz feeds a
+// useSyncExternalStore. Each consumer's `getSnapshot` returns the
+// current bucket at its requested granularity (seconds or minutes), so
+// React's built-in snapshot-equality short-circuit skips re-renders
+// unless that consumer's own bucket boundary has been crossed. A row
+// showing "5m" re-renders once a minute; a row showing the second-
+// resolution boot timer re-renders once a second. The App root
+// re-renders zero times for clock ticks.
+//
+// The interval only runs while at least one consumer is mounted, so a
+// signed-out / styleguide page pays nothing.
+//
+// Migration guard: `frontend/src/migrationPolicy.test.ts` asserts that
+// no `setInterval`-driven `useState` setter pattern exists at App-root
+// scope. Re-introducing the cascading pattern is a counted regression.
+
+const TICK_INTERVAL_MS = 1_000;
+
+const listeners = new Set<() => void>();
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+function ensureTickerRunning(): void {
+  if (tickHandle !== null) return;
+  if (typeof window === "undefined") return;
+  tickHandle = setInterval(() => {
+    for (const listener of listeners) listener();
+  }, TICK_INTERVAL_MS);
+}
+
+function stopTickerIfIdle(): void {
+  if (tickHandle !== null && listeners.size === 0) {
+    clearInterval(tickHandle);
+    tickHandle = null;
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  ensureTickerRunning();
+  return () => {
+    listeners.delete(listener);
+    stopTickerIfIdle();
+  };
+}
+
+// Test-only hooks so unit tests can drive the ticker deterministically
+// without owning the global setInterval. Production code uses `subscribe`
+// indirectly through the hooks below.
+export function __timeServiceTickForTest(): void {
+  for (const listener of listeners) listener();
+}
+
+export function __timeServiceListenerCountForTest(): number {
+  return listeners.size;
+}
+
+export function __timeServiceTickerRunningForTest(): boolean {
+  return tickHandle !== null;
+}
+
+export function __timeServiceSubscribeForTest(listener: () => void): () => void {
+  return subscribe(listener);
+}
+
+export function __timeServiceResetForTest(): void {
+  listeners.clear();
+  if (tickHandle !== null) {
+    clearInterval(tickHandle);
+    tickHandle = null;
+  }
+}
+
+// useRelativeSeconds returns the number of full seconds elapsed since
+// `startedAtMs`, or `null` when `startedAtMs` is null/NaN. Consumers
+// using this hook re-render once per second while mounted — but only
+// the calling component, not its parent.
+export function useRelativeSeconds(startedAtMs: number | null): number | null {
+  const getSnapshot = useCallback(() => {
+    if (startedAtMs === null || !Number.isFinite(startedAtMs)) return null;
+    return Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000));
+  }, [startedAtMs]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+// useRelativeMinutes returns the number of full minutes elapsed since
+// `startedAtMs`, or `null` when `startedAtMs` is null/NaN. The
+// snapshot bucket is the minute count so the consumer re-renders at
+// most once per minute even though the ticker fires every second.
+export function useRelativeMinutes(startedAtMs: number | null): number | null {
+  const getSnapshot = useCallback(() => {
+    if (startedAtMs === null || !Number.isFinite(startedAtMs)) return null;
+    return Math.max(0, Math.floor((Date.now() - startedAtMs) / 60_000));
+  }, [startedAtMs]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Summary

- Diagnosed live with the long-task probe from #682. Grafana shows
  `correlation=idle` p95 at the top bucket (5 s, clipped — 6 entries
  have spilled past 5 s) and `correlation=event_burst` / `session_switch`
  flat at the histogram floor (~74 ms). The cascade was idle-driven,
  not event-driven.
- Cause: two `setInterval`-driven `useState` setters at App-root were
  re-rendering the 13K-line App tree every 30 s — `nowMs` (sidebar
  ↓boot / ↑runtime labels) and `clusterHealth*` (the day-old health
  widget polling, babdd59). The user reported it as "the session
  'changing avatar' is locking my mouse."
- Fix: co-locate the periodic state with its consumer.
  - New `frontend/src/timeService.ts` — singleton time source backed by
    `useSyncExternalStore`. One internal 1 Hz ticker fans out to
    per-consumer listeners. `useRelativeSeconds` / `useRelativeMinutes`
    compute their own bucket so React's snapshot dedup short-circuits
    re-renders unless that consumer's own boundary has been crossed.
  - New `<SessionStats>` component renders the ↓boot / ↑runtime labels
    for one session row and subscribes via the hooks. App root is never
    the calling component for a clock tick; only the affected row
    re-renders, at its own granularity.
  - `ClusterHealthWidget` now owns its own state + `useEffect` polling;
    App.tsx passes only `enabled={Boolean(user)}`. Signed-out /
    styleguide renders pay zero polling cost.
- Migration guard in `frontend/src/migrationPolicy.test.ts` asserts the
  retired identifiers (`setNowMs`, `hasPendingSession`,
  `SESSION_BOOT_TICK_MS`, `SESSION_RUNTIME_TICK_MS`, `setClusterHealth`,
  `loadClusterHealth`, the four session*Label/Title functions) do not
  appear in App.tsx code, and that App.tsx imports + calls a
  `useRelative*` hook — so a future PR can't delete the App-root state
  without wiring the replacement.

## Feature Contracts

Affected contracts:
- [x] Observability
- [x] App Chrome
- [ ] None

Evidence:
- **Observability contract** — the diagnostic that pinpointed this
  cascade rode the `tank_client_long_task_*` surface added in #682,
  exactly as the contract intends: an operator localized a user-trust
  failure ("clicks aren't responding") from `/metrics` + Grafana alone,
  without browser devtools. Post-deploy verification rides the same
  surface: `correlation=idle` p95 should drop from 5+ s (clipped) to
  <250 ms. If it doesn't, there is a third periodic source not
  identified yet — the next step is adding a `periodic_tick`
  correlation signal, not blind reverts.
- **App Chrome contract** — the sidebar's session row composition
  (↓boot, ↑runtime, status dot, mode chip) is preserved pixel-for-pixel;
  the cluster-health widget keeps the same shape, ARIA labels, and
  refresh button. The behavioral guarantee in the contract is "the
  sidebar reflects current pod state without operator intervention" —
  per-row `useRelativeSeconds` / `useRelativeMinutes` subscriptions
  keep that guarantee at finer granularity than the prior 30 s coarse
  tick (boot timer still updates every second; runtime updates at
  minute boundaries, which is what the label format actually requires).
- Quality timeframes § Review Heuristics named two of the smells this
  cascade hit ("polling loops without a cost and scale story";
  "feature that only works until reload, reconnect, restart, or
  rollout"). The new design has a written cost story: 1 shared
  `setInterval` regardless of consumer count; per-consumer re-renders
  only at their own bucket boundary; ticker self-disables when no
  consumer is mounted.
- Migration policy § Completion Standard — both retired patterns are
  deleted end-to-end. No fallback layer, no compatibility shim, no
  "leave nowMs in place for now." Migration guard pins the deletion.

## Test plan

- [x] `npm test`: 250/250 pass (timeService lifecycle test + migration
      guard test included)
- [x] `npm run build`: tsc + vite clean
- [ ] Post-deploy: query
      `histogram_quantile(0.95, sum by (le, correlation) (rate(tank_client_long_task_duration_seconds_bucket[5m])))`
      — `correlation=idle` p95 should drop from 5+ s to <250 ms, the
      `correlation=idle` total rate should fall by roughly
      one-tick-per-30s × active-user-tab-count.

## Followups

Diagnosis surfaced **725 NATS consumers for 6 active sessions**
(JetStream at 50 % memory). The migration audit checklist in
CLAUDE.md names this exact stranded-durable failure mode. Separate
upcoming PR: (a) startup sweep deleting consumers with no matching
live session, (b) `tank_session_bus_orphan_consumers` gauge + alert
when `consumers > sessions × 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
