### PR TITLE
Use org pipeline templates

### DIFF
--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -57,7 +57,7 @@ jobs:
     # mcp.tf forget the moved mcp_azure_personal resources without
     # destroying them in Azure on apply.
     needs: secrets
-    uses: nelsong6/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
+    uses: romaine-life/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
     with:
       working_directory: infra
       backend_resource_group: infra


### PR DESCRIPTION
Repoint reusable-workflow `uses:` references from `nelsong6/pipeline-templates` to `romaine-life/pipeline-templates` (org migration; the templates repo was transferred). Mechanical owner-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)