### PR TITLE
fix: Add Gemini to PROVIDERS list in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1186,7 +1186,7 @@ const ROLLOUT_MODES = new Set<SessionMode>([
   ...CLAUDE_ROLLOUT_MODES,
   ...CODEX_ROLLOUT_MODES,
 ]);
-const PROVIDERS: Provider[] = ["anthropic", "codex", "hermes", "pi"];
+const PROVIDERS: Provider[] = ["anthropic", "codex", "gemini", "hermes", "pi"];
 
 
 function defaultModeFor(provider: Provider, interaction: SessionInteraction): DefaultSessionMode {


### PR DESCRIPTION
## Summary

This PR fixes a bug where the newly added Gemini provider is missing from the list of configurations on the splash page. Adding 'gemini' to PROVIDERS makes it visible in the UI.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Transcript Navigation
- [x] Session Lifecycle
- [x] Agent Runners
- [x] Auth And Streams
- [ ] None

Evidence:
- Restores visibility of the Gemini GUI and Config session configurations in the frontend SPA.
- All unit tests and production build completed successfully.