### PR TITLE
sweep: stranded-turn backstop — durable terminals for lost commands (#1051 PR 4)

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_debug_session_event_ledger_test.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_event_ledger_test.go
@@ -36,6 +36,10 @@ func (f *fakeDebugSessionEventLedgerStore) ShellTaskEvents(context.Context, stri
 	return nil, nil
 }
 
+func (f *fakeDebugSessionEventLedgerStore) FindStrandedTurns(context.Context, time.Time, time.Time, time.Time, int) ([]store.StrandedTurn, error) {
+	return nil, nil
+}
+
 func (f *fakeDebugSessionEventLedgerStore) FindStrandedLaunchTurns(context.Context, time.Time, time.Time, int) ([]store.StrandedLaunchTurn, error) {
 	return nil, nil
 }

--- a/backend-go/cmd/tank-operator/handlers_session_events_test.go
+++ b/backend-go/cmd/tank-operator/handlers_session_events_test.go
@@ -37,6 +37,10 @@ func (s fakeSessionEventStore) CountUserMessages(_ context.Context, _ string) (i
 	return 0, nil
 }
 
+func (s fakeSessionEventStore) FindStrandedTurns(context.Context, time.Time, time.Time, time.Time, int) ([]store.StrandedTurn, error) {
+	return nil, nil
+}
+
 func (s fakeSessionEventStore) FindStrandedLaunchTurns(context.Context, time.Time, time.Time, int) ([]store.StrandedLaunchTurn, error) {
 	return nil, nil
 }

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -550,6 +550,19 @@ func main() {
 			}
 		}()
 	}
+	// Command-plane four-outcome backstop (#1051 PR 4): a dispatched turn
+	// whose submit_turn command or runner died gets a durable
+	// turn.command_failed once the whole session has been silent past the
+	// stranding floors. Without this, a lost command is a permanent
+	// "submitted"/"streaming" ghost only diagnosable with kubectl — the
+	// 2026-06-11 incident stranded five sessions exactly this way.
+	if pgPool != nil {
+		go func() {
+			if err := runStrandedTurnSweepLoop(ctx, srv, strandedTurnSweepInterval); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Error("stranded turn sweep loop stopped", "error", err)
+			}
+		}()
+	}
 	// Backend-owned dispatch of durable attachment launches (#865): claim ready
 	// launches whose pod is Active, materialize the staged bytes into the
 	// workspace, and publish submit_turn — so the launch is delivered even if

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -818,6 +818,28 @@ func recordStrandedLaunchSwept(result string) {
 	strandedLaunchSweptTotal.WithLabelValues(result).Inc()
 }
 
+// Stranded-turn sweep: the command-plane four-outcome backstop
+// (tank-operator#1051 PR 4). result="failed" means a durable terminal was
+// written for a turn nothing else would ever have terminaled; sustained
+// nonzero rate means submit_turn commands or runners are dying and pages via
+// TankStrandedTurnsSwept.
+var strandedTurnSweptTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tank_stranded_turn_swept_total",
+		Help: "Dispatched-but-stranded turns the stranded-turn sweep observed, labeled by bounded result (failed, deferred_progressed, skipped_incomplete, persist_error).",
+	},
+	[]string{"result"},
+)
+
+func recordStrandedTurnSwept(result string) {
+	switch result {
+	case "failed", "deferred_progressed", "skipped_incomplete", "persist_error":
+	default:
+		result = "other"
+	}
+	strandedTurnSweptTotal.WithLabelValues(result).Inc()
+}
+
 var launchAttachmentStagedTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "tank_launch_attachment_staged_total",

--- a/backend-go/cmd/tank-operator/stranded_turn_sweep.go
+++ b/backend-go/cmd/tank-operator/stranded_turn_sweep.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/romaine-life/tank-operator/backend-go/internal/conversation"
+	"github.com/romaine-life/tank-operator/backend-go/internal/sessionactivity"
+	"github.com/romaine-life/tank-operator/backend-go/internal/sessionmodel"
+	"github.com/romaine-life/tank-operator/backend-go/internal/store"
+)
+
+const (
+	// strandedTurnSweepInterval mirrors the launch sweep: stranding is a rare
+	// durability gap, not a latency-sensitive path. The cost of a slow tick is
+	// only how long a stranded turn shows as submitted/streaming before it
+	// flips to failed.
+	strandedTurnSweepInterval = 60 * time.Second
+	// strandedTurnMinAgeSubmitted is the age floor for a never-claimed strand.
+	// A healthy runner claims a deliverable submit_turn within seconds (it is
+	// a queue pop), so thirty quiet minutes is many multiples of headroom. The
+	// quiet-session predicate in FindStrandedTurns carries the real safety: a
+	// turn legitimately queued behind a long-running turn lives in a session
+	// that keeps producing events and is never a candidate.
+	strandedTurnMinAgeSubmitted = 30 * time.Minute
+	// strandedTurnMinAgeProgressed is the (much longer) floor for a
+	// claimed/started turn with no terminal — a runner that died mid-turn.
+	// Live long turns emit ledger events (items, turn.usage) continuously;
+	// requiring BOTH two hours since submit AND a fully silent session for
+	// the quiet window makes a false positive require a runner that is alive
+	// yet has produced nothing durable for half an hour, which the runner's
+	// own 240s provider-stall terminal already rules out.
+	strandedTurnMinAgeProgressed = 2 * time.Hour
+	// strandedTurnQuietWindow is how long the whole session must have been
+	// silent (zero session_events of any kind) before any of its turns are
+	// candidates.
+	strandedTurnQuietWindow = 30 * time.Minute
+	// strandedTurnMaxAge bounds the historical scan off the deep ledger,
+	// matching the launch sweep's rationale: a strand older than this
+	// predates the sweep and its pod is long gone.
+	strandedTurnMaxAge = 30 * 24 * time.Hour
+	// strandedTurnBatchLimit caps rows per tick so a first-deploy backlog
+	// drains over a few ticks.
+	strandedTurnBatchLimit = 100
+
+	// strandedTurnReasonCommandLost is the durable terminal reason for a
+	// never-claimed user turn: the submit_turn command was recorded and
+	// published but no runner ever claimed it (runner-side MaxDeliver
+	// exhaustion, a dead runner process, or a publish that never landed).
+	strandedTurnReasonCommandLost = "submit_command_lost: the turn was durably submitted but no runner ever claimed it; the submit_turn command was lost (dead or wedged runner, or command-consumer exhaustion). Resubmit the message."
+	// strandedTurnReasonProgressLost is the durable terminal reason for a
+	// claimed/started turn whose runner died mid-turn without a terminal.
+	strandedTurnReasonProgressLost = "turn_progress_lost: a runner claimed this turn but stopped producing durable events and never wrote a terminal (runner process died mid-turn). Resubmit the message."
+)
+
+// runStrandedTurnSweepLoop is the command-plane four-outcome backstop: every
+// durable turn.submitted must be followed by exactly one durable terminal,
+// and when the runner side dies — a crashed runner process, a submit_turn
+// command that exhausted its runner-consumer deliveries, a pod that wedged —
+// nothing else ever writes that terminal. The 2026-06-11 incident
+// (tank-operator#1051) stranded five sessions exactly this way: turns durably
+// submitted/streaming for hours with idle runners, visible only as stuck
+// chips and only diagnosable with kubectl.
+//
+// The sweep converts each silent strand into a durable turn.command_failed so
+// the SPA renders it failed and the composer unblocks. It does NOT re-drive
+// the command: the runner's state for the turn is unknown or gone, and a
+// re-publish could double-run a turn whose work partially happened. Surfacing
+// the failure is the honest outcome; the user (or the wake machinery) decides
+// whether to resubmit.
+//
+// Safety mirrors the stranded-launch sweep, plus the quiet-session predicate:
+//   - candidates require the WHOLE session silent for strandedTurnQuietWindow,
+//     so a turn queued behind a long-running turn (live session, events
+//     flowing) or itself mid-work can never be swept;
+//   - never-claimed strands need strandedTurnMinAgeSubmitted; claimed strands
+//     need strandedTurnMinAgeProgressed on top of the silence;
+//   - turn.command_failed is terminal, so a late runner racing the sweep hits
+//     the already-terminal guard and drops the stray command;
+//   - the event_id is deterministic in turn_id, so both replicas collapse to
+//     one row at the (tank_session_id, event_id) UNIQUE constraint.
+func runStrandedTurnSweepLoop(ctx context.Context, app *appServer, interval time.Duration) error {
+	if app == nil || app.sessionEvents == nil {
+		return nil
+	}
+	if interval <= 0 {
+		interval = strandedTurnSweepInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if err := app.processStrandedTurns(ctx, time.Now().UTC()); err != nil && !errors.Is(err, context.Canceled) {
+			slog.Warn("stranded turn sweep failed", "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *appServer) processStrandedTurns(ctx context.Context, now time.Time) error {
+	if s == nil || s.sessionEvents == nil {
+		return nil
+	}
+	olderThan := now.Add(-strandedTurnMinAgeSubmitted)
+	quietSince := now.Add(-strandedTurnQuietWindow)
+	notBefore := now.Add(-strandedTurnMaxAge)
+	rows, err := s.sessionEvents.FindStrandedTurns(ctx, olderThan, quietSince, notBefore, strandedTurnBatchLimit)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.Progressed && now.Sub(row.CreatedAt) < strandedTurnMinAgeProgressed {
+			// A claimed turn gets the longer floor; it stays a candidate on
+			// later ticks if the session stays silent.
+			recordStrandedTurnSwept("deferred_progressed")
+			continue
+		}
+		if err := s.failStrandedTurn(ctx, row, now); err != nil {
+			slog.Warn("stranded turn fail-mark failed",
+				"session_id", row.SessionID,
+				"turn_id", row.TurnID,
+				"error", err)
+			// Best-effort per row; a transient write error retries next tick
+			// because the turn still has no terminal.
+			continue
+		}
+	}
+	return nil
+}
+
+// strandedTurnReason picks the terminal reason: continuation turns
+// (background-task wakes, scheduled wakeups, agent continuations) get the
+// away-error reason so the sidebar rings the summon bell — the agent promised
+// to resume while the user was away and the resume silently died — while
+// ordinary user turns fail plainly.
+func strandedTurnReason(row store.StrandedTurn) string {
+	source := strings.TrimSpace(row.Source)
+	if isBackgroundWakeTurnID(strings.TrimSpace(row.TurnID)) ||
+		source == string(conversation.TurnSubmittedSourceBackgroundTask) ||
+		source == string(conversation.TurnSubmittedSourceScheduleWakeup) ||
+		source == string(conversation.TurnSubmittedSourceAgentContinuation) {
+		return sessionactivity.AwayErrorReasonStrandedContinuation
+	}
+	if row.Progressed {
+		return strandedTurnReasonProgressLost
+	}
+	return strandedTurnReasonCommandLost
+}
+
+// failStrandedTurn emits the durable turn.command_failed for one stranded
+// turn via the same backend-event path the launch sweep uses, so transcript
+// materialization, activity refresh, and the SSE wake all fire and the SPA
+// flips the turn to failed live.
+func (s *appServer) failStrandedTurn(ctx context.Context, row store.StrandedTurn, now time.Time) error {
+	sessionID := strings.TrimSpace(row.SessionID)
+	turnID := strings.TrimSpace(row.TurnID)
+	if sessionID == "" || turnID == "" {
+		recordStrandedTurnSwept("skipped_incomplete")
+		return nil
+	}
+	storageKey := strings.TrimSpace(row.TankSessionID)
+	if storageKey == "" {
+		storageKey = sessionmodel.SessionStorageKey(s.sessionScope, sessionID)
+	}
+	runtime := strings.TrimSpace(row.Runtime)
+	if runtime == "" {
+		runtime = "claude"
+	}
+	failed := conversation.TurnCommandFailedEventMap(conversation.TurnCommandFailedArgs{
+		SessionID:         sessionID,
+		SessionStorageKey: storageKey,
+		Email:             strings.TrimSpace(row.Email),
+		TurnID:            turnID,
+		ClientNonce:       strings.TrimSpace(row.ClientNonce),
+		Runtime:           runtime,
+		Reason:            strandedTurnReason(row),
+		Now:               now,
+	})
+	if err := s.persistBackendEvent(ctx, storageKey, failed); err != nil {
+		recordStrandedTurnSwept("persist_error")
+		return err
+	}
+	recordStrandedTurnSwept("failed")
+	slog.Warn("stranded turn swept to durable terminal",
+		"session_id", sessionID,
+		"turn_id", turnID,
+		"progressed", row.Progressed,
+		"source", strings.TrimSpace(row.Source),
+		"age", now.Sub(row.CreatedAt).Truncate(time.Second).String(),
+	)
+	return nil
+}

--- a/backend-go/cmd/tank-operator/stranded_turn_sweep_test.go
+++ b/backend-go/cmd/tank-operator/stranded_turn_sweep_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/romaine-life/tank-operator/backend-go/internal/sessionactivity"
+	"github.com/romaine-life/tank-operator/backend-go/internal/store"
+)
+
+// fakeStrandedTurnStore returns canned stranded-turn rows and captures the
+// backend-owned turn.command_failed Upserts the sweep emits, plus the window
+// arguments the loop computed.
+type fakeStrandedTurnStore struct {
+	store.StubSessionEventStore
+	rows     []store.StrandedTurn
+	upserts  []map[string]any
+	gotOlder time.Time
+	gotQuiet time.Time
+	gotFloor time.Time
+	gotLimit int
+}
+
+func (f *fakeStrandedTurnStore) FindStrandedTurns(_ context.Context, olderThan, quietSince, notBefore time.Time, limit int) ([]store.StrandedTurn, error) {
+	f.gotOlder = olderThan
+	f.gotQuiet = quietSince
+	f.gotFloor = notBefore
+	f.gotLimit = limit
+	return f.rows, nil
+}
+
+func (f *fakeStrandedTurnStore) Upsert(_ context.Context, event map[string]any) (bool, error) {
+	f.upserts = append(f.upserts, event)
+	return true, nil
+}
+
+func strandedTurnSweepReason(t *testing.T, event map[string]any) string {
+	t.Helper()
+	payload, _ := event["payload"].(map[string]any)
+	if payload == nil {
+		t.Fatalf("swept terminal carries no payload: %#v", event)
+	}
+	reason, _ := payload["reason"].(string)
+	return reason
+}
+
+// TestProcessStrandedTurnsFailsNeverClaimedTurn pins the command-lost class:
+// a turn durably submitted, never claimed, in a quiet session gets a durable
+// turn.command_failed addressed to the same turn id and client nonce.
+func TestProcessStrandedTurnsFailsNeverClaimedTurn(t *testing.T) {
+	now := time.Date(2026, 6, 11, 18, 0, 0, 0, time.UTC)
+	fake := &fakeStrandedTurnStore{rows: []store.StrandedTurn{{
+		TankSessionID: "816",
+		SessionID:     "816",
+		TurnID:        "turn_06fa1847",
+		ClientNonce:   "06fa1847",
+		Email:         "nelson@romaine.life",
+		Runtime:       "codex",
+		Progressed:    false,
+		CreatedAt:     now.Add(-time.Hour),
+	}}}
+	app := &appServer{sessionEvents: fake, sessionScope: "default"}
+
+	if err := app.processStrandedTurns(context.Background(), now); err != nil {
+		t.Fatalf("processStrandedTurns: %v", err)
+	}
+	if len(fake.upserts) != 1 {
+		t.Fatalf("command_failed upserts = %d, want 1", len(fake.upserts))
+	}
+	ev := fake.upserts[0]
+	if got, _ := ev["type"].(string); got != "turn.command_failed" {
+		t.Fatalf("event type = %q, want turn.command_failed", got)
+	}
+	if got, _ := ev["turn_id"].(string); got != "turn_06fa1847" {
+		t.Fatalf("turn_id = %q", got)
+	}
+	if got, _ := ev["client_nonce"].(string); got != "06fa1847" {
+		t.Fatalf("client_nonce = %q", got)
+	}
+	if got, _ := ev["event_id"].(string); got != "turn_06fa1847:turn.command_failed" {
+		t.Fatalf("event_id = %q, want deterministic id for replica dedupe", got)
+	}
+	if reason := strandedTurnSweepReason(t, ev); !strings.HasPrefix(reason, "submit_command_lost") {
+		t.Fatalf("reason = %q, want submit_command_lost prefix", reason)
+	}
+}
+
+// TestProcessStrandedTurnsDefersYoungProgressedTurn pins the two-floor
+// contract: a claimed/started turn younger than the progressed floor is left
+// alone this tick (it stays a candidate while the session stays silent), and
+// one older than the floor is swept with the progress-lost reason.
+func TestProcessStrandedTurnsDefersYoungProgressedTurn(t *testing.T) {
+	now := time.Date(2026, 6, 11, 18, 0, 0, 0, time.UTC)
+	fake := &fakeStrandedTurnStore{rows: []store.StrandedTurn{
+		{
+			TankSessionID: "817", SessionID: "817", TurnID: "turn_young",
+			Runtime: "codex", Progressed: true,
+			CreatedAt: now.Add(-time.Hour), // > submitted floor, < progressed floor
+		},
+		{
+			TankSessionID: "817", SessionID: "817", TurnID: "turn_old",
+			Runtime: "codex", Progressed: true,
+			CreatedAt: now.Add(-3 * time.Hour),
+		},
+	}}
+	app := &appServer{sessionEvents: fake, sessionScope: "default"}
+
+	if err := app.processStrandedTurns(context.Background(), now); err != nil {
+		t.Fatalf("processStrandedTurns: %v", err)
+	}
+	if len(fake.upserts) != 1 {
+		t.Fatalf("upserts = %d, want only the old progressed turn swept", len(fake.upserts))
+	}
+	if got, _ := fake.upserts[0]["turn_id"].(string); got != "turn_old" {
+		t.Fatalf("swept turn = %q, want turn_old", got)
+	}
+	if reason := strandedTurnSweepReason(t, fake.upserts[0]); !strings.HasPrefix(reason, "turn_progress_lost") {
+		t.Fatalf("reason = %q, want turn_progress_lost prefix", reason)
+	}
+}
+
+// TestProcessStrandedTurnsClassifiesContinuationsAsAwayErrors pins the
+// summon-invariant wiring: a stranded background-wake / scheduled-wakeup /
+// agent-continuation turn carries the away-error reason so the sidebar rings
+// the bell (the agent promised to resume while the user was away and the
+// resume silently died); an ordinary user turn does not.
+func TestProcessStrandedTurnsClassifiesContinuationsAsAwayErrors(t *testing.T) {
+	now := time.Date(2026, 6, 11, 18, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name     string
+		row      store.StrandedTurn
+		wantAway bool
+	}{
+		{
+			name: "bgtask wake turn by id",
+			row: store.StrandedTurn{
+				TankSessionID: "815", SessionID: "815",
+				TurnID: "turn_bgtask-bo6om79c2", Runtime: "claude",
+				CreatedAt: now.Add(-time.Hour),
+			},
+			wantAway: true,
+		},
+		{
+			name: "schedule wakeup by source",
+			row: store.StrandedTurn{
+				TankSessionID: "815", SessionID: "815",
+				TurnID: "turn_sched1", Runtime: "claude", Source: "schedule-wakeup",
+				CreatedAt: now.Add(-time.Hour),
+			},
+			wantAway: true,
+		},
+		{
+			name: "ordinary user turn",
+			row: store.StrandedTurn{
+				TankSessionID: "816", SessionID: "816",
+				TurnID: "turn_user1", Runtime: "codex",
+				CreatedAt: now.Add(-time.Hour),
+			},
+			wantAway: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeStrandedTurnStore{rows: []store.StrandedTurn{tc.row}}
+			app := &appServer{sessionEvents: fake, sessionScope: "default"}
+			if err := app.processStrandedTurns(context.Background(), now); err != nil {
+				t.Fatalf("processStrandedTurns: %v", err)
+			}
+			if len(fake.upserts) != 1 {
+				t.Fatalf("upserts = %d, want 1", len(fake.upserts))
+			}
+			reason := strandedTurnSweepReason(t, fake.upserts[0])
+			isAway := reason == sessionactivity.AwayErrorReasonStrandedContinuation
+			if isAway != tc.wantAway {
+				t.Fatalf("reason = %q, away=%v, want away=%v", reason, isAway, tc.wantAway)
+			}
+		})
+	}
+}
+
+// TestProcessStrandedTurnsWindowArguments pins the scan bounds: candidates
+// are at least the submitted floor old, at most the max age old, and their
+// session must be quiet for the whole quiet window.
+func TestProcessStrandedTurnsWindowArguments(t *testing.T) {
+	now := time.Date(2026, 6, 11, 18, 0, 0, 0, time.UTC)
+	fake := &fakeStrandedTurnStore{}
+	app := &appServer{sessionEvents: fake, sessionScope: "default"}
+
+	if err := app.processStrandedTurns(context.Background(), now); err != nil {
+		t.Fatalf("processStrandedTurns: %v", err)
+	}
+	if want := now.Add(-strandedTurnMinAgeSubmitted); !fake.gotOlder.Equal(want) {
+		t.Fatalf("olderThan = %s, want %s", fake.gotOlder, want)
+	}
+	if want := now.Add(-strandedTurnQuietWindow); !fake.gotQuiet.Equal(want) {
+		t.Fatalf("quietSince = %s, want %s", fake.gotQuiet, want)
+	}
+	if want := now.Add(-strandedTurnMaxAge); !fake.gotFloor.Equal(want) {
+		t.Fatalf("notBefore = %s, want %s", fake.gotFloor, want)
+	}
+	if fake.gotLimit != strandedTurnBatchLimit {
+		t.Fatalf("limit = %d, want %d", fake.gotLimit, strandedTurnBatchLimit)
+	}
+}
+
+// TestProcessStrandedTurnsSkipsIncompleteRow mirrors the launch sweep: a row
+// without an addressable turn/session cannot carry a well-formed terminal.
+func TestProcessStrandedTurnsSkipsIncompleteRow(t *testing.T) {
+	now := time.Date(2026, 6, 11, 18, 0, 0, 0, time.UTC)
+	fake := &fakeStrandedTurnStore{rows: []store.StrandedTurn{{
+		TankSessionID: "816",
+		Email:         "nelson@romaine.life",
+		Runtime:       "codex",
+		CreatedAt:     now.Add(-time.Hour),
+	}}}
+	app := &appServer{sessionEvents: fake, sessionScope: "default"}
+
+	if err := app.processStrandedTurns(context.Background(), now); err != nil {
+		t.Fatalf("processStrandedTurns: %v", err)
+	}
+	if len(fake.upserts) != 0 {
+		t.Fatalf("upserts = %d, want 0 for incomplete row", len(fake.upserts))
+	}
+}

--- a/backend-go/internal/sessionactivity/activity.go
+++ b/backend-go/internal/sessionactivity/activity.go
@@ -296,11 +296,18 @@ func canTransitionToStopping(status string) bool {
 const (
 	AwayErrorReasonScheduledWakeup    = "schedule_wakeup_fire_failed"
 	AwayErrorReasonBackgroundTaskWake = "background_task_wake_fire_failed"
+	// AwayErrorReasonStrandedContinuation marks a continuation turn (a
+	// background-task wake, scheduled wakeup, or agent-continuation) whose
+	// submit_turn command was durably recorded but lost before any runner
+	// progress — swept to a terminal by the stranded-turn sweep. Same
+	// user-trust shape as the fire-failed reasons above: the agent promised
+	// to resume while the user was away, and the resume silently died.
+	AwayErrorReasonStrandedContinuation = "stranded_continuation_swept"
 )
 
 func isAwayErrorReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
-	case AwayErrorReasonScheduledWakeup, AwayErrorReasonBackgroundTaskWake:
+	case AwayErrorReasonScheduledWakeup, AwayErrorReasonBackgroundTaskWake, AwayErrorReasonStrandedContinuation:
 		return true
 	default:
 		return false

--- a/backend-go/internal/sessioncontroller/chat_activity_test.go
+++ b/backend-go/internal/sessioncontroller/chat_activity_test.go
@@ -209,6 +209,10 @@ func (s *activityEventStore) Upsert(_ context.Context, _ map[string]any) (bool, 
 	return true, nil
 }
 
+func (s *activityEventStore) FindStrandedTurns(context.Context, time.Time, time.Time, time.Time, int) ([]store.StrandedTurn, error) {
+	return nil, nil
+}
+
 func (s *activityEventStore) FindStrandedLaunchTurns(context.Context, time.Time, time.Time, int) ([]store.StrandedLaunchTurn, error) {
 	return nil, nil
 }

--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -100,6 +100,17 @@ type SessionEventStore interface {
 	// keeps the scan off the deep history. Returns at most `limit` rows, ASC
 	// by created_at (oldest strands first).
 	FindStrandedLaunchTurns(ctx context.Context, olderThan, notBefore time.Time, limit int) ([]StrandedLaunchTurn, error)
+	// FindStrandedTurns returns dispatched turns that stranded mid-lifecycle:
+	// a turn.submitted in [notBefore, olderThan) with no terminal event, in a
+	// session that has been completely quiet since quietSince. The quiet
+	// predicate is the false-positive guard — a turn legitimately queued
+	// behind a long-running turn, or itself mid-work, lives in a session that
+	// keeps producing events; a session with zero events for the whole quiet
+	// window cannot be making progress on anything. Progressed reports
+	// whether the runner ever claimed/started the turn, so the sweep can
+	// apply a longer age floor to mid-turn strands than to never-claimed
+	// ones. Backs cmd/tank-operator/stranded_turn_sweep.go.
+	FindStrandedTurns(ctx context.Context, olderThan, quietSince, notBefore time.Time, limit int) ([]StrandedTurn, error)
 }
 
 // StrandedLaunchTurn is one never-dispatched launch turn — exactly the fields
@@ -113,6 +124,23 @@ type StrandedLaunchTurn struct {
 	ClientNonce   string
 	Email         string
 	Runtime       string
+	CreatedAt     time.Time
+}
+
+// StrandedTurn is one dispatched-but-stranded turn: durably submitted, no
+// terminal, in a fully quiet session. Source carries the submit's
+// payload.source (e.g. "background-task", "schedule-wakeup") so the sweep can
+// classify continuation strands as away-errors; Progressed reports whether a
+// runner ever claimed/started the turn.
+type StrandedTurn struct {
+	TankSessionID string
+	SessionID     string
+	TurnID        string
+	ClientNonce   string
+	Email         string
+	Runtime       string
+	Source        string
+	Progressed    bool
 	CreatedAt     time.Time
 }
 
@@ -574,6 +602,91 @@ func (s *postgresSessionEventStore) FindStrandedLaunchTurns(ctx context.Context,
 	return out, nil
 }
 
+// FindStrandedTurns scans for turn.submitted rows in [notBefore, olderThan)
+// whose turn has no terminal event of any kind and whose session has been
+// completely silent since quietSince. The created_at predicates ride the
+// session_events_created_at index and the per-turn / per-session NOT EXISTS
+// subqueries ride the (tank_session_id, turn_id, order_key) and
+// (tank_session_id, created_at-capable) paths, so the outer pass is a bounded
+// time-window scan. Cross-session by design — the sweep addresses every
+// owner/scope from the per-row payload.
+func (s *postgresSessionEventStore) FindStrandedTurns(ctx context.Context, olderThan, quietSince, notBefore time.Time, limit int) ([]StrandedTurn, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	const q = `
+		SELECT
+			e.tank_session_id,
+			COALESCE(e.payload ->> 'session_id', '')             AS session_id,
+			e.turn_id,
+			COALESCE(e.payload ->> 'client_nonce', '')           AS client_nonce,
+			COALESCE(e.payload ->> 'email', '')                  AS email,
+			COALESCE(e.payload ->> 'runtime', '')                AS runtime,
+			COALESCE(e.payload -> 'payload' ->> 'source', '')    AS source,
+			EXISTS (
+				SELECT 1
+				FROM session_events p
+				WHERE p.tank_session_id = e.tank_session_id
+					AND p.turn_id = e.turn_id
+					AND p.event_type IN ('turn.claimed', 'turn.started')
+			) AS progressed,
+			e.created_at
+		FROM session_events e
+		WHERE e.event_type = 'turn.submitted'
+			AND e.turn_id IS NOT NULL
+			AND e.created_at < $1
+			AND e.created_at >= $2
+			AND NOT EXISTS (
+				SELECT 1
+				FROM session_events t
+				WHERE t.tank_session_id = e.tank_session_id
+					AND t.turn_id = e.turn_id
+					AND t.event_type IN ('turn.completed', 'turn.failed', 'turn.command_failed', 'turn.interrupted')
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM session_events quiet
+				WHERE quiet.tank_session_id = e.tank_session_id
+					AND quiet.created_at >= $3
+			)
+		ORDER BY e.created_at ASC
+		LIMIT $4
+	`
+	rows, err := s.pool.Query(ctx, q,
+		olderThan.UTC(),
+		notBefore.UTC(),
+		quietSince.UTC(),
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]StrandedTurn, 0, limit)
+	for rows.Next() {
+		var row StrandedTurn
+		if err := rows.Scan(
+			&row.TankSessionID,
+			&row.SessionID,
+			&row.TurnID,
+			&row.ClientNonce,
+			&row.Email,
+			&row.Runtime,
+			&row.Source,
+			&row.Progressed,
+			&row.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LatestLifecycleEvents returns up to `limit` recent lifecycle events
 // (the turn.* lifecycle set, including turn.awaiting_input) for one session, ascending by
 // order_key. Postgres returns the slice DESC LIMIT N and we reverse in Go;
@@ -888,6 +1001,10 @@ func (StubSessionEventStore) FindTurnTerminal(_ context.Context, _, _ string) (m
 }
 
 func (StubSessionEventStore) FindStrandedLaunchTurns(_ context.Context, _, _ time.Time, _ int) ([]StrandedLaunchTurn, error) {
+	return nil, nil
+}
+
+func (StubSessionEventStore) FindStrandedTurns(_ context.Context, _, _, _ time.Time, _ int) ([]StrandedTurn, error) {
 	return nil, nil
 }
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,6 +60,17 @@ All metric names are prefixed `tank_`. The full namespace:
   queues), and `_processed_event_age_seconds` (how far behind users'
   transcripts are). Per-session detail lives in
   `GET /api/debug/persister`, never in labels.
+- `tank_stranded_turn_swept_total{result}` — the command-plane
+  four-outcome backstop (tank-operator#1051 PR 4): dispatched turns whose
+  submit_turn command or runner died silently, swept to a durable
+  `turn.command_failed` once the whole session has been quiet past the
+  stranding floors. Bounded `result`: `failed` (terminal written — pages
+  via `TankStrandedTurnsSwept`, because each one is a real delivery loss),
+  `deferred_progressed` (claimed turn younger than the mid-turn floor,
+  re-checked next tick), `skipped_incomplete`, `persist_error`.
+  Per-sweep detail (session, turn, progressed, source) is in the
+  "stranded turn swept to durable terminal" slog line. Pairs with
+  `tank_stranded_launch_swept_total`, the create-flow equivalent.
 - `tank_stream_auth_ticket_total` — browser EventSource stream-ticket
   create/validate attempts. Labels: `operation` (`create`, `validate`),
   `stream` (`session-list`, `session-events`), and bounded `result`.

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -851,6 +851,34 @@ spec:
               persister ack floor"), then assess which sessions lost
               events via the per-session order_key continuity.
 
+        # Stranded-turn sweep activity. The sweep is the command-plane
+        # four-outcome backstop: it terminals turns whose submit_turn
+        # command or runner died silently. Each swept turn is a real
+        # delivery loss the user experienced as a frozen chip, so any
+        # sweep activity warrants a look at WHY commands are dying.
+        - alert: TankStrandedTurnsSwept
+          expr: sum(increase(tank_stranded_turn_swept_total{result="failed"}[30m])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "the stranded-turn sweep is terminaling turns — submit commands or runners are dying"
+            runbook: |
+              The sweep wrote durable turn.command_failed terminals for
+              turns that were durably submitted but never finished, in
+              sessions silent past the stranding floors. The terminal
+              itself is correct recovery; this alert is about the cause.
+              The slog line "stranded turn swept to durable terminal"
+              carries session_id, turn_id, progressed, and source per
+              sweep. progressed=false means no runner ever claimed the
+              command (runner-consumer MaxDeliver exhaustion, dead runner
+              process, or a publish that never landed — check the
+              command-publish failure counter and the runner pod's
+              restart count); progressed=true means a runner died
+              mid-turn (check that pod's previous-container logs). A
+              burst right after deploying the sweep is expected drain of
+              historical strands; a steady rate afterward is live command
+              loss.
+
         # Background-task wake fire failures. A Claude run_in_background task
         # that finishes while the session is idle registers a durable wake in
         # session_background_task_wakes; the orchestrator fire loop turns it


### PR DESCRIPTION
## Summary

PR 4 of the #1051 plan: the command-plane four-outcome backstop. A dispatched turn whose `submit_turn` command or runner dies has no other terminal writer — the incident left five sessions durably `submitted`/`streaming` for hours, recoverable only by manual interrupts that themselves timed out. The sweep (mirroring the stranded-launch sweep's shape) converts each silent strand into a durable `turn.command_failed`.

- **Candidate predicate**: `turn.submitted` with no terminal of any kind, in a session with **zero events of any kind for the whole 30-minute quiet window**. The quiet predicate is the false-positive guard: a turn legitimately queued behind a long-running turn, or itself mid-work, lives in a session that keeps producing events and is never a candidate.
- **Two floors**: 30 minutes for never-claimed strands (a healthy runner claims a deliverable command in seconds); 2 hours for claimed/started strands (a runner that died mid-turn), on top of the session silence.
- **Continuation strands ring the away bell**: a stranded background-task wake, scheduled wakeup, or agent-continuation carries the new `stranded_continuation_swept` away-error reason (the agent promised to resume while the user was away and the resume silently died — the summon invariant); ordinary user turns fail plainly with resubmit guidance.
- **No re-drive**: the runner's state for the turn is unknown or gone; a re-publish could double-run partial work. Surfacing the failure is the honest outcome. Deterministic event ids collapse both replicas to one terminal row; a late runner racing the sweep hits the existing already-terminal guard.
- **Observability**: `tank_stranded_turn_swept_total{result}`, `TankStrandedTurnsSwept` alert + runbook (each swept turn is a real delivery loss — the alert is about the cause, not the recovery), taxonomy entry.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Agent Runners** (four-outcome contract: "a durable `*_requested` event MUST be followed by exactly one durable terminal; silent strandings are a counted bug class"): the sweep is the missing terminal writer for the command-loss class. `TestProcessStrandedTurnsFailsNeverClaimedTurn` pins the terminal shape (deterministic event id, turn id, client nonce, `submit_command_lost` reason); `TestProcessStrandedTurnsDefersYoungProgressedTurn` pins the two-floor discipline; `TestProcessStrandedTurnsClassifiesContinuationsAsAwayErrors` pins the summon-invariant wiring for wake/scheduled/continuation strands vs plain user turns; window and skip tests mirror the launch sweep's pins.
- **Observability**: each swept strand is counted (`result="failed"`) and paged via `TankStrandedTurnsSwept`, with the per-strand slog line carrying session/turn/progressed/source — operators learn commands are dying from Grafana, not from user reports of frozen chips. Live acceptance after deploy: the five incident strands (sessions 810/811/815/816/817) should be swept to terminals within one tick + floors, visible in the counter and their session statuses; will confirm and note here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
