### PR TITLE
fix: recognize gemini-runner as a valid SDK runner container

### DIFF
--- a/backend-go/cmd/tank-operator/sdk_runner.go
+++ b/backend-go/cmd/tank-operator/sdk_runner.go
@@ -4,7 +4,7 @@ import corev1 "k8s.io/api/core/v1"
 
 func podHasSDKRunner(pod *corev1.Pod) bool {
 	for _, c := range pod.Spec.Containers {
-		if c.Name == "agent-runner" || c.Name == "codex-runner" {
+		if c.Name == "agent-runner" || c.Name == "codex-runner" || c.Name == "gemini-runner" {
 			return true
 		}
 	}


### PR DESCRIPTION
fix: recognize gemini-runner as a valid SDK runner container container

## Feature Contracts

Affected contracts:
- [x] None
- [ ] Other

Evidence:
- Verified Go tests compiled and passed locally.
