### PR TITLE
chore: Set revisionHistoryLimit to 0

### DIFF
--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -306,6 +306,7 @@ metadata:
     app.kubernetes.io/name: claude-api-proxy
 spec:
   replicas: 1
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: claude-api-proxy
@@ -562,6 +563,7 @@ metadata:
     app.kubernetes.io/name: codex-api-proxy
 spec:
   replicas: 1
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: codex-api-proxy
@@ -827,6 +829,7 @@ metadata:
     app.kubernetes.io/name: antigravity-api-proxy
 spec:
   replicas: 1
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: antigravity-api-proxy

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: tank-operator
 spec:
   replicas: {{ .Values.orchestrator.replicas }}
+  revisionHistoryLimit: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Sets revisionHistoryLimit to 0 to keep GitOps deployments clean.