### PR TITLE
fix(ci): add backend-go paths to antigravity fingerprint to fix caching bug

### DIFF
--- a/.github/workflows/session-images-build.yml
+++ b/.github/workflows/session-images-build.yml
@@ -53,7 +53,7 @@ jobs:
             image: antigravity-container
             dockerfile: antigravity-container/Dockerfile
             build_args: ''
-            fingerprint_paths: 'antigravity-container .dockerignore claude-container/mcp-auth-proxy'
+            fingerprint_paths: 'antigravity-container .dockerignore claude-container/mcp-auth-proxy backend-go/go.mod backend-go/go.sum backend-go/internal backend-go/cmd/tank-supervisor backend-go/cmd/antigravity-runner'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/session-images-build.yml
+++ b/.github/workflows/session-images-build.yml
@@ -40,12 +40,12 @@ jobs:
             image: claude-container
             dockerfile: claude-container/Dockerfile
             build_args: TANK_AGENT=claude
-            fingerprint_paths: 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner runner-shared'
+            fingerprint_paths: 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner runner-shared backend-go/go.mod backend-go/go.sum backend-go/internal backend-go/cmd/tank-supervisor'
           - agent: codex
             image: codex-container
             dockerfile: claude-container/Dockerfile
             build_args: TANK_AGENT=codex
-            fingerprint_paths: 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner runner-shared'
+            fingerprint_paths: 'claude-container/Dockerfile .dockerignore claude-container/mcp-auth-proxy agent-runner codex-runner runner-shared backend-go/go.mod backend-go/go.sum backend-go/internal backend-go/cmd/tank-supervisor'
           # Antigravity uses its own glibc Dockerfile (agy is a glibc-only
           # native binary), so it carries no TANK_AGENT and a distinct
           # fingerprint path set.


### PR DESCRIPTION
## Feature Contracts
Affected contracts:
- [x] None
Evidence:
Fixed a CI caching bug where Go changes in antigravity-runner were not invalidating the Docker image build cache.