### PR TITLE
Project interrupted and failed turns into an activity shell

### DIFF
--- a/backend-go/cmd/tank-operator/transcript_projection.go
+++ b/backend-go/cmd/tank-operator/transcript_projection.go
@@ -695,7 +695,7 @@ func annotateProjectionTerminal(entry map[string]any, terminals map[string]turnT
 }
 
 func compactProjectedTranscript(entries []map[string]any, activeTurnID string, terminals map[string]turnTerminalProjection) transcriptProjection {
-	activities := append(completedProjectedActivities(entries, terminals), activeProjectedActivities(entries, activeTurnID)...)
+	activities := append(terminalProjectedActivities(entries, terminals), activeProjectedActivities(entries, activeTurnID)...)
 	if len(activities) == 0 {
 		return transcriptProjection{Entries: entries, ActivityBodies: map[string]turnActivityBody{}}
 	}
@@ -739,7 +739,7 @@ func compactProjectedTranscript(entries []map[string]any, activeTurnID string, t
 	return transcriptProjection{Entries: out, ActivityBodies: bodies}
 }
 
-func completedProjectedActivities(entries []map[string]any, terminals map[string]turnTerminalProjection) []turnActivityBody {
+func terminalProjectedActivities(entries []map[string]any, terminals map[string]turnTerminalProjection) []turnActivityBody {
 	turnIndexes := map[string][]int{}
 	turnOrder := []string{}
 	for idx, entry := range entries {
@@ -756,34 +756,68 @@ func completedProjectedActivities(entries []map[string]any, terminals map[string
 	for _, turnID := range turnOrder {
 		indexes := turnIndexes[turnID]
 		terminal, ok := terminals[turnID]
-		if !ok || terminal.Status != "completed" {
+		if !ok {
 			continue
 		}
-		if len(terminal.FinalAnswerIDs) == 0 && turnHasAssistantMessage(entries, indexes) {
-			recordTranscriptMaterializationInvariantViolation("completed_turn_missing_final_answer", "completed")
-		}
-		finalIndexes := finalAnswerProjectedIndexes(entries, indexes, terminal.FinalAnswerIDs)
-		if len(terminal.FinalAnswerIDs) > 0 && len(finalIndexes) == 0 {
-			recordTranscriptMaterializationInvariantViolation("completed_turn_final_answer_missing_entry", "completed")
-		}
-		var compacted []map[string]any
-		var activityEntries []map[string]any
-		for _, idx := range indexes {
-			entry := entries[idx]
-			if isProjectedUserMessage(entry) {
-				continue
+		switch terminal.Status {
+		case "completed":
+			if activity, ok := completedTurnActivityBody(entries, indexes, terminal); ok {
+				activities = append(activities, activity)
 			}
-			activityEntries = append(activityEntries, entry)
-			if !finalIndexes[idx] {
-				compacted = append(compacted, entry)
+		case "interrupted", "failed":
+			if activity, ok := nonCompletedTerminalTurnActivityBody(entries, indexes, terminal); ok {
+				activities = append(activities, activity)
 			}
 		}
-		if len(compacted) == 0 {
-			continue
-		}
-		activities = append(activities, makeTurnActivityBody(turnID, "completed", activityEntries, compacted, false))
 	}
 	return activities
+}
+
+func completedTurnActivityBody(entries []map[string]any, indexes []int, terminal turnTerminalProjection) (turnActivityBody, bool) {
+	if len(terminal.FinalAnswerIDs) == 0 && turnHasAssistantMessage(entries, indexes) {
+		recordTranscriptMaterializationInvariantViolation("completed_turn_missing_final_answer", "completed")
+	}
+	finalIndexes := finalAnswerProjectedIndexes(entries, indexes, terminal.FinalAnswerIDs)
+	if len(terminal.FinalAnswerIDs) > 0 && len(finalIndexes) == 0 {
+		recordTranscriptMaterializationInvariantViolation("completed_turn_final_answer_missing_entry", "completed")
+	}
+	var compacted []map[string]any
+	var activityEntries []map[string]any
+	for _, idx := range indexes {
+		entry := entries[idx]
+		if isProjectedUserMessage(entry) {
+			continue
+		}
+		activityEntries = append(activityEntries, entry)
+		if !finalIndexes[idx] {
+			compacted = append(compacted, entry)
+		}
+	}
+	if len(compacted) == 0 {
+		return turnActivityBody{}, false
+	}
+	return makeTurnActivityBody(terminal.TurnID, "completed", activityEntries, compacted, false), true
+}
+
+// Interrupted/failed turns carry no final-answer marker, so all non-user, non-meta work is compacted; meta entries (Stop requested, Stopped/Turn failed) stay visible.
+func nonCompletedTerminalTurnActivityBody(entries []map[string]any, indexes []int, terminal turnTerminalProjection) (turnActivityBody, bool) {
+	var compacted []map[string]any
+	var activityEntries []map[string]any
+	for _, idx := range indexes {
+		entry := entries[idx]
+		if isProjectedUserMessage(entry) {
+			continue
+		}
+		if transcriptMapString(entry, "kind") == "meta" {
+			continue
+		}
+		activityEntries = append(activityEntries, entry)
+		compacted = append(compacted, entry)
+	}
+	if len(compacted) == 0 {
+		return turnActivityBody{}, false
+	}
+	return makeTurnActivityBody(terminal.TurnID, terminal.Status, activityEntries, compacted, false), true
 }
 
 func activeProjectedActivities(entries []map[string]any, activeTurnID string) []turnActivityBody {

--- a/backend-go/cmd/tank-operator/transcript_projection_test.go
+++ b/backend-go/cmd/tank-operator/transcript_projection_test.go
@@ -151,6 +151,151 @@ func TestProjectTranscriptEventsCompactsUnmarkedCompletedAssistantMessages(t *te
 	}
 }
 
+func TestProjectTranscriptEventsCompactsInterruptedTurnIntoActivityShell(t *testing.T) {
+	events := []map[string]any{
+		projectionTestEvent("u", "001", "user_message.created", "user", "tank", "turn-1", "turn-1:user", map[string]any{
+			"text":    "deep dive please",
+			"display": map[string]any{"kind": "plain"},
+		}),
+		projectionTestEvent("note", "002", "item.completed", "assistant", "claude", "turn-1", "turn-1:item:note", map[string]any{
+			"kind": "message",
+			"text": "Time-check before I rabbit-hole further.",
+		}),
+		projectionTestEvent("tool-start", "003", "item.started", "tool", "claude", "turn-1", "turn-1:item:tool", map[string]any{
+			"kind": "command_execution",
+			"name": "Bash",
+		}),
+		projectionTestEvent("tool-done", "004", "item.completed", "tool", "claude", "turn-1", "turn-1:item:tool", map[string]any{
+			"kind":   "command_execution",
+			"output": "ok",
+		}),
+		projectionTestEvent("interrupt-req", "005", "turn.interrupt_requested", "runner", "tank", "turn-1", "", map[string]any{}),
+		projectionTestEvent("terminal", "006", "turn.interrupted", "runner", "tank", "turn-1", "", map[string]any{}),
+	}
+
+	projection := projectTranscriptEvents(events)
+
+	kinds := projectedEntryKindList(projection.Entries)
+	want := []string{"message", "turn_activity", "meta", "meta"}
+	if !stringSlicesEqual(kinds, want) {
+		t.Fatalf("entry kinds = %#v, want %#v: %#v", kinds, want, projection.Entries)
+	}
+	if got, want := projection.Entries[0]["role"], "user"; got != want {
+		t.Fatalf("first entry role = %v, want %v", got, want)
+	}
+	shell := projection.Entries[1]
+	activity, ok := shell["activity"].(map[string]any)
+	if !ok {
+		t.Fatalf("interrupted turn activity shell missing summary: %#v", shell)
+	}
+	if got, want := activity["status"], "interrupted"; got != want {
+		t.Fatalf("activity status = %v, want %v", got, want)
+	}
+	if activity["active"] == true {
+		t.Fatalf("interrupted activity rendered active: %#v", activity)
+	}
+	if got, want := activity["toolCount"], 1; got != want {
+		t.Fatalf("activity toolCount = %v, want %v", got, want)
+	}
+	if got, want := activity["progressNoteCount"], 1; got != want {
+		t.Fatalf("activity progressNoteCount = %v, want %v: assistant prose must live inside the shell", got, want)
+	}
+	body, ok := projection.ActivityBodies["turn-1"]
+	if !ok {
+		t.Fatal("missing activity body for interrupted turn")
+	}
+	if got, want := len(body.CompactedEntryIDs), 2; got != want {
+		t.Fatalf("compacted ids count = %d, want %d: %#v", got, want, body.CompactedEntryIDs)
+	}
+	for _, id := range body.CompactedEntryIDs {
+		if id != "turn-1:item:note" && id != "turn-1:item:tool" {
+			t.Fatalf("unexpected compacted id %q; assistant prose and tool must be compacted but meta entries must remain visible", id)
+		}
+	}
+	stopRequested := projection.Entries[2]
+	if got, want := transcriptMapString(transcriptMap(stopRequested, "meta"), "title"), "Stop requested"; got != want {
+		t.Fatalf("third entry meta.title = %v, want %v", got, want)
+	}
+	stopped := projection.Entries[3]
+	if got, want := transcriptMapString(transcriptMap(stopped, "meta"), "title"), "Stopped"; got != want {
+		t.Fatalf("fourth entry meta.title = %v, want %v", got, want)
+	}
+	if got, want := transcriptMapString(stopped, "turnTerminalStatus"), "interrupted"; got != want {
+		t.Fatalf("terminal annotation = %v, want %v", got, want)
+	}
+}
+
+func TestProjectTranscriptEventsCompactsFailedTurnIntoActivityShell(t *testing.T) {
+	events := []map[string]any{
+		projectionTestEvent("u", "001", "user_message.created", "user", "tank", "turn-1", "turn-1:user", map[string]any{
+			"text":    "try this",
+			"display": map[string]any{"kind": "plain"},
+		}),
+		projectionTestEvent("tool-start", "002", "item.started", "tool", "claude", "turn-1", "turn-1:item:tool", map[string]any{
+			"kind": "command_execution",
+			"name": "Bash",
+		}),
+		projectionTestEvent("tool-done", "003", "item.completed", "tool", "claude", "turn-1", "turn-1:item:tool", map[string]any{
+			"kind":   "command_execution",
+			"output": "ok",
+		}),
+		projectionTestEvent("terminal", "004", "turn.failed", "runner", "tank", "turn-1", "", map[string]any{
+			"error": map[string]any{"message": "provider returned 500"},
+		}),
+	}
+
+	projection := projectTranscriptEvents(events)
+
+	kinds := projectedEntryKindList(projection.Entries)
+	want := []string{"message", "turn_activity", "meta"}
+	if !stringSlicesEqual(kinds, want) {
+		t.Fatalf("entry kinds = %#v, want %#v: %#v", kinds, want, projection.Entries)
+	}
+	shell := projection.Entries[1]
+	activity, ok := shell["activity"].(map[string]any)
+	if !ok {
+		t.Fatalf("failed turn activity shell missing summary: %#v", shell)
+	}
+	if got, want := activity["status"], "failed"; got != want {
+		t.Fatalf("activity status = %v, want %v", got, want)
+	}
+	if activity["active"] == true {
+		t.Fatalf("failed activity rendered active: %#v", activity)
+	}
+	if got, want := activity["toolCount"], 1; got != want {
+		t.Fatalf("activity toolCount = %v, want %v", got, want)
+	}
+	failedMeta := projection.Entries[2]
+	if got, want := transcriptMapString(transcriptMap(failedMeta, "meta"), "title"), "Turn failed"; got != want {
+		t.Fatalf("trailing meta title = %v, want %v", got, want)
+	}
+	if got, want := transcriptMapString(transcriptMap(failedMeta, "meta"), "detail"), "provider returned 500"; got != want {
+		t.Fatalf("trailing meta detail = %v, want %v", got, want)
+	}
+}
+
+func TestProjectTranscriptEventsSkipsActivityShellForBareInterruptedTurn(t *testing.T) {
+	events := []map[string]any{
+		projectionTestEvent("u", "001", "user_message.created", "user", "tank", "turn-1", "turn-1:user", map[string]any{
+			"text":    "stop immediately",
+			"display": map[string]any{"kind": "plain"},
+		}),
+		projectionTestEvent("interrupt-req", "002", "turn.interrupt_requested", "runner", "tank", "turn-1", "", map[string]any{}),
+		projectionTestEvent("terminal", "003", "turn.interrupted", "runner", "tank", "turn-1", "", map[string]any{}),
+	}
+
+	projection := projectTranscriptEvents(events)
+
+	for _, entry := range projection.Entries {
+		if transcriptMapString(entry, "kind") == "turn_activity" {
+			t.Fatalf("bare interrupted turn produced empty activity shell: %#v", projection.Entries)
+		}
+	}
+	if _, ok := projection.ActivityBodies["turn-1"]; ok {
+		t.Fatal("bare interrupted turn produced an activity body with no compacted children")
+	}
+}
+
 func TestProjectTranscriptEventsCollapsesActiveTurnBeforeFinalAnswer(t *testing.T) {
 	events := []map[string]any{
 		projectionTestEvent("u", "001", "user_message.created", "user", "tank", "turn-1", "turn-1:user", map[string]any{
@@ -216,4 +361,24 @@ func projectionFinalAnswerPayload(timelineIDs ...string) map[string]any {
 			"timeline_ids": timelineIDs,
 		},
 	}
+}
+
+func projectedEntryKindList(entries []map[string]any) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, transcriptMapString(entry, "kind"))
+	}
+	return out
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/backend-go/cmd/tank-operator/transcript_projection_test.go
+++ b/backend-go/cmd/tank-operator/transcript_projection_test.go
@@ -212,8 +212,8 @@ func TestProjectTranscriptEventsCompactsInterruptedTurnIntoActivityShell(t *test
 			t.Fatalf("unexpected compacted id %q; assistant prose and tool must be compacted but meta entries must remain visible", id)
 		}
 	}
-	stopRequested := projection.Entries[2]
-	if got, want := transcriptMapString(transcriptMap(stopRequested, "meta"), "title"), "Stop requested"; got != want {
+	interruptRequestedMeta := projection.Entries[2]
+	if got, want := transcriptMapString(transcriptMap(interruptRequestedMeta, "meta"), "title"), "Stop requested"; got != want {
 		t.Fatalf("third entry meta.title = %v, want %v", got, want)
 	}
 	stopped := projection.Entries[3]

--- a/backend-go/internal/store/session_transcript_rows.go
+++ b/backend-go/internal/store/session_transcript_rows.go
@@ -15,7 +15,7 @@ import (
 )
 
 const transcriptRowCursorSeparator = "\x1f"
-const transcriptRowBackfillVersion = 2
+const transcriptRowBackfillVersion = 3
 
 type SessionTranscriptRowStore interface {
 	ReplaceForTurn(ctx context.Context, tankSessionID, turnID string, entries []map[string]any) error

--- a/docs/features/transcript/contract.md
+++ b/docs/features/transcript/contract.md
@@ -73,6 +73,13 @@ other.
   placeholder for that turn. The browser must not hide the `...` row while
   waiting for a separately-delivered activity summary to set the same active
   turn id.
+- An interrupted or failed turn projects an activity shell on the same shape
+  as a completed turn whenever it produced any non-meta work. Without a
+  successful terminal there is no durable final-answer marker, so tool calls,
+  partial assistant prose, reasoning, and background tasks all live inside
+  the shell. The shell carries `status: "interrupted"` or `status: "failed"`,
+  and the durable `Stop requested` and `Stopped` / `Turn failed` meta entries
+  remain visible in the main transcript outside the shell.
 - Turn activity may show a log copy of assistant prose, including prose that
   later becomes the final answer, but that copy is not a second settled
   transcript message.
@@ -126,3 +133,7 @@ other.
 - A completed turn may show the final assistant prose in the main transcript
   while also retaining a log copy in Turn activity, without counting it as two
   transcript messages.
+- An interrupted turn that produced tool calls and partial assistant prose
+  projects a single `turn_activity` shell wrapping that work, with the
+  `Stop requested` and `Stopped` meta markers visible after the shell. Tool
+  rows must not appear inline between the user message and the terminal meta.


### PR DESCRIPTION
## Summary

- Interrupted turns (Stop, or declining an `AskUserQuestion` approval) and failed turns were not compacted into a `turn_activity` shell, so their tool rows and partial assistant prose dumped inline into the main transcript and buried the final assistant message among the tools. This is the bug investigated in tank sessions 269/270: an interrupted turn materialized as `user → 22× tool rows → assistant → Stopped` with **no `turn_activity` row at all**, versus a completed turn's clean `user → turn_activity → final assistant`.
- Root cause: `compactProjectedTranscript` only built an activity body when `terminal.Status == "completed"`. Interrupted/`failed` terminals matched neither the completed branch nor the active-turn branch, so every entry passed through inline. PR #703 made this user-visible by removing the frontend client-side `compactCompletedTurnEntries` fallback (which had the same latent gap).
- Fix: renamed `completedProjectedActivities` → `terminalProjectedActivities` and added `nonCompletedTerminalTurnActivityBody`, which compacts every non-user, non-meta entry for `interrupted`/`failed` turns into the same shell completed turns use (`status: "interrupted"` / `"failed"`). The `Stop requested` and `Stopped` / `Turn failed` meta markers stay visible outside the shell so the user can see how the turn ended without expanding it.
- Because there is no successful terminal, there is no durable final-answer marker; all partial assistant prose lives in the shell log rather than being inferred as a settled message — consistent with the contract's "must not infer finality from a trailing assistant message" rule.
- Bumped `transcriptRowBackfillVersion` 2 → 3 so existing materialized rows (sessions 269/270 and every prior interrupted turn) re-project on the next backend startup; new interrupted turns re-materialize automatically when `turn.interrupted` arrives.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- **Contract updated** (`docs/features/transcript/contract.md`): new Live Behavior invariant — "An interrupted or failed turn projects an activity shell on the same shape as a completed turn… tool calls, partial assistant prose, reasoning, and background tasks all live inside the shell… the durable `Stop requested` and `Stopped` / `Turn failed` meta entries remain visible" — plus a matching Acceptance Check ("Tool rows must not appear inline between the user message and the terminal meta").
- **New unit tests** (`transcript_projection_test.go`):
  - `TestProjectTranscriptEventsCompactsInterruptedTurnIntoActivityShell` — asserts `message / turn_activity / meta / meta` shape, `status: "interrupted"`, both the partial assistant note and the tool are compacted (`progressNoteCount=1, toolCount=1`), and the `Stop requested` + `Stopped` metas stay visible with the `turnTerminalStatus: "interrupted"` annotation.
  - `TestProjectTranscriptEventsCompactsFailedTurnIntoActivityShell` — asserts `status: "failed"` shell + visible `Turn failed` meta carrying the provider error detail.
  - `TestProjectTranscriptEventsSkipsActivityShellForBareInterruptedTurn` — a stop with no tool/prose work produces no empty shell.
- **No regression**: the 5 pre-existing projection tests (completed-turn, explicit-marker, unmarked-completed, active-turn, attachments) still pass. Full `go test ./...`, `go vet ./...`, frontend `npm test` (264/264), and `tsc --noEmit` are green.
- **Durable-ledger confirmation**: session 268's interrupted turn `turn_bce26142-…` (stopped on an AskUserQuestion approval) showed the broken inline-tool shape in `session_transcript_rows`; this projection change is what the diagnosis in session 269 recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)