### PR TITLE
fix: Use correct skill trigger prefix ($) for Gemini provider

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -964,10 +964,10 @@ func promptMatchesSkillTrigger(provider, skillName, prompt string) bool {
 }
 
 func skillPromptTrigger(provider, skillName string) string {
-	if provider == "codex" || provider == "hermes" {
-		return "$" + skillName
+	if provider == "claude" {
+		return "/" + skillName
 	}
-	return "/" + skillName
+	return "$" + skillName
 }
 
 func sdkProviderForMode(mode string) (string, bool) {


### PR DESCRIPTION
## Summary

This PR fixes a bug where creating a Gemini session fails with a 400 Bad Request error when the 'test' skill preset is selected.

The frontend sends '\' as the skill trigger because Gemini is a non-Claude provider. However, the Go backend was expecting '/test' because provider == 'gemini' fell through to the default '/test' trigger instead of '\'.

This change updates skillPromptTrigger to return '/' only for Claude (claude provider), and '\$' for all other providers (Codex, Hermes, Gemini).

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Transcript Navigation
- [x] Session Lifecycle
- [x] Agent Runners
- [x] Auth And Streams
- [ ] None

Evidence:
- Restores successful session creation when launching Gemini with the 'Code + test' preset.
- All Go backend tests pass successfully.