### PR TITLE
fix: Register gemini-runner-launch.sh in session-configmap.yaml

### DIFF
--- a/k8s/templates/session-configmap.yaml
+++ b/k8s/templates/session-configmap.yaml
@@ -23,6 +23,8 @@ data:
 {{ .Files.Get "session-config/agent-runner-launch.sh" | indent 4 }}
   codex-runner-launch.sh: |
 {{ .Files.Get "session-config/codex-runner-launch.sh" | indent 4 }}
+  gemini-runner-launch.sh: |
+{{ .Files.Get "session-config/gemini-runner-launch.sh" | indent 4 }}
   repo-cloner.sh: |
 {{ .Files.Get "session-config/repo-cloner.sh" | indent 4 }}
 {{- range $path, $_ := $.Files.Glob "session-config/docs/**" }}


### PR DESCRIPTION
## Summary

This PR registers gemini-runner-launch.sh in the Helm chart's session-configmap.yaml template.

Previously, the launch script was omitted from the ConfigMap definition. As a result, when the orchestrator attempted to mount it as a file inside the gemini-runner container in the session pod, Kubernetes created an empty directory instead, causing the container to crash with exit code 126 (Is a directory).

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Transcript Navigation
- [x] Session Lifecycle
- [x] Agent Runners
- [x] Auth And Streams
- [ ] None

Evidence:
- Registers the script so it mounts properly as a file.
- helm template parses successfully without errors.