### PR TITLE
fix(bootstrap): export TERM=xterm-256color in bashrc and bash_profile

### DIFF
--- a/k8s/session-config/session-pod-bootstrap.sh
+++ b/k8s/session-config/session-pod-bootstrap.sh
@@ -222,3 +222,8 @@ EOF
     fi
     ;;
 esac
+
+# Ensure TERM is always set to xterm-256color in interactive shell sessions
+echo "export TERM=xterm-256color" >> "${HOME}/.bashrc"
+echo "export TERM=xterm-256color" >> "${HOME}/.bash_profile"
+


### PR DESCRIPTION
## Summary

- Appended `export TERM=xterm-256color` to both `~/.bashrc` and `~/.bash_profile` in the session pod bootstrap script (`session-pod-bootstrap.sh`). This guarantees that interactive shells (login or non-login) started in the sandbox container always have the correct color settings.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Ran `go test ./cmd/tank-operator -run TestSessionPodBootstrapScript` to verify that bootstrap config generation and tests succeed.
