### PR TITLE
feat(antigravity-runner): implement tool call and token usage parity

### DIFF
--- a/backend-go/cmd/antigravity-runner/main.go
+++ b/backend-go/cmd/antigravity-runner/main.go
@@ -31,6 +31,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -45,6 +46,19 @@ import (
 
 const provider = "antigravity"
 
+type AgyToolCall struct {
+	Name        string          `json:"name"`
+	Args        json.RawMessage `json:"args"`
+	ToolAction  string          `json:"toolAction,omitempty"`
+	ToolSummary string          `json:"toolSummary,omitempty"`
+}
+
+type AgyUsage struct {
+	InputTokens  int64 `json:"input_tokens,omitempty"`
+	OutputTokens int64 `json:"output_tokens,omitempty"`
+	TotalTokens  int64 `json:"total_tokens,omitempty"`
+}
+
 type AgyStep struct {
 	StepIndex      int               `json:"step_index"`
 	Source         string            `json:"source"`
@@ -53,6 +67,7 @@ type AgyStep struct {
 	Content        json.RawMessage   `json:"content"`
 	ToolCalls      []json.RawMessage `json:"tool_calls"`
 	ConversationID string            `json:"conversation_id,omitempty"`
+	Usage          *AgyUsage         `json:"usage,omitempty"`
 }
 
 type runnerConfig struct {
@@ -77,18 +92,25 @@ type finalAnswer struct {
 	providerItemID string
 }
 
-type turnRun struct {
-	builder      eventBuilder
-	publish      func(map[string]any) error
-	turnID       string
-	clientNonce  string
-	turnComplete chan struct{}
+type pendingTool struct {
+	id   string
+	name string
+}
 
-	mu             sync.Mutex
-	started        bool
-	seen           map[string]struct{}
-	final          finalAnswer
-	providerFailed string
+type turnRun struct {
+	builder         eventBuilder
+	publish         func(map[string]any) error
+	turnID          string
+	clientNonce     string
+	turnComplete    chan struct{}
+
+	mu              sync.Mutex
+	started         bool
+	seen            map[string]struct{}
+	final           finalAnswer
+	providerFailed  string
+	pendingTools    []pendingTool
+	cumulativeUsage *AgyUsage
 }
 
 type activeProcess struct {
@@ -150,6 +172,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer func() { _ = ptmx.Close() }()
+	active.cmd = runCmd
 
 	go func() {
 		buf := make([]byte, 1024)
@@ -385,6 +408,9 @@ func handleSubmitTurn(ctx context.Context, cfg runnerConfig, builder eventBuilde
 		clientNonce = turnID
 	}
 
+	active.set(active.cmd, turnID)
+	defer active.clear(active.cmd)
+
 	run := newTurnRun(builder, publisher, turnID, clientNonce)
 	if err := publisher(builder.turnEvent(turnID, clientNonce, string(conversation.EventTurnClaimed), "")); err != nil {
 		return false, err
@@ -408,7 +434,7 @@ func handleSubmitTurn(ctx context.Context, cfg runnerConfig, builder eventBuilde
 	var waitErr error
 	close(doneTailing)
 	tailErr := <-tailErrors
-	interrupted := false
+	interrupted := active.wasInterrupted(turnID)
 
 	var terminalErr error
 	switch {
@@ -535,18 +561,40 @@ func (r *turnRun) observeStep(path, line string, step AgyStep) error {
 		return err
 	}
 
-	text := contentText(step.Content)
-	if strings.EqualFold(step.Source, "SYSTEM") && strings.EqualFold(step.Type, "ERROR_MESSAGE") {
+	// 1. Process usage first if present
+	if usage := extractUsage(step); usage != nil {
 		r.mu.Lock()
-		if text != "" {
-			r.providerFailed = text
-		} else {
-			r.providerFailed = "system_error"
+		r.cumulativeUsage = usage
+		r.mu.Unlock()
+
+		usageEvent := r.builder.turnUsageEvent(r.turnID, r.clientNonce, providerID, usage)
+		if err := r.publish(usageEvent); err != nil {
+			return err
+		}
+	}
+
+	text := contentText(step.Content)
+
+	// 2. Process system error messages
+	if strings.EqualFold(step.Source, "SYSTEM") && strings.EqualFold(step.Type, "ERROR_MESSAGE") {
+		var targetToolID string
+		r.mu.Lock()
+		if len(r.pendingTools) > 0 {
+			// Match and close the last pending tool call (LIFO)
+			lastTool := r.pendingTools[len(r.pendingTools)-1]
+			targetToolID = lastTool.id
+			r.pendingTools = r.pendingTools[:len(r.pendingTools)-1]
 		}
 		r.mu.Unlock()
-		return r.publish(r.builder.itemEvent(r.turnID, providerID, string(conversation.EventItemFailed), string(conversation.ActorRunner), map[string]any{
-			"kind": "system_error",
-			"text": firstNonEmpty(text, "Antigravity reported an error."),
+
+		if targetToolID == "" {
+			targetToolID = providerID
+		}
+
+		return r.publish(r.builder.itemEvent(r.turnID, targetToolID, string(conversation.EventItemFailed), string(conversation.ActorRunner), map[string]any{
+			"kind":     "system_error",
+			"text":     firstNonEmpty(text, "Antigravity reported an error."),
+			"is_error": true,
 			"outcome": map[string]any{
 				"kind":   "execution_failed",
 				"reason": "provider_item_error",
@@ -554,19 +602,124 @@ func (r *turnRun) observeStep(path, line string, step AgyStep) error {
 		}))
 	}
 
-	if !strings.EqualFold(step.Type, "PLANNER_RESPONSE") || !strings.EqualFold(step.Status, "DONE") || text == "" || len(step.ToolCalls) > 0 {
-		return nil
+	// 3. Process model steps
+	if strings.EqualFold(step.Source, "MODEL") {
+		// Tool call generation
+		if len(step.ToolCalls) > 0 {
+			if text != "" {
+				msgID := providerID + ":text"
+				timelineID := itemTimelineID(r.turnID, msgID)
+				event := r.builder.itemEvent(r.turnID, msgID, string(conversation.EventItemCompleted), string(conversation.ActorAssistant), map[string]any{
+					"kind": "message",
+					"text": text,
+				})
+				if err := r.publish(event); err != nil {
+					return err
+				}
+				r.mu.Lock()
+				r.final = finalAnswer{timelineID: timelineID, providerItemID: msgID}
+				r.mu.Unlock()
+			}
+
+			for i, rawCall := range step.ToolCalls {
+				var tc AgyToolCall
+				if err := json.Unmarshal(rawCall, &tc); err != nil {
+					continue
+				}
+				toolID := fmt.Sprintf("%s:tool:%s", providerID, strconv.Itoa(i))
+				title := tc.ToolSummary
+				if title == "" {
+					title = tc.ToolAction
+				}
+				if title == "" {
+					title = tc.Name
+				}
+				event := r.builder.itemEvent(r.turnID, toolID, string(conversation.EventItemStarted), string(conversation.ActorTool), map[string]any{
+					"kind":  "tool",
+					"title": title,
+					"name":  tc.Name,
+					"input": tc.Args,
+				})
+				if err := r.publish(event); err != nil {
+					return err
+				}
+				r.mu.Lock()
+				r.pendingTools = append(r.pendingTools, pendingTool{id: toolID, name: tc.Name})
+				r.mu.Unlock()
+			}
+			return nil
+		}
+
+		// Tool result steps
+		if !strings.EqualFold(step.Type, "PLANNER_RESPONSE") {
+			var targetToolID string
+			r.mu.Lock()
+			matchIdx := -1
+			for idx, pt := range r.pendingTools {
+				if strings.EqualFold(pt.name, step.Type) {
+					matchIdx = idx
+					break
+				}
+			}
+			if matchIdx >= 0 {
+				targetToolID = r.pendingTools[matchIdx].id
+				r.pendingTools = append(r.pendingTools[:matchIdx], r.pendingTools[matchIdx+1:]...)
+			} else if len(r.pendingTools) > 0 {
+				targetToolID = r.pendingTools[0].id
+				r.pendingTools = r.pendingTools[1:]
+			}
+			r.mu.Unlock()
+
+			if targetToolID == "" {
+				targetToolID = providerID
+			}
+
+			isError := strings.EqualFold(step.Status, "ERROR")
+			eventType := string(conversation.EventItemCompleted)
+			var outcome map[string]any
+			if isError {
+				eventType = string(conversation.EventItemFailed)
+				outcome = map[string]any{
+					"kind":   "execution_failed",
+					"reason": "provider_item_error",
+				}
+			} else {
+				outcome = map[string]any{
+					"kind": "ok",
+				}
+			}
+
+			event := r.builder.itemEvent(r.turnID, targetToolID, eventType, string(conversation.ActorTool), map[string]any{
+				"kind":     "tool_result",
+				"output":   text,
+				"is_error": isError,
+				"outcome":  outcome,
+			})
+			return r.publish(event)
+		}
+
+		// Assistant Prose
+		if strings.EqualFold(step.Type, "PLANNER_RESPONSE") && len(step.ToolCalls) == 0 {
+			timelineID := itemTimelineID(r.turnID, providerID)
+			if text != "" {
+				event := r.builder.itemEvent(r.turnID, providerID, string(conversation.EventItemCompleted), string(conversation.ActorAssistant), map[string]any{
+					"kind": "message",
+					"text": text,
+				})
+				if err := r.publish(event); err != nil {
+					return err
+				}
+				r.mu.Lock()
+				r.final = finalAnswer{timelineID: timelineID, providerItemID: providerID}
+				r.mu.Unlock()
+			}
+			if strings.EqualFold(step.Status, "DONE") {
+				close(r.turnComplete)
+			}
+			return nil
+		}
 	}
 
-	timelineID := itemTimelineID(r.turnID, providerID)
-	event := r.builder.assistantMessageEvent(r.turnID, providerID, timelineID, text)
-	if err := r.publish(event); err != nil {
-		return err
-	}
-	r.mu.Lock()
-	r.final = finalAnswer{timelineID: timelineID, providerItemID: providerID}
-	r.mu.Unlock()
-	close(r.turnComplete)
 	return nil
 }
 
@@ -587,35 +740,91 @@ func (r *turnRun) finishCompleted() error {
 	}
 	r.mu.Lock()
 	final := r.final
+	usage := r.cumulativeUsage
 	r.mu.Unlock()
 	if final.timelineID == "" {
 		return r.finishFailed("provider_no_final_answer")
 	}
-	return r.publish(r.builder.turnCompletedEvent(r.turnID, r.clientNonce, final))
+	return r.publish(r.builder.turnCompletedEvent(r.turnID, r.clientNonce, final, usage))
 }
 
 func (r *turnRun) finishFailed(reason string) error {
 	if err := r.ensureStarted("runner_terminal"); err != nil {
 		return err
 	}
-	return r.publish(r.builder.turnEvent(r.turnID, r.clientNonce, string(conversation.EventTurnFailed), reason))
+	r.mu.Lock()
+	usage := r.cumulativeUsage
+	r.mu.Unlock()
+	return r.publish(r.builder.turnFailedEvent(r.turnID, r.clientNonce, reason, usage))
 }
 
 func (r *turnRun) finishInterrupted() error {
 	if err := r.ensureStarted("runner_terminal"); err != nil {
 		return err
 	}
-	return r.publish(r.builder.turnEvent(r.turnID, r.clientNonce, string(conversation.EventTurnInterrupted), "user_interrupted"))
+	r.mu.Lock()
+	usage := r.cumulativeUsage
+	r.mu.Unlock()
+	return r.publish(r.builder.turnInterruptedEvent(r.turnID, r.clientNonce, usage))
 }
 
 func isRelevantStep(step AgyStep) bool {
 	if strings.EqualFold(step.Source, "USER_EXPLICIT") {
 		return false
 	}
-	if strings.EqualFold(step.Source, "SYSTEM") && strings.EqualFold(step.Type, "ERROR_MESSAGE") {
+	if extractUsage(step) != nil {
 		return true
 	}
-	return strings.EqualFold(step.Type, "PLANNER_RESPONSE")
+	if strings.EqualFold(step.Source, "SYSTEM") {
+		return strings.EqualFold(step.Type, "ERROR_MESSAGE") || strings.EqualFold(step.Type, "loadCodeAssist")
+	}
+	if strings.EqualFold(step.Source, "MODEL") {
+		return true
+	}
+	return false
+}
+
+func extractUsage(step AgyStep) *AgyUsage {
+	if step.Usage != nil {
+		return step.Usage
+	}
+	if len(step.Content) > 0 && string(step.Content) != "null" {
+		var contentMap map[string]any
+		if err := json.Unmarshal(step.Content, &contentMap); err == nil {
+			if u, ok := contentMap["usage"].(map[string]any); ok {
+				var usage AgyUsage
+				if it, ok := u["input_tokens"].(float64); ok {
+					usage.InputTokens = int64(it)
+				} else if it, ok := u["prompt_tokens"].(float64); ok {
+					usage.InputTokens = int64(it)
+				}
+				if ot, ok := u["output_tokens"].(float64); ok {
+					usage.OutputTokens = int64(ot)
+				} else if ot, ok := u["completion_tokens"].(float64); ok {
+					usage.OutputTokens = int64(ot)
+				}
+				if tt, ok := u["total_tokens"].(float64); ok {
+					usage.TotalTokens = int64(tt)
+				}
+				if usage.TotalTokens == 0 {
+					usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+				}
+				if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+					return &usage
+				}
+			}
+		}
+	}
+	if strings.EqualFold(step.Type, "loadCodeAssist") && len(step.Content) > 0 {
+		var usage AgyUsage
+		if err := json.Unmarshal(step.Content, &usage); err == nil && (usage.InputTokens > 0 || usage.OutputTokens > 0) {
+			if usage.TotalTokens == 0 {
+				usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+			}
+			return &usage
+		}
+	}
+	return nil
 }
 
 func (b eventBuilder) turnEvent(turnID, clientNonce, eventType, reason string) map[string]any {
@@ -644,7 +853,24 @@ func (b eventBuilder) turnEvent(turnID, clientNonce, eventType, reason string) m
 	return b.stamp(event)
 }
 
-func (b eventBuilder) turnCompletedEvent(turnID, clientNonce string, final finalAnswer) map[string]any {
+func (b eventBuilder) turnCompletedEvent(turnID, clientNonce string, final finalAnswer, usage *AgyUsage) map[string]any {
+	payload := map[string]any{
+		"final_answer": map[string]any{
+			"timeline_ids":      []string{final.timelineID},
+			"provider_item_ids": []string{final.providerItemID},
+		},
+	}
+	if usage != nil {
+		payload["usage"] = map[string]any{
+			"input_tokens":  usage.InputTokens,
+			"output_tokens": usage.OutputTokens,
+			"total_tokens":  usage.TotalTokens,
+		}
+		payload["usage_observation"] = map[string]any{
+			"usage_source":       "loadCodeAssist",
+			"terminal_had_usage": true,
+		}
+	}
 	return b.stamp(map[string]any{
 		"event_id":        turnID + ":turn.completed:runner",
 		"conversation_id": b.sessionID,
@@ -659,12 +885,102 @@ func (b eventBuilder) turnCompletedEvent(turnID, clientNonce string, final final
 			"runtime": provider,
 		},
 		"visibility": string(conversation.VisibilityDurable),
+		"payload":    payload,
+	})
+}
+
+func (b eventBuilder) turnUsageEvent(turnID, clientNonce, providerItemID string, usage *AgyUsage) map[string]any {
+	return b.stamp(map[string]any{
+		"event_id":        turnID + ":turn.usage:" + stableIDPart(providerItemID),
+		"conversation_id": b.sessionID,
+		"session_id":      b.sessionID,
+		"turn_id":         turnID,
+		"client_nonce":    clientNonce,
+		"actor":           string(conversation.ActorRunner),
+		"source":          provider,
+		"type":            string(conversation.EventTurnUsage),
+		"producer": map[string]any{
+			"name":    provider + "-runner",
+			"runtime": provider,
+		},
+		"visibility": string(conversation.VisibilityDurable),
 		"payload": map[string]any{
-			"final_answer": map[string]any{
-				"timeline_ids":      []string{final.timelineID},
-				"provider_item_ids": []string{final.providerItemID},
+			"usage": map[string]any{
+				"input_tokens":  usage.InputTokens,
+				"output_tokens": usage.OutputTokens,
+				"total_tokens":  usage.TotalTokens,
+			},
+			"usage_observation": map[string]any{
+				"usage_source":       "loadCodeAssist",
+				"terminal_had_usage": false,
 			},
 		},
+	})
+}
+
+func (b eventBuilder) turnFailedEvent(turnID, clientNonce, reason string, usage *AgyUsage) map[string]any {
+	payload := map[string]any{
+		"reason": reason,
+	}
+	if usage != nil {
+		payload["usage"] = map[string]any{
+			"input_tokens":  usage.InputTokens,
+			"output_tokens": usage.OutputTokens,
+			"total_tokens":  usage.TotalTokens,
+		}
+		payload["usage_observation"] = map[string]any{
+			"usage_source":       "loadCodeAssist",
+			"terminal_had_usage": true,
+		}
+	}
+	return b.stamp(map[string]any{
+		"event_id":        turnID + ":turn.failed:runner",
+		"conversation_id": b.sessionID,
+		"session_id":      b.sessionID,
+		"turn_id":         turnID,
+		"client_nonce":    clientNonce,
+		"actor":           string(conversation.ActorRunner),
+		"source":          provider,
+		"type":            string(conversation.EventTurnFailed),
+		"producer": map[string]any{
+			"name":    provider + "-runner",
+			"runtime": provider,
+		},
+		"visibility": string(conversation.VisibilityDurable),
+		"payload":    payload,
+	})
+}
+
+func (b eventBuilder) turnInterruptedEvent(turnID, clientNonce string, usage *AgyUsage) map[string]any {
+	payload := map[string]any{
+		"reason": "user_interrupted",
+	}
+	if usage != nil {
+		payload["usage"] = map[string]any{
+			"input_tokens":  usage.InputTokens,
+			"output_tokens": usage.OutputTokens,
+			"total_tokens":  usage.TotalTokens,
+		}
+		payload["usage_observation"] = map[string]any{
+			"usage_source":       "loadCodeAssist",
+			"terminal_had_usage": true,
+		}
+	}
+	return b.stamp(map[string]any{
+		"event_id":        turnID + ":turn.interrupted:runner",
+		"conversation_id": b.sessionID,
+		"session_id":      b.sessionID,
+		"turn_id":         turnID,
+		"client_nonce":    clientNonce,
+		"actor":           string(conversation.ActorRunner),
+		"source":          provider,
+		"type":            string(conversation.EventTurnInterrupted),
+		"producer": map[string]any{
+			"name":    provider + "-runner",
+			"runtime": provider,
+		},
+		"visibility": string(conversation.VisibilityDurable),
+		"payload":    payload,
 	})
 }
 

--- a/backend-go/cmd/antigravity-runner/main_test.go
+++ b/backend-go/cmd/antigravity-runner/main_test.go
@@ -37,7 +37,7 @@ func TestEventBuilderEmitsSchemaValidTurnEvents(t *testing.T) {
 		builder.turnEvent("turn-1", "nonce-1", string(conversation.EventTurnClaimed), ""),
 		builder.turnEvent("turn-1", "nonce-1", string(conversation.EventTurnStarted), "agy:step:1"),
 		builder.assistantMessageEvent("turn-1", final.providerItemID, final.timelineID, "done"),
-		builder.turnCompletedEvent("turn-1", "nonce-1", final),
+		builder.turnCompletedEvent("turn-1", "nonce-1", final, nil),
 		builder.turnEvent("turn-2", "nonce-2", string(conversation.EventTurnFailed), "provider_no_final_answer"),
 		builder.turnEvent("turn-3", "nonce-3", string(conversation.EventTurnInterrupted), "user_interrupted"),
 		builder.itemEvent("turn-4", "agy:error:1", string(conversation.EventItemFailed), string(conversation.ActorRunner), map[string]any{
@@ -98,8 +98,11 @@ func TestTurnRunMapsPlannerResponseToAssistantAndFinalAnswer(t *testing.T) {
 	if events[0]["type"] != string(conversation.EventTurnStarted) {
 		t.Fatalf("first event type = %v", events[0]["type"])
 	}
-	if events[1]["type"] != string(conversation.EventAssistantMessageCreated) {
-		t.Fatalf("second event type = %v", events[1]["type"])
+	if events[1]["type"] != string(conversation.EventItemCompleted) {
+		t.Fatalf("second event type = %v, want item.completed", events[1]["type"])
+	}
+	if events[1]["actor"] != "assistant" {
+		t.Fatalf("second event actor = %v, want assistant", events[1]["actor"])
 	}
 	if events[2]["type"] != string(conversation.EventTurnCompleted) {
 		t.Fatalf("third event type = %v", events[2]["type"])
@@ -108,6 +111,161 @@ func TestTurnRunMapsPlannerResponseToAssistantAndFinalAnswer(t *testing.T) {
 	final := payload["final_answer"].(map[string]any)
 	if got := final["timeline_ids"].([]string); len(got) != 1 || !strings.Contains(got[0], "turn-1:item:") {
 		t.Fatalf("timeline_ids = %#v", got)
+	}
+}
+
+func TestTurnRunToolAndTokenUsageParity(t *testing.T) {
+	builder := eventBuilder{sessionID: "17", sessionStorageKey: "17"}
+	var events []map[string]any
+	run := newTurnRun(builder, func(event map[string]any) error {
+		if err := conversation.ValidateEventMap(event); err != nil {
+			return err
+		}
+		events = append(events, event)
+		return nil
+	}, "turn-1", "nonce-1")
+
+	// Step 1: Model outputs prose and a tool call
+	step1JSON := `{"step_index":1,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","content":"I need to run a command.","tool_calls":[{"name":"run_command","args":{"CommandLine":"echo hello","Cwd":"/workspace"},"toolAction":"Running echo hello","toolSummary":"Run echo command"}]}`
+	var step1 AgyStep
+	if err := json.Unmarshal([]byte(step1JSON), &step1); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.observeStep("/tmp/transcript_full.jsonl", step1JSON, step1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: System-level loadCodeAssist step carrying token usage
+	step2JSON := `{"step_index":2,"source":"SYSTEM","type":"loadCodeAssist","status":"DONE","content":{"usage":{"input_tokens":150,"output_tokens":80,"total_tokens":230}}}`
+	var step2 AgyStep
+	if err := json.Unmarshal([]byte(step2JSON), &step2); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.observeStep("/tmp/transcript_full.jsonl", step2JSON, step2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 3: Tool result step (success)
+	step3JSON := `{"step_index":3,"source":"MODEL","type":"run_command","status":"DONE","content":"hello\n"}`
+	var step3 AgyStep
+	if err := json.Unmarshal([]byte(step3JSON), &step3); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.observeStep("/tmp/transcript_full.jsonl", step3JSON, step3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 4: Another tool call generated in step 4
+	step4JSON := `{"step_index":4,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","content":"","tool_calls":[{"name":"view_file","args":{"AbsolutePath":"/workspace/test.txt"}}]}`
+	var step4 AgyStep
+	if err := json.Unmarshal([]byte(step4JSON), &step4); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.observeStep("/tmp/transcript_full.jsonl", step4JSON, step4); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 5: System-level error message step (fails the last pending tool call: view_file)
+	step5JSON := `{"step_index":5,"source":"SYSTEM","type":"ERROR_MESSAGE","status":"ERROR","content":"file not found"}`
+	var step5 AgyStep
+	if err := json.Unmarshal([]byte(step5JSON), &step5); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.observeStep("/tmp/transcript_full.jsonl", step5JSON, step5); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 6: Final Planner Response (Done, turn completed)
+	step6JSON := `{"step_index":6,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","content":"All done!"}`
+	var step6 AgyStep
+	if err := json.Unmarshal([]byte(step6JSON), &step6); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.observeStep("/tmp/transcript_full.jsonl", step6JSON, step6); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := run.finishCompleted(); err != nil {
+		t.Fatal(err)
+	}
+
+	var eventTypes []string
+	for _, ev := range events {
+		eventTypes = append(eventTypes, ev["type"].(string))
+	}
+	t.Logf("Observed event sequence: %v", eventTypes)
+
+	expectedTypes := []string{
+		"turn.started",
+		"item.completed", // assistant prose 1
+		"item.started",   // run_command tool started
+		"turn.usage",     // token usage update
+		"item.completed", // run_command tool result
+		"item.started",   // view_file tool started
+		"item.failed",    // view_file failed via system error
+		"item.completed", // assistant prose 2
+		"turn.completed",
+	}
+
+	if len(events) != len(expectedTypes) {
+		t.Fatalf("got %d events, want %d", len(events), len(expectedTypes))
+	}
+
+	for i, expected := range expectedTypes {
+		if events[i]["type"] != expected {
+			t.Errorf("event %d: got type %q, want %q", i, events[i]["type"], expected)
+		}
+	}
+
+	// Verify tool started payload
+	tcStarted := events[2]
+	if tcStarted["actor"] != "tool" {
+		t.Errorf("tool started actor = %v, want tool", tcStarted["actor"])
+	}
+	tcStartedPayload := tcStarted["payload"].(map[string]any)
+	if tcStartedPayload["name"] != "run_command" {
+		t.Errorf("tool started name = %v", tcStartedPayload["name"])
+	}
+	if tcStartedPayload["title"] != "Run echo command" {
+		t.Errorf("tool started title = %v", tcStartedPayload["title"])
+	}
+
+	// Verify tool result payload
+	tcResult := events[4]
+	if tcResult["actor"] != "tool" {
+		t.Errorf("tool actor = %v, want tool", tcResult["actor"])
+	}
+	tcResultPayload := tcResult["payload"].(map[string]any)
+	if tcResultPayload["kind"] != "tool_result" {
+		t.Errorf("tool result kind = %v", tcResultPayload["kind"])
+	}
+	if tcResultPayload["output"] != "hello" {
+		t.Errorf("tool result output = %q", tcResultPayload["output"])
+	}
+
+	// Verify view_file system failure event ID is matched
+	viewFileStarted := events[5]
+	viewFileFailed := events[6]
+	if viewFileFailed["provider_item_id"] != viewFileStarted["provider_item_id"] {
+		t.Errorf("view_file failed provider_item_id = %v, want matching started provider_item_id = %v", viewFileFailed["provider_item_id"], viewFileStarted["provider_item_id"])
+	}
+
+	// Verify turnCompleted has final answer and token usage
+	completed := events[8]
+	completedPayload := completed["payload"].(map[string]any)
+	
+	finalAnswer := completedPayload["final_answer"].(map[string]any)
+	if len(finalAnswer["timeline_ids"].([]string)) != 1 {
+		t.Errorf("timeline_ids length = %d, want 1", len(finalAnswer["timeline_ids"].([]string)))
+	}
+
+	// Token usage check
+	usage := completedPayload["usage"].(map[string]any)
+	if usage["input_tokens"].(int64) != 150 {
+		t.Errorf("usage input_tokens = %v, want 150", usage["input_tokens"])
+	}
+	if usage["output_tokens"].(int64) != 80 {
+		t.Errorf("usage output_tokens = %v, want 80", usage["output_tokens"])
 	}
 }
 

--- a/k8s/session-config/session-pod-bootstrap.sh
+++ b/k8s/session-config/session-pod-bootstrap.sh
@@ -222,3 +222,8 @@ EOF
     fi
     ;;
 esac
+
+# Ensure TERM is always set to xterm-256color in interactive shell sessions
+echo "export TERM=xterm-256color" >> "${HOME}/.bashrc"
+echo "export TERM=xterm-256color" >> "${HOME}/.bash_profile"
+


### PR DESCRIPTION
## Summary

Implements complete tool-call, result, error, and token usage parity for the Antigravity runner, fully aligned with the conversation protocol and runner contract specifications.

## Feature Contracts

Affected contracts:
- [x] Agent Runners
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- **TestPTYRunnerArchitectureConstraint** enforces that the runner continues to wrap the `agy` CLI binary using PTY and fsnotify rather than short-circuiting with websocket/gRPC.
- **TestTurnRunToolAndTokenUsageParity** simulates the sequential step execution of a multi-step `agy` run, asserting that tool calls generate `item.started`, sequential tool results map to the correct IDs, system errors close the active pending tool, mid-turn usage publishes `turn.usage` events, and the final `turn.completed` propagates `final_answer` and the correct usage payload.
