### PR TITLE
Sweep orphan JetStream consumers at orchestrator startup

### DIFF
--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -267,7 +267,14 @@ func main() {
 
 	sessionScope := envDefault("SESSION_REGISTRY_SCOPE", "default")
 
-	// 5. Init session registry.
+	// 5. Init session registry. We also retain the concrete
+	// *sessionregistry.Store (when Postgres is wired) because the
+	// orphan-consumer sweep needs a scope-wide session_id query that
+	// isn't on the sessions.SessionRegistry interface.
+	var sessionRegStore *sessionregistry.Store
+	if pgPool != nil {
+		sessionRegStore = sessionregistry.NewPostgresStore(pgPool, sessionScope)
+	}
 	sessionReg := buildSessionRegistry(pgPool, sessionScope)
 
 	// 6. Init session events store for the SDK runners' canonical stream.
@@ -487,6 +494,15 @@ func main() {
 			}()
 		}
 	}
+
+	// Orphan-consumer sweep. Periodically deletes stranded JetStream
+	// consumers (per-session data/control consumers that nothing
+	// cleans up when a session goes away). Without this loop, deleted
+	// sessions leak consumers until the JetStream RAM budget is
+	// saturated — observed at 725 consumers / 6 live sessions on
+	// 2026-05-25. Skipped in stub mode where there's no real
+	// Postgres or NATS to operate against.
+	startOrphanConsumerSweeps(ctx, sessionBus, sessionRegStore, sessionScope)
 
 	// 12. Register all routes. Internal session handlers authenticate via
 	// the auth.romaine.life service-principal JWT path (#486 Stage 4); the

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -217,6 +217,37 @@ var (
 		Help:    "Duration from session_events row Upsert returning to the NATS wake publish completing.",
 		Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
 	})
+	// NATS orphan-consumer sweep observability. Every (session,
+	// provider) pair owns 2 durable JetStream consumers; nothing
+	// deletes them when a session goes away (the runner-side
+	// ensureConsumer only creates). Without the sweep, deleted
+	// sessions accumulate stranded consumers that eat the JetStream
+	// RAM budget — observed at 725 consumers for 6 live sessions on
+	// 2026-05-25. internal/sessionbus.SweepOrphanConsumers does the
+	// cleanup; these metrics surface its behavior so an operator can
+	// tell whether the sweep is running, finding orphans, and
+	// successfully deleting them.
+	sessionBusOrphanConsumersGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "tank_session_bus_orphan_consumers",
+		Help: "Stranded JetStream consumers observed in the most recent sweep pass (consumers whose session_id has no matching row in this scope, older than the safety threshold).",
+	})
+	sessionBusConsumersScannedGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "tank_session_bus_consumers_scanned",
+		Help: "Total JetStream consumers observed on the session bus in the most recent sweep pass (across all scopes).",
+	})
+	sessionBusOrphanConsumerDeletedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_bus_orphan_consumers_deleted_total",
+		Help: "JetStream consumers the orphan sweep successfully deleted (cumulative).",
+	})
+	sessionBusOrphanConsumerDeleteErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tank_session_bus_orphan_consumer_delete_errors_total",
+		Help: "Orphan-consumer delete attempts that failed (cumulative). Non-zero rate means the sweep is identifying orphans but NATS is refusing to remove them.",
+	})
+	sessionBusOrphanSweepPassesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tank_session_bus_orphan_sweep_passes_total",
+		Help: "Orphan-sweep passes, partitioned by outcome (ok / error). Steady-state expectation: ok dominates; error > 0 means the sweep itself is failing (NATS unreachable, list consumers timing out, etc).",
+	}, []string{"result"})
+
 	// Per-event-type emit counter — the candidate-C stethoscope. When
 	// the server's emit-by-type vs the client's receive-by-type
 	// (tank_session_event_client_received_total, ingested through
@@ -1366,6 +1397,29 @@ func (promWakeMetrics) RecordCommandPublishFailed(kind string, reason string) {
 		sessionBusCommandKindLabel(kind),
 		sessionBusCommandReasonLabel(reason),
 	).Inc()
+}
+
+// promSweepMetrics adapts sessionbus.SweepResult into the Prometheus
+// gauges + counters defined above. The gauges are last-observed
+// snapshots (overwritten each pass); the counters are cumulative
+// (added each pass). Pair with recordSessionBusOrphanSweepResult,
+// which records the per-pass outcome label for the alert that fires
+// when the sweep itself is broken.
+type promSweepMetrics struct{}
+
+func (promSweepMetrics) RecordSweepPass(result sessionbus.SweepResult) {
+	sessionBusOrphanConsumersGauge.Set(float64(result.Orphans))
+	sessionBusConsumersScannedGauge.Set(float64(result.Scanned))
+	if result.Deleted > 0 {
+		sessionBusOrphanConsumerDeletedTotal.Add(float64(result.Deleted))
+	}
+	if result.Errors > 0 {
+		sessionBusOrphanConsumerDeleteErrorsTotal.Add(float64(result.Errors))
+	}
+}
+
+func recordSessionBusOrphanSweepResult(result string) {
+	sessionBusOrphanSweepPassesTotal.WithLabelValues(result).Inc()
 }
 
 // sessionBusCommandKindLabel is the prom-side validator for the kind

--- a/backend-go/cmd/tank-operator/orphan_consumer_sweep.go
+++ b/backend-go/cmd/tank-operator/orphan_consumer_sweep.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionbus"
+	"github.com/nelsong6/tank-operator/backend-go/internal/sessionregistry"
+)
+
+// Orphan-consumer sweep cadence. The 5-minute initial delay lets
+// pre-deploy session pods reconnect and re-register their consumers
+// after an orchestrator restart, so a freshly-restarted orchestrator
+// doesn't briefly see existing consumers as orphans during the
+// reconnect window. The 15-minute MinAge inside SweepOrphanConsumers
+// is the second safety net for the same race; the initial delay
+// shaves the first sweep down to safer ground regardless.
+const (
+	orphanSweepInitialDelay = 5 * time.Minute
+	orphanSweepInterval     = 1 * time.Hour
+	orphanSweepPassTimeout  = 90 * time.Second
+)
+
+// startOrphanConsumerSweeps runs the durable cleanup loop that
+// removes stranded JetStream consumers from the TANK_SESSION_BUS
+// stream. Background: every session owns two durable consumers (data
+// plane + control plane per provider); the runner-side
+// ensureConsumer / ensureControlConsumer only creates them, so
+// deleted sessions leak consumers indefinitely. The 2026-05-25
+// observation was 725 consumers for 6 live sessions, eating ~50 % of
+// the JetStream RAM budget. CLAUDE.md's migration audit checklist
+// names this exact failure mode; this loop is the durable
+// remediation.
+//
+// Skipped when either dependency is nil — stub-mode local dev has
+// no Postgres pool to list live sessions from and no real JetStream
+// stream to sweep.
+func startOrphanConsumerSweeps(
+	ctx context.Context,
+	bus *sessionbus.Bus,
+	registry *sessionregistry.Store,
+	scope string,
+) {
+	if bus == nil || registry == nil {
+		slog.Info("orphan consumer sweep: skipped (no bus or registry)",
+			"scope", scope,
+			"bus_wired", bus != nil,
+			"registry_wired", registry != nil,
+		)
+		return
+	}
+	go runOrphanConsumerSweepLoop(ctx, bus, registry, scope)
+}
+
+func runOrphanConsumerSweepLoop(
+	ctx context.Context,
+	bus *sessionbus.Bus,
+	registry *sessionregistry.Store,
+	scope string,
+) {
+	// Initial delay so existing runners can re-register their
+	// consumers post-orchestrator-restart before we treat anything
+	// as orphan.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(orphanSweepInitialDelay):
+	}
+
+	runOnce := func() {
+		passCtx, cancel := context.WithTimeout(ctx, orphanSweepPassTimeout)
+		defer cancel()
+
+		live, err := registry.ListAllIDsForScope(passCtx)
+		if err != nil {
+			slog.Warn("orphan consumer sweep: list live sessions failed",
+				"scope", scope, "error", err)
+			recordSessionBusOrphanSweepResult("error")
+			return
+		}
+
+		result, err := bus.SweepOrphanConsumers(passCtx, sessionbus.SweepConfig{
+			LiveSessionIDs: live,
+		})
+		if err != nil {
+			slog.Warn("orphan consumer sweep failed",
+				"scope", scope, "error", err)
+			recordSessionBusOrphanSweepResult("error")
+			return
+		}
+		promSweepMetrics{}.RecordSweepPass(result)
+		recordSessionBusOrphanSweepResult("ok")
+		slog.Info("orphan consumer sweep complete",
+			"scope", scope,
+			"live_session_ids", len(live),
+			"scanned", result.Scanned,
+			"skipped_out_of_scope", result.SkippedOutOfScope,
+			"skipped_live", result.SkippedLive,
+			"skipped_too_young", result.SkippedTooYoung,
+			"orphans", result.Orphans,
+			"deleted", result.Deleted,
+			"errors", result.Errors,
+		)
+	}
+
+	runOnce()
+	ticker := time.NewTicker(orphanSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runOnce()
+		}
+	}
+}

--- a/backend-go/internal/sessionbus/sweep.go
+++ b/backend-go/internal/sessionbus/sweep.go
@@ -1,0 +1,225 @@
+package sessionbus
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// SweepOrphanConsumers walks every JetStream consumer on this bus's
+// stream and deletes the ones whose decoded session_id is not in
+// liveSessionIDs. Persister consumers and consumers belonging to a
+// different orchestrator's scope are skipped.
+//
+// Why this exists: every (session, provider) pair owns two durable
+// consumers — a data-plane consumer (max_ack_pending=1) and a
+// control-plane consumer (max_ack_pending=16). The runner-side
+// ensureConsumer / ensureControlConsumer in runner-shared/sessionBus.js
+// only CREATES these consumers; nothing deletes them when a session
+// goes away. Over the lifetime of the JetStream pod the cohort of
+// stranded consumers accumulates without bound and eats into the
+// JetStream RAM budget (the chart caps each replica at 256 MiB).
+// Observed on 2026-05-25: 725 consumers for 6 live sessions, ~50 % of
+// the JetStream memory cap. The migration audit checklist in
+// CLAUDE.md names this exact failure mode ("For wire-format changes
+// affecting durable JetStream consumers, confirm the cutover includes
+// an explicit remediation for existing consumers — a deploy alone
+// cannot repair them"). This sweep is the durable remediation: it
+// runs at orchestrator startup and on a periodic loop so a
+// post-deploy backlog clears on its own.
+//
+// Safety: consumers younger than MinAge are kept regardless, so a
+// session whose registry row exists but whose runner hasn't yet
+// listed (the create-time race) is never deleted. The orchestrator's
+// own scope_token is the only filter — cross-scope orchestrators (prod
+// + a test slot sharing one NATS) each sweep only their own
+// consumers.
+
+// SweepConfig configures one sweep pass. LiveSessionIDs is the
+// authoritative set of session_ids in this scope that own legitimate
+// consumers; anything not in this set is deletion-eligible (subject
+// to MinAge).
+type SweepConfig struct {
+	LiveSessionIDs map[string]struct{}
+	// MinAge caps how recent a consumer can be before the sweep
+	// considers it. Defaults to 15 minutes; tests can dial down.
+	MinAge time.Duration
+	// Now returns wall time for the age check. Hook for tests.
+	Now func() time.Time
+}
+
+// SweepResult summarizes one pass for telemetry + logging.
+type SweepResult struct {
+	Scanned           int
+	SkippedOutOfScope int
+	SkippedLive       int
+	SkippedTooYoung   int
+	Orphans           int
+	Deleted           int
+	Errors            int
+}
+
+// SweepMetrics receives per-pass counts. Wired to Prometheus at the
+// orchestrator's observability layer; the interface here keeps this
+// package from importing prometheus directly.
+type SweepMetrics interface {
+	RecordSweepPass(result SweepResult)
+}
+
+// ConsumerSweepSource is the small JetStream surface the sweep
+// depends on. Defined here (and satisfied by the *Bus.jetstream
+// adapter below) so unit tests can supply an in-memory fake instead
+// of spinning up an embedded NATS.
+type ConsumerSweepSource interface {
+	ListConsumers(ctx context.Context) ([]*jetstream.ConsumerInfo, error)
+	DeleteConsumer(ctx context.Context, name string) error
+}
+
+// SweepOrphanConsumers runs one sweep pass against this bus's NATS
+// JetStream stream. Individual delete failures are logged + counted
+// in result.Errors but do not abort the pass — the next periodic run
+// will retry.
+func (b *Bus) SweepOrphanConsumers(ctx context.Context, cfg SweepConfig) (SweepResult, error) {
+	if b == nil || b.js == nil {
+		return SweepResult{}, errors.New("session bus unavailable")
+	}
+	source := &busConsumerSweepSource{js: b.js, stream: b.stream}
+	return RunConsumerSweep(ctx, source, b.scope, cfg)
+}
+
+// RunConsumerSweep is the pure-logic core of the sweep, taking an
+// abstract ConsumerSweepSource so unit tests can drive it without
+// touching JetStream. The Bus method above is the production wiring.
+func RunConsumerSweep(ctx context.Context, source ConsumerSweepSource, scope string, cfg SweepConfig) (SweepResult, error) {
+	if source == nil {
+		return SweepResult{}, errors.New("consumer sweep source is required")
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	minAge := cfg.MinAge
+	if minAge <= 0 {
+		minAge = 15 * time.Minute
+	}
+	myScopeToken := ScopeToken(scope)
+
+	infos, err := source.ListConsumers(ctx)
+	if err != nil {
+		return SweepResult{}, fmt.Errorf("list consumers: %w", err)
+	}
+
+	var result SweepResult
+	for _, info := range infos {
+		if info == nil {
+			continue
+		}
+		result.Scanned++
+		sessionID, ok := DecodeConsumerSessionID(info.Name, myScopeToken)
+		if !ok {
+			result.SkippedOutOfScope++
+			continue
+		}
+		if _, alive := cfg.LiveSessionIDs[sessionID]; alive {
+			result.SkippedLive++
+			continue
+		}
+		age := cfg.Now().Sub(info.Created)
+		if age < minAge {
+			result.SkippedTooYoung++
+			continue
+		}
+		result.Orphans++
+		if err := source.DeleteConsumer(ctx, info.Name); err != nil {
+			slog.Warn("orphan consumer delete failed",
+				"consumer", info.Name,
+				"session_id", sessionID,
+				"scope", scope,
+				"age_seconds", age.Seconds(),
+				"error", err,
+			)
+			result.Errors++
+			continue
+		}
+		slog.Info("orphan consumer deleted",
+			"consumer", info.Name,
+			"session_id", sessionID,
+			"scope", scope,
+			"age_seconds", age.Seconds(),
+		)
+		result.Deleted++
+	}
+	return result, nil
+}
+
+// DecodeConsumerSessionID extracts the public session_id from a
+// runner-side consumer name produced by runner-shared/sessionBus.js:
+//
+//	consumerName()         -> <provider>_<scopeToken>_<sessionIDToken>
+//	controlConsumerName()  -> <provider>_control_<scopeToken>_<sessionIDToken>
+//
+// Returns ok=false for any name that doesn't match this scope — the
+// persister consumer `tank-session-event-persister-<scopeToken>` uses
+// `-` separators and falls into this branch, as does any consumer from
+// a different orchestrator scope. strings.LastIndex on the scope-token
+// needle handles base64-url scope tokens that may themselves contain
+// `_`.
+func DecodeConsumerSessionID(name, myScopeToken string) (string, bool) {
+	if name == "" || myScopeToken == "" {
+		return "", false
+	}
+	needle := "_" + myScopeToken + "_"
+	idx := strings.LastIndex(name, needle)
+	if idx < 0 {
+		return "", false
+	}
+	prefix := name[:idx]
+	suffix := name[idx+len(needle):]
+	if prefix == "" || suffix == "" {
+		return "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(suffix)
+	if err != nil {
+		return "", false
+	}
+	sessionID := strings.TrimSpace(string(raw))
+	if sessionID == "" {
+		return "", false
+	}
+	return sessionID, true
+}
+
+// busConsumerSweepSource adapts the live JetStream calls to the small
+// ConsumerSweepSource interface RunConsumerSweep depends on. The Bus's
+// js + stream are captured at sweep time.
+type busConsumerSweepSource struct {
+	js     jetstream.JetStream
+	stream string
+}
+
+func (s *busConsumerSweepSource) ListConsumers(ctx context.Context) ([]*jetstream.ConsumerInfo, error) {
+	stream, err := s.js.Stream(ctx, s.stream)
+	if err != nil {
+		return nil, fmt.Errorf("get stream %q: %w", s.stream, err)
+	}
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	lister := stream.ListConsumers(listCtx)
+	var out []*jetstream.ConsumerInfo
+	for info := range lister.Info() {
+		out = append(out, info)
+	}
+	if err := lister.Err(); err != nil {
+		return out, fmt.Errorf("list consumers: %w", err)
+	}
+	return out, nil
+}
+
+func (s *busConsumerSweepSource) DeleteConsumer(ctx context.Context, name string) error {
+	return s.js.DeleteConsumer(ctx, s.stream, name)
+}

--- a/backend-go/internal/sessionbus/sweep_test.go
+++ b/backend-go/internal/sessionbus/sweep_test.go
@@ -1,0 +1,284 @@
+package sessionbus
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestDecodeConsumerSessionID(t *testing.T) {
+	defaultScope := ScopeToken("default")
+	otherScope := ScopeToken("test-slot-7")
+	enc := func(s string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(s))
+	}
+
+	cases := []struct {
+		name           string
+		consumerName   string
+		myScopeToken   string
+		wantSessionID  string
+		wantOK         bool
+	}{
+		{
+			name:          "data-plane consumer in our scope decodes session id",
+			consumerName:  "claude_" + defaultScope + "_" + enc("216"),
+			myScopeToken:  defaultScope,
+			wantSessionID: "216",
+			wantOK:        true,
+		},
+		{
+			name:          "control-plane consumer in our scope decodes session id",
+			consumerName:  "claude_control_" + defaultScope + "_" + enc("216"),
+			myScopeToken:  defaultScope,
+			wantSessionID: "216",
+			wantOK:        true,
+		},
+		{
+			name:          "codex provider decodes the same way",
+			consumerName:  "codex_" + defaultScope + "_" + enc("232"),
+			myScopeToken:  defaultScope,
+			wantSessionID: "232",
+			wantOK:        true,
+		},
+		{
+			name:         "consumer in a different scope is skipped",
+			consumerName: "claude_" + otherScope + "_" + enc("99"),
+			myScopeToken: defaultScope,
+			wantOK:       false,
+		},
+		{
+			name:         "persister consumer name is skipped (uses dashes, not underscores)",
+			consumerName: "tank-session-event-persister-" + defaultScope,
+			myScopeToken: defaultScope,
+			wantOK:       false,
+		},
+		{
+			name:         "empty name is rejected",
+			consumerName: "",
+			myScopeToken: defaultScope,
+			wantOK:       false,
+		},
+		{
+			name:         "name with no scope-token substring is rejected",
+			consumerName: "claude_garbage_token",
+			myScopeToken: defaultScope,
+			wantOK:       false,
+		},
+		{
+			name:         "trailing token that isn't valid base64 is rejected",
+			consumerName: "claude_" + defaultScope + "_!!!notbase64",
+			myScopeToken: defaultScope,
+			wantOK:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotOK := DecodeConsumerSessionID(tc.consumerName, tc.myScopeToken)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (id=%q)", gotOK, tc.wantOK, gotID)
+			}
+			if gotOK && gotID != tc.wantSessionID {
+				t.Fatalf("session_id = %q, want %q", gotID, tc.wantSessionID)
+			}
+		})
+	}
+}
+
+// fakeSweepSource is the in-memory ConsumerSweepSource used by the
+// sweep unit tests. Capture-by-construction lets us assert exactly
+// which consumers the sweep tried to delete.
+type fakeSweepSource struct {
+	consumers   []*jetstream.ConsumerInfo
+	deleted     []string
+	deleteErrFn func(name string) error
+	listErr     error
+}
+
+func (f *fakeSweepSource) ListConsumers(_ context.Context) ([]*jetstream.ConsumerInfo, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.consumers, nil
+}
+
+func (f *fakeSweepSource) DeleteConsumer(_ context.Context, name string) error {
+	if f.deleteErrFn != nil {
+		if err := f.deleteErrFn(name); err != nil {
+			return err
+		}
+	}
+	f.deleted = append(f.deleted, name)
+	return nil
+}
+
+func mkConsumer(name string, ageMinutes int, now time.Time) *jetstream.ConsumerInfo {
+	return &jetstream.ConsumerInfo{
+		Name:    name,
+		Created: now.Add(-time.Duration(ageMinutes) * time.Minute),
+	}
+}
+
+func TestRunConsumerSweepDeletesOrphansOldEnough(t *testing.T) {
+	scope := "default"
+	scopeToken := ScopeToken(scope)
+	now := time.Date(2026, 5, 26, 6, 0, 0, 0, time.UTC)
+	live216 := base64.RawURLEncoding.EncodeToString([]byte("216"))
+	dead404 := base64.RawURLEncoding.EncodeToString([]byte("404"))
+	dead505 := base64.RawURLEncoding.EncodeToString([]byte("505"))
+
+	source := &fakeSweepSource{
+		consumers: []*jetstream.ConsumerInfo{
+			mkConsumer("claude_"+scopeToken+"_"+live216, 60, now),            // live, skip
+			mkConsumer("claude_control_"+scopeToken+"_"+live216, 60, now),    // live, skip
+			mkConsumer("claude_"+scopeToken+"_"+dead404, 60, now),            // orphan, delete
+			mkConsumer("claude_control_"+scopeToken+"_"+dead404, 60, now),    // orphan, delete
+			mkConsumer("codex_"+scopeToken+"_"+dead505, 60, now),             // orphan, delete
+			mkConsumer("claude_"+scopeToken+"_"+dead404, 1, now),             // too-young duplicate, skip
+			mkConsumer("tank-session-event-persister-"+scopeToken, 999, now), // persister, skip
+			mkConsumer("claude_"+ScopeToken("test-slot-3")+"_"+dead404, 60, now), // other scope, skip
+		},
+	}
+
+	result, err := RunConsumerSweep(
+		context.Background(),
+		source,
+		scope,
+		SweepConfig{
+			LiveSessionIDs: map[string]struct{}{"216": {}},
+			MinAge:         15 * time.Minute,
+			Now:            func() time.Time { return now },
+		},
+	)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if result.Scanned != 8 {
+		t.Errorf("Scanned = %d, want 8", result.Scanned)
+	}
+	if result.SkippedLive != 2 {
+		t.Errorf("SkippedLive = %d, want 2", result.SkippedLive)
+	}
+	if result.SkippedOutOfScope != 2 {
+		t.Errorf("SkippedOutOfScope = %d, want 2 (persister + other-scope)", result.SkippedOutOfScope)
+	}
+	if result.SkippedTooYoung != 1 {
+		t.Errorf("SkippedTooYoung = %d, want 1", result.SkippedTooYoung)
+	}
+	if result.Orphans != 3 {
+		t.Errorf("Orphans = %d, want 3", result.Orphans)
+	}
+	if result.Deleted != 3 {
+		t.Errorf("Deleted = %d, want 3", result.Deleted)
+	}
+	if result.Errors != 0 {
+		t.Errorf("Errors = %d, want 0", result.Errors)
+	}
+
+	// Pin the exact deletion set so we don't accidentally widen the
+	// blast radius in a future change.
+	wantDeleted := map[string]bool{
+		"claude_" + scopeToken + "_" + dead404:         true,
+		"claude_control_" + scopeToken + "_" + dead404: true,
+		"codex_" + scopeToken + "_" + dead505:          true,
+	}
+	for _, name := range source.deleted {
+		if !wantDeleted[name] {
+			t.Errorf("unexpected delete of %q", name)
+		}
+		delete(wantDeleted, name)
+	}
+	for missing := range wantDeleted {
+		t.Errorf("expected delete of %q did not happen", missing)
+	}
+}
+
+func TestRunConsumerSweepCountsDeleteFailuresWithoutAborting(t *testing.T) {
+	scope := "default"
+	scopeToken := ScopeToken(scope)
+	now := time.Date(2026, 5, 26, 6, 0, 0, 0, time.UTC)
+
+	source := &fakeSweepSource{
+		consumers: []*jetstream.ConsumerInfo{
+			mkConsumer("claude_"+scopeToken+"_"+base64.RawURLEncoding.EncodeToString([]byte("100")), 60, now),
+			mkConsumer("claude_"+scopeToken+"_"+base64.RawURLEncoding.EncodeToString([]byte("200")), 60, now),
+			mkConsumer("claude_"+scopeToken+"_"+base64.RawURLEncoding.EncodeToString([]byte("300")), 60, now),
+		},
+		deleteErrFn: func(name string) error {
+			if strings.HasSuffix(name, base64.RawURLEncoding.EncodeToString([]byte("200"))) {
+				return errors.New("transient NATS error")
+			}
+			return nil
+		},
+	}
+
+	result, err := RunConsumerSweep(
+		context.Background(),
+		source,
+		scope,
+		SweepConfig{
+			LiveSessionIDs: map[string]struct{}{},
+			MinAge:         15 * time.Minute,
+			Now:            func() time.Time { return now },
+		},
+	)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if result.Orphans != 3 {
+		t.Errorf("Orphans = %d, want 3", result.Orphans)
+	}
+	if result.Deleted != 2 {
+		t.Errorf("Deleted = %d, want 2 (the third should be counted as an error, not aborted)", result.Deleted)
+	}
+	if result.Errors != 1 {
+		t.Errorf("Errors = %d, want 1", result.Errors)
+	}
+}
+
+func TestRunConsumerSweepRequiresSource(t *testing.T) {
+	_, err := RunConsumerSweep(context.Background(), nil, "default", SweepConfig{})
+	if err == nil {
+		t.Fatal("expected error when source is nil")
+	}
+}
+
+func TestRunConsumerSweepUsesDefaultMinAgeWhenZero(t *testing.T) {
+	scope := "default"
+	scopeToken := ScopeToken(scope)
+	now := time.Date(2026, 5, 26, 6, 0, 0, 0, time.UTC)
+	session100 := base64.RawURLEncoding.EncodeToString([]byte("100"))
+
+	source := &fakeSweepSource{
+		consumers: []*jetstream.ConsumerInfo{
+			// 10 minutes old; under the default 15m floor.
+			mkConsumer("claude_"+scopeToken+"_"+session100, 10, now),
+		},
+	}
+
+	result, err := RunConsumerSweep(
+		context.Background(),
+		source,
+		scope,
+		SweepConfig{
+			LiveSessionIDs: map[string]struct{}{},
+			// MinAge intentionally left zero
+			Now: func() time.Time { return now },
+		},
+	)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if result.SkippedTooYoung != 1 {
+		t.Fatalf("SkippedTooYoung = %d, want 1 (default MinAge should be 15m)", result.SkippedTooYoung)
+	}
+	if result.Deleted != 0 {
+		t.Fatalf("Deleted = %d, want 0", result.Deleted)
+	}
+}

--- a/backend-go/internal/sessionregistry/registry.go
+++ b/backend-go/internal/sessionregistry/registry.go
@@ -140,6 +140,38 @@ func (s *Store) List(ctx context.Context, owner string) ([]sessionmodel.SessionR
 	return records, rows.Err()
 }
 
+// ListAllIDsForScope returns every session_id in this orchestrator's
+// scope, regardless of owner. Used by the NATS orphan-consumer sweep
+// to decide which JetStream durable consumers still belong to a live
+// session — the sweep's "live" predicate is just "row exists in this
+// scope", visible or not. Soft-deleted (visible=false) rows still
+// count as live for the sweep purpose because the pod and its
+// consumers may still be terminating.
+//
+// Scope-wide rather than per-owner because consumer names encode
+// (scope, session_id) only — there is no owner dimension on the
+// consumer side.
+func (s *Store) ListAllIDsForScope(ctx context.Context) (map[string]struct{}, error) {
+	const q = `SELECT session_id FROM sessions WHERE session_scope = $1`
+	rows, err := s.pool.Query(ctx, q, s.scope)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]struct{}{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		id = strings.TrimSpace(id)
+		if id != "" {
+			out[id] = struct{}{}
+		}
+	}
+	return out, rows.Err()
+}
+
 // unmarshalJSONB turns a jsonb column's raw bytes into the
 // map[string]any the snapshot handler expects to render. Empty/NULL
 // columns return nil, which the SPA renders as "no state set."

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -106,6 +106,25 @@ All metric names are prefixed `tank_`. The full namespace:
   candidate-B zombie-SSE detector: the browser's silence watchdog
   observes the idle interval whenever a connected stream has gone
   >30 s without emitting events while a turn is in flight.
+- `tank_session_bus_orphan_consumers` /
+  `tank_session_bus_consumers_scanned` /
+  `tank_session_bus_orphan_consumers_deleted_total` /
+  `tank_session_bus_orphan_consumer_delete_errors_total` /
+  `tank_session_bus_orphan_sweep_passes_total{result}` — the durable
+  remediation surface for stranded JetStream consumers. Every (session,
+  provider) pair owns two durable consumers (data + control); the
+  runner-side `ensureConsumer` / `ensureControlConsumer` only creates,
+  so deleted sessions leak consumers indefinitely (observed at 725
+  consumers / 6 live sessions on 2026-05-25, ~50 % of the JetStream
+  RAM budget). The orchestrator runs `SweepOrphanConsumers` on a
+  5-minute initial delay then hourly; each pass lists consumers,
+  decodes session_id, deletes any orphan older than 15 minutes
+  (`MinAge` floor). The gauges are last-pass snapshots; the
+  `_deleted_total` / `_delete_errors_total` counters are cumulative.
+  Alerts: `TankSessionBusOrphanSweepFailing` (sweep itself broken),
+  `TankSessionBusOrphanConsumersHigh` (sweep running but backlog
+  growing). See `backend-go/internal/sessionbus/sweep.go` for the
+  decoder + per-pass logic.
 - `tank_client_long_task_*` — browser-reported main-thread long-task
   diagnostics ingested through `POST /api/client-metrics/long-tasks`.
   The SPA installs a `PerformanceObserver({type: "longtask"})` probe

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -830,6 +830,65 @@ spec:
               on its own node (anti-affinity guarantees this but a
               drain/upgrade window can temporarily violate it).
 
+        # Orphan-consumer sweep failing. The sweep is the durable
+        # remediation for stranded JetStream consumers (per-session
+        # data/control consumers that nothing deletes when a session
+        # goes away). If the sweep itself is broken, consumers
+        # accumulate without bound and eventually saturate the
+        # JetStream memory budget — observed at 725 consumers / 6
+        # live sessions on 2026-05-25. Sibling to
+        # TankSessionBusOrphanConsumersHigh below: this alert is
+        # "the cleanup tool is broken"; that one is "the cleanup
+        # tool is running but the backlog is growing anyway."
+        - alert: TankSessionBusOrphanSweepFailing
+          expr: rate(tank_session_bus_orphan_sweep_passes_total{result="error"}[1h]) > 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "orphan-consumer sweep has failed every pass in the last hour"
+            runbook: |
+              Per-pass slog line is "orphan consumer sweep failed"
+              (NATS list-consumers error) or "orphan consumer sweep:
+              list live sessions failed" (Postgres error). Inspect
+              tank-operator pod logs for the surrounding error.
+              Pair with TankNATSReconnectStorm (NATS-side) and
+              TankPgConnectionSaturation (Postgres-side) — the
+              sweep depends on both being healthy.
+
+        # Orphan consumers stayed high across multiple sweep cycles.
+        # The sweep runs hourly with a 15-minute MinAge floor; if
+        # this alert fires, deletes are either failing or new orphans
+        # are being created faster than the sweep can keep up. The
+        # 50-orphan threshold is roughly "an order of magnitude
+        # higher than legitimate active-consumer headroom" — 6
+        # active sessions × 2 consumers/provider × 2 providers = ~25
+        # legitimate; a sustained 50+ orphans means the cleanup is
+        # not keeping pace.
+        - alert: TankSessionBusOrphanConsumersHigh
+          expr: tank_session_bus_orphan_consumers > 50
+          for: 4h
+          labels:
+            severity: warning
+          annotations:
+            summary: "tank_session_bus_orphan_consumers stayed > 50 for 4h despite sweep running"
+            runbook: |
+              The sweep observed > 50 orphan-eligible consumers for
+              four consecutive hourly passes. Two failure modes:
+              (a) deletes are failing — check
+              tank_session_bus_orphan_consumer_delete_errors_total
+              rate; non-zero means NATS is refusing to remove
+              consumers (server-side ACL? consumer in a bad state?).
+              (b) deletes are succeeding but new orphans are being
+              created faster than cleanup — check
+              rate(tank_session_bus_orphan_consumers_deleted_total[1h])
+              against rate(tank_session_bus_consumers_scanned[1h]).
+              The consumer naming convention is
+              `{provider}_{scopeToken}_{sessionIdToken}` (data plane)
+              and `{provider}_control_{scopeToken}_{sessionIdToken}`
+              (control plane); see
+              backend-go/internal/sessionbus/sweep.go for the parser.
+
     - name: tank-operator.api-proxy
       rules:
         - alert: TankApiProxyRefreshStorm


### PR DESCRIPTION
## Summary

- Every (session, provider) pair owns two durable JetStream consumers
  (data + control). The runner-side `ensureConsumer` /
  `ensureControlConsumer` only CREATES them; nothing cleans up on
  session deletion. Observed 2026-05-25 while investigating the
  click-unresponsiveness symptom: **725 consumers for 6 live
  sessions**, JetStream at ~50 % of its 256 MiB memory budget.
  CLAUDE.md's migration audit checklist names this exact stranded-
  durable-consumer failure mode.
- New `internal/sessionbus.SweepOrphanConsumers` lists every consumer
  on `TANK_SESSION_BUS`, decodes the runner-side
  `<provider>_<scopeToken>_<sessionIdToken>` name shape (and the
  `*_control_*` control-plane variant), and deletes any consumer
  whose decoded `session_id` is not in this scope's live registry —
  subject to a 15-minute `MinAge` floor so a session whose runner
  hasn't yet listed is never racy.
- `cmd/tank-operator/orphan_consumer_sweep.go` runs the sweep on a
  5-minute initial delay then hourly. The initial delay gives
  pre-deploy session pods time to re-register post-orchestrator-
  restart; the `MinAge` floor is the second safety net.
- Scope-isolated: only consumers whose name decodes to this
  orchestrator's `scopeToken` are touched. Cross-scope orchestrators
  (prod + a test slot sharing one NATS) each sweep only their own
  consumers — no risk of accidental cross-environment GC.

## Feature Contracts

Affected contracts:
- [x] Observability
- [x] Agent Runners
- [ ] None

Evidence:
- **Observability contract** — adds the durable remediation surface
  the contract requires for resource-leak failure modes. New series:
  `tank_session_bus_orphan_consumers`,
  `tank_session_bus_consumers_scanned`,
  `tank_session_bus_orphan_consumers_deleted_total`,
  `tank_session_bus_orphan_consumer_delete_errors_total`,
  `tank_session_bus_orphan_sweep_passes_total{result}`. All
  cardinality-bounded (zero per-session / per-pod / per-consumer
  labels). Two PrometheusRule alerts in
  `k8s/templates/observability.yaml`:
  `TankSessionBusOrphanSweepFailing` distinguishes "the cleanup tool
  is broken" from `TankSessionBusOrphanConsumersHigh` which
  distinguishes "the cleanup tool is running but the backlog is
  growing anyway." Each runbook annotation names specific candidate
  root causes the alert distinguishes (per the contract's Acceptance
  Checks). Existing `TankJetStreamConsumerStalled` already had a
  runbook line about manual orphan removal via `nats` CLI in
  `nats-box`; that escalation path stays valid as a fallback.
- **Agent Runners contract** — the consumer leak isn't a
  silent-stranding shape (it doesn't make active sessions misbehave;
  it eats NATS memory until JetStream pressure becomes a separate
  failure mode). But the consumer naming this PR's parser depends on
  (`<provider>_<scopeToken>_<sessionIdToken>`) is owned by
  `runner-shared/sessionBus.js` `ensureConsumer` /
  `ensureControlConsumer`. The parser comment + the migration audit
  checklist reference pin the wire-format dependency so a future
  runner rename of the consumer name shape would need to land
  alongside a parser update here.

## Test plan

- [x] `go test ./internal/sessionbus/`: 5 new tests pass (parser
      cases, deletion logic with mixed live/orphan/too-young/
      out-of-scope consumers, delete-failure counted without
      aborting the pass, default `MinAge` floor)
- [x] `go test ./cmd/tank-operator/`: full package green (the new
      `promSweepMetrics` adapter + `recordSessionBusOrphanSweepResult`
      compile-link with the existing observability layer)
- [x] `go test ./internal/sessionregistry/`: green (`ListAllIDsForScope`
      added; existing tests unchanged)
- [x] `go build ./...`: clean
- [ ] `helm template`: deferred to CI (helm not available locally)
- [ ] Post-deploy: 5 minutes after rollout, hit
      `https://tank.romaine.life/api/cluster-health` and confirm
      `nats.jetstream.consumers` drops from 725 toward `2 ×
      active_sessions × providers_per_session` (~12 for the current
      6 codex_gui sessions). Confirm
      `rate(tank_session_bus_orphan_consumers_deleted_total[1h])`
      shows non-zero deletes on the first hourly pass, then
      `tank_session_bus_orphan_consumers` settles near 0.

## Safety / scope notes

- The 15-minute `MinAge` is the load-bearing safety check against
  the session-create race (registry row exists, runner hasn't yet
  called `ensureConsumer`). The 5-minute initial delay is a second
  safety net specifically for orchestrator-restart timing.
- Cross-scope isolation is at the parser level
  (`DecodeConsumerSessionID` returns `ok=false` for any consumer
  whose `scopeToken` doesn't match), pinned by the
  "consumer_in_a_different_scope_is_skipped" parser test. The
  persister consumer (`tank-session-event-persister-<scopeToken>`)
  uses `-` separators rather than `_`, so it falls into the
  same skip branch — pinned by the
  "persister_consumer_name_is_skipped" test.
- Delete failures are counted but do not abort the pass, so a single
  bad consumer can't block cleanup of the rest. The next hourly pass
  retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
