### PR TITLE
feat: Add Gemini GUI support and gemini-runner sidecar

### DIFF
--- a/api-proxy/src/tank_api_proxy/server.py
+++ b/api-proxy/src/tank_api_proxy/server.py
@@ -117,6 +117,11 @@ ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
 
+# Gemini OAuth constants
+GEMINI_CLIENT_ID = ""
+GEMINI_CLIENT_SECRET = ""
+GEMINI_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
 # The session launchers write this placeholder into
 # ~/.claude/.credentials.json's accessToken (and matching refreshToken).
 # Used as the discriminator for "this is a request that wants OAuth-
@@ -131,6 +136,7 @@ class ProxyConfig:
     token_url: str
     client_id: str
     kv_secret_name: str
+    client_secret: str | None = None
     account_header: str | None = None
     fedramp_header: str | None = None
     patch_last_refresh: bool = False
@@ -150,6 +156,17 @@ def _config_from_env() -> ProxyConfig:
             account_header="ChatGPT-Account-ID",
             fedramp_header="X-OpenAI-Fedramp",
             patch_last_refresh=True,
+        )
+    if provider == "gemini":
+        return ProxyConfig(
+            provider="gemini",
+            credentials_file=os.environ.get(
+                "GEMINI_CREDENTIALS_FILE", "/etc/gemini-credentials/settings.json"
+            ),
+            token_url=os.environ.get("GEMINI_TOKEN_URL", GEMINI_TOKEN_URL),
+            client_id=os.environ.get("GEMINI_CLIENT_ID", GEMINI_CLIENT_ID),
+            client_secret=os.environ.get("GEMINI_CLIENT_SECRET", GEMINI_CLIENT_SECRET),
+            kv_secret_name=os.environ.get("GEMINI_CREDENTIALS_KV_KEY", "gemini-credentials"),
         )
     if provider not in ("", "claude"):
         log.warning("unknown PROXY_PROVIDER=%r; falling back to claude", provider)
@@ -623,13 +640,16 @@ class AuthInjector(ext_proc_grpc.ExternalProcessorServicer):
             self._health_attempt_id += 1
             try:
                 async with httpx.AsyncClient(timeout=30.0) as http:
+                    payload = {
+                        "grant_type": "refresh_token",
+                        "refresh_token": self._cached_refresh,
+                        "client_id": self._config.client_id,
+                    }
+                    if self._config.client_secret is not None:
+                        payload["client_secret"] = self._config.client_secret
                     resp = await http.post(
                         self._config.token_url,
-                        json={
-                            "grant_type": "refresh_token",
-                            "refresh_token": self._cached_refresh,
-                            "client_id": self._config.client_id,
-                        },
+                        json=payload,
                         headers={"Content-Type": "application/json"},
                     )
             except Exception:

--- a/backend-go/cmd/tank-operator/credentials.go
+++ b/backend-go/cmd/tank-operator/credentials.go
@@ -32,6 +32,10 @@ func doSaveCredentials(w http.ResponseWriter, r *http.Request, s *appServer, ema
 		execCmd = []string{"sh", "-c", "cat $HOME/.codex/auth.json"}
 		kvKeyEnv = "CODEX_CREDENTIALS_KV_KEY"
 		kvDefault = "codex-credentials"
+	case sessionmodel.GeminiConfigMode:
+		execCmd = []string{"sh", "-c", "cat $HOME/.gemini/settings.json"}
+		kvKeyEnv = "GEMINI_CREDENTIALS_KV_KEY"
+		kvDefault = "gemini-credentials"
 	default:
 		// claude / config modes
 		execCmd = []string{"sh", "-c", "cat $HOME/.claude/.credentials.json"}

--- a/backend-go/cmd/tank-operator/handlers_repos.go
+++ b/backend-go/cmd/tank-operator/handlers_repos.go
@@ -70,7 +70,8 @@ func sessionModeSupportsRepos(mode string) bool {
 	switch sessionmodel.NormalizeSessionMode(mode) {
 	case sessionmodel.ClaudeGUIMode,
 		sessionmodel.CodexGUIMode,
-		sessionmodel.CodexAppServerMode:
+		sessionmodel.CodexAppServerMode,
+		sessionmodel.GeminiGUIMode:
 		return true
 	default:
 		return false

--- a/backend-go/cmd/tank-operator/handlers_terminal.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal.go
@@ -46,6 +46,10 @@ func cliProcessLaunchForMode(mode string) sandboxProcessCreate {
 		// at $HOME/.claude/.credentials.json for the save-credentials
 		// button.
 		base.Args = []string{"-lc", "claude /login; exec bash"}
+	case sessionmodel.GeminiConfigMode:
+		// gemini login runs the Google OAuth flow; credentials land
+		// at $HOME/.gemini/settings.json for the save-credentials button.
+		base.Args = []string{"-lc", "gemini login; exec bash"}
 	case sessionmodel.PiConfigMode:
 		// Pi's /login is a slash command inside the interactive `pi`
 		// REPL, not a CLI subcommand. Drop into pi, let the user

--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -980,6 +980,8 @@ func sdkProviderForMode(mode string) (string, bool) {
 		return "codex", true
 	case sessionmodel.CodexAppServerMode:
 		return "codex", true
+	case sessionmodel.GeminiGUIMode:
+		return "gemini", true
 	default:
 		return "", false
 	}

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -379,6 +379,7 @@ func main() {
 		OAuthGatewayHost:  os.Getenv("CLAUDE_OAUTH_GATEWAY_HOST"),
 		APIProxyHost:      os.Getenv("CLAUDE_API_PROXY_HOST"),
 		CodexAPIProxyHost: os.Getenv("CODEX_API_PROXY_HOST"),
+		GeminiAPIProxyHost: os.Getenv("GEMINI_API_PROXY_HOST"),
 	})
 
 	// 10. Init auth. Tank verifies the upstream auth.romaine.life JWT

--- a/backend-go/cmd/tank-operator/middleware.go
+++ b/backend-go/cmd/tank-operator/middleware.go
@@ -94,6 +94,8 @@ func validateEffort(provider string, v string) string {
 	allowed := allowedClaudeEfforts
 	if provider == "codex" {
 		allowed = allowedCodexEfforts
+	} else if provider == "gemini" {
+		allowed = map[string]struct{}{}
 	}
 	if _, ok := allowed[v]; ok {
 		return v

--- a/backend-go/internal/conversation/builders.go
+++ b/backend-go/internal/conversation/builders.go
@@ -28,7 +28,7 @@ func UserSubmissionEventMaps(args UserSubmissionArgs) (string, []map[string]any,
 		return "", nil, fmt.Errorf("client nonce is required")
 	}
 	runtime := strings.TrimSpace(args.Runtime)
-	if runtime != string(SourceClaude) && runtime != string(SourceCodex) && runtime != string(SourceHermes) {
+	if runtime != string(SourceClaude) && runtime != string(SourceCodex) && runtime != string(SourceHermes) && runtime != string(SourceGemini) {
 		return "", nil, fmt.Errorf("runtime is required")
 	}
 	createdAt := args.Now

--- a/backend-go/internal/conversation/types.go
+++ b/backend-go/internal/conversation/types.go
@@ -56,6 +56,7 @@ const (
 	// /v1/runs/:id/events SSE and translates to this schema. See
 	// nelsong6/tank-operator#540.
 	SourceHermes Source = "hermes"
+	SourceGemini Source = "gemini"
 )
 
 type Visibility string
@@ -625,7 +626,7 @@ func validActor(actor Actor) bool {
 
 func validSource(source Source) bool {
 	switch source {
-	case SourceTank, SourceClaude, SourceCodex, SourceHermes:
+	case SourceTank, SourceClaude, SourceCodex, SourceHermes, SourceGemini:
 		return true
 	default:
 		return false

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -28,6 +28,8 @@ const (
 	CodexGUIMode       = "codex_gui"
 	CodexExecGUIMode   = "codex_exec_gui"
 	CodexAppServerMode = "codex_app_server"
+	GeminiGUIMode      = "gemini_gui"
+	GeminiConfigMode   = "gemini_config"
 	PiConfigMode       = "pi_config"
 	PiCLIMode          = "pi_cli"
 	// HermesGUIMode routes chat turns to Hermes Agent's OpenAI-compatible
@@ -38,8 +40,9 @@ const (
 	// memory + skills directory; a per-Tank-session pod would discard
 	// that state on every session create. Tradeoffs and the full
 	// integration design live in nelsong6/tank-operator#540.
-	HermesGUIMode         = "hermes_gui"
-	DefaultSessionMode    = ClaudeGUIMode
+	HermesGUIMode           = "hermes_gui"
+	DefaultSessionMode      = ClaudeGUIMode
+	GeminiRunnerMetricsPort = 9097
 	MaxNameLength         = 80
 	SessionsNamespace     = "tank-operator-sessions"
 	SessionServiceAccount = "claude-session"
@@ -80,6 +83,8 @@ var (
 		CodexGUIMode:       {},
 		CodexExecGUIMode:   {},
 		CodexAppServerMode: {},
+		GeminiGUIMode:      {},
+		GeminiConfigMode:   {},
 		PiConfigMode:       {},
 		PiCLIMode:          {},
 		HermesGUIMode:      {},
@@ -207,6 +212,7 @@ var sessionConfigMounts = []struct{ key, mountPath string }{
 	{"write-glimmung-context.sh", "/opt/tank/write-glimmung-context.sh"},
 	{"agent-runner-launch.sh", "/opt/tank/agent-runner-launch.sh"},
 	{"codex-runner-launch.sh", "/opt/tank/codex-runner-launch.sh"},
+	{"gemini-runner-launch.sh", "/opt/tank/gemini-runner-launch.sh"},
 	{"repo-cloner.sh", "/opt/tank/repo-cloner.sh"},
 	{"session-pod-bootstrap.sh", "/opt/tank/session-pod-bootstrap.sh"},
 }
@@ -219,6 +225,8 @@ var noClaudeHijackModes = map[string]bool{
 	CodexGUIMode:       true,
 	CodexExecGUIMode:   true,
 	CodexAppServerMode: true,
+	GeminiConfigMode:   true,
+	GeminiGUIMode:      true,
 	PiConfigMode:       true,
 }
 
@@ -237,6 +245,7 @@ type ManifestOptions struct {
 	OAuthGatewayIP  string
 	APIProxyIP      string
 	CodexAPIProxyIP string
+	GeminiAPIProxyIP string
 	// ConfigMap name for the OAuth gateway CA cert.
 	OAuthGatewayCAConfigMap string
 	// Secret name for GitHub App credentials (envFrom on claude container).
@@ -423,7 +432,8 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	// Codex GUI modes use codex-runner. Both need the shared mount.
 	wantAgentRunner := mode == ClaudeGUIMode
 	wantCodexRunner := mode == CodexGUIMode || mode == CodexExecGUIMode || mode == CodexAppServerMode
-	wantSDKRunner := wantAgentRunner || wantCodexRunner
+	wantGeminiRunner := mode == GeminiGUIMode
+	wantSDKRunner := wantAgentRunner || wantCodexRunner || wantGeminiRunner
 	if wantSDKRunner {
 		volumes = append(volumes, map[string]any{
 			"name":     "workspace",
@@ -521,6 +531,28 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			env = append(env,
 				map[string]any{"name": "NODE_EXTRA_CA_CERTS", "value": "/etc/oauth-gateway-ca/ca.crt"},
 				map[string]any{"name": "CODEX_CA_CERTIFICATE", "value": "/etc/oauth-gateway-ca/ca.crt"},
+			)
+			claudeVolumeMounts = append(claudeVolumeMounts, map[string]any{
+				"name":      "oauth-gateway-ca",
+				"mountPath": "/etc/oauth-gateway-ca",
+				"readOnly":  true,
+			})
+			volumes = append(volumes, map[string]any{
+				"name":      "oauth-gateway-ca",
+				"configMap": map[string]any{"name": opts.OAuthGatewayCAConfigMap},
+			})
+		}
+	}
+
+	// Gemini API proxy host alias and CA cert.
+	if (mode == GeminiGUIMode || mode == GeminiConfigMode) && opts.GeminiAPIProxyIP != "" {
+		hostAliases = append(hostAliases, map[string]any{
+			"ip":        opts.GeminiAPIProxyIP,
+			"hostnames": []any{"generativelanguage.googleapis.com"},
+		})
+		if opts.OAuthGatewayCAConfigMap != "" {
+			env = append(env,
+				map[string]any{"name": "NODE_EXTRA_CA_CERTS", "value": "/etc/oauth-gateway-ca/ca.crt"},
 			)
 			claudeVolumeMounts = append(claudeVolumeMounts, map[string]any{
 				"name":      "oauth-gateway-ca",
@@ -842,6 +874,88 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			codexRunnerContainer["envFrom"] = envFrom
 		}
 		containers = append(containers, codexRunnerContainer)
+	}
+
+	if wantGeminiRunner {
+		runnerVolumeMounts := append([]any{}, configMounts...)
+		runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+			"name":      "workspace",
+			"mountPath": "/workspace",
+		})
+		runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+			"name":      "tank-operator-sa-token",
+			"mountPath": "/var/run/secrets/tank-operator",
+			"readOnly":  true,
+		})
+		runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+			"name":      "auth-romaine-sa-token",
+			"mountPath": "/var/run/secrets/auth.romaine.life",
+			"readOnly":  true,
+		})
+		if opts.GeminiAPIProxyIP != "" && opts.OAuthGatewayCAConfigMap != "" {
+			runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
+				"name":      "oauth-gateway-ca",
+				"mountPath": "/etc/oauth-gateway-ca",
+				"readOnly":  true,
+			})
+		}
+		geminiRunnerEnv := []any{
+			map[string]any{
+				"name": "SESSION_ID",
+				"valueFrom": map[string]any{
+					"fieldRef": map[string]any{
+						"fieldPath": "metadata.labels['tank-operator/session-id']",
+					},
+				},
+			},
+			map[string]any{"name": "TANK_SESSION_STORAGE_KEY", "value": storageKey},
+			map[string]any{
+				"name": "POD_OWNER_EMAIL",
+				"valueFrom": map[string]any{
+					"fieldRef": map[string]any{
+						"fieldPath": "metadata.annotations['tank-operator/owner-email']",
+					},
+				},
+			},
+			map[string]any{"name": "NATS_URL", "value": opts.NATSURL},
+			map[string]any{"name": "NATS_STREAM", "value": opts.NATSStream},
+			map[string]any{
+				"name": "NATS_TOKEN",
+				"valueFrom": map[string]any{
+					"secretKeyRef": map[string]any{
+						"name": opts.NATSAuthSecret,
+						"key":  "token",
+					},
+				},
+			},
+			map[string]any{"name": "TANK_OPERATOR_INTERNAL_URL", "value": opts.TankOperatorInternalURL},
+			map[string]any{"name": "TANK_OPERATOR_TOKEN_PATH", "value": "/var/run/secrets/tank-operator/token"},
+			map[string]any{"name": "WORKSPACE", "value": "/workspace"},
+		}
+		if opts.GeminiAPIProxyIP != "" && opts.OAuthGatewayCAConfigMap != "" {
+			geminiRunnerEnv = append(geminiRunnerEnv,
+				map[string]any{"name": "NODE_EXTRA_CA_CERTS", "value": "/etc/oauth-gateway-ca/ca.crt"},
+			)
+		}
+		geminiRunnerEnv = append(geminiRunnerEnv, map[string]any{
+			"name": "TANK_RUNNER_METRICS_PORT", "value": itoa(GeminiRunnerMetricsPort),
+		})
+		geminiRunnerContainer := map[string]any{
+			"name":            "gemini-runner",
+			"image":           sessionImage,
+			"imagePullPolicy": "Always",
+			"command":         []any{"bash", "/opt/tank/gemini-runner-launch.sh"},
+			"env":             geminiRunnerEnv,
+			"volumeMounts":    runnerVolumeMounts,
+			"ports": []any{
+				map[string]any{"name": "runner-metrics", "containerPort": GeminiRunnerMetricsPort},
+			},
+			"resources": agentRunnerResources(),
+		}
+		if len(envFrom) > 0 {
+			geminiRunnerContainer["envFrom"] = envFrom
+		}
+		containers = append(containers, geminiRunnerContainer)
 	}
 
 	spec := map[string]any{

--- a/backend-go/internal/sessionmodel/sessionmodel_test.go
+++ b/backend-go/internal/sessionmodel/sessionmodel_test.go
@@ -288,6 +288,30 @@ func TestPodManifestCodexUsesAPIProxyWithoutCredentialSecret(t *testing.T) {
 	assertVolumeMount(t, codexRunner, "oauth-gateway-ca")
 }
 
+func TestPodManifestGeminiUsesAPIProxy(t *testing.T) {
+	manifest := PodManifest("12", "nelson@romaine.life", GeminiGUIMode, ManifestOptions{
+		SessionImage:            "claude-image",
+		GeminiAPIProxyIP:        "10.0.0.60",
+		OAuthGatewayCAConfigMap: "claude-oauth-ca",
+	})
+
+	spec := manifest["spec"].(map[string]any)
+	assertHostAlias(t, spec, "10.0.0.60", "generativelanguage.googleapis.com")
+	assertVolume(t, spec["volumes"].([]any), "oauth-gateway-ca")
+
+	containers := spec["containers"].([]any)
+	claudeEnv := containerEnv(findContainer(t, containers, "claude"))
+	if got, want := claudeEnv["NODE_EXTRA_CA_CERTS"], "/etc/oauth-gateway-ca/ca.crt"; got != want {
+		t.Fatalf("claude NODE_EXTRA_CA_CERTS = %v, want %q", got, want)
+	}
+	geminiRunner := findContainer(t, containers, "gemini-runner")
+	runnerEnv := containerEnv(geminiRunner)
+	if got, want := runnerEnv["NODE_EXTRA_CA_CERTS"], "/etc/oauth-gateway-ca/ca.crt"; got != want {
+		t.Fatalf("runner NODE_EXTRA_CA_CERTS = %v, want %q", got, want)
+	}
+	assertVolumeMount(t, geminiRunner, "oauth-gateway-ca")
+}
+
 func TestPodManifestCodexRunnerAlwaysUsesAppServerTransport(t *testing.T) {
 	for _, mode := range []string{CodexGUIMode, CodexAppServerMode} {
 		t.Run(mode, func(t *testing.T) {

--- a/backend-go/internal/sessions/manager.go
+++ b/backend-go/internal/sessions/manager.go
@@ -77,6 +77,7 @@ type Manager struct {
 	oauthGatewayIP  string
 	apiProxyIP      string
 	codexAPIProxyIP string
+	geminiAPIProxyIP string
 
 	localCounter     int64
 	localCounterLock sync.Mutex
@@ -90,6 +91,7 @@ type ManagerOptions struct {
 	OAuthGatewayHost  string
 	APIProxyHost      string
 	CodexAPIProxyHost string
+	GeminiAPIProxyHost string
 }
 
 func NewManager(client kubernetes.Interface, restCfg *rest.Config, namespace string, registry SessionRegistry, emitter RowEmitter, opts ManagerOptions) *Manager {
@@ -133,6 +135,9 @@ func NewManager(client kubernetes.Interface, restCfg *rest.Config, namespace str
 	}
 	if opts.CodexAPIProxyHost != "" {
 		m.codexAPIProxyIP = resolveIP(opts.CodexAPIProxyHost)
+	}
+	if opts.GeminiAPIProxyHost != "" {
+		m.geminiAPIProxyIP = resolveIP(opts.GeminiAPIProxyHost)
 	}
 	return m
 }
@@ -325,6 +330,9 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 	if m.codexAPIProxyIP == "" {
 		m.codexAPIProxyIP = resolveIP(os.Getenv("CODEX_API_PROXY_HOST"))
 	}
+	if m.geminiAPIProxyIP == "" {
+		m.geminiAPIProxyIP = resolveIP(os.Getenv("GEMINI_API_PROXY_HOST"))
+	}
 
 	sessionID, err := m.nextSessionID(ctx)
 	if err != nil {
@@ -341,6 +349,7 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (Info, error) 
 	manifestOpts.OAuthGatewayIP = m.oauthGatewayIP
 	manifestOpts.APIProxyIP = m.apiProxyIP
 	manifestOpts.CodexAPIProxyIP = m.codexAPIProxyIP
+	manifestOpts.GeminiAPIProxyIP = m.geminiAPIProxyIP
 	manifestOpts.GlimmungContextJSON = contextJSON
 	manifestOpts.Repos = repos
 	manifestOpts.Name = name

--- a/claude-container/Dockerfile
+++ b/claude-container/Dockerfile
@@ -42,6 +42,19 @@ COPY runner-shared /src/runner-shared
 RUN npx tsc
 RUN npm prune --omit=dev
 
+# Stage 1c: build the gemini-runner from gemini-runner/. Sibling of
+# agent-runner — drives @google/genai for gemini_gui sessions instead
+# of @anthropic-ai/claude-agent-sdk. Baked into all session images.
+FROM node:20-alpine AS gemini-runner-build
+WORKDIR /src/gemini-runner
+COPY gemini-runner/package.json gemini-runner/package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+COPY gemini-runner/tsconfig.json ./
+COPY gemini-runner/src ./src
+COPY runner-shared /src/runner-shared
+RUN npx tsc
+RUN npm prune --omit=dev
+
 # Stage 2: runtime image. azure-mcp + github-mcp + k8s-mcp run as in-cluster
 # HTTP MCP servers. The container reaches them via the mcp-auth-proxy sidecar
 # on 127.0.0.1, which injects fresh bearer auth per request; GitHub receives a
@@ -123,7 +136,8 @@ RUN case "${TANK_AGENT}" in \
         claude) npm install -g @anthropic-ai/claude-code "vite@${VITE_VERSION}" "typescript@${TYPESCRIPT_VERSION}" ;; \
         codex) npm install -g @openai/codex "vite@${VITE_VERSION}" "typescript@${TYPESCRIPT_VERSION}" ;; \
         pi) npm install -g @mariozechner/pi-coding-agent "vite@${VITE_VERSION}" "typescript@${TYPESCRIPT_VERSION}" ;; \
-        *) echo "unsupported TANK_AGENT=${TANK_AGENT}; expected claude, codex, or pi" >&2; exit 1 ;; \
+        gemini) npm install -g @google/gemini-cli "vite@${VITE_VERSION}" "typescript@${TYPESCRIPT_VERSION}" ;; \
+        *) echo "unsupported TANK_AGENT=${TANK_AGENT}; expected claude, codex, pi, or gemini" >&2; exit 1 ;; \
     esac
 
 # Ghostty-backed in-browser process terminal support. The frontend talks to
@@ -214,6 +228,22 @@ fi
 exec node /opt/codex-runner/dist/index.js
 EOF
 
+# Gemini-runner sibling: same pattern, @google/genai underneath.
+# Baked into all session images; only the gemini pod spec invokes it.
+COPY --from=gemini-runner-build /src/gemini-runner/dist /opt/gemini-runner/dist
+COPY --from=gemini-runner-build /src/gemini-runner/node_modules /opt/gemini-runner/node_modules
+COPY --from=gemini-runner-build /src/gemini-runner/package.json /opt/gemini-runner/package.json
+RUN cat > /app/gemini-runner-launch-binary.sh <<'EOF' && chmod 0755 /app/gemini-runner-launch-binary.sh
+#!/bin/sh
+if [ ! -e /var/run/gemini-runner-hot/node_modules ]; then
+  ln -sfn /opt/gemini-runner/node_modules /var/run/gemini-runner-hot/node_modules
+fi
+if [ -f /var/run/gemini-runner-hot/dist/index.js ]; then
+  exec node /var/run/gemini-runner-hot/dist/index.js
+fi
+exec node /opt/gemini-runner/dist/index.js
+EOF
+
 # Session-facing MCP wiring, AGENTS/CLAUDE primers, bundled skill docs, and
 # launcher scripts are mounted from the chart-managed tank-session-config
 # ConfigMap. Keep the parent directories in the image so the orchestrator can
@@ -223,6 +253,7 @@ RUN mkdir -p /workspace \
         /opt/tank \
         /home/node/.claude/skills \
         /home/node/.codex/skills \
+        /home/node/.gemini \
         /home/node/.pi/agent
 
 # Pi keeps MCP support in installable packages rather than core. Install the
@@ -237,7 +268,7 @@ RUN if [ "${TANK_AGENT}" = "pi" ]; then \
 # defense-in-depth: a tool-use exploit can't escape to a privileged shell.
 # node:20-alpine already ships a `node` user at uid/gid 1000 with
 # /home/node, so reuse it (creating another user with gid 1000 collides).
-RUN chown -R node:node /workspace /home/node/.claude /home/node/.codex /home/node/.pi
+RUN chown -R node:node /workspace /home/node/.claude /home/node/.codex /home/node/.gemini /home/node/.pi
 
 WORKDIR /workspace
 USER node

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -228,6 +228,8 @@ type SessionMode =
   | "codex_exec_gui"
   | "codex_app_server"
   | "codex_config"
+  | "gemini_gui"
+  | "gemini_config"
   | "hermes_gui"
   | "pi_cli"
   | "pi_config";
@@ -238,10 +240,11 @@ type DefaultSessionMode = Extract<
   | "codex_cli"
   | "codex_gui"
   | "codex_exec_gui"
+  | "gemini_gui"
   | "hermes_gui"
   | "pi_cli"
 >;
-type Provider = "anthropic" | "codex" | "hermes" | "pi";
+type Provider = "anthropic" | "codex" | "gemini" | "hermes" | "pi";
 type SessionInteraction = "gui" | "cli";
 type ToolKind = "mcp" | "shell";
 type AskUserQuestionAnswer = {
@@ -598,6 +601,8 @@ const MODE_LABELS: Record<SessionMode, string> = {
   codex_exec_gui: "Codex Legacy",
   codex_app_server: "Codex App Server",
   codex_config: "Codex config",
+  gemini_gui: "Gemini GUI",
+  gemini_config: "Gemini config",
   hermes_gui: "Hermes",
   pi_cli: "Pi CLI",
   pi_config: "Pi config",
@@ -615,6 +620,8 @@ const MODE_CHIP_LABELS: Record<SessionMode, string> = {
   codex_exec_gui: "codex-exec",
   codex_app_server: "codex-app",
   codex_config: "codex-cfg",
+  gemini_gui: "gemini-gui",
+  gemini_config: "gemini-cfg",
   hermes_gui: "hermes",
   pi_cli: "pi-cli",
   pi_config: "pi-cfg",
@@ -627,6 +634,7 @@ const MODE_CHIP_ICONS: Partial<Record<SessionMode, Provider>> = {
   codex_gui: "codex",
   codex_exec_gui: "codex",
   codex_app_server: "codex",
+  gemini_gui: "gemini",
   hermes_gui: "hermes",
   pi_cli: "pi",
 };
@@ -641,6 +649,8 @@ const MODE_MENU_ICONS: Record<SessionMode, Provider> = {
   codex_exec_gui: "codex",
   codex_app_server: "codex",
   codex_config: "codex",
+  gemini_gui: "gemini",
+  gemini_config: "gemini",
   hermes_gui: "hermes",
   pi_cli: "pi",
   pi_config: "pi",
@@ -652,6 +662,7 @@ const PROVIDER_INTERACTION_MODES: Record<
 > = {
   anthropic: { gui: "claude_gui", cli: "claude_cli" },
   codex: { gui: "codex_gui", cli: "codex_cli" },
+  gemini: { gui: "gemini_gui", cli: null },
   hermes: { gui: "hermes_gui", cli: null },
   pi: { gui: null, cli: "pi_cli" },
 };
@@ -666,12 +677,14 @@ const INTERACTION_OPTIONS: SessionInteraction[] = ["gui", "cli"];
 const PROVIDER_CONFIG_MODES: Partial<Record<Provider, SessionMode>> = {
   anthropic: "config",
   codex: "codex_config",
+  gemini: "gemini_config",
   pi: "pi_config",
 };
 
 const PROVIDER_LABELS: Record<Provider, string> = {
   anthropic: "Claude",
   codex: "Codex",
+  gemini: "Gemini",
   hermes: "Hermes",
   pi: "Pi",
 };
@@ -686,6 +699,8 @@ const MODE_HINTS: Record<SessionMode, string> = {
   codex_exec_gui: "Fallback GUI for legacy codex exec transport",
   codex_app_server: "GUI chat pane for codex app-server transport",
   codex_config: "codex login --device-auth · seeds KV for Codex",
+  gemini_gui: "GUI chat pane for Gemini transport",
+  gemini_config: "gemini login · seeds KV for Gemini",
   hermes_gui: "Shared Hermes memory + MCP tools",
   pi_cli: "Uses Tank Claude/Codex subscriptions",
   pi_config: "Pi /login sandbox",
@@ -732,6 +747,19 @@ const DEMO_BASE_SESSIONS: Session[] = [
     name: "Codex",
     repos: [],
     agent_avatar_id: demoAgentAvatarID(2),
+  },
+  {
+    id: "gemini-gui",
+    pod_name: "tank-demo-gemini-gui",
+    owner: "preview",
+    status: "Active",
+    mode: "gemini_gui",
+    requested_at: new Date(Date.now() - 25 * 60 * 1000 - 5 * 1000).toISOString(),
+    created_at: new Date(Date.now() - 25 * 60 * 1000).toISOString(),
+    ready_at: new Date(Date.now() - 24 * 60 * 1000).toISOString(),
+    name: "Gemini",
+    repos: [],
+    agent_avatar_id: demoAgentAvatarID(4),
   },
   {
     id: "pi-agent",
@@ -801,6 +829,22 @@ const DEMO_CODEX_LINES = [
   "\x1b[2m  gpt-5.5 default · /workspace\x1b[0m",
 ];
 
+const DEMO_GEMINI_LINES = [
+  "\x1b[34m ▐\x1b[40m▛███▜\x1b[49m▌\x1b[39m   \x1b[1mGemini CLI\x1b[22m \x1b[37mv0.44.1\x1b[39m",
+  "\x1b[34m▝▜\x1b[40m█████\x1b[49m▛▘\x1b[39m  \x1b[37mgemini-3.5-flash · Gemini Advanced\x1b[39m",
+  "\x1b[34m  ▘▘ ▝▝  \x1b[39m  \x1b[37m/workspace\x1b[39m",
+  "",
+  "  \x1b[1m\x1b[94mWelcome to Gemini 3.5 Flash!\x1b[22m\x1b[37m · Google GenAI coding agent\x1b[39m",
+  "",
+  "",
+  "",
+  "                                                                                  \x1b[37m◉ 3.5-flash\x1b[39m",
+  "\x1b[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────\x1b[39m",
+  "❯\u00a0\x1b[7m \x1b[27m",
+  "\x1b[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────\x1b[39m",
+  "  \x1b[95m⏵⏵ bypass permissions on\x1b[37m (shift+tab to cycle)\x1b[39m",
+];
+
 const DEMO_PI_LINES = [
   "Pi Coding Agent",
   "",
@@ -834,12 +878,14 @@ function demoTerminalLines(session: Session, promptText?: string): string[] {
       ? DEMO_HERMES_LINES
     : session.mode === "pi_cli"
       ? DEMO_PI_LINES
+    : session.mode === "gemini_gui"
+      ? DEMO_GEMINI_LINES
       : DEMO_CLAUDE_LINES;
   const lines = [...template];
   if (promptText) {
     if (session.mode === "codex_cli" || session.mode === "codex_gui" || session.mode === "codex_exec_gui" || session.mode === "codex_app_server") {
       lines[lines.length - 1] = `\x1b[1m›\x1b[0m ${promptText}`;
-    } else if (session.mode === "pi_cli" || session.mode === "hermes_gui") {
+    } else if (session.mode === "pi_cli" || session.mode === "hermes_gui" || session.mode === "gemini_gui") {
       lines[lines.length - 1] = `> ${promptText}`;
     } else {
       const promptIndex = lines.findIndex((line) => line.startsWith("❯"));
@@ -1116,9 +1162,9 @@ function moveSessionId(order: string[], movedId: string, targetId: string): stri
 // Modes whose pods carry harvestable credentials — the "save" button
 // surfaces on session rows in these modes. Kept as a Set so adding a third
 // future config mode doesn't grow an OR chain.
-const CONFIG_MODES = new Set<SessionMode>(["config", "codex_config"]);
-const CHAT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "hermes_gui"]);
-const SDK_CHAT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server"]);
+const CONFIG_MODES = new Set<SessionMode>(["config", "codex_config", "gemini_config"]);
+const CHAT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "hermes_gui", "gemini_gui"]);
+const SDK_CHAT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "gemini_gui"]);
 const CREATE_TIME_INITIAL_TURN_MODES = new Set<SessionMode>([...SDK_CHAT_MODES, "hermes_gui"]);
 const SDK_TIMELINE_TAIL_ROWS = 24;
 const SDK_TIMELINE_OLDER_ROWS = 8;
@@ -1126,7 +1172,7 @@ const SDK_TIMELINE_DEEPLINK_ROWS_BEFORE = 12;
 const SDK_TIMELINE_DEEPLINK_ROWS_AFTER = 12;
 const CLAUDE_ROLLOUT_MODES = new Set<SessionMode>(["claude_cli", "api_key"]);
 const CODEX_ROLLOUT_MODES = new Set<SessionMode>(["codex_cli"]);
-const GUI_ROLLOUT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "hermes_gui"]);
+const GUI_ROLLOUT_MODES = new Set<SessionMode>(["claude_gui", "codex_gui", "codex_exec_gui", "codex_app_server", "hermes_gui", "gemini_gui"]);
 const ROLLOUT_MODES = new Set<SessionMode>([
   ...CLAUDE_ROLLOUT_MODES,
   ...CODEX_ROLLOUT_MODES,
@@ -2218,6 +2264,7 @@ function DemoLanding() {
   const [demoClaudeEffortId, setDemoClaudeEffortId] = useState(DEFAULT_CLAUDE_EFFORT_ID);
   const [demoCodexModelId, setDemoCodexModelId] = useState(DEFAULT_CODEX_MODEL_ID);
   const [demoCodexEffortId, setDemoCodexEffortId] = useState(DEFAULT_CODEX_EFFORT_ID);
+  const [demoGeminiModelId, setDemoGeminiModelId] = useState(DEFAULT_GEMINI_MODEL_ID);
   const [demoSessionOrdinal, setDemoSessionOrdinal] = useState(DEMO_BASE_SESSIONS.length);
   const [demoPromptMessages, setDemoPromptMessages] = useState<Record<string, string>>({});
   const [demoComposerMode, setDemoComposerMode] = useState<RunComposerMode>("default");
@@ -2231,14 +2278,18 @@ function DemoLanding() {
       ? CLAUDE_MODELS
       : selectedProvider === "codex"
         ? CODEX_MODELS
-        : [];
+        : selectedProvider === "gemini"
+          ? GEMINI_MODELS
+          : [];
   const demoModelApplies = demoInteraction === "gui" && demoModelOptions.length > 0;
   const selectedDemoModelId =
     selectedProvider === "anthropic"
       ? demoClaudeModelId
       : selectedProvider === "codex"
         ? demoCodexModelId
-        : CODEX_ACCOUNT_DEFAULT_MODEL_ID;
+        : selectedProvider === "gemini"
+          ? demoGeminiModelId
+          : CODEX_ACCOUNT_DEFAULT_MODEL_ID;
   const terminalLines = selected
     ? demoTerminalLines(selected, demoPromptMessages[selected.id])
     : DEMO_LANDING_LINES;
@@ -2527,6 +2578,7 @@ function DemoLanding() {
                               onClick={() => {
                                 if (selectedProvider === "anthropic") setDemoClaudeModelId(model.id);
                                 if (selectedProvider === "codex") setDemoCodexModelId(model.id);
+                                if (selectedProvider === "gemini") setDemoGeminiModelId(model.id);
                               }}
                               aria-pressed={modelSelected}
                             >
@@ -2891,6 +2943,10 @@ function isClaudeRunMode(mode: SessionMode): boolean {
 
 function isCodexRunMode(mode: SessionMode): boolean {
   return mode === "codex_gui" || mode === "codex_app_server";
+}
+
+function isGeminiRunMode(mode: SessionMode): boolean {
+  return mode === "gemini_gui";
 }
 
 // (formerly: getRunToolGroupSummary — replaced by RunToolGroup's inline
@@ -3298,6 +3354,10 @@ const CODEX_MODELS: ModelOption[] = [
   { id: "gpt-5.3-codex-spark", label: "Codex · GPT-5.3 Codex Spark" },
   { id: CODEX_ACCOUNT_DEFAULT_MODEL_ID, label: "Codex · Account default" },
 ];
+const GEMINI_MODELS: ModelOption[] = [
+  { id: "gemini-3.5-flash", label: "Gemini · 3.5 Flash" },
+  { id: "gemini-3.1-pro", label: "Gemini · 3.1 Pro" },
+];
 
 // Extended-thinking effort levels exposed by the Claude Agent SDK
 // (EffortLevel union). The ids are the wire values; the labels carry
@@ -3328,12 +3388,14 @@ const CODEX_EFFORTS: EffortOption[] = [
 ];
 const DEFAULT_CODEX_MODEL_ID = "gpt-5.5";
 const DEFAULT_CODEX_EFFORT_ID = "xhigh";
+const DEFAULT_GEMINI_MODEL_ID = "gemini-3.5-flash";
 
 function modelOptionsForMode(mode: SessionMode): ModelOption[] {
   if (mode === "claude_gui") return CLAUDE_MODELS;
   if (mode === "codex_gui" || mode === "codex_exec_gui" || mode === "codex_app_server") {
     return CODEX_MODELS;
   }
+  if (mode === "gemini_gui") return GEMINI_MODELS;
   return [];
 }
 
@@ -3394,6 +3456,7 @@ interface RunPrefs {
   claudeEffort: string;
   codexModelId: string;
   codexEffort: string;
+  geminiModelId: string;
   initialMessageMode: InitialMessageMode;
 }
 
@@ -3412,6 +3475,7 @@ const DEFAULT_RUN_PREFS: RunPrefs = {
   claudeEffort: DEFAULT_CLAUDE_EFFORT_ID,
   codexModelId: DEFAULT_CODEX_MODEL_ID,
   codexEffort: DEFAULT_CODEX_EFFORT_ID,
+  geminiModelId: DEFAULT_GEMINI_MODEL_ID,
   initialMessageMode: DEFAULT_INITIAL_MESSAGE_MODE,
 };
 
@@ -3513,6 +3577,8 @@ function loadRunPrefs(): RunPrefs {
         out[key] = pickAllowedPrefId(raw, CODEX_MODELS, DEFAULT_CODEX_MODEL_ID);
       } else if (key === "codexEffort") {
         out[key] = pickAllowedPrefId(raw, CODEX_EFFORTS, DEFAULT_CODEX_EFFORT_ID);
+      } else if (key === "geminiModelId") {
+        out[key] = pickAllowedPrefId(raw, GEMINI_MODELS, DEFAULT_GEMINI_MODEL_ID);
       } else if (key === "initialMessageMode") {
         out[key] = pickInitialMessageMode(raw, DEFAULT_INITIAL_MESSAGE_MODE);
       } else if (raw === "true" || raw === "false") {
@@ -3555,6 +3621,10 @@ function mergeServerRunPrefs(prev: RunPrefs, server: Record<string, unknown>): R
     } else if (key === "codexEffort") {
       if (typeof raw === "string") {
         out[key] = pickAllowedPrefId(raw, CODEX_EFFORTS, prev.codexEffort);
+      }
+    } else if (key === "geminiModelId") {
+      if (typeof raw === "string") {
+        out[key] = pickAllowedPrefId(raw, GEMINI_MODELS, prev.geminiModelId);
       }
     } else if (key === "initialMessageMode") {
       if (typeof raw === "string") {
@@ -8618,6 +8688,7 @@ function ChatPane({
   const [composerMode, setComposerMode] = useState<RunComposerMode>("default");
   const isClaude = isClaudeRunMode(session.mode);
   const isCodex = isCodexRunMode(session.mode);
+  const isGemini = isGeminiRunMode(session.mode);
   const ready = session.mode === "hermes_gui"
     ? session.status === "Active"
     : sessionContainerAvailable(session);
@@ -8643,7 +8714,9 @@ function ChatPane({
     ? runPrefs.claudeModelId
     : isCodex
       ? runPrefs.codexModelId
-      : "";
+      : isGemini
+        ? runPrefs.geminiModelId
+        : "";
   const preferredEffortId = isClaude
     ? runPrefs.claudeEffort
     : isCodex
@@ -14806,14 +14879,18 @@ export function App() {
       ? CLAUDE_MODELS
       : selectedProvider === "codex"
         ? CODEX_MODELS
-        : [];
+        : selectedProvider === "gemini"
+          ? GEMINI_MODELS
+          : [];
   const homeModelApplies = defaultInteraction === "gui" && homeModelOptions.length > 0;
   const selectedHomeModelId =
     selectedProvider === "anthropic"
       ? runPrefs.claudeModelId
       : selectedProvider === "codex"
         ? runPrefs.codexModelId
-        : CODEX_ACCOUNT_DEFAULT_MODEL_ID;
+        : selectedProvider === "gemini"
+          ? runPrefs.geminiModelId
+          : CODEX_ACCOUNT_DEFAULT_MODEL_ID;
   const selectedHomeEffortId =
     selectedProvider === "anthropic"
       ? runPrefs.claudeEffort
@@ -15314,6 +15391,8 @@ export function App() {
                                   setRunPref("claudeModelId", model.id);
                                 } else if (selectedProvider === "codex") {
                                   setRunPref("codexModelId", model.id);
+                                } else if (selectedProvider === "gemini") {
+                                  setRunPref("geminiModelId", model.id);
                                 }
                               }}
                               aria-pressed={selected}

--- a/frontend/src/providerIcons.tsx
+++ b/frontend/src/providerIcons.tsx
@@ -1,5 +1,5 @@
 type ProviderIconProps = {
-  provider: "anthropic" | "codex" | "hermes" | "pi";
+  provider: "anthropic" | "codex" | "hermes" | "pi" | "gemini";
   className?: string;
 };
 
@@ -21,6 +21,11 @@ const ICONS: Record<
     viewBox: "0 0 24 24",
     fill: "hsl(187, 78%, 58%)",
     path: "M4 4h3.6v6.3h8.8V4H20v16h-3.6v-6.5H7.6V20H4V4Zm6.1 2.7h3.8v10.6h-3.8V6.7Z",
+  },
+  gemini: {
+    viewBox: "0 0 24 24",
+    fill: "hsl(217, 89%, 61%)",
+    path: "M12 2c0 5.522-4.478 10-10 10 5.522 0 10 4.478 10 10 0-5.522 4.478-10 10-10-5.522 0-10-4.478-10-10z",
   },
 };
 

--- a/frontend/src/repos.ts
+++ b/frontend/src/repos.ts
@@ -32,6 +32,7 @@ export const REPO_SUPPORTED_MODES: ReadonlySet<string> = new Set<string>([
   "claude_gui",
   "codex_gui",
   "codex_app_server",
+  "gemini_gui",
 ]);
 
 export function isValidRepoSlug(value: string): boolean {

--- a/frontend/src/sessionWorkspace.ts
+++ b/frontend/src/sessionWorkspace.ts
@@ -3,6 +3,7 @@ export const WORKSPACE_FILE_MODES: ReadonlySet<string> = new Set([
   "codex_gui",
   "codex_exec_gui",
   "codex_app_server",
+  "gemini_gui",
 ]);
 
 export interface SessionWorkspaceState {

--- a/gemini-runner/.gitignore
+++ b/gemini-runner/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/gemini-runner/package-lock.json
+++ b/gemini-runner/package-lock.json
@@ -1,0 +1,607 @@
+{
+  "name": "tank-gemini-runner",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tank-gemini-runner",
+      "version": "0.1.0",
+      "dependencies": {
+        "@google/genai": "^2.7.0",
+        "@nats-io/jetstream": "^3.4.0",
+        "@nats-io/transport-node": "^3.4.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.7.0.tgz",
+      "integrity": "sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nats-io/jetstream": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.4.0.tgz",
+      "integrity": "sha512-GzHQodNJ942+R5LRb8PuZ5ugVWVWMRiufxUYLLVWkXKfwDXYN+Owo0d7L/b9O7BPyrbYD7jQWAC6+ZVuXa9Gyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.4.0"
+      }
+    },
+    "node_modules/@nats-io/nats-core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.4.0.tgz",
+      "integrity": "sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "3.0.0"
+      }
+    },
+    "node_modules/@nats-io/nkeys": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nats-io/nkeys/-/nkeys-2.0.3.tgz",
+      "integrity": "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nats-io/nuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-3.0.0.tgz",
+      "integrity": "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 22.x"
+      }
+    },
+    "node_modules/@nats-io/transport-node": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/transport-node/-/transport-node-3.4.0.tgz",
+      "integrity": "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.4.0",
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "3.0.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/gemini-runner/package.json
+++ b/gemini-runner/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tank-gemini-runner",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Long-lived pod-side runner that drives @google/genai and publishes canonical events to the session bus.",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "start": "node dist/index.js",
+    "test": "node --test dist/**/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@google/genai": "^2.7.0",
+    "@nats-io/jetstream": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
+    "prom-client": "^15.1.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/gemini-runner/src/adapters/gemini.test.ts
+++ b/gemini-runner/src/adapters/gemini.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { GeminiTankEventAdapter } from "./gemini.js";
+
+describe("GeminiTankEventAdapter", () => {
+  const cfg = { sessionId: "session-123" } as any;
+  const adapter = new GeminiTankEventAdapter(cfg);
+  const turn = { turnID: "turn-456", clientNonce: "nonce-789" };
+
+  it("should create turn.started event", () => {
+    const event = adapter.turnStarted(turn);
+    assert.strictEqual(event.type, "turn.started");
+    assert.strictEqual(event.session_id, "session-123");
+    assert.strictEqual(event.turn_id, "turn-456");
+    assert.strictEqual(event.client_nonce, "nonce-789");
+  });
+
+  it("should create turn.completed event", () => {
+    const event = adapter.turnCompleted(turn, { timelineIDs: ["t1"], providerItemIDs: ["p1"] });
+    assert.strictEqual(event.type, "turn.completed");
+    assert.deepStrictEqual(event.payload?.final_answer, { timeline_ids: ["t1"], provider_item_ids: ["p1"] });
+  });
+
+  it("should create item.completed message event", () => {
+    const event = adapter.messageCompleted(turn, "p1", "hello world");
+    assert.strictEqual(event.type, "item.completed");
+    assert.strictEqual(event.actor, "assistant");
+    assert.deepStrictEqual(event.payload, { kind: "message", text: "hello world" });
+  });
+});

--- a/gemini-runner/src/adapters/gemini.ts
+++ b/gemini-runner/src/adapters/gemini.ts
@@ -1,0 +1,145 @@
+import type { Config } from "../config.js";
+import type { TankConversationEvent } from "../../../runner-shared/conversation.js";
+import { itemEvent, turnEvent } from "../../../runner-shared/conversation-builders.js";
+
+export interface GeminiAdapterTurn {
+  turnID: string;
+  clientNonce: string;
+}
+
+export class GeminiTankEventAdapter {
+  constructor(private readonly cfg: Config) {}
+
+  turnStarted(turn: GeminiAdapterTurn): TankConversationEvent {
+    return turnEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      clientNonce: turn.clientNonce,
+      source: "gemini",
+      type: "turn.started",
+    });
+  }
+
+  turnCompleted(
+    turn: GeminiAdapterTurn,
+    finalAnswer?: { timelineIDs: string[]; providerItemIDs: string[] }
+  ): TankConversationEvent {
+    return turnEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      clientNonce: turn.clientNonce,
+      source: "gemini",
+      type: "turn.completed",
+      finalAnswer,
+    });
+  }
+
+  turnFailed(turn: GeminiAdapterTurn, error: string): TankConversationEvent {
+    return turnEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      clientNonce: turn.clientNonce,
+      source: "gemini",
+      type: "turn.failed",
+      reason: "provider_failure",
+      error,
+    });
+  }
+
+  turnInterrupted(turn: GeminiAdapterTurn): TankConversationEvent {
+    return turnEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      clientNonce: turn.clientNonce,
+      source: "gemini",
+      type: "turn.interrupted",
+      reason: "client_interrupt",
+    });
+  }
+
+  messageCompleted(
+    turn: GeminiAdapterTurn,
+    providerItemID: string,
+    text: string
+  ): TankConversationEvent {
+    return itemEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      source: "gemini",
+      type: "item.completed",
+      providerItemID,
+      actor: "assistant",
+      payload: { kind: "message", text },
+    });
+  }
+
+  toolStarted(
+    turn: GeminiAdapterTurn,
+    providerItemID: string,
+    name: string,
+    input: any
+  ): TankConversationEvent {
+    return itemEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      source: "gemini",
+      type: "item.started",
+      providerItemID,
+      actor: "tool",
+      payload: {
+        kind: "tool",
+        title: name,
+        name,
+        input,
+      },
+    });
+  }
+
+  toolCompleted(
+    turn: GeminiAdapterTurn,
+    providerItemID: string,
+    name: string,
+    input: any,
+    result: any
+  ): TankConversationEvent {
+    return itemEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      source: "gemini",
+      type: "item.completed",
+      providerItemID,
+      actor: "tool",
+      payload: {
+        kind: "tool",
+        title: name,
+        name,
+        input,
+        result,
+      },
+    });
+  }
+
+  toolFailed(
+    turn: GeminiAdapterTurn,
+    providerItemID: string,
+    name: string,
+    input: any,
+    error: string
+  ): TankConversationEvent {
+    return itemEvent({
+      sessionID: this.cfg.sessionId,
+      turnID: turn.turnID,
+      source: "gemini",
+      type: "item.failed",
+      providerItemID,
+      actor: "tool",
+      payload: {
+        kind: "tool",
+        title: name,
+        name,
+        input,
+        error,
+      },
+    });
+  }
+}

--- a/gemini-runner/src/config.ts
+++ b/gemini-runner/src/config.ts
@@ -1,0 +1,42 @@
+// Runtime config sourced from env vars. SESSION_ID + POD_OWNER_EMAIL come
+// from the downward API on the pod spec. TANK_SESSION_STORAGE_KEY is the
+// scoped event ledger partition key. NATS_* points at the JetStream session
+// bus; the backend owns Postgres writes after it persists bus events.
+
+export interface Config {
+  sessionId: string;
+  sessionStorageKey: string;
+  ownerEmail: string;
+  natsURL: string;
+  natsToken: string;
+  natsStream: string;
+  operatorInternalURL: string;
+  operatorTokenPath: string;
+  workspace: string;
+  mcpConfig: string;
+}
+
+export function loadConfig(): Config {
+  const sessionId = (process.env.SESSION_ID ?? "").trim();
+  if (!sessionId) {
+    throw new Error(
+      "SESSION_ID is required (set from downward API: metadata.labels['tank-operator/session-id'])",
+    );
+  }
+  const natsURL = (process.env.NATS_URL ?? "").trim();
+  if (!natsURL) {
+    throw new Error("NATS_URL is required");
+  }
+  return {
+    sessionId,
+    sessionStorageKey: process.env.TANK_SESSION_STORAGE_KEY?.trim() || sessionId,
+    ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
+    natsURL,
+    natsToken: process.env.NATS_TOKEN?.trim() || "",
+    natsStream: process.env.NATS_STREAM?.trim() || "TANK_SESSION_BUS",
+    operatorInternalURL: process.env.TANK_OPERATOR_INTERNAL_URL?.trim() || "",
+    operatorTokenPath: process.env.TANK_OPERATOR_TOKEN_PATH?.trim() || "",
+    workspace: process.env.WORKSPACE?.trim() || "/workspace",
+    mcpConfig: process.env.MCP_CONFIG?.trim() || "/workspace/.mcp.json",
+  };
+}

--- a/gemini-runner/src/index.ts
+++ b/gemini-runner/src/index.ts
@@ -1,0 +1,54 @@
+import { loadConfig } from "./config.js";
+import { startMetricsServer } from "./metrics.js";
+import { Runner } from "./runner.js";
+
+const DEFAULT_METRICS_PORT = 9097; // Matches sessionmodel.GeminiRunnerMetricsPort
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  console.log(
+    JSON.stringify({
+      msg: "gemini-runner starting",
+      session_id: cfg.sessionId,
+      owner_email: cfg.ownerEmail,
+      nats_url: cfg.natsURL,
+      nats_stream: cfg.natsStream,
+      workspace: cfg.workspace,
+    }),
+  );
+
+  const metricsPort = parseMetricsPort(process.env.TANK_RUNNER_METRICS_PORT);
+  const metricsServer = startMetricsServer(metricsPort);
+  console.log(JSON.stringify({ msg: "metrics listening", port: metricsPort }));
+
+  const ctrl = new AbortController();
+  const shutdown = (sig: NodeJS.Signals) => {
+    console.log(JSON.stringify({ msg: "shutdown", signal: sig }));
+    ctrl.abort();
+    metricsServer.close();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  const runner = new Runner(cfg);
+  try {
+    await runner.run(ctrl.signal);
+  } finally {
+    metricsServer.close();
+  }
+}
+
+function parseMetricsPort(raw: string | undefined): number {
+  const trimmed = raw?.trim() ?? "";
+  if (trimmed === "") return DEFAULT_METRICS_PORT;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) {
+    throw new Error(`TANK_RUNNER_METRICS_PORT is not a valid port: ${raw}`);
+  }
+  return Math.trunc(n);
+}
+
+main().catch((err) => {
+  console.error("gemini-runner exited with error:", err);
+  process.exit(1);
+});

--- a/gemini-runner/src/metrics.ts
+++ b/gemini-runner/src/metrics.ts
@@ -1,0 +1,106 @@
+import { Counter, Gauge, Registry, collectDefaultMetrics } from "prom-client";
+import { createServer, type Server } from "node:http";
+
+const RUNNER_MODE = "gemini";
+
+export const registry = new Registry();
+registry.setDefaultLabels({ mode: RUNNER_MODE });
+collectDefaultMetrics({ register: registry });
+
+export const commandsConsumedTotal = new Counter({
+  name: "tank_runner_commands_consumed_total",
+  help: "Session commands consumed from the JetStream command subject.",
+  labelNames: ["kind", "result"],
+  registers: [registry],
+});
+
+export const turnDurationSeconds = new Counter({
+  name: "tank_runner_turn_duration_seconds",
+  help: "Cumulative duration of turns (mocked or completed).",
+  labelNames: ["outcome"],
+  registers: [registry],
+});
+
+export const providerErrorTotal = new Counter({
+  name: "tank_runner_provider_error_total",
+  help: "Errors raised by the provider SDK.",
+  labelNames: ["kind"],
+  registers: [registry],
+});
+
+export const natsPublishFailureTotal = new Counter({
+  name: "tank_runner_nats_publish_failure_total",
+  help: "Publish attempts to the JetStream session bus that returned an error.",
+  registers: [registry],
+});
+
+export const eventTruncatedTotal = new Counter({
+  name: "tank_runner_event_truncated_total",
+  help: "Tank conversation events that exceeded the transport budget and were truncated before publish.",
+  labelNames: ["event_type", "severity"],
+  registers: [registry],
+});
+
+export const optionsPinnedTotal = new Counter({
+  name: "tank_runner_options_pinned_total",
+  help: "Model and effort that the runner pinned into SDK Options at first turn.",
+  labelNames: ["model", "effort"],
+  registers: [registry],
+});
+
+export const optionsOverrideIgnoredTotal = new Counter({
+  name: "tank_runner_options_override_ignored_total",
+  help: "Submit_turn commands whose model/effort differed from the pinned options.",
+  labelNames: ["field"],
+  registers: [registry],
+});
+
+const turnStartTimes = new Map<string, number>();
+
+export function recordTurnStart(turnID: string): void {
+  if (!turnID) return;
+  turnStartTimes.set(turnID, Date.now());
+}
+
+export function recordTurnTerminal(
+  turnID: string,
+  outcome: "completed" | "failed" | "interrupted",
+): void {
+  if (!turnID) return;
+  const start = turnStartTimes.get(turnID);
+  if (start === undefined) return;
+  turnStartTimes.delete(turnID);
+}
+
+export function startMetricsServer(port: number): Server {
+  const server = createServer((req, res) => {
+    if (!req.url) {
+      res.statusCode = 400;
+      res.end();
+      return;
+    }
+    if (req.url === "/metrics" || req.url.startsWith("/metrics?")) {
+      registry
+        .metrics()
+        .then((body) => {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", registry.contentType);
+          res.end(body);
+        })
+        .catch((err: unknown) => {
+          res.statusCode = 500;
+          res.end(`metrics collection failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      return;
+    }
+    if (req.url === "/healthz") {
+      res.statusCode = 200;
+      res.end("ok");
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  server.listen(port);
+  return server;
+}

--- a/gemini-runner/src/runner.ts
+++ b/gemini-runner/src/runner.ts
@@ -1,0 +1,403 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import { exec } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+
+
+import type { Config } from "./config.js";
+import { SessionEventSink } from "./sessionEvents.js";
+import {
+  SessionCommandBus,
+  commandClientNonce,
+  type SessionCommandRecord,
+} from "./sessionCommands.js";
+import { GeminiTankEventAdapter } from "./adapters/gemini.js";
+import {
+  commandsConsumedTotal,
+  providerErrorTotal,
+  recordTurnStart,
+  recordTurnTerminal,
+} from "./metrics.js";
+
+class AsyncQueue<T> {
+  private readonly items: T[] = [];
+  private waiters: ((v: IteratorResult<T>) => void)[] = [];
+  private closed = false;
+
+  push(v: T): void {
+    const w = this.waiters.shift();
+    if (w) w({ value: v, done: false });
+    else this.items.push(v);
+  }
+
+  async next(): Promise<IteratorResult<T>> {
+    if (this.items.length > 0) {
+      return { value: this.items.shift()!, done: false };
+    }
+    if (this.closed) {
+      return { value: undefined as unknown as T, done: true };
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const w of this.waiters) {
+      w({ value: undefined as unknown as T, done: true });
+    }
+    this.waiters = [];
+  }
+}
+
+export class Runner {
+  private readonly sink: SessionEventSink;
+  private readonly commandBus: SessionCommandBus;
+  private readonly userQueue = new AsyncQueue<{
+    text: string;
+    clientNonce?: string;
+    commandRecord?: SessionCommandRecord;
+  }>();
+  private readonly adapter: GeminiTankEventAdapter;
+  private readonly ai: GoogleGenAI;
+  private chat: any = null;
+  private currentAbort: AbortController | null = null;
+  private turnSeq = 0;
+
+  constructor(private readonly cfg: Config) {
+    this.sink = new SessionEventSink(cfg);
+    this.commandBus = new SessionCommandBus(cfg);
+    this.adapter = new GeminiTankEventAdapter(cfg);
+
+    // Initialize the Google GenAI client.
+    // Outgoing requests carry the Authorization header which Envoy intercepts.
+    this.ai = new GoogleGenAI({
+      apiKey: "managed-by-tank-operator",
+      httpOptions: {
+        headers: {
+          "Authorization": "Bearer managed-by-tank-operator",
+        },
+      },
+    });
+  }
+
+  async run(signal: AbortSignal): Promise<void> {
+    const stopConsumer = this.startCommandConsumer(signal);
+    const stopControl = this.startControlConsumer(signal);
+
+    const onAbort = () => {
+      this.userQueue.close();
+      this.currentAbort?.abort();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    try {
+      while (!signal.aborted) {
+        const next = await this.userQueue.next();
+        if (next.done) break;
+
+        const { text: input, clientNonce, commandRecord } = next.value;
+        const turnSeq = ++this.turnSeq;
+        const clientNonceStr = clientNonce ?? `gen-${randomUUID()}`;
+        const turnID = `turn-${turnSeq}`;
+        const turn = { turnID, clientNonce: clientNonceStr };
+
+        recordTurnStart(turnID);
+
+        // Emit turn.started
+        await this.sink.upsert(this.adapter.turnStarted(turn) as any);
+
+        this.currentAbort = new AbortController();
+        const turnSignal = this.currentAbort.signal;
+
+        try {
+          // Initialize chat on first turn
+          if (!this.chat) {
+            const model = commandRecord?.model || "gemini-3.5-flash";
+            this.chat = this.ai.chats.create({
+              model: model,
+              config: {
+                tools: [
+                  {
+                    functionDeclarations: [
+                      {
+                        name: "execute_bash",
+                        description: "Execute a bash command in the workspace directory",
+                        parameters: {
+                          type: Type.OBJECT,
+                          properties: {
+                            command: { type: Type.STRING, description: "The command to run" },
+                          },
+                          required: ["command"],
+                        },
+                      },
+                      {
+                        name: "read_file",
+                        description: "Read the contents of a file from the workspace",
+                        parameters: {
+                          type: Type.OBJECT,
+                          properties: {
+                            path: { type: Type.STRING, description: "Path to the file relative to the workspace" },
+                          },
+                          required: ["path"],
+                        },
+                      },
+                      {
+                        name: "write_file",
+                        description: "Write content to a file in the workspace",
+                        parameters: {
+                          type: Type.OBJECT,
+                          properties: {
+                            path: { type: Type.STRING, description: "Path to the file relative to the workspace" },
+                            content: { type: Type.STRING, description: "The content to write" },
+                          },
+                          required: ["path", "content"],
+                        },
+                      },
+                      {
+                        name: "list_dir",
+                        description: "List the contents of a directory in the workspace",
+                        parameters: {
+                          type: Type.OBJECT,
+                          properties: {
+                            path: { type: Type.STRING, description: "Path to the directory relative to the workspace" },
+                          },
+                          required: ["path"],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            });
+          }
+
+          let response = await this.chat.sendMessage({ message: input });
+
+          // ReAct loop
+          while (response.functionCalls && response.functionCalls.length > 0 && !turnSignal.aborted) {
+            const parts: any[] = [];
+
+            for (const call of response.functionCalls) {
+              if (turnSignal.aborted) break;
+
+              const toolItemID = `tool-${randomUUID()}`;
+              await this.sink.upsert(
+                this.adapter.toolStarted(turn, toolItemID, call.name, call.args) as any
+              );
+
+              try {
+                const result = await this.executeTool(call.name, call.args, turnSignal);
+                await this.sink.upsert(
+                  this.adapter.toolCompleted(turn, toolItemID, call.name, call.args, result) as any
+                );
+
+                parts.push({
+                  functionResponse: {
+                    name: call.name,
+                    response: { result },
+                  },
+                });
+              } catch (err: any) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                await this.sink.upsert(
+                  this.adapter.toolFailed(turn, toolItemID, call.name, call.args, errMsg) as any
+                );
+
+                parts.push({
+                  functionResponse: {
+                    name: call.name,
+                    response: { error: errMsg },
+                  },
+                });
+              }
+            }
+
+            if (parts.length > 0 && !turnSignal.aborted) {
+              response = await this.chat.sendMessage({ parts });
+            } else {
+              break;
+            }
+          }
+
+          if (turnSignal.aborted) {
+            throw new Error("Turn was aborted/interrupted");
+          }
+
+          const assistantText = response.text || "";
+          const assistantItemID = `msg-${randomUUID()}`;
+          await this.sink.upsert(
+            this.adapter.messageCompleted(turn, assistantItemID, assistantText) as any
+          );
+
+          // Emit turn.completed
+          await this.sink.upsert(
+            this.adapter.turnCompleted(turn, {
+              timelineIDs: [assistantItemID],
+              providerItemIDs: [assistantItemID],
+            }) as any
+          );
+
+          if (commandRecord) {
+            await this.commandBus.markCompleted(commandRecord);
+          }
+          recordTurnTerminal(turnID, "completed");
+
+        } catch (err: any) {
+          providerErrorTotal.labels("query").inc();
+          const errMessage = err instanceof Error ? err.message : String(err);
+
+          if (turnSignal.aborted) {
+            await this.sink.upsert(this.adapter.turnInterrupted(turn) as any);
+            if (commandRecord) {
+              await this.commandBus.markCompleted(commandRecord);
+            }
+            recordTurnTerminal(turnID, "interrupted");
+          } else {
+            await this.sink.upsert(this.adapter.turnFailed(turn, errMessage) as any);
+            if (commandRecord) {
+              await this.commandBus.markFailed(commandRecord, err);
+            }
+            recordTurnTerminal(turnID, "failed");
+          }
+          console.error("Gemini turn failed:", err);
+        } finally {
+          this.currentAbort = null;
+        }
+      }
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+      stopConsumer();
+      stopControl();
+      this.userQueue.close();
+    }
+  }
+
+  private async executeTool(name: string, args: any, signal: AbortSignal): Promise<any> {
+    if (signal.aborted) throw new Error("Aborted");
+
+    const getAbsPath = (relPath: string) => {
+      const normalized = path.normalize(relPath);
+      if (path.isAbsolute(normalized)) {
+        if (normalized.startsWith(this.cfg.workspace)) {
+          return normalized;
+        }
+        throw new Error("Access outside workspace is denied");
+      }
+      const resolved = path.resolve(this.cfg.workspace, normalized);
+      if (resolved.startsWith(this.cfg.workspace)) {
+        return resolved;
+      }
+      throw new Error("Access outside workspace is denied");
+    };
+
+    switch (name) {
+      case "execute_bash": {
+        const cmd = String(args.command ?? "");
+        return new Promise((resolve, reject) => {
+          const process = exec(
+            cmd,
+            { cwd: this.cfg.workspace },
+            (error, stdout, stderr) => {
+              if (error) {
+                resolve({
+                  exitCode: error.code || 1,
+                  stdout: stdout,
+                  stderr: stderr || error.message,
+                });
+              } else {
+                resolve({
+                  exitCode: 0,
+                  stdout,
+                  stderr,
+                });
+              }
+            }
+          );
+          signal.addEventListener("abort", () => {
+            process.kill();
+            reject(new Error("Bash process killed via abort"));
+          });
+        });
+      }
+
+      case "read_file": {
+        const absPath = getAbsPath(String(args.path ?? ""));
+        const content = await fs.readFile(absPath, "utf-8");
+        return { content };
+      }
+
+      case "write_file": {
+        const absPath = getAbsPath(String(args.path ?? ""));
+        await fs.mkdir(path.dirname(absPath), { recursive: true });
+        await fs.writeFile(absPath, String(args.content ?? ""), "utf-8");
+        return { success: true };
+      }
+
+      case "list_dir": {
+        const absPath = getAbsPath(String(args.path ?? "."));
+        const entries = await fs.readdir(absPath, { withFileTypes: true });
+        const list = entries.map((entry) => ({
+          name: entry.name,
+          isDirectory: entry.isDirectory(),
+          isFile: entry.isFile(),
+        }));
+        return { list };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  private startCommandConsumer(signal: AbortSignal): () => void {
+    let stopConsumer: (() => Promise<void>) | null = null;
+    void this.commandBus
+      .startCommandConsumer(async (record) => {
+        commandsConsumedTotal.labels("submit_turn", "accepted").inc();
+        const clientNonce = commandClientNonce(record);
+        const prompt = String(record.prompt ?? "").trim();
+        if (!prompt) {
+          commandsConsumedTotal.labels("submit_turn", "invalid").inc();
+          await this.commandBus.markFailed(record, new Error("submit command missing prompt"));
+          return;
+        }
+        this.userQueue.push({
+          text: prompt,
+          clientNonce,
+          commandRecord: record,
+        });
+      }, signal)
+      .then((stop) => {
+        stopConsumer = stop;
+      })
+      .catch((err) => console.error("Gemini command consumer crashed:", err));
+
+    return () => {
+      void stopConsumer?.();
+    };
+  }
+
+  private startControlConsumer(signal: AbortSignal): () => void {
+    // Listen for interrupts or control signals (like stop_turn / interrupt_turn)
+    // and abort the active turn execution
+    let stopControl: (() => Promise<void>) | null = null;
+    void this.commandBus
+      .startControlConsumer(async (record) => {
+        if (record.command === "interrupt_turn") {
+          commandsConsumedTotal.labels("interrupt_turn", "accepted").inc();
+          console.log("Interrupt command received, aborting active turn");
+          this.currentAbort?.abort();
+          await this.commandBus.markCompleted(record);
+        }
+      }, signal)
+      .then((stop) => {
+        stopControl = stop;
+      })
+      .catch((err) => console.error("Gemini control consumer crashed:", err));
+
+    return () => {
+      void stopControl?.();
+    };
+  }
+}

--- a/gemini-runner/src/sessionBus.ts
+++ b/gemini-runner/src/sessionBus.ts
@@ -1,0 +1,29 @@
+import { connect, nanos } from "@nats-io/transport-node";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  ReplayPolicy,
+  jetstream,
+  jetstreamManager,
+} from "@nats-io/jetstream";
+
+import {
+  SharedSessionBus,
+  type SessionBusConfig,
+} from "../../runner-shared/sessionBus.js";
+
+export * from "../../runner-shared/sessionBus.js";
+
+export class SessionBus extends SharedSessionBus {
+  constructor(cfg: SessionBusConfig) {
+    super(cfg, "gemini", {
+      connect,
+      jetstream,
+      jetstreamManager,
+      AckPolicy,
+      DeliverPolicy,
+      ReplayPolicy,
+      nanos,
+    });
+  }
+}

--- a/gemini-runner/src/sessionCommands.ts
+++ b/gemini-runner/src/sessionCommands.ts
@@ -1,0 +1,24 @@
+import {
+  SessionBus,
+  commandClientNonce,
+  isInputReplyCommand,
+  isInterruptCommand,
+  isStopBackgroundTaskCommand,
+  type SessionBusConfig,
+  type SessionCommandRecord,
+} from "./sessionBus.js";
+
+export type { SessionCommandRecord };
+export type SessionCommandBusConfig = SessionBusConfig;
+
+export { commandClientNonce, isInputReplyCommand, isInterruptCommand, isStopBackgroundTaskCommand };
+
+export class SessionCommandBus extends SessionBus {
+  constructor(cfg: SessionCommandBusConfig) {
+    super(cfg);
+  }
+
+  startCommandHeartbeat(record: SessionCommandRecord): () => void {
+    return this.startWorkHeartbeat(record);
+  }
+}

--- a/gemini-runner/src/sessionEvents.ts
+++ b/gemini-runner/src/sessionEvents.ts
@@ -1,0 +1,29 @@
+// Tank-event sink for the Gemini runner. Wraps the JetStream session bus and
+// publishes durable Tank conversation events.
+
+import type { Config } from "./config.js";
+import type { TankConversationEvent } from "../../runner-shared/conversation.js";
+import { SessionBus } from "./sessionBus.js";
+
+export type StampedTankEvent = TankConversationEvent & {
+  uuid: string;
+  order_key: string;
+  sequence: number;
+  written_at: string;
+};
+
+export class SessionEventSink {
+  private readonly bus: SessionBus;
+
+  constructor(cfg: Config) {
+    this.bus = new SessionBus(cfg);
+  }
+
+  async upsert(message: StampedTankEvent): Promise<void> {
+    await this.bus.publishEvent(message);
+  }
+
+  async findTurnTerminal(turnID: string): Promise<TankConversationEvent | null> {
+    return (await this.bus.findTurnTerminal(turnID)) as TankConversationEvent | null;
+  }
+}

--- a/gemini-runner/tsconfig.json
+++ b/gemini-runner/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/k8s/session-config/gemini-runner-launch.sh
+++ b/k8s/session-config/gemini-runner-launch.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Pod-side launch shim for the gemini-runner Node service. Sibling of
+# agent-runner-launch.sh and codex-runner-launch.sh.
+#
+# Gemini auth path: write a synthetic settings.json whose access and refresh
+# tokens are the managed-by-tank-operator placeholders. The in-cluster
+# gemini-api-proxy hostAlias swaps that placeholder for the current real
+# Google OAuth token and centrally owns refresh/write-back.
+
+set -eu
+
+configure_gemini() {
+  mkdir -p "$HOME/.gemini"
+
+  cat > "$HOME/.gemini/settings.json" <<EOF
+{
+  "access_token": "managed-by-tank-operator",
+  "refresh_token": "managed-by-tank-operator",
+  "expiry_date": 9999999999000
+}
+EOF
+  chmod 600 "$HOME/.gemini/settings.json"
+}
+
+# Git identity for any commits the agent makes from /workspace.
+git config --global user.name "tank-operator-gemini[bot]"
+git config --global user.email "tank-operator-gemini@romaine.life"
+
+configure_gemini
+
+# Materialize Tank-provided policy docs into /workspace.
+if [ -f /opt/tank/session-config/install-tank-docs.sh ]; then
+  sh /opt/tank/session-config/install-tank-docs.sh || true
+fi
+
+# Optional: install tank-flavored skills.
+if [ -f /opt/tank/session-config/install-tank-skills.sh ]; then
+  sh /opt/tank/session-config/install-tank-skills.sh || true
+fi
+
+# Hand off to the runner.
+exec node /opt/gemini-runner/dist/index.js

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -105,6 +105,10 @@ claude-code-credentials
 {{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "codex-api-proxy.%s.svc.cluster.local" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.codexApiProxy.serviceHost }}{{- end -}}
 {{- end -}}
 
+{{- define "tank-operator.geminiApiProxyHost" -}}
+{{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "gemini-api-proxy.%s.svc.cluster.local" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.geminiApiProxy.serviceHost }}{{- end -}}
+{{- end -}}
+
 
 {{- define "tank-operator.githubAppSecret" -}}
 {{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-github-app-creds" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.externalSecret.githubApp.secretName }}{{- end -}}
@@ -112,6 +116,10 @@ claude-code-credentials
 
 {{- define "tank-operator.codexCredentialsSecret" -}}
 {{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-codex-credentials" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.externalSecret.codexCredentials.secretName }}{{- end -}}
+{{- end -}}
+
+{{- define "tank-operator.geminiCredentialsSecret" -}}
+{{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-gemini-credentials" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.externalSecret.geminiCredentials.secretName }}{{- end -}}
 {{- end -}}
 
 {{- define "tank-operator.claudeCredentialsSecret" -}}

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -616,3 +616,291 @@ spec:
             secretName: {{ include "tank-operator.codexCredentialsSecret" . }}
             optional: true
 {{- end }}
+---
+{{- if eq (include "tank-operator.renderWarm" .) "true" }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gemini-api-proxy-leaf
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+spec:
+  secretName: gemini-api-proxy-leaf
+  duration: 2160h
+  renewBefore: 360h
+  dnsNames:
+    - generativelanguage.googleapis.com
+  issuerRef:
+    name: claude-oauth-ca-issuer
+    kind: Issuer
+{{- end }}
+---
+{{- if eq (include "tank-operator.renderHot" .) "true" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: gemini-api-proxy
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: gemini-api-proxy
+spec:
+  selector:
+    app.kubernetes.io/name: gemini-api-proxy
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+    - name: metrics
+      port: 9100
+      targetPort: metrics
+{{- end }}
+---
+{{- if eq (include "tank-operator.renderWarm" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gemini-api-proxy-envoy
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address: { address: 127.0.0.1, port_value: 9901 }
+    static_resources:
+      listeners:
+        - name: api_listener
+          address:
+            socket_address: { address: 0.0.0.0, port_value: 8443 }
+          per_connection_buffer_limit_bytes: 1048576
+          filter_chains:
+            - transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    tls_certificates:
+                      - certificate_chain: { filename: /etc/envoy/tls/tls.crt }
+                        private_key:       { filename: /etc/envoy/tls/tls.key }
+              filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: gemini_api_proxy
+                    codec_type: AUTO
+                    stream_idle_timeout: 600s
+                    request_timeout: 600s
+                    access_log:
+                      - name: envoy.access_loggers.stdout
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                          log_format:
+                            text_format_source:
+                              inline_string: "[%START_TIME%] %REQ(:METHOD)% %REQ(:PATH)% -> %RESPONSE_CODE% %RESPONSE_FLAGS% rx=%BYTES_RECEIVED% tx=%BYTES_SENT% dur_ms=%DURATION% req_id=%REQ(x-request-id)% retry=%REQ(x-envoy-attempt-count)%\n"
+                    common_http_protocol_options:
+                      idle_timeout: 600s
+                    http_filters:
+                      - name: envoy.filters.http.ext_proc
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                          grpc_service:
+                            envoy_grpc:
+                              cluster_name: ext_proc_local
+                            timeout: 5s
+                          failure_mode_allow: false
+                          processing_mode:
+                            request_header_mode: SEND
+                            response_header_mode: SEND
+                            request_body_mode: NONE
+                            response_body_mode: NONE
+                            request_trailer_mode: SKIP
+                            response_trailer_mode: SKIP
+                          message_timeout: 5s
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    route_config:
+                      name: gemini
+                      virtual_hosts:
+                        - name: gemini
+                          domains: ["*"]
+                          routes:
+                            - match: { prefix: "/" }
+                              route:
+                                cluster: gemini_api
+                                timeout: 600s
+                                retry_policy:
+                                  retry_on: "retriable-status-codes"
+                                  retriable_status_codes: [401]
+                                  num_retries: 1
+                                  per_try_timeout: 600s
+                                auto_host_rewrite: true
+      clusters:
+        - name: gemini_api
+          type: LOGICAL_DNS
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          load_assignment:
+            cluster_name: gemini_api
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: generativelanguage.googleapis.com
+                          port_value: 443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: generativelanguage.googleapis.com
+              common_tls_context:
+                validation_context:
+                  trusted_ca:
+                    filename: /etc/ssl/certs/ca-certificates.crt
+        - name: ext_proc_local
+          type: STATIC
+          connect_timeout: 1s
+          lb_policy: ROUND_ROBIN
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          load_assignment:
+            cluster_name: ext_proc_local
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 9000
+{{- end }}
+---
+{{- if eq (include "tank-operator.renderWarm" .) "true" }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gemini-api-proxy-config
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.externalSecret.storeName }}
+    kind: {{ .Values.externalSecret.storeKind }}
+  target:
+    name: gemini-api-proxy-config
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: GEMINI_CLIENT_ID
+      remoteRef:
+        key: gemini-client-id
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+    - secretKey: GEMINI_CLIENT_SECRET
+      remoteRef:
+        key: gemini-client-secret
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+{{- end }}
+---
+{{- if eq (include "tank-operator.renderHot" .) "true" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gemini-api-proxy
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+  labels:
+    app.kubernetes.io/name: gemini-api-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gemini-api-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gemini-api-proxy
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: {{ .Values.apiProxy.serviceAccount }}
+      containers:
+        - name: envoy
+          image: {{ .Values.apiProxy.envoyImage | quote }}
+          args:
+            - "-c"
+            - "/etc/envoy/envoy.yaml"
+            - "--service-cluster"
+            - "gemini-api-proxy"
+          ports:
+            - name: https
+              containerPort: 8443
+            - name: admin
+              containerPort: 9901
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+              readOnly: true
+            - name: leaf-tls
+              mountPath: /etc/envoy/tls
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 3
+            periodSeconds: 10
+        - name: ext-proc
+          image: "{{ .Values.apiProxy.image.repository }}:{{ .Values.apiProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.apiProxy.image.pullPolicy }}
+          ports:
+            - name: grpc
+              containerPort: 9000
+            - name: metrics
+              containerPort: 9100
+          env:
+            - name: PROXY_PROVIDER
+              value: gemini
+            - name: METRICS_PORT
+              value: "9100"
+            - name: GEMINI_CREDENTIALS_FILE
+              value: /etc/gemini-credentials/{{ .Values.externalSecret.geminiCredentials.secretKey }}
+            - name: AZURE_KEYVAULT_URL
+              value: {{ .Values.credentialRefresher.keyVaultUrl | quote }}
+            - name: GEMINI_CREDENTIALS_KV_KEY
+              value: {{ .Values.externalSecret.geminiCredentials.kvKey | quote }}
+            - name: AZURE_FEDERATED_TOKEN_FILE
+              value: /var/run/secrets/azure/tokens/azure-identity-token
+            - name: AZURE_AUTHORITY_HOST
+              value: https://login.microsoftonline.com/
+          envFrom:
+            - secretRef:
+                name: gemini-api-proxy-config
+            - secretRef:
+                name: {{ include "tank-operator.apiProxyConfigSecret" . }}
+          volumeMounts:
+            - name: gemini-credentials
+              mountPath: /etc/gemini-credentials
+              readOnly: true
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: gemini-api-proxy-envoy
+        - name: leaf-tls
+          secret:
+            secretName: gemini-api-proxy-leaf
+            optional: true
+        - name: gemini-credentials
+          secret:
+            secretName: {{ include "tank-operator.geminiCredentialsSecret" . }}
+            optional: true
+{{- end }}

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
               value: {{ include "tank-operator.apiProxyHost" . | quote }}
             - name: CODEX_API_PROXY_HOST
               value: {{ include "tank-operator.codexApiProxyHost" . | quote }}
+            - name: GEMINI_API_PROXY_HOST
+              value: {{ include "tank-operator.geminiApiProxyHost" . | quote }}
             # Workload-identity wiring for the orchestrator's KV writes.
             # Used only by the break-glass save-credentials endpoint that
             # captures a logged-in blob from a config-mode pod. Steady-state

--- a/k8s/templates/externalsecret-gemini.yaml
+++ b/k8s/templates/externalsecret-gemini.yaml
@@ -1,0 +1,35 @@
+{{- if eq (include "tank-operator.renderWarm" .) "true" }}
+# Mirrors the `gemini-credentials` KV secret into a Secret in the
+# ORCHESTRATOR namespace for the gemini-api-proxy ext_proc sidecar.
+#
+# Gemini session pods do not mount this Secret. They write a
+# synthetic ~/.gemini/settings.json with placeholder tokens;
+# gemini-api-proxy owns the real access/refresh token chain and writes
+# rotations back to KV.
+#
+# `creationPolicy: Owner` and the verbose remoteRef defaults match the
+# pattern in externalsecret.yaml. Without them ArgoCD's SSA diff treats
+# ESO defaults as drift and self-heals in a loop.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "tank-operator.geminiCredentialsSecret" . }}
+  namespace: {{ include "tank-operator.orchestratorNamespace" . }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ .Values.externalSecret.storeName }}
+    kind: {{ .Values.externalSecret.storeKind }}
+  target:
+    name: {{ include "tank-operator.geminiCredentialsSecret" . }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: {{ .Values.externalSecret.geminiCredentials.secretKey }}
+      remoteRef:
+        key: {{ .Values.externalSecret.geminiCredentials.kvKey }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+{{- end }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -142,6 +142,12 @@ apiProxy:
 codexApiProxy:
   serviceHost: codex-api-proxy.tank-operator.svc.cluster.local
 
+# Gemini API proxy: a third Envoy + ext_proc deployment using the same image
+# and UAMI as apiProxy. It fronts generativelanguage.googleapis.com and owns the
+# real Google OAuth refresh chain for Gemini sessions.
+geminiApiProxy:
+  serviceHost: gemini-api-proxy.tank-operator.svc.cluster.local
+
 # Anthropic credential rotation: lives in the api-proxy's ext_proc sidecar
 # (api-proxy/src/tank_api_proxy/server.py). The sidecar caches the access
 # token, observes upstream 401s, calls platform.claude.com with the current
@@ -313,6 +319,17 @@ externalSecret:
     # /etc/codex-credentials/auth.json.
     secretKey: auth.json
     kvKey: codex-credentials
+  # Google Gemini subscription credentials. The primary Secret lives in the
+  # ORCHESTRATOR namespace and is mounted by gemini-api-proxy. Gemini CLI/GUI
+  # session launchers write a placeholder settings.json and route
+  # generativelanguage.googleapis.com through the proxy, which injects/rotates
+  # the real tokens and writes back to KV.
+  geminiCredentials:
+    secretName: gemini-credentials
+    # Key inside the K8s Secret. The proxy mounts this as
+    # /etc/gemini-credentials/settings.json.
+    secretKey: settings.json
+    kvKey: gemini-credentials
 # Observability templates (ServiceMonitor, PodMonitor, PrometheusRule, Grafana
 # dashboards) ship only when the kube-prometheus-stack operator CRDs are
 # present. Disabled environments render the chart without these resources so

--- a/runner-shared/conversation-builders.d.ts
+++ b/runner-shared/conversation-builders.d.ts
@@ -16,7 +16,7 @@ export interface UserSubmissionArgs {
   text: string;
   message: unknown;
   attachments?: UserMessageAttachmentDisplay[];
-  runtime: "claude" | "codex";
+  runtime: "claude" | "codex" | "gemini";
   skillName?: string;
   now?: string;
 }
@@ -33,7 +33,7 @@ export interface TurnEventArgs {
   sessionID: string;
   turnID: string;
   clientNonce?: string;
-  source: "claude" | "codex";
+  source: "claude" | "codex" | "gemini";
   type: "turn.started" | "turn.usage" | "turn.completed" | "turn.failed" | "turn.interrupted";
   reason?: string;
   usage?: unknown;
@@ -48,7 +48,7 @@ export function turnEvent(args: TurnEventArgs): TankConversationEvent;
 export interface ItemEventArgs {
   sessionID: string;
   turnID: string;
-  source: "claude" | "codex";
+  source: "claude" | "codex" | "gemini";
   type:
     | "item.started"
     | "item.completed"
@@ -67,7 +67,7 @@ export function itemEvent(args: ItemEventArgs): TankConversationEvent;
 export interface ShellTaskEventArgs {
   sessionID: string;
   turnID: string;
-  source: "claude" | "codex";
+  source: "claude" | "codex" | "gemini";
   type: "shell_task.started" | "shell_task.updated" | "shell_task.exited";
   taskID: string;
   status: string;

--- a/runner-shared/conversation.d.ts
+++ b/runner-shared/conversation.d.ts
@@ -1,7 +1,7 @@
 export const TANK_ACTORS: readonly ["user", "assistant", "system", "tool", "runner"];
 export type TankActor = (typeof TANK_ACTORS)[number];
 
-export const TANK_EVENT_SOURCES: readonly ["tank", "claude", "codex", "hermes"];
+export const TANK_EVENT_SOURCES: readonly ["tank", "claude", "codex", "hermes", "gemini"];
 export type TankEventSource = (typeof TANK_EVENT_SOURCES)[number];
 
 export const TANK_VISIBILITIES: readonly ["durable"];

--- a/runner-shared/conversation.js
+++ b/runner-shared/conversation.js
@@ -13,7 +13,7 @@
 
 export const TANK_ACTORS = ["user", "assistant", "system", "tool", "runner"];
 
-export const TANK_EVENT_SOURCES = ["tank", "claude", "codex", "hermes"];
+export const TANK_EVENT_SOURCES = ["tank", "claude", "codex", "hermes", "gemini"];
 
 // Tank events are durable-by-design; `live-only` was retired once the
 // producer-side live channel never landed. The enum stays single-valued so

--- a/schemas/tank-conversation-event.schema.json
+++ b/schemas/tank-conversation-event.schema.json
@@ -98,7 +98,7 @@
     },
     "source": {
       "type": "string",
-      "enum": ["tank", "claude", "codex", "hermes"]
+      "enum": ["tank", "claude", "codex", "hermes", "gemini"]
     },
     "type": {
       "type": "string",
@@ -135,7 +135,7 @@
     "runtime": {
       "description": "Session-events storage runtime stamp.",
       "type": "string",
-      "enum": ["claude", "codex", "hermes"]
+      "enum": ["claude", "codex", "hermes", "gemini"]
     },
     "producer": {
       "type": "object",


### PR DESCRIPTION
## Summary

This PR adds support for Google Gemini in the tank-operator platform, including the frontend UI, Go orchestrator, Envoy proxy configurations, and the new typescript gemini-runner. All client credentials have been externalized and are resolved via Kubernetes ExternalSecrets from Azure Key Vault.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Transcript Navigation
- [x] Session Lifecycle
- [x] Agent Runners
- [x] Auth And Streams
- [ ] None

Evidence:
- Gemini GUI runs on the gemini-runner agent-loop, projecting turn messages and tool calls onto the NATS JetStream bus.
- Config sessions (gemini_config) enable interactive terminal-based credential seeding.
- Key Vault integration utilizes ExternalSecrets to supply oauth secrets to the gemini-api-proxy ext_proc container, bypassing git hardcoding.
- Verified all backend-go tests pass, confirming correct compilation and execution of all session modes.