### PR TITLE
fix(ui): hide duplicate antigravity config button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23554,30 +23554,32 @@ function AuthenticatedApp() {
                           {/* Credential-mint sessions remain a setup shortcut
                               even though Antigravity GUI is selectable through
                               the provider picker. */}
-                          <button
-                            className="home-quick-action"
-                            onClick={() => createSession("antigravity_config")}
-                            disabled={
-                              busy ||
-                              !createModeAllowedByRunOptions(
-                                "antigravity_config",
-                                sessionRunOptions,
-                              )
-                            }
-                          >
-                            <ProviderIcon
-                              provider="antigravity"
-                              className="home-quick-icon"
-                            />
-                            <span className="home-quick-main">
-                              <span className="home-quick-title">
-                                {MODE_LABELS["antigravity_config"]}
+                          {configMode !== "antigravity_config" && (
+                            <button
+                              className="home-quick-action"
+                              onClick={() => createSession("antigravity_config")}
+                              disabled={
+                                busy ||
+                                !createModeAllowedByRunOptions(
+                                  "antigravity_config",
+                                  sessionRunOptions,
+                                )
+                              }
+                            >
+                              <ProviderIcon
+                                provider="antigravity"
+                                className="home-quick-icon"
+                              />
+                              <span className="home-quick-main">
+                                <span className="home-quick-title">
+                                  {MODE_LABELS["antigravity_config"]}
+                                </span>
+                                <span className="home-quick-sub">
+                                  {MODE_HINTS["antigravity_config"]}
+                                </span>
                               </span>
-                              <span className="home-quick-sub">
-                                {MODE_HINTS["antigravity_config"]}
-                              </span>
-                            </span>
-                          </button>
+                            </button>
+                          )}
                         </div>
                         {REPO_SUPPORTED_MODES.has(defaultSessionMode) && (
                           <RepoPicker


### PR DESCRIPTION
Hides the hardcoded antigravity_config shortcut when it is already being rendered dynamically by the configMode provider logic.

## Feature Contracts
Affected contracts:
- [x] None

Evidence:
This only fixes a client-side conditional render for a button. No feature contracts changed.