### PR TITLE
infra: drop unused github provider + github-pat (last PAT consumer)

### DIFF
--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -23,31 +23,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  # The shared tofu template doesn't fetch any KV secrets, and infra/
-  # uses the `github` provider which needs a PAT. Fetch it in a separate
-  # job, mask it with ::add-mask::, and pass the value into the shared
-  # workflow as a tofu_vars -var (var.github_pat is declared
-  # sensitive=true in infra/variables.tf so it won't appear in plan
-  # output / PR plan comments). Job outputs honor add-mask propagation,
-  # which is what keeps the value out of CI logs.
-  secrets:
-    name: Fetch github-pat from Key Vault
-    runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
-    outputs:
-      github_pat: ${{ steps.kv.outputs.github_pat }}
-    steps:
-      - uses: azure/login@v2
-        with:
-          client-id: ${{ vars.ARM_CLIENT_ID }}
-          tenant-id: ${{ vars.ARM_TENANT_ID }}
-          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
-      - id: kv
-        run: |
-          GITHUB_PAT=$(az keyvault secret show --vault-name romaine-kv --name github-pat --query value -o tsv)
-          echo "::add-mask::$GITHUB_PAT"
-          echo "github_pat=$GITHUB_PAT" >> "$GITHUB_OUTPUT"
-
   tofu:
     # Shared template handles checkout, OIDC login, shared-providers
     # overlay from infra-bootstrap, init/plan/apply, and the plan PR
@@ -56,7 +31,6 @@ jobs:
     # OpenTofu 1.10) works — that's what lets the `removed` blocks in
     # mcp.tf forget the moved mcp_azure_personal resources without
     # destroying them in Azure on apply.
-    needs: secrets
     uses: romaine-life/pipeline-templates/.github/workflows/tofu-plan-apply-template.yml@main
     with:
       working_directory: infra
@@ -65,9 +39,4 @@ jobs:
       backend_container: tfstate
       backend_key: tank-operator.tfstate
       tofu_version: '1.12.0'
-      # github_pat is the only tofu_var we plumb through — the github
-      # provider explicitly reads it. azurerm/azuread auto-detect
-      # subscription/tenant from the ARM_* env vars the shared template
-      # exports for OIDC.
-      tofu_vars: '-var=github_pat=${{ needs.secrets.outputs.github_pat }}'
     secrets: inherit

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -13,12 +13,3 @@ provider "azuread" {
 }
 
 provider "random" {}
-
-# Repo-scoped Actions variables require admin perms that the default
-# GITHUB_TOKEN doesn't have. Use the same `github-pat` PAT in KV that
-# infra-bootstrap uses; the tofu workflow fetches it in a preliminary
-# job, masks it, and passes it through `tofu_vars` as -var=github_pat=…
-provider "github" {
-  owner = "nelsong6"
-  token = var.github_pat
-}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,9 +1,3 @@
-variable "github_pat" {
-  description = "GitHub PAT for the github provider. Fetched from KV by the tofu workflow's secrets job and passed via tofu_vars -var=github_pat=… into the shared plan/apply template."
-  type        = string
-  sensitive   = true
-}
-
 variable "key_vault_name" {
   description = "Name of the Key Vault that stores the OAuth client secret + cookie secret."
   type        = string


### PR DESCRIPTION
tank-operator's `infra/` tofu has **no `github_*` resources** (migrated out to per-app repos), so the `github` provider (owner=nelsong6) + `var.github_pat` + the workflow's github-pat fetch were dead code. Removed. **Expected plan: no changes.**

This is the **last consumer** of the `romaine-kv/github-pat` secret — once this merges, the (leaked) PAT can finally be revoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)