### PR TITLE
Move initial-message directives to live-editable ConfigMap

### DIFF
--- a/backend-go/cmd/tank-operator/main_test.go
+++ b/backend-go/cmd/tank-operator/main_test.go
@@ -66,6 +66,53 @@ func TestConfig(t *testing.T) {
 	if body["fork_session_prompt_template"] == "" {
 		t.Fatalf("missing fork_session_prompt_template: %#v", body)
 	}
+	// Initial-message mode directives default to their const fallback when no
+	// ConfigMap file is mounted, so /api/config is never empty pre-mount.
+	for _, key := range []string{
+		"initial_mode_diagnose_directive",
+		"initial_mode_quality_gaps_directive",
+		"initial_mode_go_long_directive",
+		"initial_mode_test_directive",
+	} {
+		if body[key] == "" {
+			t.Fatalf("missing %s: %#v", key, body)
+		}
+	}
+}
+
+func TestConfigReadsInitialModeDirectiveFiles(t *testing.T) {
+	// Each directive key reads its mounted ConfigMap file when present, so a
+	// live edit on main flows through without a frontend rebuild.
+	cases := []struct{ env, key string }{
+		{"TANK_INITIAL_MODE_DIAGNOSE_FILE", "initial_mode_diagnose_directive"},
+		{"TANK_INITIAL_MODE_QUALITY_GAPS_FILE", "initial_mode_quality_gaps_directive"},
+		{"TANK_INITIAL_MODE_GO_LONG_FILE", "initial_mode_go_long_directive"},
+		{"TANK_INITIAL_MODE_TEST_FILE", "initial_mode_test_directive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "directive.md")
+			want := "live-edited directive for " + tc.key
+			if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv(tc.env, path)
+			response := httptest.NewRecorder()
+
+			config(response, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d", response.Code)
+			}
+			var body map[string]string
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if got := body[tc.key]; got != want {
+				t.Fatalf("%s = %q, want %q", tc.key, got, want)
+			}
+		})
+	}
 }
 
 func TestConfigDefaultsAuthURL(t *testing.T) {

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -304,6 +304,28 @@ func publicConfig() map[string]string {
 			os.Getenv("TANK_FORK_SESSION_PROMPT_FILE"),
 			defaultForkSessionPromptTemplate,
 		),
+		// Splash-page initial-message mode directives. Source of truth is the
+		// markdown under k8s/app-config/, rendered into the app-config
+		// ConfigMap and mounted into this pod; editing those files on main
+		// (ArgoCD sync) changes the directive with no image rebuild. The
+		// const fallbacks below only apply during first-install ordering
+		// before the ConfigMap is mounted (mirrors fork_session_prompt_template).
+		"initial_mode_diagnose_directive": readOptionalFile(
+			os.Getenv("TANK_INITIAL_MODE_DIAGNOSE_FILE"),
+			defaultInitialModeDiagnoseDirective,
+		),
+		"initial_mode_quality_gaps_directive": readOptionalFile(
+			os.Getenv("TANK_INITIAL_MODE_QUALITY_GAPS_FILE"),
+			defaultInitialModeQualityGapsDirective,
+		),
+		"initial_mode_go_long_directive": readOptionalFile(
+			os.Getenv("TANK_INITIAL_MODE_GO_LONG_FILE"),
+			defaultInitialModeGoLongDirective,
+		),
+		"initial_mode_test_directive": readOptionalFile(
+			os.Getenv("TANK_INITIAL_MODE_TEST_FILE"),
+			defaultInitialModeTestDirective,
+		),
 	}
 }
 
@@ -318,6 +340,43 @@ Source session pointer:
 ` + "```json" + `
 {{source_session_json}}
 ` + "```"
+
+// Initial-message mode directive fallbacks. These mirror the canonical text in
+// k8s/app-config/initial-mode-*.md and are served only when the ConfigMap file
+// is not mounted (first-install ordering / local dev). The mounted file is the
+// live source of truth in-cluster, so these consts are allowed to lag a live
+// edit — the SPA carries the same fallback for the offline path.
+const defaultInitialModeDiagnoseDirective = `Initial message type: diagnose — first message only.
+
+When you respond to this first message, investigate the issue, gather evidence, and report findings only; do not edit files or make code changes in this turn.
+
+The no-code stance applies to this first turn only — once I reply, treat the session normally and make code changes when the work calls for it.`
+
+const defaultInitialModeQualityGapsDirective = `Initial message type: address this issue and inspect the quality/migration gaps it exposes.
+
+Read /workspace/.tank/docs/quality-timeframes.md and /workspace/.tank/docs/migration-policy.md before planning.
+
+If either policy doc is missing, report that as a session setup gap before proceeding.
+
+Make the required code changes and call out any gaps against those docs.`
+
+const defaultInitialModeGoLongDirective = `Initial message type: go long. This is the long-horizon, heavy-solution bar — the durable solution is the only acceptable outcome, and the docs named below are binding invariants, not suggestions.
+
+Before planning, read /workspace/.tank/docs/quality-timeframes.md, /workspace/.tank/docs/migration-policy.md, and /workspace/.tank/docs/product-inspirations.md.
+
+If any of those docs is missing, report it as a session setup gap before proceeding.
+
+Once the in-scope repo is cloned, also read whichever of its own design/quality docs exist (docs/quality-timeframes*.md, docs/migration-policy*.md, docs/design-system*.md, docs/product-inspirations*.md, docs/architecture*.md, any design-system/SKILL.md, plus AGENTS.md and CLAUDE.md). The repo's own docs win where they are more specific; the global invariants set the floor.
+
+Heavy is the default: do not present a minimal fix as the option and do not ask me to choose quick-vs-thorough. If the full solution is too large for one PR, write the full plan first and stage it so each step leaves the system coherent.
+
+Settled decisions stay settled: do not reintroduce a route, flag, type, test, doc, or UI path that a prior change deliberately removed. Treat legacy, compatibility, fallback, and temporary as deletion targets, not design options.
+
+Definition of done is quality-timeframes.md — check the work against it before calling it complete, and name any remaining hardening as unfinished scope rather than optional.`
+
+const defaultInitialModeTestDirective = `Initial message type: make code changes and immediately run the test skill for this.
+
+Use the test skill workflow as part of implementation and keep the test environment updated while validating.`
 
 func readOptionalFile(path string, fallback string) string {
 	if strings.TrimSpace(path) == "" {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -411,6 +411,14 @@ type ForkSessionRequest = {
 type AppPublicConfig = {
   session_scope?: string;
   fork_session_prompt_template?: string;
+  // Splash-page initial-message mode directives, sourced live from the
+  // app-config ConfigMap via /api/config so they can be edited against main
+  // without a frontend rebuild. The DEFAULT_INITIAL_MODE_*_DIRECTIVE consts
+  // below are the offline fallback when the fetch is empty or fails.
+  initial_mode_diagnose_directive?: string;
+  initial_mode_quality_gaps_directive?: string;
+  initial_mode_go_long_directive?: string;
+  initial_mode_test_directive?: string;
 };
 
 const DEFAULT_FORK_SESSION_PROMPT_TEMPLATE = [
@@ -425,6 +433,50 @@ const DEFAULT_FORK_SESSION_PROMPT_TEMPLATE = [
   "```json",
   "{{source_session_json}}",
   "```",
+].join("\n");
+
+// Offline fallbacks for the splash-page initial-message directives. The live
+// value comes from /api/config (app-config ConfigMap); these only apply when
+// that fetch is empty or fails. They mirror k8s/app-config/initial-mode-*.md
+// and the Go const fallbacks in server.go, and are allowed to lag a live edit.
+const DEFAULT_INITIAL_MODE_DIAGNOSE_DIRECTIVE = [
+  "Initial message type: diagnose — first message only.",
+  "",
+  "When you respond to this first message, investigate the issue, gather evidence, and report findings only; do not edit files or make code changes in this turn.",
+  "",
+  "The no-code stance applies to this first turn only — once I reply, treat the session normally and make code changes when the work calls for it.",
+].join("\n");
+
+const DEFAULT_INITIAL_MODE_QUALITY_GAPS_DIRECTIVE = [
+  "Initial message type: address this issue and inspect the quality/migration gaps it exposes.",
+  "",
+  "Read /workspace/.tank/docs/quality-timeframes.md and /workspace/.tank/docs/migration-policy.md before planning.",
+  "",
+  "If either policy doc is missing, report that as a session setup gap before proceeding.",
+  "",
+  "Make the required code changes and call out any gaps against those docs.",
+].join("\n");
+
+const DEFAULT_INITIAL_MODE_GO_LONG_DIRECTIVE = [
+  "Initial message type: go long. This is the long-horizon, heavy-solution bar — the durable solution is the only acceptable outcome, and the docs named below are binding invariants, not suggestions.",
+  "",
+  "Before planning, read /workspace/.tank/docs/quality-timeframes.md, /workspace/.tank/docs/migration-policy.md, and /workspace/.tank/docs/product-inspirations.md.",
+  "",
+  "If any of those docs is missing, report it as a session setup gap before proceeding.",
+  "",
+  "Once the in-scope repo is cloned, also read whichever of its own design/quality docs exist (docs/quality-timeframes*.md, docs/migration-policy*.md, docs/design-system*.md, docs/product-inspirations*.md, docs/architecture*.md, any design-system/SKILL.md, plus AGENTS.md and CLAUDE.md). The repo's own docs win where they are more specific; the global invariants set the floor.",
+  "",
+  "Heavy is the default: do not present a minimal fix as the option and do not ask me to choose quick-vs-thorough. If the full solution is too large for one PR, write the full plan first and stage it so each step leaves the system coherent.",
+  "",
+  "Settled decisions stay settled: do not reintroduce a route, flag, type, test, doc, or UI path that a prior change deliberately removed. Treat legacy, compatibility, fallback, and temporary as deletion targets, not design options.",
+  "",
+  "Definition of done is quality-timeframes.md — check the work against it before calling it complete, and name any remaining hardening as unfinished scope rather than optional.",
+].join("\n");
+
+const DEFAULT_INITIAL_MODE_TEST_DIRECTIVE = [
+  "Initial message type: make code changes and immediately run the test skill for this.",
+  "",
+  "Use the test skill workflow as part of implementation and keep the test environment updated while validating.",
 ].join("\n");
 
 let appConfigPromise: Promise<AppPublicConfig> | null = null;
@@ -2704,45 +2756,32 @@ function attachmentDisplayTitle(attachment: { errorMsg?: string; label?: string;
   return label === attachment.name ? label : `${label} (${attachment.name})`;
 }
 
-function initialMessageModeDirective(mode: InitialMessageMode): string {
-  if (mode === "diagnose") {
-    return [
-      "Initial message type: diagnose issue without writing code.",
-      "Investigate, gather evidence, and report findings only.",
-      "Do not edit files or make code changes unless I explicitly ask in a later message.",
-    ].join(" ");
-  }
-  if (mode === "quality_gaps") {
-    return [
-      "Initial message type: address this issue and inspect the quality/migration gaps it exposes.",
-      "Read /workspace/.tank/docs/quality-timeframes.md and /workspace/.tank/docs/migration-policy.md before planning.",
-      "If either policy doc is missing, report that as a session setup gap before proceeding.",
-      "Make the required code changes and call out any gaps against those docs.",
-    ].join(" ");
-  }
-  if (mode === "go_long") {
-    return [
-      "Initial message type: go long. This is the long-horizon, heavy-solution bar — the durable solution is the only acceptable outcome, and the docs named below are binding invariants, not suggestions.",
-      "Before planning, read /workspace/.tank/docs/quality-timeframes.md, /workspace/.tank/docs/migration-policy.md, and /workspace/.tank/docs/product-inspirations.md.",
-      "If any of those docs is missing, report it as a session setup gap before proceeding.",
-      "Once the in-scope repo is cloned, also read whichever of its own design/quality docs exist (docs/quality-timeframes*.md, docs/migration-policy*.md, docs/design-system*.md, docs/product-inspirations*.md, docs/architecture*.md, any design-system/SKILL.md, plus AGENTS.md and CLAUDE.md). The repo's own docs win where they are more specific; the global invariants set the floor.",
-      "Heavy is the default: do not present a minimal fix as the option and do not ask me to choose quick-vs-thorough. If the full solution is too large for one PR, write the full plan first and stage it so each step leaves the system coherent.",
-      "Settled decisions stay settled: do not reintroduce a route, flag, type, test, doc, or UI path that a prior change deliberately removed. Treat legacy, compatibility, fallback, and temporary as deletion targets, not design options.",
-      "Definition of done is quality-timeframes.md — check the work against it before calling it complete, and name any remaining hardening as unfinished scope rather than optional.",
-    ].join(" ");
-  }
-  if (mode === "test") {
-    return [
-      "Initial message type: make code changes and immediately run the test skill for this.",
-      "Use the test skill workflow as part of implementation and keep the test environment updated while validating.",
-    ].join(" ");
-  }
-  return "";
+// Resolve the directive prepended to the first turn for a given initial-message
+// mode. The live text comes from /api/config (the app-config ConfigMap, so it
+// is editable against main without a frontend rebuild); the baked-in
+// DEFAULT_INITIAL_MODE_*_DIRECTIVE consts are the offline fallback when the
+// fetch is empty or fails. Mirrors forkSessionPromptTemplate().
+async function initialMessageModeDirective(mode: InitialMessageMode): Promise<string> {
+  if (mode === "direct") return "";
+  const config = await fetchAppPublicConfig();
+  const [served, fallback] = ((): [string | undefined, string] => {
+    switch (mode) {
+      case "diagnose":
+        return [config.initial_mode_diagnose_directive, DEFAULT_INITIAL_MODE_DIAGNOSE_DIRECTIVE];
+      case "quality_gaps":
+        return [config.initial_mode_quality_gaps_directive, DEFAULT_INITIAL_MODE_QUALITY_GAPS_DIRECTIVE];
+      case "go_long":
+        return [config.initial_mode_go_long_directive, DEFAULT_INITIAL_MODE_GO_LONG_DIRECTIVE];
+      case "test":
+        return [config.initial_mode_test_directive, DEFAULT_INITIAL_MODE_TEST_DIRECTIVE];
+    }
+  })();
+  return typeof served === "string" && served.trim() ? served.trim() : fallback;
 }
 
-function composeInitialMessageModePrompt(mode: InitialMessageMode, text: string): string {
+async function composeInitialMessageModePrompt(mode: InitialMessageMode, text: string): Promise<string> {
   const trimmed = text.trim();
-  const directive = initialMessageModeDirective(mode);
+  const directive = await initialMessageModeDirective(mode);
   if (!directive) return trimmed;
   return trimmed ? `${directive}\n\n${trimmed}` : directive;
 }
@@ -14221,7 +14260,7 @@ export function App() {
       homeEditingDefaultTitleRef.current,
     );
     const requestedInitialSkillName = initialSkillName ?? initialMessageModeSkillName(initialMessageMode);
-    const seedPrompt = composeInitialMessageModePrompt(initialMessageMode, initialPrompt?.trim() ?? "");
+    const seedPrompt = await composeInitialMessageModePrompt(initialMessageMode, initialPrompt?.trim() ?? "");
     const pendingHomeAttachments = sessionModeSupportsWorkspaceFiles(mode) ? [...homeAttachments] : [];
     const seedTurnRequested =
       (seedPrompt || pendingHomeAttachments.length > 0 || requestedInitialSkillName) &&

--- a/frontend/src/migrationPolicy.test.ts
+++ b/frontend/src/migrationPolicy.test.ts
@@ -45,6 +45,13 @@ const appChromeCapabilitiesSource = readSource(
 const chatScrollMetricsHandlerSource = readSource(
   "../../backend-go/cmd/tank-operator/handlers_client_metrics.go",
 );
+const appConfigMapSource = readSource("../../k8s/templates/app-configmap.yaml");
+const appDeploymentSource = readSource("../../k8s/templates/deployment.yaml");
+const tankServerGoSource = readSource("../../backend-go/cmd/tank-operator/server.go");
+const initialModeDiagnoseSource = readSource("../../k8s/app-config/initial-mode-diagnose.md");
+const initialModeQualityGapsSource = readSource("../../k8s/app-config/initial-mode-quality-gaps.md");
+const initialModeGoLongSource = readSource("../../k8s/app-config/initial-mode-go-long.md");
+const initialModeTestSource = readSource("../../k8s/app-config/initial-mode-test.md");
 
 test("session activity is not refreshed by a steady interval", () => {
   assert.equal(appSource.includes("POLL_INTERVAL_MS"), false);
@@ -730,18 +737,87 @@ test("web search transcript tools use the web glyph", () => {
 test("home splash initial-message modes rewrite the first turn deliberately", () => {
   assert.match(appSource, /type InitialMessageMode = "direct" \| "diagnose" \| "quality_gaps" \| "go_long" \| "test"/);
   assert.equal(appSource.includes("composeInitialMessageModePrompt"), true);
-  assert.equal(appSource.includes("Initial message type: diagnose issue without writing code."), true);
-  assert.equal(appSource.includes("/workspace/.tank/docs/quality-timeframes.md"), true);
-  assert.equal(appSource.includes("/workspace/.tank/docs/migration-policy.md"), true);
-  // "Go long" is the creation-time twin of the /north-star skill: a directive
-  // mode that bakes the three binding invariant docs into turn one with no
-  // skill dependency (the directive is pure prompt text persisted at create,
-  // so it does not require any on-disk skill to exist yet).
-  assert.equal(appSource.includes("Initial message type: go long."), true);
-  assert.equal(appSource.includes("/workspace/.tank/docs/product-inspirations.md"), true);
-  assert.match(appSource, /go_long[\s\S]*Settled decisions stay settled/);
   assert.match(appSource, /initialMessageModeSkillName\(mode: InitialMessageMode\): SkillStateName \| undefined/);
   assert.match(appSource, /initialMode !== "direct"[\s\S]*chatModeForHomePrompt\(defaultSessionMode\)/);
+});
+
+test("initial-message directives are sourced from the app-config ConfigMap, not baked into the SPA", () => {
+  // The directive text moved out of compiled SPA code into k8s/app-config/*.md
+  // so it is editable against main without a frontend rebuild: markdown file ->
+  // app-config ConfigMap (.Files.Get) -> /api/config (readOptionalFile) -> SPA
+  // fetch with an offline const fallback. This mirrors fork_session_prompt_template.
+  // The migration is complete when the four directive files exist, are wired
+  // through the ConfigMap + deployment env + server.go, and the SPA resolves
+  // them async from config instead of returning inline literals.
+
+  // SPA reads directives from /api/config, with const fallbacks, async.
+  assert.match(
+    appSource,
+    /async function initialMessageModeDirective\(mode: InitialMessageMode\): Promise<string>/,
+  );
+  assert.match(appSource, /await fetchAppPublicConfig\(\)/);
+  for (const key of [
+    "initial_mode_diagnose_directive",
+    "initial_mode_quality_gaps_directive",
+    "initial_mode_go_long_directive",
+    "initial_mode_test_directive",
+  ]) {
+    assert.equal(appSource.includes(key), true, `App.tsx missing config key ${key}`);
+    assert.equal(tankServerGoSource.includes(key), true, `server.go missing config key ${key}`);
+  }
+  assert.match(appSource, /await composeInitialMessageModePrompt\(/);
+
+  // The old persistent-stance diagnose phrasing must not be reintroduced
+  // anywhere — it is the bug this change fixes (agents read it as a
+  // never-write-code stance for the whole session, not just turn one).
+  assert.equal(appSource.includes("diagnose issue without writing code"), false);
+  assert.equal(initialModeDiagnoseSource.includes("diagnose issue without writing code"), false);
+
+  // Reworded diagnose directive scopes the no-code stance to the first turn.
+  assert.equal(initialModeDiagnoseSource.includes("first message only"), true);
+  assert.equal(initialModeDiagnoseSource.includes("this first turn only"), true);
+
+  // Other modes relocated to markdown with their invariants intact.
+  assert.equal(initialModeQualityGapsSource.includes("/workspace/.tank/docs/quality-timeframes.md"), true);
+  assert.equal(initialModeQualityGapsSource.includes("/workspace/.tank/docs/migration-policy.md"), true);
+  assert.equal(initialModeGoLongSource.includes("Initial message type: go long."), true);
+  assert.equal(initialModeGoLongSource.includes("/workspace/.tank/docs/product-inspirations.md"), true);
+  assert.equal(initialModeGoLongSource.includes("Settled decisions stay settled"), true);
+  assert.equal(initialModeTestSource.includes("run the test skill"), true);
+
+  // ConfigMap renders all four files via .Files.Get.
+  for (const file of [
+    "initial-mode-diagnose.md",
+    "initial-mode-quality-gaps.md",
+    "initial-mode-go-long.md",
+    "initial-mode-test.md",
+  ]) {
+    assert.equal(
+      appConfigMapSource.includes(`.Files.Get "app-config/${file}"`),
+      true,
+      `app-configmap.yaml does not render ${file}`,
+    );
+  }
+
+  // Deployment points each directive env var at the mounted ConfigMap file.
+  for (const [envVar, file] of [
+    ["TANK_INITIAL_MODE_DIAGNOSE_FILE", "initial-mode-diagnose.md"],
+    ["TANK_INITIAL_MODE_QUALITY_GAPS_FILE", "initial-mode-quality-gaps.md"],
+    ["TANK_INITIAL_MODE_GO_LONG_FILE", "initial-mode-go-long.md"],
+    ["TANK_INITIAL_MODE_TEST_FILE", "initial-mode-test.md"],
+  ]) {
+    assert.equal(appDeploymentSource.includes(envVar), true, `deployment.yaml missing ${envVar}`);
+    assert.equal(
+      appDeploymentSource.includes(`/etc/tank-operator/app-config/${file}`),
+      true,
+      `deployment.yaml missing mount path for ${file}`,
+    );
+    assert.equal(
+      tankServerGoSource.includes(`os.Getenv("${envVar}")`),
+      true,
+      `server.go does not read ${envVar}`,
+    );
+  }
 });
 
 test("quality gap policy docs are bundled into session config", () => {

--- a/k8s/app-config/initial-mode-diagnose.md
+++ b/k8s/app-config/initial-mode-diagnose.md
@@ -1,0 +1,5 @@
+Initial message type: diagnose — first message only.
+
+When you respond to this first message, investigate the issue, gather evidence, and report findings only; do not edit files or make code changes in this turn.
+
+The no-code stance applies to this first turn only — once I reply, treat the session normally and make code changes when the work calls for it.

--- a/k8s/app-config/initial-mode-go-long.md
+++ b/k8s/app-config/initial-mode-go-long.md
@@ -1,0 +1,13 @@
+Initial message type: go long. This is the long-horizon, heavy-solution bar — the durable solution is the only acceptable outcome, and the docs named below are binding invariants, not suggestions.
+
+Before planning, read /workspace/.tank/docs/quality-timeframes.md, /workspace/.tank/docs/migration-policy.md, and /workspace/.tank/docs/product-inspirations.md.
+
+If any of those docs is missing, report it as a session setup gap before proceeding.
+
+Once the in-scope repo is cloned, also read whichever of its own design/quality docs exist (docs/quality-timeframes*.md, docs/migration-policy*.md, docs/design-system*.md, docs/product-inspirations*.md, docs/architecture*.md, any design-system/SKILL.md, plus AGENTS.md and CLAUDE.md). The repo's own docs win where they are more specific; the global invariants set the floor.
+
+Heavy is the default: do not present a minimal fix as the option and do not ask me to choose quick-vs-thorough. If the full solution is too large for one PR, write the full plan first and stage it so each step leaves the system coherent.
+
+Settled decisions stay settled: do not reintroduce a route, flag, type, test, doc, or UI path that a prior change deliberately removed. Treat legacy, compatibility, fallback, and temporary as deletion targets, not design options.
+
+Definition of done is quality-timeframes.md — check the work against it before calling it complete, and name any remaining hardening as unfinished scope rather than optional.

--- a/k8s/app-config/initial-mode-quality-gaps.md
+++ b/k8s/app-config/initial-mode-quality-gaps.md
@@ -1,0 +1,7 @@
+Initial message type: address this issue and inspect the quality/migration gaps it exposes.
+
+Read /workspace/.tank/docs/quality-timeframes.md and /workspace/.tank/docs/migration-policy.md before planning.
+
+If either policy doc is missing, report that as a session setup gap before proceeding.
+
+Make the required code changes and call out any gaps against those docs.

--- a/k8s/app-config/initial-mode-test.md
+++ b/k8s/app-config/initial-mode-test.md
@@ -1,0 +1,3 @@
+Initial message type: make code changes and immediately run the test skill for this.
+
+Use the test skill workflow as part of implementation and keep the test environment updated while validating.

--- a/k8s/templates/app-configmap.yaml
+++ b/k8s/templates/app-configmap.yaml
@@ -9,4 +9,12 @@ metadata:
 data:
   fork-session.md: |
 {{ .Files.Get "app-config/fork-session.md" | indent 4 }}
+  initial-mode-diagnose.md: |
+{{ .Files.Get "app-config/initial-mode-diagnose.md" | indent 4 }}
+  initial-mode-quality-gaps.md: |
+{{ .Files.Get "app-config/initial-mode-quality-gaps.md" | indent 4 }}
+  initial-mode-go-long.md: |
+{{ .Files.Get "app-config/initial-mode-go-long.md" | indent 4 }}
+  initial-mode-test.md: |
+{{ .Files.Get "app-config/initial-mode-test.md" | indent 4 }}
 {{- end }}

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -75,6 +75,14 @@ spec:
               value: /app/static
             - name: TANK_FORK_SESSION_PROMPT_FILE
               value: /etc/tank-operator/app-config/fork-session.md
+            - name: TANK_INITIAL_MODE_DIAGNOSE_FILE
+              value: /etc/tank-operator/app-config/initial-mode-diagnose.md
+            - name: TANK_INITIAL_MODE_QUALITY_GAPS_FILE
+              value: /etc/tank-operator/app-config/initial-mode-quality-gaps.md
+            - name: TANK_INITIAL_MODE_GO_LONG_FILE
+              value: /etc/tank-operator/app-config/initial-mode-go-long.md
+            - name: TANK_INITIAL_MODE_TEST_FILE
+              value: /etc/tank-operator/app-config/initial-mode-test.md
             {{- if and (eq (include "tank-operator.isTestEnv" .) "true") .Values.staticOverride.enabled }}
             - name: TANK_OPERATOR_STATIC_OVERRIDE_DIR
               value: {{ .Values.staticOverride.mountPath | quote }}


### PR DESCRIPTION
## Summary

Finishes work started in tank session 339 (which died on a Claude provider error: `400 ... thinking blocks in the latest assistant message cannot be modified`).

The splash-page initial-message mode directives (`diagnose`, `quality_gaps`, `go_long`, `test`) were hardcoded in the compiled SPA (`App.tsx → initialMessageModeDirective`), so editing the prose required a frontend rebuild + image bump + deploy. This relocates the directive text to repo markdown under `k8s/app-config/`, reusing the existing `fork-session.md` mechanism end to end:

```
markdown file → app-config ConfigMap (.Files.Get) → /api/config (readOptionalFile) → SPA fetch with an offline const fallback
```

Editing a directive file on `main` (ArgoCD sync) now changes the directive **with no image rebuild**. The orchestrator re-reads the mounted file per request; the Go/TS const fallbacks only apply pre-mount (first-install ordering / local dev), matching `fork_session_prompt_template`.

Also **rewords the diagnose directive** to scope the no-code stance to the first turn only — *"diagnose — first message only … once I reply, treat the session normally and make code changes when the work calls for it."* The prior phrasing read as a permanent never-write-code stance for the whole session, which confused agents.

`initialMessageModeDirective` / `composeInitialMessageModePrompt` become async (they await the already-cached config fetch); the sole caller `createSession` is already async.

### Files
- `k8s/app-config/initial-mode-*.md` — new directive source of truth (4 files)
- `k8s/templates/app-configmap.yaml` — render the 4 files via `.Files.Get`
- `k8s/templates/deployment.yaml` — 4 env vars on the existing `app-config` mount
- `backend-go/cmd/tank-operator/server.go` — 4 `publicConfig()` keys + const fallbacks
- `frontend/src/App.tsx` — async resolver reading config with offline fallback
- `*_test.go` / `migrationPolicy.test.ts` — behavior + migration guards

### Design note
Deliberately **no** `markdown === const` equality test. That would defeat the feature — a future live prose edit on `main` would fail CI unless the baked consts were rebuilt too. The guards assert the *mechanism* (files exist, wired through ConfigMap + deployment env + server.go, sourced from config in the SPA) and that the old persistent-stance phrasing can't be reintroduced — same drift model as `fork-session.md`.

## Feature Contracts

Affected contracts:
- [x] None

Evidence:
- No `docs/features/` contract covers initial-message modes (grepped `app-chrome` and the rest). This is a delivery-mechanism move (compiled-in → ConfigMap) plus a one-directive wording fix; no contract invariant changes. Directive semantics for `quality_gaps` / `go_long` / `test` are relocated verbatim — guard test asserts their invariant substrings (doc paths, "Settled decisions stay settled", test-skill) survive in the markdown.
- `go test ./cmd/tank-operator/...` — green (config keys default non-empty + honor mounted files).
- `npm test` — 338 pass, incl. the rewritten migration guard; `tsc --noEmit` clean.
- `helm template` — all 4 files render into the ConfigMap; all 4 env vars resolve to mounted paths; reworded diagnose text confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
