### PR TITLE
fix: resolve CLI terminal input focus, double cursor, and color output

### DIFF
--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -544,6 +544,7 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 	// Environment variables for the claude container.
 	env := []any{
 		map[string]any{"name": "SANDBOX_AGENT_PORT", "value": itoa(opts.SandboxAgentPort)},
+		map[string]any{"name": "TERM", "value": "xterm-256color"},
 		// TANK_SESSION_MODE drives session-pod-bootstrap.sh's per-mode
 		// seeding (~/.codex/config.toml, ~/.claude/settings.json, etc.).
 		// Also surfaced inside the user's shell, so `echo $TANK_SESSION_MODE`

--- a/backend-go/internal/sessionmodel/testdata/manifest_fixture.json
+++ b/backend-go/internal/sessionmodel/testdata/manifest_fixture.json
@@ -24,7 +24,8 @@
       "TANK_GLIMMUNG_RUN_REF": "",
       "TANK_GLIMMUNG_TOUCHPOINT_REF": "",
       "TANK_GLIMMUNG_VALIDATION_URL": "",
-      "TANK_SESSION_MODE": "codex_gui"
+      "TANK_SESSION_MODE": "codex_gui",
+      "TERM": "xterm-256color"
     },
     "container_images": {
       "sandbox": "romainecr.azurecr.io/codex-container:latest",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6810,6 +6810,24 @@ button:disabled {
   background: var(--bg-base, #0a0a0a) !important;
 }
 
+.run-process-terminal textarea {
+  position: absolute !important;
+  opacity: 0 !important;
+  left: -9999px !important;
+  top: 0 !important;
+  width: 1px !important;
+  height: 1px !important;
+  z-index: -10 !important;
+  background: transparent !important;
+  color: transparent !important;
+  border: none !important;
+  outline: none !important;
+  box-shadow: none !important;
+  resize: none !important;
+  pointer-events: none !important;
+  caret-color: transparent !important;
+}
+
 .run-shell-loading,
 .run-shell-error {
   height: 100%;


### PR DESCRIPTION
## Summary

- Fixed the interactive in-browser CLI terminal duplicate cursor by hiding the input textarea programmatically with CSS rules.
- Fixed keyboard input focus rejection on the CLI terminal by ensuring the hidden textarea is styled correctly to avoid interfering with click events.
- Fixed black-and-white rendering of the terminal by adding `TERM=xterm-256color` to the sandbox container's environment variables in the pod manifest.
- Updated unit test fixture `manifest_fixture.json` to reflect the new env var.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Ran `go test ./internal/sessionmodel/...` in `backend-go` to verify the manifest fixture output matches:
  ```
  ok      github.com/romaine-life/tank-operator/backend-go/internal/sessionmodel  0.373s
  ```
- Checked that the frontend build compiles successfully with `npm run build`:
  ```
  vite v5.4.21 building for production...
  ✓ built in 7.47s
  ```
