### PR TITLE
infra: scale postgres flexible server SKU to B2s

### DIFF
--- a/infra/postgres.tf
+++ b/infra/postgres.tf
@@ -6,8 +6,8 @@
 # expects of a durable history store — indexed queries, real backups via PITR,
 # point-in-time recovery — without paying Cosmos's per-RU write costs.
 #
-# Sized for hobby/portfolio scale: B1ms (1 vCore burstable, 2 GiB RAM), single
-# AZ, no HA tier. ~$15/mo flat vs ~$73/mo Cosmos serverless at current write
+# Sized for hobby/portfolio scale: B2s (2 vCores burstable, 4 GiB RAM), single
+# AZ, no HA tier. ~$30/mo flat vs ~$73/mo Cosmos serverless at current write
 # volume.
 #
 # Auth: both password and AAD enabled at the server level. The orchestrator
@@ -41,7 +41,7 @@ resource "azurerm_postgresql_flexible_server" "tank_operator" {
   location = "westus3"
 
   version    = "16"
-  sku_name   = "B_Standard_B1ms"
+  sku_name   = "B_Standard_B2s"
   storage_mb = 32768
   zone       = "1"
 


### PR DESCRIPTION
## Summary

- Upgrades database compute SKU from B1ms to B2s to resolve connection saturation (SQLSTATE 53300) errors.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- Verified via OpenTofu plan workflow; not touching code features.