### PR TITLE
fix(runner): wait for agy CLI to be ready before NATS consumption

### DIFF
--- a/backend-go/cmd/antigravity-runner/main.go
+++ b/backend-go/cmd/antigravity-runner/main.go
@@ -172,6 +172,13 @@ func main() {
 		}
 	}()
 
+	readyCtx, readyCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer readyCancel()
+	if err := waitForCliReady(readyCtx, cfg.agyHome); err != nil {
+		slog.Error("agy CLI failed to become ready", "error", err)
+		os.Exit(1)
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -185,6 +192,35 @@ func main() {
 	wg.Wait()
 	slog.Info("antigravity cli runner exited")
 }
+
+func waitForCliReady(ctx context.Context, agyHome string) error {
+	logPath := filepath.Join(agyHome, "cli.log")
+	slog.Info("waiting for agy CLI to be ready...", "log_path", logPath)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				slog.Debug("failed to read agy log path", "error", err)
+				continue
+			}
+			if bytes.Contains(data, []byte("CLI ready for user input")) {
+				slog.Info("agy CLI is ready for user input")
+				return nil
+			}
+		}
+	}
+}
+
 
 func loadConfig() (runnerConfig, error) {
 	storageKey := firstEnv("TANK_SESSION_STORAGE_KEY", "SESSION_STORAGE_KEY")


### PR DESCRIPTION
## Summary

- Wait for the agy CLI to be fully ready for input (by scanning `cli.log` for the string `CLI ready for user input`) before starting the NATS command consumers in the runner. This prevents Turn 1 prompts (which are already queued in NATS when the runner starts) from being written to the PTY and dropped before the CLI is initialized.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Tests pass locally (`go test ./...`).
- The runner blocks data/control NATS consumers until `waitForCliReady` returns success. This guarantees that `handleSubmitTurn` (which writes to the PTY) is only invoked after the CLI has outputted the `"CLI ready for user input"` log line.
