### PR TITLE
fix: revert Gemini runner and proxy routing to Google AI Studio

### DIFF
--- a/backend-go/cmd/tank-operator/sdk_runner.go
+++ b/backend-go/cmd/tank-operator/sdk_runner.go
@@ -4,7 +4,7 @@ import corev1 "k8s.io/api/core/v1"
 
 func podHasSDKRunner(pod *corev1.Pod) bool {
 	for _, c := range pod.Spec.Containers {
-		if c.Name == "agent-runner" || c.Name == "codex-runner" {
+		if c.Name == "agent-runner" || c.Name == "codex-runner" || c.Name == "gemini-runner" {
 			return true
 		}
 	}

--- a/gemini-runner/src/runner.ts
+++ b/gemini-runner/src/runner.ts
@@ -69,11 +69,7 @@ export class Runner {
     this.commandBus = new SessionCommandBus(cfg);
     this.adapter = new GeminiTankEventAdapter(cfg);
 
-    // Initialize the Google GenAI client.
-    // Outgoing requests carry the Authorization header which Envoy intercepts.
     this.ai = new GoogleGenAI({
-      vertexai: true,
-      project: process.env.GOOGLE_CLOUD_PROJECT || undefined,
       apiKey: "managed-by-tank-operator",
       httpOptions: {
         headers: {

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -629,7 +629,6 @@ spec:
   renewBefore: 360h
   dnsNames:
     - generativelanguage.googleapis.com
-    - us-central1-aiplatform.googleapis.com
   issuerRef:
     name: claude-oauth-ca-issuer
     kind: Issuer
@@ -752,13 +751,13 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: us-central1-aiplatform.googleapis.com
+                          address: generativelanguage.googleapis.com
                           port_value: 443
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              sni: us-central1-aiplatform.googleapis.com
+              sni: generativelanguage.googleapis.com
               common_tls_context:
                 validation_context:
                   trusted_ca:


### PR DESCRIPTION
Revert Gemini session runner and API proxy back to Google AI Studio API endpoints while retaining the user token auth flow. Vertex AI predict endpoints require enterprise billing contexts which personal Google accounts do not possess.

## Summary

Revert Gemini session runner and API proxy back to Google AI Studio API endpoints.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- Go unit tests pass.