### PR TITLE
fix(gemini-runner): use generated timeline_id for finalAnswer

### DIFF
--- a/gemini-runner/src/runner.ts
+++ b/gemini-runner/src/runner.ts
@@ -334,18 +334,20 @@ export class Runner {
 
       // Emit assistant message complete if text was generated
       const assistantItemID = `msg-${randomUUID()}`;
+      let timelineItemID = assistantItemID;
       if (assistantText) {
-        timelineIDs.push(assistantItemID);
-        await this.dispatch(
-          this.adapter.messageCompleted(turn, assistantItemID, assistantText)
-        );
+        const event = this.adapter.messageCompleted(turn, assistantItemID, assistantText);
+        if (event.timeline_id) {
+          timelineItemID = event.timeline_id;
+        }
+        await this.dispatch(event);
       }
 
       // Emit turn.completed
       await this.dispatch(
         this.adapter.turnCompleted(turn, {
-          timelineIDs,
-          providerItemIDs: timelineIDs
+          timelineIDs: assistantText ? [timelineItemID] : [],
+          providerItemIDs: assistantText ? [assistantItemID] : []
         })
       );
 


### PR DESCRIPTION
## Summary

- Fixed an issue where the Gemini runner response text was staying in the Turns tab (compacted) rather than being promoted to the main chat transcript. This occurred because the `turn.completed` event's `finalAnswer.timelineIDs` array carried the raw `providerItemID` (e.g. `msg-UUID`), whereas the assistant message event's actual `timeline_id` is fully qualified (e.g., `turn_XYZ:item:msg-UUID`). Using the generated `event.timeline_id` matches the logic in the Claude and Codex runners.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Running `npm run build && npm test` in `gemini-runner` passes.
- Go tests in `backend-go` pass successfully.
