### PR TITLE
fix(gemini): mock loadCodeAssist and route cloudcode-pa to proxy

### DIFF
--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -543,7 +543,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	if (mode == GeminiGUIMode || mode == GeminiConfigMode) && opts.GeminiAPIProxyIP != "" {
 		hostAliases = append(hostAliases, map[string]any{
 			"ip":        opts.GeminiAPIProxyIP,
-			"hostnames": []any{"generativelanguage.googleapis.com", "us-central1-aiplatform.googleapis.com", "oauth2.googleapis.com", "www.googleapis.com"},
+			"hostnames": []any{"generativelanguage.googleapis.com", "us-central1-aiplatform.googleapis.com", "oauth2.googleapis.com", "www.googleapis.com", "cloudcode-pa.googleapis.com"},
 		})
 		if opts.OAuthGatewayCAConfigMap != "" {
 			env = append(env,

--- a/backend-go/internal/sessionmodel/sessionmodel_test.go
+++ b/backend-go/internal/sessionmodel/sessionmodel_test.go
@@ -295,6 +295,7 @@ func TestPodManifestGeminiUsesAPIProxy(t *testing.T) {
 	spec := manifest["spec"].(map[string]any)
 	assertHostAlias(t, spec, "10.0.0.60", "generativelanguage.googleapis.com")
 	assertHostAlias(t, spec, "10.0.0.60", "us-central1-aiplatform.googleapis.com")
+	assertHostAlias(t, spec, "10.0.0.60", "cloudcode-pa.googleapis.com")
 	assertVolume(t, spec["volumes"].([]any), "oauth-gateway-ca")
 
 	containers := spec["containers"].([]any)

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -629,6 +629,8 @@ spec:
   renewBefore: 360h
   dnsNames:
     - generativelanguage.googleapis.com
+    - oauth2.googleapis.com
+    - www.googleapis.com
   issuerRef:
     name: claude-oauth-ca-issuer
     kind: Issuer

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -631,6 +631,7 @@ spec:
     - generativelanguage.googleapis.com
     - oauth2.googleapis.com
     - www.googleapis.com
+    - cloudcode-pa.googleapis.com
   issuerRef:
     name: claude-oauth-ca-issuer
     kind: Issuer
@@ -739,6 +740,15 @@ data:
                                 status: 200
                                 body:
                                   inline_string: '{"email":"fullnelsongrip@gmail.com","email_verified":true}'
+                              response_headers_to_add:
+                                - header:
+                                    key: "content-type"
+                                    value: "application/json"
+                            - match: { path: "/v1internal:loadCodeAssist" }
+                              direct_response:
+                                status: 200
+                                body:
+                                  inline_string: '{"currentTier":{"id":"standard","name":"Standard","hasOnboardedPreviously":true},"cloudaicompanionProject":"dummy-project"}'
                               response_headers_to_add:
                                 - header:
                                     key: "content-type"

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -730,11 +730,19 @@ data:
                                 status: 200
                                 body:
                                   inline_string: '{"audience":"681255809395-oo8ft2oprdnyp9e3aqf6av3hmdib135j.apps.googleusercontent.com","scope":"https://www.googleapis.com/auth/cloud-platform openid","expires_in":3599}'
+                              response_headers_to_add:
+                                - header:
+                                    key: "content-type"
+                                    value: "application/json"
                             - match: { path: "/oauth2/v2/userinfo" }
                               direct_response:
                                 status: 200
                                 body:
                                   inline_string: '{"email":"fullnelsongrip@gmail.com","email_verified":true}'
+                              response_headers_to_add:
+                                - header:
+                                    key: "content-type"
+                                    value: "application/json"
                             - match: { prefix: "/" }
                               route:
                                 cluster: gemini_api


### PR DESCRIPTION
## Summary

Mock cloudcode-pa.googleapis.com/v1internal:loadCodeAssist and route cloudcode-pa.googleapis.com to the API proxy via hostAliases, allowing the Gemini CLI to bypass Code Assist project checks under oauth-personal mode.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- Verified by checking direct response headers set in api-proxy.yaml and verifying via script.