### PR TITLE
persister: zero the processed-event-age gauge when idle (false backlog page)

### DIFF
--- a/backend-go/internal/sessionbus/persister.go
+++ b/backend-go/internal/sessionbus/persister.go
@@ -671,7 +671,17 @@ func (d *persistDispatcher) sampleLoop(ctx context.Context, consumer jetstream.C
 			continue
 		}
 		d.metrics.RecordPersisterConsumerLag(float64(info.NumPending), float64(info.NumAckPending))
-		d.metrics.RecordPersisterQueueDepth(d.queueDepth())
+		queueDepth := d.queueDepth()
+		d.metrics.RecordPersisterQueueDepth(queueDepth)
+		// The processed-event-age gauge is set per completed batch, so with
+		// zero traffic it freezes at the last batch's value — after a
+		// backlog drain that frozen value is hours, and the backlog alert
+		// pages on a healthy idle persister (observed on the #1051 deploy
+		// itself). Nothing pending anywhere means transcripts are current:
+		// say so.
+		if info.NumPending == 0 && info.NumAckPending == 0 && queueDepth == 0 {
+			d.metrics.RecordProcessedEventAge(0)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1052, found during its own live acceptance: `tank_session_event_persister_processed_event_age_seconds` is set per completed batch, so with zero traffic it freezes at the last batch's value. After the #1051 backlog drain the frozen value was hours old and `TankSessionEventPersisterBacklog` paged on a healthy idle persister. The sampler now reports zero age when the consumer has nothing pending, nothing in flight, and the in-process queues are empty — "nothing waiting" means "transcripts are current."

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Observability** (alerts own the wake-someone-up boundary; a false page is a defect in the surface): the firing `TankSessionEventPersisterBacklog` instance on the post-#1052 deploy is the reproduction; after this deploys, the gauge drops to 0 within one 10s sample on an idle persister and the alert resolves. `go test ./internal/sessionbus/ -count=1` green (including the embedded-JetStream integration tests). Will confirm alert resolution in Grafana after merge and note it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
