### PR TITLE
feat(proxy): route play, www, and oauth2 googleapis.com domains through antigravity-api-proxy

### DIFF
--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -763,7 +763,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	if (mode == AntigravityGUIMode || mode == AntigravityCLIMode) && opts.AntigravityAPIProxyIP != "" {
 		hostAliases = append(hostAliases, map[string]any{
 			"ip":        opts.AntigravityAPIProxyIP,
-			"hostnames": []any{"cloudcode-pa.googleapis.com", "daily-cloudcode-pa.googleapis.com"},
+			"hostnames": []any{"cloudcode-pa.googleapis.com", "daily-cloudcode-pa.googleapis.com", "play.googleapis.com", "www.googleapis.com", "oauth2.googleapis.com"},
 		})
 		if mode == AntigravityCLIMode && opts.OAuthGatewayCAConfigMap != "" {
 			claudeVolumeMounts = append(claudeVolumeMounts, map[string]any{

--- a/backend-go/internal/sessionmodel/sessionmodel_test.go
+++ b/backend-go/internal/sessionmodel/sessionmodel_test.go
@@ -377,6 +377,9 @@ func TestPodManifestAntigravityGUIRunnerProxiedNoCredMount(t *testing.T) {
 	// Instead: host-alias agy's Google host to the proxy + trust its CA.
 	assertHostAlias(t, spec, "10.0.0.42", "cloudcode-pa.googleapis.com")
 	assertHostAlias(t, spec, "10.0.0.42", "daily-cloudcode-pa.googleapis.com")
+	assertHostAlias(t, spec, "10.0.0.42", "play.googleapis.com")
+	assertHostAlias(t, spec, "10.0.0.42", "www.googleapis.com")
+	assertHostAlias(t, spec, "10.0.0.42", "oauth2.googleapis.com")
 	assertVolume(t, spec["volumes"].([]any), "oauth-gateway-ca")
 	assertVolumeMount(t, runner, "oauth-gateway-ca")
 	assertVolumeMount(t, runner, "session-config")

--- a/k8s/templates/api-proxy.yaml
+++ b/k8s/templates/api-proxy.yaml
@@ -668,6 +668,9 @@ spec:
   dnsNames:
     - cloudcode-pa.googleapis.com
     - daily-cloudcode-pa.googleapis.com
+    - play.googleapis.com
+    - www.googleapis.com
+    - oauth2.googleapis.com
   issuerRef:
     name: claude-oauth-ca-issuer
     kind: Issuer
@@ -758,11 +761,55 @@ data:
                       name: cloudcode
                       virtual_hosts:
                         - name: cloudcode
-                          domains: ["*"]
+                          domains:
+                            - "cloudcode-pa.googleapis.com"
+                            - "daily-cloudcode-pa.googleapis.com"
                           routes:
                             - match: { prefix: "/" }
                               route:
                                 cluster: cloudcode_api
+                                timeout: 600s
+                                retry_policy:
+                                  retry_on: "retriable-status-codes"
+                                  retriable_status_codes: [401]
+                                  num_retries: 1
+                                  per_try_timeout: 600s
+                                auto_host_rewrite: true
+                        - name: www_google
+                          domains:
+                            - "www.googleapis.com"
+                          routes:
+                            - match: { prefix: "/" }
+                              route:
+                                cluster: www_api
+                                timeout: 600s
+                                retry_policy:
+                                  retry_on: "retriable-status-codes"
+                                  retriable_status_codes: [401]
+                                  num_retries: 1
+                                  per_try_timeout: 600s
+                                auto_host_rewrite: true
+                        - name: play_google
+                          domains:
+                            - "play.googleapis.com"
+                          routes:
+                            - match: { prefix: "/" }
+                              route:
+                                cluster: play_api
+                                timeout: 600s
+                                retry_policy:
+                                  retry_on: "retriable-status-codes"
+                                  retriable_status_codes: [401]
+                                  num_retries: 1
+                                  per_try_timeout: 600s
+                                auto_host_rewrite: true
+                        - name: oauth2_google
+                          domains:
+                            - "oauth2.googleapis.com"
+                          routes:
+                            - match: { prefix: "/" }
+                              route:
+                                cluster: oauth2_api
                                 timeout: 600s
                                 retry_policy:
                                   retry_on: "retriable-status-codes"
@@ -795,6 +842,75 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
               sni: cloudcode-pa.googleapis.com
+              common_tls_context:
+                validation_context:
+                  trusted_ca:
+                    filename: /etc/ssl/certs/ca-certificates.crt
+        - name: www_api
+          type: LOGICAL_DNS
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: www_api
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: www.googleapis.com
+                          port_value: 443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: www.googleapis.com
+              common_tls_context:
+                validation_context:
+                  trusted_ca:
+                    filename: /etc/ssl/certs/ca-certificates.crt
+        - name: play_api
+          type: LOGICAL_DNS
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: play_api
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: play.googleapis.com
+                          port_value: 443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: play.googleapis.com
+              common_tls_context:
+                validation_context:
+                  trusted_ca:
+                    filename: /etc/ssl/certs/ca-certificates.crt
+        - name: oauth2_api
+          type: LOGICAL_DNS
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: oauth2_api
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: oauth2.googleapis.com
+                          port_value: 443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: oauth2.googleapis.com
               common_tls_context:
                 validation_context:
                   trusted_ca:


### PR DESCRIPTION
## Summary

- Intercept background Google API requests (`www.googleapis.com`, `play.googleapis.com`, `oauth2.googleapis.com`) in the `antigravity-api-proxy`.
- Inject the real consumer OAuth access token in place of the `managed-by-tank-operator` placeholder token for telemetry and user profile lookups.
- Resolves client-side `401 Unauthorized` warnings in the UI/logs while using `agy`.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [x] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Re-issued the certificate with new SANs and verified the Envoy changes.
- Executed `curl` inside a test pod mimicking a session pod and confirmed the proxy intercepts and returns a `200 OK` user profile instead of a `401` error.
- Go unit tests in `sessionmodel_test.go` pass.
