### PR TITLE
fix(frontend): resolve terminal input focus and shortcut conflicts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18361,7 +18361,7 @@ function ChatPane({
         targetIsComposer: !!textarea && e.target === textarea,
         activeTab,
       });
-      if (action === "ignore") return;
+      if (action === "ignore" || isTextEntryShortcutTarget(e.target)) return;
 
       e.preventDefault();
       e.stopPropagation();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6810,21 +6810,12 @@ button:disabled {
   background: var(--bg-base, #0a0a0a) !important;
 }
 
-.run-process-terminal textarea {
-  position: absolute !important;
-  opacity: 0 !important;
-  left: -9999px !important;
-  top: 0 !important;
-  width: 1px !important;
-  height: 1px !important;
-  z-index: -10 !important;
+.xterm .xterm-helper-textarea {
   background: transparent !important;
   color: transparent !important;
-  border: none !important;
+  border: 0 !important;
   outline: none !important;
   box-shadow: none !important;
-  resize: none !important;
-  pointer-events: none !important;
   caret-color: transparent !important;
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -28,6 +28,7 @@ import { StyleguideToolIcons } from "./styleguide/tool-icons";
 import { StyleguideType } from "./styleguide/type";
 import { StyleguideWelcomeCard } from "./styleguide/welcome-card";
 import "./fonts.css";
+import "./xterm.css";
 import "./index.css";
 
 if (typeof document !== "undefined") {

--- a/frontend/src/xterm.css
+++ b/frontend/src/xterm.css
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2014 The xterm.js authors. All rights reserved.
+ * Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
+ * https://github.com/chjj/term.js
+ * @license MIT
+ */
+
+.xterm {
+    cursor: text;
+    position: relative;
+    user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+}
+
+.xterm.focus,
+.xterm:focus {
+    outline: none;
+}
+
+.xterm .xterm-helpers {
+    position: absolute;
+    top: 0;
+    z-index: 5;
+}
+
+.xterm .xterm-helper-textarea {
+    padding: 0;
+    border: 0;
+    margin: 0;
+    position: absolute;
+    opacity: 0;
+    left: -9999em;
+    top: 0;
+    width: 0;
+    height: 0;
+    z-index: -5;
+    white-space: nowrap;
+    overflow: hidden;
+    resize: none;
+}
+
+.xterm .composition-view {
+    background: #000;
+    color: #FFF;
+    display: none;
+    position: absolute;
+    white-space: nowrap;
+    z-index: 1;
+}
+
+.xterm .composition-view.active {
+    display: block;
+}
+
+.xterm .xterm-viewport {
+    background-color: #000;
+    overflow-y: scroll;
+    cursor: default;
+    position: absolute;
+    right: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
+}
+
+.xterm .xterm-screen {
+    position: relative;
+}
+
+.xterm .xterm-screen canvas {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.xterm .xterm-scroll-area {
+    visibility: hidden;
+}
+
+.xterm-char-measure-element {
+    display: inline-block;
+    visibility: hidden;
+    position: absolute;
+    top: 0;
+    left: -9999em;
+    line-height: normal;
+}
+
+.xterm.enable-mouse-events {
+    cursor: default;
+}
+
+.xterm.xterm-cursor-pointer,
+.xterm .xterm-cursor-pointer {
+    cursor: pointer;
+}
+
+.xterm.column-select.focus {
+    cursor: crosshair;
+}
+
+.xterm .xterm-accessibility,
+.xterm .xterm-message {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 10;
+    color: transparent;
+    pointer-events: none;
+}
+
+.xterm .live-region {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.xterm-dim {
+    opacity: 1 !important;
+}
+
+.xterm-underline-1 { text-decoration: underline; }
+.xterm-underline-2 { text-decoration: double underline; }
+.xterm-underline-3 { text-decoration: wavy underline; }
+.xterm-underline-4 { text-decoration: dotted underline; }
+.xterm-underline-5 { text-decoration: dashed underline; }
+
+.xterm-overline {
+    text-decoration: overline;
+}
+
+.xterm-overline.xterm-underline-1 { text-decoration: overline underline; }
+.xterm-overline.xterm-underline-2 { text-decoration: overline double underline; }
+.xterm-overline.xterm-underline-3 { text-decoration: overline wavy underline; }
+.xterm-overline.xterm-underline-4 { text-decoration: overline dotted underline; }
+.xterm-overline.xterm-underline-5 { text-decoration: overline dashed underline; }
+
+.xterm-strikethrough {
+    text-decoration: line-through;
+}
+
+.xterm-screen .xterm-decoration-container .xterm-decoration {
+	z-index: 6;
+	position: absolute;
+}
+
+.xterm-screen .xterm-decoration-container .xterm-decoration.xterm-decoration-top-layer {
+	z-index: 7;
+}
+
+.xterm-decoration-overview-ruler {
+    z-index: 8;
+    position: absolute;
+    top: 0;
+    right: 0;
+    pointer-events: none;
+}
+
+.xterm-decoration-top {
+    z-index: 2;
+    position: relative;
+}


### PR DESCRIPTION
## Summary

Resolves CLI terminal input focus and key hijacking conflicts.
- Adopts the standard `xterm.css` styling rules for the terminal container and helper elements to support `ghostty-web` / `xterm.js` out of the box.
- Removes custom hacked textarea styles from `index.css` and applies standard Tailwind resets to `.xterm-helper-textarea` so the input buffer is cleanly hidden without breaking layout or focus.
- Fixes the global `/` shortcut keydown listener in `App.tsx` so it ignores keypresses when focus is inside a text entry element (via `isTextEntryShortcutTarget(e.target)`), preventing input hijacking in the terminal, settings, or file editors.

## Feature Contracts

Affected contracts:
- [x] Agent Runners
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Frontend unit tests pass cleanly (`596 passed`).
- All Go unit tests pass cleanly.
