### PR TITLE
fix(frontend): support repo selection and workspace files in gemini_test mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -250,7 +250,7 @@ type DefaultSessionMode = Extract<
   | "gemini_test"
   | "hermes_gui"
 >;
-type Provider = "anthropic" | "codex" | "gemini" | "hermes";
+type Provider = "anthropic" | "codex" | "gemini" | "gemini_test" | "hermes";
 type SessionInteraction = "gui" | "cli";
 type ToolKind = "mcp" | "shell";
 type AskUserQuestionAnswer = {
@@ -668,6 +668,7 @@ const PROVIDER_INTERACTION_MODES: Record<
   anthropic: { gui: "claude_gui", cli: "claude_cli" },
   codex: { gui: "codex_gui", cli: "codex_cli" },
   gemini: { gui: "gemini_gui", cli: null },
+  gemini_test: { gui: "gemini_test", cli: null },
   hermes: { gui: "hermes_gui", cli: null },
 };
 
@@ -688,6 +689,7 @@ const PROVIDER_LABELS: Record<Provider, string> = {
   anthropic: "Claude",
   codex: "Codex",
   gemini: "Gemini",
+  gemini_test: "Gemini Test",
   hermes: "Hermes",
 };
 
@@ -1148,7 +1150,7 @@ const ROLLOUT_MODES = new Set<SessionMode>([
   ...CLAUDE_ROLLOUT_MODES,
   ...CODEX_ROLLOUT_MODES,
 ]);
-const PROVIDERS: Provider[] = ["anthropic", "codex", "gemini", "hermes"];
+const PROVIDERS: Provider[] = ["anthropic", "codex", "gemini", "gemini_test", "hermes"];
 
 
 function defaultModeFor(provider: Provider, interaction: SessionInteraction): DefaultSessionMode {

--- a/frontend/src/providerIcons.tsx
+++ b/frontend/src/providerIcons.tsx
@@ -1,10 +1,10 @@
 type ProviderIconProps = {
-  provider: "anthropic" | "codex" | "hermes" | "pi" | "gemini";
+  provider: "anthropic" | "codex" | "hermes" | "pi" | "gemini" | "gemini_test";
   className?: string;
 };
 
 const ICONS: Record<
-  Exclude<ProviderIconProps["provider"], "codex">,
+  Exclude<ProviderIconProps["provider"], "codex" | "gemini_test">,
   { path: string; viewBox: string; fill: string }
 > = {
   anthropic: {
@@ -30,7 +30,8 @@ const ICONS: Record<
 };
 
 export function ProviderIcon({ provider, className }: ProviderIconProps) {
-  if (provider === "codex") {
+  const resolvedProvider = provider === "gemini_test" ? "gemini" : provider;
+  if (resolvedProvider === "codex") {
     return (
       <img
         className={className}
@@ -42,7 +43,7 @@ export function ProviderIcon({ provider, className }: ProviderIconProps) {
     );
   }
 
-  const icon = ICONS[provider];
+  const icon = ICONS[resolvedProvider as Exclude<ProviderIconProps["provider"], "codex" | "gemini_test">];
 
   return (
     <svg

--- a/frontend/src/repos.ts
+++ b/frontend/src/repos.ts
@@ -33,6 +33,7 @@ export const REPO_SUPPORTED_MODES: ReadonlySet<string> = new Set<string>([
   "codex_gui",
   "codex_app_server",
   "gemini_gui",
+  "gemini_test",
 ]);
 
 export function isValidRepoSlug(value: string): boolean {

--- a/frontend/src/sessionWorkspace.ts
+++ b/frontend/src/sessionWorkspace.ts
@@ -4,6 +4,7 @@ export const WORKSPACE_FILE_MODES: ReadonlySet<string> = new Set([
   "codex_exec_gui",
   "codex_app_server",
   "gemini_gui",
+  "gemini_test",
 ]);
 
 export interface SessionWorkspaceState {


### PR DESCRIPTION
## Summary

- Support Git repository selection and workspace file explorer for gemini_test sessions.
- Expose a new 'Gemini Test' provider button in the landing/home panels to launch gemini_test sessions directly from the UI.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- Verified that the Vite production build and all frontend unit tests pass successfully.
- Verified session creation and turn execution for a gemini_test session (session-386) on the cluster.