### PR TITLE
fix(ci): correct trigger and fingerprint paths for Go antigravity runner

### DIFF
--- a/.github/workflows/docker-build-check.yaml
+++ b/.github/workflows/docker-build-check.yaml
@@ -76,7 +76,7 @@ jobs:
             cache-ref: romainecr.azurecr.io/antigravity-container-build-cache:antigravity
             image-repo: antigravity-container
             fingerprint-image: antigravity
-            fingerprint-paths: antigravity-container .dockerignore claude-container/mcp-auth-proxy
+            fingerprint-paths: antigravity-container .dockerignore claude-container/mcp-auth-proxy backend-go/go.mod backend-go/go.sum backend-go/internal backend-go/cmd/tank-supervisor backend-go/cmd/antigravity-runner
           # Standalone mcp-auth-proxy image for sibling consumers
           # (nelsong6/hermes today). Built from the same package source
           # Tank session pods bake inline, but published as its own

--- a/.github/workflows/session-images-build.yml
+++ b/.github/workflows/session-images-build.yml
@@ -8,7 +8,7 @@ on:
       - 'antigravity-container/**'
       - 'agent-runner/**'
       - 'codex-runner/**'
-      - 'antigravity-runner/**'
+      - 'backend-go/cmd/antigravity-runner/**'
       - 'runner-shared/**'
       - 'scripts/image-fingerprint.sh'
       - '.github/workflows/session-images-build.yml'


### PR DESCRIPTION
## Summary

- Corrects fingerprint paths in \docker-build-check.yaml\ and trigger paths in \session-images-build.yml\ to point to the actual Go runner codebase under \ackend-go/cmd/antigravity-runner\.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [x] None

Evidence:
- This is a CI trigger/path correction change only, which will be verified by the next Docker Build Check run logs.