### PR TITLE
fix(gemini-runner): align turnID generation with orchestrator

### DIFF
--- a/gemini-runner/src/runner.ts
+++ b/gemini-runner/src/runner.ts
@@ -25,7 +25,10 @@ import {
   isDurableTankConversationEvent,
   type TankConversationEvent,
 } from "../../runner-shared/conversation.js";
-import { stampTankEvent } from "../../runner-shared/conversation-builders.js";
+import {
+  stampTankEvent,
+  turnIDForClientNonce,
+} from "../../runner-shared/conversation-builders.js";
 import { truncateEventIfOversized } from "../../runner-shared/sessionBus.js";
 
 class AsyncQueue<T> {
@@ -68,7 +71,6 @@ export class Runner {
   }>();
   private readonly adapter: GeminiTankEventAdapter;
   private currentAbort: AbortController | null = null;
-  private turnSeq = 0;
   private sessionExists = false;
 
   constructor(private readonly cfg: Config) {
@@ -130,9 +132,8 @@ export class Runner {
         if (next.done) break;
 
         const { text: input, clientNonce, commandRecord } = next.value;
-        const turnSeq = ++this.turnSeq;
         const clientNonceStr = clientNonce ?? `gen-${randomUUID()}`;
-        const turnID = `turn-${turnSeq}`;
+        const turnID = turnIDForClientNonce(clientNonceStr);
         const turn = { turnID, clientNonce: clientNonceStr };
 
         recordTurnStart(turnID);


### PR DESCRIPTION
## Summary

This PR aligns the turnID generation in the gemini-runner with the other runners (Claude and Codex). It uses turnIDForClientNonce(clientNonce) instead of local turnSeq-based turnID generation. This matches the turn_id expectation of the orchestrator and Go backend, allowing the turn status to transition to completed.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Replaced turnSeq-based turnID generation with turnIDForClientNonce.
- Verified TypeScript builds clean.