### PR TITLE
fix(frontend): fix compilation errors from Pi cleanup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1141,7 +1141,7 @@ const ROLLOUT_MODES = new Set<SessionMode>([
   ...CLAUDE_ROLLOUT_MODES,
   ...CODEX_ROLLOUT_MODES,
 ]);
-const PROVIDERS: Provider[] = ["anthropic", "codex", "gemini", "hermes", "pi"];
+const PROVIDERS: Provider[] = ["anthropic", "codex", "gemini", "hermes"];
 
 
 function defaultModeFor(provider: Provider, interaction: SessionInteraction): DefaultSessionMode {

--- a/frontend/src/styleguide/portfolio-workspace.tsx
+++ b/frontend/src/styleguide/portfolio-workspace.tsx
@@ -9,7 +9,6 @@ import {
   InfoIcon,
   MonitorIcon,
   SettingsIcon,
-  TerminalIcon,
   XIcon,
 } from "lucide-react";
 import { ProviderIcon } from "../providerIcons";


### PR DESCRIPTION
Removes the obsolete 'pi' provider from the PROVIDERS list and cleans up an unused import of TerminalIcon to resolve compilation errors from the Pi cleanup PR.