### PR TITLE
fix(orchestrator): add oauth2 and www to gemini-api-proxy cert dnsNames

### DIFF
--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -629,6 +629,8 @@ spec:
   renewBefore: 360h
   dnsNames:
     - generativelanguage.googleapis.com
+    - oauth2.googleapis.com
+    - www.googleapis.com
   issuerRef:
     name: claude-oauth-ca-issuer
     kind: Issuer


### PR DESCRIPTION
## Summary

Adds oauth2.googleapis.com and www.googleapis.com to the dnsNames list of the gemini-api-proxy-leaf Certificate. This ensures that the gemini CLI can perform TLS validation when checking tokeninfo against oauth2.googleapis.com.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- Tested manually with the gemini CLI in a session pod. Cert verification failed with Hostname/IP mismatch before this change.