### PR TITLE
docs: clarify that check-pr-body failures must not be bypassed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ the test directly proves the contract invariant. Do not mark a PR ready, ask
 for merge, or merge it yourself when the Feature Contracts section is missing
 or incomplete.
 
+Always wait for all CI checks/tests to complete successfully on GitHub before merging a PR. Merging a PR before checks finish will break the image build/tagging workflow on main.
+
 When adding or substantially changing named product behavior, check whether the
 relevant feature folder needs a `capabilities.md` entry. Capability ledgers are
 for behavior a future agent should be able to name, audit, or retire without

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ the test directly proves the contract invariant. Do not mark a PR ready, ask
 for merge, or merge it yourself when the Feature Contracts section is missing
 or incomplete.
 
-Always wait for all CI checks/tests to complete successfully on GitHub before merging a PR. Merging a PR before checks finish will break the image build/tagging workflow on main.
+Always wait for all CI checks/tests to complete successfully on GitHub before merging a PR. Merging a PR before checks finish will break the image build/tagging workflow on main. This includes the PR body checklist check (check-pr-body) — do not bypass or ignore these failures.
 
 When adding or substantially changing named product behavior, check whether the
 relevant feature folder needs a `capabilities.md` entry. Capability ledgers are


### PR DESCRIPTION
## Summary

Adds a note in CLAUDE.md clarifying that PR checklist failures (check-pr-body) are part of the CI checks that must pass before merging.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- Documentation only update in CLAUDE.md.