### PR TITLE
fix(terminal): restore antigravity CLI mode with TUI (-p) in Ghostty

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_terminal.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal.go
@@ -57,6 +57,8 @@ func cliProcessLaunchForMode(mode string) sandboxProcessCreate {
 		// to ~/.gemini/antigravity-cli/antigravity-oauth-token, which the
 		// save-credentials button harvests.
 		base.Args = []string{"-lc", "agy; exec bash"}
+	case sessionmodel.AntigravityCLIMode:
+		base.Args = []string{"-lc", "agy -p; exec bash"}
 	default:
 		base.Args = []string{"-l"}
 	}

--- a/backend-go/cmd/tank-operator/handlers_terminal_test.go
+++ b/backend-go/cmd/tank-operator/handlers_terminal_test.go
@@ -32,6 +32,8 @@ func TestCliProcessLaunchForMode_ConfigWizards(t *testing.T) {
 	}{
 		{sessionmodel.CodexConfigMode, []string{"-lc", "codex login --device-auth; exec bash"}},
 		{sessionmodel.ConfigMode, []string{"-lc", "claude /login; exec bash"}},
+		{sessionmodel.AntigravityConfigMode, []string{"-lc", "agy; exec bash"}},
+		{sessionmodel.AntigravityCLIMode, []string{"-lc", "agy -p; exec bash"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.mode, func(t *testing.T) {


### PR DESCRIPTION
Restores the Antigravity CLI mode so it correctly launches the TUI via Ghostty.

## Feature Contracts
Affected contracts:
- [x] None

Evidence:
Changes only the launch arguments for Antigravity CLI mode in the terminal handler and does not alter any existing feature contracts.