### PR TITLE
mcp-auth-proxy: retry transient upstream failures; JSON-shape exhaustion

### DIFF
--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/metrics.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/metrics.py
@@ -58,6 +58,19 @@ auth_romaine_exchange_total = Counter(
     ["result"],
 )
 
+# Per-attempt retry counter. Outcomes:
+#   - transport_error: aiohttp.ClientError on the upstream call
+#   - transient_status: upstream returned 502 / 503 / 504
+#   - exhausted: all attempts failed; surfaced to the SDK as JSON-shaped 502
+# Non-zero rate is expected during normal upstream pod rotations; a
+# sustained high rate with no exhaustion means the retry budget is
+# masking a real upstream regression that operators should still see.
+proxy_retries_total = Counter(
+    "tank_mcp_auth_proxy_retries_total",
+    "Per-attempt retries the mcp-auth-proxy ran against an upstream MCP server.",
+    ["mcp_server", "outcome"],
+)
+
 
 def _status_class(status: int) -> str:
     if 200 <= status < 300:
@@ -83,6 +96,11 @@ def record_sa_token_read(result: str) -> None:
 def record_auth_romaine_exchange(result: str) -> None:
     """result is one of: success, http_error, exception, invalid_response, cache_hit."""
     auth_romaine_exchange_total.labels(result=result).inc()
+
+
+def record_proxy_retry(mcp_server: str, outcome: str) -> None:
+    """outcome is one of: transport_error, transient_status, exhausted."""
+    proxy_retries_total.labels(mcp_server=mcp_server, outcome=outcome).inc()
 
 
 @asynccontextmanager

--- a/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
+++ b/claude-container/mcp-auth-proxy/src/mcp_auth_proxy/server.py
@@ -44,15 +44,61 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from aiohttp import ClientSession, ClientTimeout, web
+from aiohttp import ClientError, ClientSession, ClientTimeout, web
 
 from .metrics import (
     record_auth_romaine_exchange,
     record_proxy_request,
+    record_proxy_retry,
     record_sa_token_read,
     start_metrics_server,
     upstream_timer,
 )
+
+# Bounded retry budget for transient upstream failures (transport
+# errors, 502/503/504). The unrecoverable failure mode this exists to
+# prevent: aiohttp.ClientError or a 502 returned to the Claude agent
+# SDK lands a plain-text body that crashes the SDK's JSON parser, the
+# server gets marked "not connected", and no further calls are
+# attempted until the session restarts. Mirrors the OAuth-discovery
+# JSON-404 fix that already lives at the top of this file — same
+# class of unrecoverable SDK state, different trigger. See
+# nelsong6/tank-operator#... (this PR).
+#
+# Cap kept tight (3 attempts over ~1.3s total) so a genuinely dead
+# upstream surfaces fast, while a normal pod-rotation window (typically
+# 100-800ms) is invisible to the SDK.
+_MAX_UPSTREAM_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = (0.1, 0.3)
+_TRANSIENT_UPSTREAM_STATUSES = (502, 503, 504)
+
+
+def _retry_delay(attempt_index: int) -> float:
+    """Return the sleep duration before retry `attempt_index + 1`.
+    attempt_index is 0-indexed; the first retry sleeps
+    _RETRY_BACKOFF_SECONDS[0], the second sleeps [1], etc. Anything
+    beyond the table length re-uses the last value."""
+    if attempt_index < 0:
+        return 0.0
+    if attempt_index >= len(_RETRY_BACKOFF_SECONDS):
+        return _RETRY_BACKOFF_SECONDS[-1]
+    return _RETRY_BACKOFF_SECONDS[attempt_index]
+
+
+def _json_upstream_error(status: int, reason: str, *, mcp_label: str, attempts: int) -> web.Response:
+    """Terminal upstream failure response. JSON-shaped so the Claude
+    agent SDK's MCP transport parses it cleanly instead of landing on
+    a plain-text body that leaves the connection unrecoverable across
+    the session lifetime."""
+    return web.json_response(
+        {
+            "error": "upstream_unavailable",
+            "error_description": reason,
+            "mcp_server": mcp_label,
+            "attempts": attempts,
+        },
+        status=status,
+    )
 
 log = logging.getLogger(__name__)
 
@@ -339,34 +385,134 @@ def _make_handler(
 
         body = await request.read()
         url = upstream + request.path_qs
-        try:
-            async with upstream_timer(mcp_label):
-                async with http.request(
-                    request.method,
-                    url,
-                    headers=forwarded_headers,
-                    data=body,
-                    allow_redirects=False,
-                ) as upstream_resp:
-                    status = upstream_resp.status
-                    response = web.StreamResponse(
-                        status=status,
-                        headers={
-                            k: v
-                            for k, v in upstream_resp.headers.items()
-                            if k.lower() not in _STRIP_RESPONSE_HEADERS
-                        },
+
+        # Bounded-retry loop. Two failure modes are retried because the
+        # SDK has no recovery for them within a session:
+        #   - aiohttp.ClientError before we start streaming (upstream
+        #     pod rotation: connection refused / reset / DNS flap).
+        #   - HTTP 502/503/504 from the upstream (kube-rbac-proxy
+        #     sidecar in front of the MCP returns 502 briefly while
+        #     the MCP container restarts).
+        # Anything past response.prepare() is mid-stream; we surface
+        # the broken stream rather than mask a real regression.
+        last_failure_reason = "all retry attempts failed"
+
+        for attempt in range(_MAX_UPSTREAM_ATTEMPTS):
+            started_streaming = False
+            try:
+                async with upstream_timer(mcp_label):
+                    async with http.request(
+                        request.method,
+                        url,
+                        headers=forwarded_headers,
+                        data=body,
+                        allow_redirects=False,
+                    ) as upstream_resp:
+                        status = upstream_resp.status
+
+                        # Transient upstream statuses get handled
+                        # entirely inside this branch BEFORE we call
+                        # response.prepare() — once streaming starts
+                        # we can't fail back into the loop without
+                        # leaving the SDK to parse a truncated body,
+                        # which is the exact unrecoverable state this
+                        # whole change exists to prevent.
+                        if status in _TRANSIENT_UPSTREAM_STATUSES:
+                            # Drain so the connection returns to the
+                            # pool cleanly rather than getting closed.
+                            await upstream_resp.read()
+                            record_proxy_retry(mcp_label, "transient_status")
+                            last_failure_reason = (
+                                f"upstream returned transient status {status}"
+                            )
+                            if attempt < _MAX_UPSTREAM_ATTEMPTS - 1:
+                                log.info(
+                                    "upstream %s returned %d on attempt %d/%d; retrying",
+                                    url,
+                                    status,
+                                    attempt + 1,
+                                    _MAX_UPSTREAM_ATTEMPTS,
+                                )
+                                await asyncio.sleep(_retry_delay(attempt))
+                                continue
+                            # Final attempt was still transient: do
+                            # NOT pass the upstream's body through —
+                            # an upstream "Bad Gateway" plain-text
+                            # body would crash the SDK's JSON parser
+                            # just as badly as a transport error.
+                            # Fall through to the exhaustion path
+                            # below.
+                            log.warning(
+                                "upstream %s returned %d on final attempt %d/%d",
+                                url,
+                                status,
+                                attempt + 1,
+                                _MAX_UPSTREAM_ATTEMPTS,
+                            )
+                            break
+
+                        response = web.StreamResponse(
+                            status=status,
+                            headers={
+                                k: v
+                                for k, v in upstream_resp.headers.items()
+                                if k.lower() not in _STRIP_RESPONSE_HEADERS
+                            },
+                        )
+                        await response.prepare(request)
+                        started_streaming = True
+                        async for chunk in upstream_resp.content.iter_any():
+                            await response.write(chunk)
+                        await response.write_eof()
+                record_proxy_request(mcp_label, status)
+                return response
+            except ClientError as exc:
+                if started_streaming:
+                    # Mid-stream drop. The wire is already committed
+                    # to a partial response; let it surface as the
+                    # broken stream it is rather than mask a real
+                    # upstream regression with a confusing retry that
+                    # writes JSON on top of partial bytes.
+                    log.warning(
+                        "upstream %s dropped mid-stream on attempt %d: %r",
+                        url,
+                        attempt + 1,
+                        exc,
                     )
-                    await response.prepare(request)
-                    async for chunk in upstream_resp.content.iter_any():
-                        await response.write(chunk)
-                    await response.write_eof()
-            record_proxy_request(mcp_label, status)
-            return response
-        except Exception:
-            log.exception("upstream request to %s failed", url)
-            record_proxy_request(mcp_label, 502)
-            return web.Response(status=502, text="upstream request failed")
+                    record_proxy_request(mcp_label, 502)
+                    raise
+                record_proxy_retry(mcp_label, "transport_error")
+                last_failure_reason = f"transport error: {exc!r}"
+                if attempt >= _MAX_UPSTREAM_ATTEMPTS - 1:
+                    log.warning(
+                        "upstream request to %s failed after %d attempts: %r",
+                        url,
+                        attempt + 1,
+                        exc,
+                    )
+                    break
+                log.info(
+                    "upstream request to %s failed on attempt %d/%d (%r); retrying",
+                    url,
+                    attempt + 1,
+                    _MAX_UPSTREAM_ATTEMPTS,
+                    exc,
+                )
+                await asyncio.sleep(_retry_delay(attempt))
+
+        # Retry budget exhausted. Return a JSON-shaped 502 so the SDK's
+        # MCP transport parser doesn't crash on a plain-text body and
+        # leave the connection unrecoverable for the rest of the
+        # session — same shape as the OAuth discovery 404 short-circuit
+        # at the top of this file.
+        record_proxy_retry(mcp_label, "exhausted")
+        record_proxy_request(mcp_label, 502)
+        return _json_upstream_error(
+            502,
+            last_failure_reason,
+            mcp_label=mcp_label,
+            attempts=_MAX_UPSTREAM_ATTEMPTS,
+        )
 
     return handler
 

--- a/claude-container/mcp-auth-proxy/tests/test_server.py
+++ b/claude-container/mcp-auth-proxy/tests/test_server.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from aiohttp import ClientSession, ClientTimeout, web
+from aiohttp.test_utils import TestClient, TestServer
 
-from mcp_auth_proxy.server import AuthRomaineServiceProvider
+from mcp_auth_proxy.server import (
+    _MAX_UPSTREAM_ATTEMPTS,
+    AuthRomaineServiceProvider,
+    _make_handler,
+)
 
 
 class _FakeResponse:
@@ -120,3 +127,162 @@ def test_auth_romaine_service_provider_rejects_expired_response(tmp_path) -> Non
 
     with pytest.raises(RuntimeError, match="response was invalid"):
         asyncio.run(provider.token())
+
+
+# --- retry-loop tests ----------------------------------------------
+#
+# The handler exists to prevent an unrecoverable "MCP server not
+# connected" state in the Claude agent SDK. The relevant failure
+# modes:
+#   - upstream transport error during pod rotation (no response yet,
+#     safe to retry the whole call)
+#   - upstream 502/503/504 returned by the kube-rbac-proxy sidecar
+#     while the MCP container restarts (safe to retry; no body has
+#     been streamed back to the client yet)
+#   - terminal exhaustion (must return JSON-shaped 502 so the SDK's
+#     JSON parser doesn't crash on a plain-text body and leave the
+#     transport stuck for the rest of the session)
+
+
+class _StaticTokenProvider:
+    def __init__(self, token: str = "test-token") -> None:
+        self._token = token
+
+    async def token(self) -> str:
+        return self._token
+
+
+async def _flapping_upstream_app(status_sequence: list[int], success_body: bytes) -> tuple[web.Application, list[int]]:
+    """Upstream test app that returns each status in `status_sequence`
+    in order, then 200 with `success_body` from then on. Records every
+    call's index so tests can assert how many attempts the proxy made."""
+    call_index = [0]
+
+    async def handler(request: web.Request) -> web.Response:
+        idx = call_index[0]
+        call_index[0] += 1
+        if idx < len(status_sequence):
+            return web.Response(status=status_sequence[idx], text=f"transient {status_sequence[idx]}")
+        return web.Response(status=200, body=success_body, content_type="application/json")
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", handler)
+    return app, call_index
+
+
+async def _proxy_app_for(upstream_url: str, http: ClientSession) -> web.Application:
+    handler = _make_handler(upstream_url, http, _StaticTokenProvider())
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", handler)
+    return app
+
+
+async def _run_proxy_against_upstream(status_sequence: list[int], success_body: bytes = b'{"ok":true}') -> tuple[int, str, int]:
+    """Wire upstream + proxy via TestServer, POST one request through,
+    return (response_status, response_text, upstream_call_count)."""
+    upstream_app, call_index = await _flapping_upstream_app(status_sequence, success_body)
+    upstream_server = TestServer(upstream_app)
+    await upstream_server.start_server()
+    try:
+        http = ClientSession(timeout=ClientTimeout(total=10, sock_connect=2))
+        try:
+            upstream_url = f"http://{upstream_server.host}:{upstream_server.port}"
+            proxy_app = await _proxy_app_for(upstream_url, http)
+            proxy_server = TestServer(proxy_app)
+            client = TestClient(proxy_server)
+            await client.start_server()
+            try:
+                resp = await client.post("/mcp/some/path", data=b'{"jsonrpc":"2.0"}')
+                text = await resp.text()
+                return resp.status, text, call_index[0]
+            finally:
+                await client.close()
+        finally:
+            await http.close()
+    finally:
+        await upstream_server.close()
+
+
+def test_handler_retries_transient_5xx_then_succeeds() -> None:
+    # First call: 503 (kube-rbac-proxy returning transient while MCP
+    # pod restarts). Second call: 200. Proxy must hide the 503 from
+    # the client.
+    status, body, calls = asyncio.run(
+        _run_proxy_against_upstream([503], success_body=b'{"jsonrpc":"2.0","result":"ok"}')
+    )
+    assert status == 200
+    assert body == '{"jsonrpc":"2.0","result":"ok"}'
+    assert calls == 2  # one failed, one succeeded
+
+
+def test_handler_retries_502_then_504_then_succeeds() -> None:
+    # Worst case within budget: two transient statuses then success.
+    status, body, calls = asyncio.run(
+        _run_proxy_against_upstream([502, 504], success_body=b'{"ok":1}')
+    )
+    assert status == 200
+    assert body == '{"ok":1}'
+    assert calls == 3
+
+
+def test_handler_returns_json_502_after_budget_exhausted() -> None:
+    # All three attempts return 502 — must surface as a JSON-shaped
+    # 502 so the SDK's MCP transport parses it cleanly instead of
+    # leaving the server marked "not connected".
+    status, body, calls = asyncio.run(
+        _run_proxy_against_upstream([502, 502, 502])
+    )
+    assert status == 502
+    assert calls == _MAX_UPSTREAM_ATTEMPTS == 3
+    payload = json.loads(body)
+    assert payload["error"] == "upstream_unavailable"
+    assert payload["attempts"] == _MAX_UPSTREAM_ATTEMPTS
+    assert "mcp_server" in payload
+
+
+def test_handler_passes_non_transient_4xx_through_without_retry() -> None:
+    # 401/403/404/etc. are real upstream answers — never retry them.
+    # A 401 from the MCP means kube-rbac-proxy rejected our bearer;
+    # retrying just spams the IdP.
+    status, body, calls = asyncio.run(
+        _run_proxy_against_upstream([401])
+    )
+    assert status == 401
+    assert calls == 1
+    assert body == "transient 401"
+
+
+async def _run_proxy_against_dead_upstream() -> tuple[int, str]:
+    """No upstream listening at all → ClientConnectorError on every
+    attempt. Must exhaust the retry budget and return JSON 502."""
+    http = ClientSession(timeout=ClientTimeout(total=10, sock_connect=1))
+    try:
+        # Reserve a port by binding then immediately closing — the
+        # subsequent connect attempts get ECONNREFUSED.
+        import socket
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        upstream_url = f"http://127.0.0.1:{port}"
+        proxy_app = await _proxy_app_for(upstream_url, http)
+        proxy_server = TestServer(proxy_app)
+        client = TestClient(proxy_server)
+        await client.start_server()
+        try:
+            resp = await client.post("/mcp/some/path", data=b"{}")
+            text = await resp.text()
+            return resp.status, text
+        finally:
+            await client.close()
+    finally:
+        await http.close()
+
+
+def test_handler_returns_json_502_on_transport_error() -> None:
+    status, body = asyncio.run(_run_proxy_against_dead_upstream())
+    assert status == 502
+    payload = json.loads(body)
+    assert payload["error"] == "upstream_unavailable"
+    assert payload["attempts"] == _MAX_UPSTREAM_ATTEMPTS
+    assert "transport error" in payload["error_description"]


### PR DESCRIPTION
## Summary

The mcp-auth-proxy sidecar in every session pod was surfacing transport errors and upstream 502/503/504s as **plain-text 502** to the Claude agent SDK. The SDK parses every MCP transport body as JSON; a plain-text body crashes the parser and the SDK marks the MCP server "not connected" for the rest of the session. The only recovery was a full session restart — a workflow-level failure for any session whose upstream MCP pod rotated.

This PR adds a bounded retry loop around outbound MCP calls and guarantees a **JSON-shaped 502** on terminal exhaustion, so the SDK transport stays alive through normal upstream pod rotations.

- **Retry policy:** up to 3 attempts with 0.1s + 0.3s backoff. Retries fire on `aiohttp.ClientError` (transport-level) and on upstream 502/503/504. Non-transient 4xx/5xx pass through immediately.
- **Streaming safety:** all retry decisions happen BEFORE `response.prepare(request)`. Once we start streaming we never fail back into the retry loop — that would truncate the wire and crash the SDK parser, defeating the whole purpose.
- **Mid-stream errors:** if a `ClientError` fires after `prepare()`, log and re-raise. Don't mask a real upstream regression by writing JSON on top of partial bytes.
- **Exhaustion shape:** terminal failure returns `{"error": "upstream_unavailable", "error_description": ..., "mcp_server": <label>, "attempts": 3}` with `Content-Type: application/json`. Mirrors the OAuth-discovery 404 short-circuit already at the top of `server.py` that fixes the exact same SDK-state class of bug for a different trigger.
- **Observability:** new `tank_mcp_auth_proxy_retries_total{mcp_server, outcome}` counter. Outcomes: `transport_error`, `transient_status`, `exhausted`. Sustained non-zero `exhausted` rate is a real upstream regression; non-zero `transport_error` / `transient_status` with no `exhausted` is expected pod-rotation churn.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Agent Runners** — the contract "orchestrator rollout must not cancel runner work while the session pod and runner remain alive" extends to upstream MCP pod rotations: an MCP pod rotating in another namespace must not strand the runner's MCP transport for the rest of the session. Before this PR, the agent-runner SDK was being silently stranded the moment any upstream MCP returned a plain-text 502. Proof: 5 new tests in `claude-container/mcp-auth-proxy/tests/test_server.py` drive a flapping aiohttp upstream and assert (a) 503→200 is invisible to the client, (b) 502→504→200 (worst case in budget) still recovers, (c) terminal exhaustion returns a JSON body the SDK transport parser accepts instead of plain text, (d) non-transient 4xx still passes through unmodified (no retry on real upstream answers), (e) dead upstream → JSON 502 after budget spent. All 9 tests pass (`9 passed in 1.59s`).
- **Observability** — new `tank_mcp_auth_proxy_retries_total{mcp_server, outcome}` counter (label cardinality bounded by the 6-entry `LISTENERS` map, no per-request labels). Outcomes split the workflow regression we just diagnosed in nelsong6/tank-operator session pod into three distinct symptoms an operator can alert on: `transport_error` (upstream pod rotation), `transient_status` (kube-rbac-proxy 5xx), `exhausted` (real upstream regression — the only one that should page). Same `tank_*` namespace + cardinality discipline documented in `docs/observability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)