### PR TITLE
observability: TankTurnNumberMissing must not count by-design-unnumbered wake turns (#1051 PR 3)

### DIFF
--- a/backend-go/cmd/tank-operator/transcript_rows_materializer.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer.go
@@ -525,7 +525,15 @@ func stampTurnNumbers(sessionID string, numbers map[string]int64, entries []map[
 			}
 		}
 		if transcriptMapString(entry, "kind") == "turn_activity" {
-			if _, ok := numbers[turnID]; !ok {
+			// Background-wake continuation turns are unnumbered BY DESIGN:
+			// migration 0139 excludes them from the allocator because
+			// numbering them minted separately navigable /turns/{n} for
+			// continuation mechanics (the session-655 turn 56/57 defect).
+			// Counting them here made TankTurnNumberMissing fire on intended
+			// state — 12 standing false alerts during the 2026-06-11
+			// incident, drowning the real signal the alert exists for
+			// (allocation-trigger regressions on user-visible turns).
+			if _, ok := numbers[turnID]; !ok && !isBackgroundWakeTurnID(turnID) {
 				recordTurnNumberMissing("materialize")
 				slog.Warn("durable turn number missing for materialized shell",
 					"session_id", sessionID,

--- a/backend-go/cmd/tank-operator/transcript_turn_number_stamp_test.go
+++ b/backend-go/cmd/tank-operator/transcript_turn_number_stamp_test.go
@@ -109,6 +109,62 @@ func TestMaterializerRecordsMissingTurnNumber(t *testing.T) {
 	}
 }
 
+// TestMaterializerDoesNotCountUnnumberedWakeTurnShells pins the migration-0139
+// contract at the observability boundary: background-wake continuation turns
+// (turn_bgtask-<task>) are excluded from durable numbering by design, so a
+// wake-turn shell materializing without a number is intended state — it must
+// not increment the missing-number counter TankTurnNumberMissing alerts on,
+// and must still render unstamped. During the 2026-06-11 incident this
+// mis-count produced 12 standing false alerts.
+func TestMaterializerDoesNotCountUnnumberedWakeTurnShells(t *testing.T) {
+	before := testutil.ToFloat64(turnNumberMissingTotal.WithLabelValues("materialize"))
+	// A wake turn with no origin-task context in the ledger: the projection
+	// cannot fold it into a parent, so it materializes as a standalone
+	// turn_bgtask-* shell — the production shape behind the false alerts.
+	wakeEvents := []map[string]any{
+		projectionTestEvent("wake-submitted", "001", "turn.submitted", "runner", "tank", "turn_bgtask-orphan", "", map[string]any{
+			"status": "submitted", "source": "background-task", "task_id": "orphan",
+			"prompt": "A background task you started earlier has finished.",
+		}),
+		projectionTestEvent("wake-tool", "002", "item.completed", "tool", "claude", "turn_bgtask-orphan", "turn_bgtask-orphan:item:tool-1", map[string]any{
+			"kind": "command_execution", "output": "ok",
+		}),
+		projectionTestEvent("wake-final", "003", "item.completed", "assistant", "claude", "turn_bgtask-orphan", "turn_bgtask-orphan:item:final", map[string]any{
+			"kind": "message", "text": "done",
+		}),
+		projectionTestEvent("wake-terminal", "004", "turn.completed", "runner", "claude", "turn_bgtask-orphan", "", projectionFinalAnswerPayload("turn_bgtask-orphan:item:final")),
+	}
+	eventStore := fakeSessionEventStore{
+		pages: map[string]store.SessionEventPage{
+			"": {Events: wakeEvents, FoundOldest: true, FoundNewest: true},
+		},
+	}
+	rowStore := &recordingTranscriptRowsStore{}
+	materializer := transcriptRowsMaterializer{
+		events: eventStore,
+		rows:   rowStore,
+		// Numbering active, and (correctly, per 0139) no row for the wake turn.
+		turns: fakeSessionTurnStore{byTurnID: map[string]int64{}},
+	}
+
+	if err := materializer.RefreshEvent(context.Background(), wakeEvents[len(wakeEvents)-1]); err != nil {
+		t.Fatalf("RefreshEvent: %v", err)
+	}
+	shell := findTurnActivityShell(rowStore.sessionEntries)
+	if shell == nil {
+		t.Fatalf("no wake turn_activity shell in session entries: %#v", rowStore.sessionEntries)
+	}
+	if got := transcriptMapString(shell, "turnId"); got != "turn_bgtask-orphan" {
+		t.Fatalf("shell turnId = %q, want the standalone wake turn", got)
+	}
+	if _, stamped := shell["turnNumber"]; stamped {
+		t.Fatalf("wake-turn shell must not be stamped: %#v", shell["turnNumber"])
+	}
+	if after := testutil.ToFloat64(turnNumberMissingTotal.WithLabelValues("materialize")); after != before {
+		t.Fatalf("missing-number counter must not count by-design-unnumbered wake turns: delta=%v", after-before)
+	}
+}
+
 // TestMaterializerSkipsStampingWhenNumberingInactive proves the stub store
 // (no-Postgres mode) neither stamps nor spams the missing-number counter.
 func TestMaterializerSkipsStampingWhenNumberingInactive(t *testing.T) {

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -447,18 +447,28 @@ spec:
           annotations:
             summary: "turn-activity shells materialized without a durable session_turns number (phase={{`{{ $labels.phase }}`}})"
             runbook: |
-              A turn_activity shell was projected for a turn that has no
-              row in session_turns while durable numbering is active. The
-              public route /sessions/{id}/turns/{n} cannot resolve such a
-              turn and the UI cannot label it. Expectation is zero: the
-              tank_session_events_allocate_turn_number trigger numbers
-              every turn on its first session_events insert, and the
-              0086-0093 backfill numbered all pre-existing turns.
+              A turn_activity shell was projected for a USER-VISIBLE turn
+              that has no row in session_turns while durable numbering is
+              active. The public route /sessions/{id}/turns/{n} cannot
+              resolve such a turn and the UI cannot label it. Expectation
+              is zero: the tank_session_events_allocate_turn_number
+              trigger numbers every user-visible turn on its first
+              session_events insert, and the 0086-0093 backfill numbered
+              all pre-existing turns.
 
-              A nonzero rate means the allocation trigger regressed or an
-              event carrying a turn_id reached session_events without
-              firing it. Confirm the trigger is attached
-              (SELECT tgname FROM pg_trigger WHERE tgrelid =
+              Background-wake continuation turns (turn_bgtask-<task>) do
+              NOT count here: migration 0139 excludes them from the
+              allocator by design (they fold into their originating turn
+              and must never be separately navigable), and the
+              materializer's counter call site excludes them to match.
+              If this fires naming a turn_bgtask-* id, the call-site
+              exclusion regressed — see
+              TestMaterializerDoesNotCountUnnumberedWakeTurnShells.
+
+              Otherwise a nonzero rate means the allocation trigger
+              regressed or an event carrying a turn_id reached
+              session_events without firing it. Confirm the trigger is
+              attached (SELECT tgname FROM pg_trigger WHERE tgrelid =
               'session_events'::regclass) and check session_turns for the
               turn_id named in the matching slog.Warn line
               "durable turn number missing for materialized shell".


### PR DESCRIPTION
## Summary

PR 3 of the #1051 plan, re-scoped by what the diagnosis actually found. The plan assumed `turn_bgtask-*` wake turns were failing to acquire `session_turns` numbers (12 standing `TankTurnNumberMissing` alerts). Direct DB inspection showed: trigger attached and enabled, all 1,166 wake-turn events in session 815 carry the `turn_id` column — and **migration 0139 (shipped with #1037) deliberately excludes wake turns from the allocator**, because numbering them minted separately navigable `/turns/{n}` for continuation mechanics (the session-655 turn 56/57 defect). The numbering behavior is settled design.

The actual defect was the observability surface: the materializer's missing-number counter predates 0139 and kept treating the intended state as an allocation regression — false alerts drowning the exact signal the alert exists for. Fix: the stamp call site excludes `isBackgroundWakeTurnID` shells; the runbook documents the carve-out and names the pinning test; user-visible turns without numbers still count and alert exactly as before.

No backfill migration: numbering wake turns is the rejected behavior, not the missing one.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [x] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Transcript Navigation** (`turn_activity` shells carry the durable `turnNumber`; the number's owner is `session_turns`): unchanged for user-visible turns — `TestMaterializerStampsDurableTurnNumber` and `TestMaterializerRecordsMissingTurnNumber` still pass unmodified, proving real turns are stamped and real gaps still count. The new `TestMaterializerDoesNotCountUnnumberedWakeTurnShells` pins 0139's contract at the materializer boundary: a standalone wake shell renders unstamped and does not increment the counter.
- **Observability** (alerts own the wake-someone-up boundary; a standing false alert is a defect in the surface): the live `TankTurnNumberMissing{phase=materialize}` rate — currently re-warning every materialization pass of session 815 — returns to zero on deploy without any data change, which is the acceptance evidence (will confirm in Grafana and note here). Runbook updated so a future `turn_bgtask-*` appearance is correctly read as a call-site regression rather than a trigger regression.

Diagnosis trail (schema/trigger/column verification via break-glass psql, migration 0139 discovery) recorded on #1051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
