### PR TITLE
fix(runner): wait until agy input loop is authenticated and initialized

### DIFF
--- a/backend-go/cmd/antigravity-runner/main.go
+++ b/backend-go/cmd/antigravity-runner/main.go
@@ -195,7 +195,7 @@ func main() {
 
 func waitForCliReady(ctx context.Context, agyHome string) error {
 	logPath := filepath.Join(agyHome, "cli.log")
-	slog.Info("waiting for agy CLI to be ready...", "log_path", logPath)
+	slog.Info("waiting for agy CLI to complete initialization and authentication...", "log_path", logPath)
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -203,7 +203,7 @@ func waitForCliReady(ctx context.Context, agyHome string) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("agy CLI failed to initialize: %w", ctx.Err())
 		case <-ticker.C:
 			data, err := os.ReadFile(logPath)
 			if err != nil {
@@ -213,8 +213,8 @@ func waitForCliReady(ctx context.Context, agyHome string) error {
 				slog.Debug("failed to read agy log path", "error", err)
 				continue
 			}
-			if bytes.Contains(data, []byte("CLI ready for user input")) {
-				slog.Info("agy CLI is ready for user input")
+			if bytes.Contains(data, []byte("Auth done received")) || bytes.Contains(data, []byte("Reloading system slash commands")) {
+				slog.Info("agy CLI is fully authenticated and ready for user input")
 				return nil
 			}
 		}


### PR DESCRIPTION
## Summary

- Blocks NATS command consumption in the runner until `agy` logs `"Auth done received"` or `"Reloading system slash commands"`.
- This ensures that bubbletea TUI TUI input loop is fully initialized and authenticated before the runner sends user keystrokes (preventing early prompts from being ignored/dropped by the TUI).
- Errors out (fails the startup) if it fails to find either log line before the context timeout expires.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Tests pass locally (`go test ./...`).
- Inspecting the `agy` logs of `session-766` shows that authentication and input loop initialization complete asynchronously about 1.5 seconds after `"CLI ready for user input"` is printed, which was causing the runner to write prompts too early.
