### PR TITLE
fix(operator): generalize background task wake and stop for all sdk providers

### DIFF
--- a/backend-go/cmd/tank-operator/background_task_wakes.go
+++ b/backend-go/cmd/tank-operator/background_task_wakes.go
@@ -82,9 +82,9 @@ func (s *appServer) handleInternalRegisterBackgroundTaskWake(w http.ResponseWrit
 		return
 	}
 	provider, ok := sdkProviderForMode(info.Mode)
-	if !ok || provider != "claude" {
+	if !ok {
 		recordBackgroundTaskWakeRegister("unknown", "bad_request")
-		writeError(w, http.StatusBadRequest, "background task wakes are only supported for Claude SDK sessions")
+		writeError(w, http.StatusBadRequest, "session mode does not support background task wakes")
 		return
 	}
 

--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -419,9 +419,9 @@ func (s *appServer) handleStopBackgroundTask(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
-	normalizedMode := sessionmodel.NormalizeSessionMode(info.Mode)
-	if normalizedMode != sessionmodel.CodexGUIMode && normalizedMode != sessionmodel.CodexAppServerMode {
-		writeError(w, http.StatusBadRequest, "background task stop is only supported for Codex app-server transport sessions")
+	provider, ok := sdkProviderForMode(info.Mode)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "session mode does not support background task stops")
 		return
 	}
 	if s.sessionBus == nil {
@@ -437,7 +437,7 @@ func (s *appServer) handleStopBackgroundTask(w http.ResponseWriter, r *http.Requ
 		SessionID:            sessionID,
 		SessionStorageKey:    storageKey,
 		Email:                owner,
-		Provider:             "codex",
+		Provider:             provider,
 		Source:               "background-stop",
 		TurnID:               stopTurnID,
 		ClientNonce:          targetTurnID,
@@ -454,7 +454,7 @@ func (s *appServer) handleStopBackgroundTask(w http.ResponseWriter, r *http.Requ
 			Email:             owner,
 			TurnID:            stopTurnID,
 			ClientNonce:       targetTurnID,
-			Runtime:           "codex",
+			Runtime:           provider,
 			Reason:            "publish_background_stop_failed: " + err.Error(),
 			Now:               time.Now().UTC(),
 		})

--- a/backend-go/cmd/tank-operator/handlers_turns_test.go
+++ b/backend-go/cmd/tank-operator/handlers_turns_test.go
@@ -1574,7 +1574,7 @@ func TestStopBackgroundTaskPublishesControlCommand(t *testing.T) {
 	}
 }
 
-func TestStopBackgroundTaskRejectsClaudeSession(t *testing.T) {
+func TestStopBackgroundTaskAcceptsClaudeSession(t *testing.T) {
 	bus := &recordingSessionBus{}
 	app := testTurnsApp(t, bus, sdkSessionPod("session-64", "64", "user@example.com", sessionmodel.ClaudeGUIMode, "claude-runner"))
 	req := authedBackgroundStopRequest(t, "64", "task-123", `{"turn_id":"turn-abc"}`)
@@ -1582,11 +1582,11 @@ func TestStopBackgroundTaskRejectsClaudeSession(t *testing.T) {
 
 	app.handleStopBackgroundTask(resp, req)
 
-	if resp.Code != http.StatusBadRequest {
+	if resp.Code != http.StatusAccepted {
 		t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
 	}
-	if len(bus.commands) != 0 {
-		t.Fatalf("published commands = %d, want 0", len(bus.commands))
+	if len(bus.commands) != 1 {
+		t.Fatalf("published commands = %d, want 1", len(bus.commands))
 	}
 }
 


### PR DESCRIPTION
## Summary
This removes the hardcoded 'claude' restriction on background task wakes and the 'codex' restriction on background task stops, enabling feature parity across all session modes (Claude, Codex, Antigravity).

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- I removed the hardcoded `provider != "claude"` check in `background_task_wakes.go`.
- I removed the hardcoded Codex mode check in `handlers_turns.go` for background stops.
- Verified by updating and passing the backend tests in `handlers_turns_test.go` and `go test ./...`.
