### PR TITLE
fix(orchestrator): populate ActivityBodies for turns with zero compacted entries

### DIFF
--- a/backend-go/cmd/tank-operator/transcript_projection.go
+++ b/backend-go/cmd/tank-operator/transcript_projection.go
@@ -803,12 +803,19 @@ func annotateProjectionTerminal(entry map[string]any, terminals map[string]turnT
 
 func compactProjectedTranscript(entries []map[string]any, activeTurnID string, terminals map[string]turnTerminalProjection) transcriptProjection {
 	activities := append(terminalProjectedActivities(entries, terminals), activeProjectedActivities(entries, activeTurnID)...)
+	bodies := map[string]turnActivityBody{}
+	for _, activity := range activities {
+		bodies[activity.TurnID] = activity
+	}
 	if len(activities) == 0 {
-		return transcriptProjection{Entries: entries, ActivityBodies: map[string]turnActivityBody{}}
+		return transcriptProjection{Entries: entries, ActivityBodies: bodies}
 	}
 	activityByInsertIndex := map[int]turnActivityBody{}
 	compactedIndexes := map[int]bool{}
 	for _, activity := range activities {
+		if len(activity.CompactedEntryIDs) == 0 {
+			continue
+		}
 		insertBefore := 0
 		if len(activity.Entries) > 0 {
 			insertBefore = projectedEntryIndex(entries, activity.Entries[0])
@@ -823,7 +830,6 @@ func compactProjectedTranscript(entries []map[string]any, activeTurnID string, t
 		}
 	}
 	out := make([]map[string]any, 0, len(entries))
-	bodies := map[string]turnActivityBody{}
 	for idx, entry := range entries {
 		if activity, ok := activityByInsertIndex[idx]; ok {
 			shell := map[string]any{
@@ -843,7 +849,6 @@ func compactProjectedTranscript(entries []map[string]any, activeTurnID string, t
 				shell["usageObservation"] = usageObservation
 			}
 			out = append(out, shell)
-			bodies[activity.TurnID] = activity
 		}
 		if !compactedIndexes[idx] {
 			out = append(out, entry)
@@ -895,7 +900,7 @@ func terminalProjectedActivities(entries []map[string]any, terminals map[string]
 				compacted = append(compacted, entry)
 			}
 		}
-		if len(compacted) == 0 {
+		if len(activityEntries) == 0 {
 			continue
 		}
 		activities = append(activities, makeTurnActivityBody(turnID, terminal.Status, activityEntries, compacted, false))

--- a/backend-go/cmd/tank-operator/transcript_projection_test.go
+++ b/backend-go/cmd/tank-operator/transcript_projection_test.go
@@ -530,6 +530,49 @@ func TestProjectTranscriptEventsAnnouncementInterruptedCarriesTerminalStatus(t *
 	t.Fatalf("missing needs_input_announcement entry: %#v", projection.Entries)
 }
 
+func TestProjectTranscriptEventsPopulatesActivityBodiesForTurnsWithoutCompactedEntries(t *testing.T) {
+	events := []map[string]any{
+		projectionTestEvent("u", "001", "user_message.created", "user", "tank", "turn-1", "turn-1:user", map[string]any{
+			"text":    "hello",
+			"display": map[string]any{"kind": "plain"},
+		}),
+		projectionTestEvent("final", "002", "item.completed", "assistant", "codex", "turn-1", "turn-1:item:final", map[string]any{
+			"kind": "agent_message",
+			"text": "hi there",
+		}),
+		projectionTestEvent("terminal", "003", "turn.completed", "runner", "codex", "turn-1", "", projectionFinalAnswerPayload("turn-1:item:final")),
+	}
+
+	projection := projectTranscriptEvents(events)
+
+	// We expect the main timeline entries to NOT contain a turn_activity shell.
+	// So we should have exactly 2 entries (user message and assistant message).
+	if got, want := len(projection.Entries), 2; got != want {
+		t.Fatalf("projected entries = %d, want %d: %#v", got, want, projection.Entries)
+	}
+	if got, want := projection.Entries[0]["kind"], "message"; got != want {
+		t.Fatalf("first entry kind = %v, want %s", got, want)
+	}
+	if got, want := projection.Entries[1]["kind"], "message"; got != want {
+		t.Fatalf("second entry kind = %v, want %s", got, want)
+	}
+
+	// We expect the activity body for the turn to be populated.
+	body, ok := projection.ActivityBodies["turn-1"]
+	if !ok {
+		t.Fatal("missing activity body for turn-1")
+	}
+	if got, want := len(body.Entries), 1; got != want {
+		t.Fatalf("activity body entries = %d, want %d", got, want)
+	}
+	if got, want := body.Entries[0]["id"], "turn-1:item:final"; got != want {
+		t.Fatalf("activity body entry id = %v, want %s", got, want)
+	}
+	if got, want := len(body.CompactedEntryIDs), 0; got != want {
+		t.Fatalf("compacted ids count = %d, want %d", got, want)
+	}
+}
+
 func projectionTestEvent(eventID, orderKey, eventType, actor, source, turnID, timelineID string, payload map[string]any) map[string]any {
 	event := map[string]any{
 		"event_id":   eventID,


### PR DESCRIPTION
## Summary

This PR ensures that turns without compacted events (such as simple responses in `gemini-test` mode) still have their turn activity bodies populated in the projection's `ActivityBodies` map, allowing the frontend's turns page to display the assistant's response instead of rendering a blank "No turn activity". We also ensure that no blank or empty `turn_activity` shell is inserted into the main timeline for these turns.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Added `TestProjectTranscriptEventsPopulatesActivityBodiesForTurnsWithoutCompactedEntries` to `transcript_projection_test.go` to explicitly verify that a turn with only a final assistant response correctly populates `ActivityBodies[turnID]` with the response, while preventing a `turn_activity` shell from being generated in the main timeline. All tests pass.
