### PR TITLE
feat: mount gemini-credentials-test read-only to avoid runner overwrite

### DIFF
--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -366,10 +366,11 @@ func main() {
 			GeminiSessionImage:      geminiSessionImage,
 			SessionScope:            sessionScope,
 			TankOperatorInternalURL: tankOperatorInternalURL,
-			GitHubAppSecret:         envDefault("GITHUB_APP_SECRET", sessionmodel.DefaultGitHubAppSecret),
-			NATSURL:                 envDefault("NATS_URL", ""),
-			NATSStream:              envDefault("NATS_STREAM", "TANK_SESSION_BUS"),
-			NATSAuthSecret:          envDefault("NATS_AUTH_SECRET", "tank-nats-auth"),
+			GitHubAppSecret:             envDefault("GITHUB_APP_SECRET", sessionmodel.DefaultGitHubAppSecret),
+			GeminiCredentialsTestSecret: envDefault("GEMINI_CREDENTIALS_TEST_SECRET", "gemini-credentials-test"),
+			NATSURL:                     envDefault("NATS_URL", ""),
+			NATSStream:                  envDefault("NATS_STREAM", "TANK_SESSION_BUS"),
+			NATSAuthSecret:              envDefault("NATS_AUTH_SECRET", "tank-nats-auth"),
 			// Test-slot agent-runner hot-swap. Off by default; the chart
 			// turns this on only when the chart runs in hot test-slot mode.
 			// See scripts/check-session-pod-hot-swap-migration.mjs and

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -248,6 +248,8 @@ type ManifestOptions struct {
 	OAuthGatewayCAConfigMap string
 	// Secret name for GitHub App credentials (envFrom on claude container).
 	GitHubAppSecret string
+	// Secret name for Gemini test credentials.
+	GeminiCredentialsTestSecret string
 	// SDK runners use NATS JetStream for durable command/event delivery.
 	NATSURL        string
 	NATSStream     string
@@ -565,16 +567,21 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	}
 
 	if mode == GeminiTestMode {
+		secretName := opts.GeminiCredentialsTestSecret
+		if secretName == "" {
+			secretName = "gemini-credentials-test"
+		}
 		volumes = append(volumes, map[string]any{
-			"name": "gemini-credentials",
+			"name": "gemini-credentials-test",
 			"secret": map[string]any{
-				"secretName": "gemini-credentials",
+				"secretName": secretName,
 				"optional":   true,
 			},
 		})
 		claudeVolumeMounts = append(claudeVolumeMounts, map[string]any{
-			"name":      "gemini-credentials",
-			"mountPath": "/etc/gemini-credentials",
+			"name":      "gemini-credentials-test",
+			"mountPath": "/home/node/.gemini/oauth_creds.json",
+			"subPath":   "oauth_creds.json",
 			"readOnly":  true,
 		})
 	}
@@ -914,8 +921,9 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 		}
 		if mode == GeminiTestMode {
 			runnerVolumeMounts = append(runnerVolumeMounts, map[string]any{
-				"name":      "gemini-credentials",
-				"mountPath": "/etc/gemini-credentials",
+				"name":      "gemini-credentials-test",
+				"mountPath": "/home/node/.gemini/oauth_creds.json",
+				"subPath":   "oauth_creds.json",
 				"readOnly":  true,
 			})
 		}

--- a/k8s/session-config/gemini-runner-launch.sh
+++ b/k8s/session-config/gemini-runner-launch.sh
@@ -25,6 +25,9 @@ EOF
 
   if [ -f /etc/gemini-credentials/oauth_creds.json ]; then
     cp /etc/gemini-credentials/oauth_creds.json "$HOME/.gemini/oauth_creds.json"
+    chmod 600 "$HOME/.gemini/oauth_creds.json"
+  elif [ -f "$HOME/.gemini/oauth_creds.json" ]; then
+    echo "oauth_creds.json already exists (possibly mounted). Skipping generation."
   else
     cat > "$HOME/.gemini/oauth_creds.json" <<EOF
 {
@@ -36,8 +39,8 @@ EOF
   "expiry_date": 9999999999000
 }
 EOF
+    chmod 600 "$HOME/.gemini/oauth_creds.json"
   fi
-  chmod 600 "$HOME/.gemini/oauth_creds.json"
 }
 
 # Git identity for any commits the agent makes from /workspace.

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -122,6 +122,15 @@ claude-code-credentials
 {{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-gemini-credentials" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.externalSecret.geminiCredentials.secretName }}{{- end -}}
 {{- end -}}
 
+{{- define "tank-operator.geminiCredentialsTestSecret" -}}
+{{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-gemini-credentials-test" (include "tank-operator.slotName" .) }}{{- else -}}gemini-credentials-test{{- end -}}
+{{- end -}}
+
+{{- define "tank-operator.geminiCredentialsTestKvKey" -}}
+{{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-gemini-credentials-test" (include "tank-operator.slotName" .) }}{{- else -}}gemini-credentials-test{{- end -}}
+{{- end -}}
+
+
 {{- define "tank-operator.claudeCredentialsSecret" -}}
 {{- if eq (include "tank-operator.isTestEnv" .) "true" -}}{{ printf "%s-claude-code-credentials" (include "tank-operator.slotName" .) }}{{- else -}}{{ .Values.externalSecret.claudeCredentials.secretName }}{{- end -}}
 {{- end -}}

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
               value: {{ include "tank-operator.githubAppSecret" . | quote }}
             - name: CODEX_CREDENTIALS_SECRET
               value: {{ include "tank-operator.codexCredentialsSecret" . | quote }}
+            - name: GEMINI_CREDENTIALS_TEST_SECRET
+              value: {{ include "tank-operator.geminiCredentialsTestSecret" . | quote }}
+
             - name: IDLE_TIMEOUT_SECONDS
               value: {{ .Values.session.idleTimeoutSeconds | quote }}
             - name: REAPER_INTERVAL_SECONDS

--- a/k8s/templates/externalsecret-gemini.yaml
+++ b/k8s/templates/externalsecret-gemini.yaml
@@ -55,4 +55,28 @@ spec:
         decodingStrategy: None
         metadataPolicy: None
         nullBytePolicy: Ignore
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "tank-operator.geminiCredentialsTestSecret" . }}
+  namespace: {{ include "tank-operator.sessionsNamespace" . }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ .Values.externalSecret.storeName }}
+    kind: {{ .Values.externalSecret.storeKind }}
+  target:
+    name: {{ include "tank-operator.geminiCredentialsTestSecret" . }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: oauth_creds.json
+      remoteRef:
+        key: {{ include "tank-operator.geminiCredentialsTestKvKey" . }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
 {{- end }}
+


### PR DESCRIPTION
## Summary

Mounts the gemini-credentials-test secret read-only directly inside the pod at /home/node/.gemini/oauth_creds.json for gemini_test sessions to avoid runner overwrite, without requiring image builds.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Helm templates compile and render without errors.
- Go backend tests pass successfully.
