### PR TITLE
backend writes: move transcript projection off the HTTP request path (#1051 PR 2a)

### DIFF
--- a/backend-go/cmd/tank-operator/async_transcript_refresher.go
+++ b/backend-go/cmd/tank-operator/async_transcript_refresher.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// asyncTranscriptRefresher moves the backend-direct write path's
+// transcript-row projection off the HTTP request. Before this, every
+// persistBackendEvent ran a full RefreshEvent inline — on a
+// background-task-heavy session that is a whole-session re-projection inside
+// the request, which is how Stop on session 815 exceeded 240s during the
+// 2026-06-11 incident recovery ("persist interrupt request: context
+// canceled", tank-operator#1051 finding 3). The bus-persister path has always
+// refreshed asynchronously relative to its producers; this unifies the
+// backend-direct path with that shape.
+//
+// Semantics preserved:
+//   - The durable contract is the session_events row, written synchronously
+//     before the handler responds — only the derived projection moves.
+//   - Refresh-then-wake ordering: the per-session SSE wake fires after the
+//     projection refresh completes, exactly as the bus persister does, so a
+//     woken reader always sees the refreshed rows.
+//   - Per-session serial workers with batch coalescing reuse the
+//     materializer's RefreshEventBatch classification — N queued events for
+//     one session cost one projection pass.
+//   - A refresh failure is logged and counted; the rows converge via the
+//     on-read EnsureSession resync, the documented projection-staleness
+//     recovery. The ledger row is already durable either way.
+type asyncTranscriptRefresher struct {
+	ctx          context.Context
+	materializer transcriptRowsMaterializer
+	wake         func(storageKey string)
+
+	mu     sync.Mutex
+	queues map[string][]asyncRefreshItem
+	active map[string]bool
+}
+
+type asyncRefreshItem struct {
+	event map[string]any
+}
+
+func newAsyncTranscriptRefresher(ctx context.Context, materializer transcriptRowsMaterializer, wake func(storageKey string)) *asyncTranscriptRefresher {
+	return &asyncTranscriptRefresher{
+		ctx:          ctx,
+		materializer: materializer,
+		wake:         wake,
+		queues:       map[string][]asyncRefreshItem{},
+		active:       map[string]bool{},
+	}
+}
+
+// enqueue routes one just-persisted backend event to its session's serial
+// refresh queue, spawning a worker if none is running.
+func (r *asyncTranscriptRefresher) enqueue(storageKey string, event map[string]any) {
+	if r == nil || event == nil {
+		return
+	}
+	r.mu.Lock()
+	r.queues[storageKey] = append(r.queues[storageKey], asyncRefreshItem{event: event})
+	startWorker := !r.active[storageKey]
+	if startWorker {
+		r.active[storageKey] = true
+	}
+	r.mu.Unlock()
+	if startWorker {
+		go r.runWorker(storageKey)
+	}
+}
+
+func (r *asyncTranscriptRefresher) runWorker(storageKey string) {
+	for {
+		r.mu.Lock()
+		queue := r.queues[storageKey]
+		if len(queue) == 0 || r.ctx.Err() != nil {
+			r.active[storageKey] = false
+			delete(r.queues, storageKey)
+			r.mu.Unlock()
+			return
+		}
+		r.queues[storageKey] = nil
+		r.mu.Unlock()
+
+		events := make([]map[string]any, len(queue))
+		for i, item := range queue {
+			events[i] = item.event
+		}
+		started := time.Now()
+		if err := r.materializer.RefreshEventBatch(r.ctx, events); err != nil {
+			recordTranscriptRowMaterialization("backend_async", transcriptRowMaterializationFailureResult(r.ctx, err), time.Since(started))
+			slog.Warn("backend async transcript refresh failed; rows converge via on-read resync",
+				"storage_key", storageKey,
+				"events", len(events),
+				"error", err,
+			)
+		} else {
+			recordTranscriptRowMaterialization("backend_async", "refreshed", time.Since(started))
+		}
+		// Refresh-then-wake, success or not: on failure the woken reader's
+		// staleness check triggers the on-read resync sooner rather than
+		// waiting out the SSE heartbeat.
+		if r.wake != nil && storageKey != "" {
+			r.wake(storageKey)
+		}
+	}
+}

--- a/backend-go/cmd/tank-operator/async_transcript_refresher_test.go
+++ b/backend-go/cmd/tank-operator/async_transcript_refresher_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/romaine-life/tank-operator/backend-go/internal/store"
+)
+
+// orderRecordingRowsStore records the relative order of projection writes so
+// the refresh-then-wake contract is checkable.
+type orderRecordingRowsStore struct {
+	recordingTranscriptRowsStore
+	mu       sync.Mutex
+	replaces int
+}
+
+func (s *orderRecordingRowsStore) ReplaceForTurn(ctx context.Context, sessionID string, turnID string, entries []map[string]any) error {
+	s.mu.Lock()
+	s.replaces++
+	s.mu.Unlock()
+	return s.recordingTranscriptRowsStore.ReplaceForTurn(ctx, sessionID, turnID, entries)
+}
+
+func (s *orderRecordingRowsStore) replaceCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.replaces
+}
+
+func asyncRefresherTestEvent(turnID, eventID, orderKey string) map[string]any {
+	return projectionTestEvent(eventID, orderKey, "item.completed", "tool", "codex", turnID, turnID+":item:"+eventID, map[string]any{
+		"kind":   "command_execution",
+		"output": "ok",
+	})
+}
+
+// TestAsyncTranscriptRefresherWakesAfterRefresh pins the ordering contract
+// inherited from the bus persister: the SSE wake fires only after the
+// projection refresh for the queued events has completed, so a woken reader
+// always sees the refreshed rows.
+func TestAsyncTranscriptRefresherWakesAfterRefresh(t *testing.T) {
+	events := []map[string]any{asyncRefresherTestEvent("turn-1", "a", "001")}
+	rowStore := &orderRecordingRowsStore{}
+	eventStore := fakeSessionEventStore{
+		pages: map[string]store.SessionEventPage{
+			"": {Events: events, FoundOldest: true, FoundNewest: true},
+		},
+	}
+	materializer := transcriptRowsMaterializer{events: eventStore, rows: rowStore}
+
+	var mu sync.Mutex
+	var wakes []int // replace-count observed at each wake
+	r := newAsyncTranscriptRefresher(context.Background(), materializer, func(string) {
+		mu.Lock()
+		wakes = append(wakes, rowStore.replaceCount())
+		mu.Unlock()
+	})
+
+	r.enqueue("63", events[0])
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		done := len(wakes) >= 1
+		mu.Unlock()
+		if done {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("wake never fired")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if wakes[0] < 1 {
+		t.Fatalf("wake fired before any projection write (replaces at wake = %d)", wakes[0])
+	}
+}
+
+// TestAsyncTranscriptRefresherCoalescesQueuedEvents pins the cost contract:
+// events queued for one session while a refresh is in flight are drained as
+// one batch — at most one extra projection pass, not one per event.
+func TestAsyncTranscriptRefresherCoalescesQueuedEvents(t *testing.T) {
+	turnEvents := []map[string]any{
+		asyncRefresherTestEvent("turn-1", "a", "001"),
+		asyncRefresherTestEvent("turn-1", "b", "002"),
+		asyncRefresherTestEvent("turn-1", "c", "003"),
+		asyncRefresherTestEvent("turn-1", "d", "004"),
+	}
+	gate := make(chan struct{})
+	rowStore := &orderRecordingRowsStore{}
+	eventStore := blockingFirstReadEventStore{
+		fakeSessionEventStore: fakeSessionEventStore{
+			pages: map[string]store.SessionEventPage{
+				"": {Events: turnEvents, FoundOldest: true, FoundNewest: true},
+			},
+		},
+		gate: gate,
+	}
+	materializer := transcriptRowsMaterializer{events: eventStore, rows: rowStore}
+
+	var mu sync.Mutex
+	wakeCount := 0
+	r := newAsyncTranscriptRefresher(context.Background(), materializer, func(string) {
+		mu.Lock()
+		wakeCount++
+		mu.Unlock()
+	})
+
+	// First event starts a worker that blocks inside its ledger read; the
+	// next three queue behind it and must drain as ONE batch.
+	r.enqueue("63", turnEvents[0])
+	eventStore.waitForFirstRead(t)
+	r.enqueue("63", turnEvents[1])
+	r.enqueue("63", turnEvents[2])
+	r.enqueue("63", turnEvents[3])
+	close(gate)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		done := wakeCount >= 2
+		mu.Unlock()
+		if done {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected 2 wakes (first event, then coalesced batch); got %d", wakeCount)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Give a stray per-event worker a moment to disprove coalescing.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if wakeCount != 2 {
+		t.Fatalf("wakes = %d, want exactly 2 (one per drain, not one per event)", wakeCount)
+	}
+}
+
+// blockingFirstReadEventStore blocks the first per-turn ledger read until the
+// gate opens, so the coalescing test can stack a queue behind an in-flight
+// refresh deterministically.
+type blockingFirstReadEventStore struct {
+	fakeSessionEventStore
+	gate      chan struct{}
+	firstOnce sync.Once
+	firstSeen chan struct{}
+}
+
+func (s blockingFirstReadEventStore) EventsForTurnAfter(ctx context.Context, sessionID, turnID, afterOrderKey string, limit int) (store.SessionEventPage, error) {
+	if s.firstSeen != nil {
+		s.firstOnce.Do(func() { close(s.firstSeen) })
+	}
+	<-s.gate
+	return s.fakeSessionEventStore.EventsForTurnAfter(ctx, sessionID, turnID, afterOrderKey, limit)
+}
+
+func (s *blockingFirstReadEventStore) waitForFirstRead(t *testing.T) {
+	t.Helper()
+	// The worker is in flight once it blocks on the gate; a short settle is
+	// sufficient because enqueue spawned it synchronously.
+	time.Sleep(20 * time.Millisecond)
+}
+
+// TestAsyncTranscriptRefresherWakesOnRefreshFailure pins the degraded-path
+// contract: a projection failure still wakes SSE (the woken reader's
+// staleness check triggers the on-read resync) and never panics the worker.
+func TestAsyncTranscriptRefresherWakesOnRefreshFailure(t *testing.T) {
+	rowStore := &failingTranscriptRowsStore{}
+	eventStore := fakeSessionEventStore{
+		pages: map[string]store.SessionEventPage{
+			"": {Events: []map[string]any{asyncRefresherTestEvent("turn-1", "a", "001")}, FoundOldest: true, FoundNewest: true},
+		},
+	}
+	materializer := transcriptRowsMaterializer{events: eventStore, rows: rowStore}
+
+	woke := make(chan struct{}, 1)
+	r := newAsyncTranscriptRefresher(context.Background(), materializer, func(string) {
+		select {
+		case woke <- struct{}{}:
+		default:
+		}
+	})
+
+	r.enqueue("63", asyncRefresherTestEvent("turn-1", "a", "001"))
+
+	select {
+	case <-woke:
+	case <-time.After(5 * time.Second):
+		t.Fatal("failure path never woke SSE")
+	}
+}
+
+type failingTranscriptRowsStore struct {
+	recordingTranscriptRowsStore
+}
+
+func (s *failingTranscriptRowsStore) ReplaceForTurn(context.Context, string, string, []map[string]any) error {
+	return context.DeadlineExceeded
+}

--- a/backend-go/cmd/tank-operator/handlers_turns.go
+++ b/backend-go/cmd/tank-operator/handlers_turns.go
@@ -51,9 +51,6 @@ func (s *appServer) persistBackendEvent(ctx context.Context, storageKey string, 
 		}
 		return err
 	}
-	if err := s.refreshTranscriptRowsForEvent(ctx, event); err != nil {
-		return err
-	}
 	// Silent-stranding observability: bump the lifecycle counter for the
 	// five bounding types after the durable write commits. The
 	// backend-direct path writes user_message.created + turn.submitted
@@ -73,7 +70,18 @@ func (s *appServer) persistBackendEvent(ctx context.Context, storageKey string, 
 		}
 		recordTurnTerminalMissingClientNonce(source, eventType)
 	}
-	if s.sessionBus != nil && storageKey != "" {
+	// The transcript-row projection runs on the per-session async worker,
+	// which fires the SSE wake after the refresh completes (refresh-then-
+	// wake, same ordering the bus persister guarantees). Running it inline
+	// here was tank-operator#1051 finding 3: a whole-session re-projection
+	// inside the HTTP request, which timed out Stop on background-task-heavy
+	// sessions. The durable contract — the session_events row — was written
+	// synchronously above.
+	if s.transcriptRefresher != nil {
+		s.transcriptRefresher.enqueue(storageKey, event)
+	} else if s.sessionBus != nil && storageKey != "" {
+		// Degraded boot / test fixtures: no async worker. Rows converge via
+		// the on-read resync; signal SSE directly.
 		if err := s.sessionBus.PublishSessionEventWake(ctx, storageKey); err != nil {
 			slog.Warn("session event wake publish failed",
 				"storage_key", storageKey, "event_type", event["type"], "error", err)
@@ -81,17 +89,6 @@ func (s *appServer) persistBackendEvent(ctx context.Context, storageKey string, 
 	}
 	s.refreshActivityForBackendEvent(ctx, storageKey, event)
 	return nil
-}
-
-func (s *appServer) refreshTranscriptRowsForEvent(ctx context.Context, event map[string]any) error {
-	if s == nil || s.sessionEvents == nil || s.transcriptRows == nil {
-		return nil
-	}
-	return (transcriptRowsMaterializer{
-		events: s.sessionEvents,
-		rows:   s.transcriptRows,
-		turns:  s.turns,
-	}).RefreshEvent(ctx, event)
 }
 
 func (s *appServer) refreshActivityForBackendEvent(ctx context.Context, storageKey string, event map[string]any) {

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -478,6 +478,12 @@ func main() {
 		sessionEvents:                sessionEventsStore,
 		transcriptRows:               transcriptRowsStore,
 		turns:                        turnsStore,
+		transcriptRefresher: newAsyncTranscriptRefresher(ctx, transcriptMaterializer, func(storageKey string) {
+			if err := sessionBus.PublishSessionEventWake(context.Background(), storageKey); err != nil {
+				slog.Warn("backend async refresh wake publish failed",
+					"storage_key", storageKey, "error", err)
+			}
+		}),
 		avatars:                      avatarStore,
 		avatarImages:                 avatarImageStore,
 		avatarUploads:                avatarUploadAttemptStore,

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -2305,6 +2305,11 @@ func transcriptRowMaterializationTriggerLabel(raw string) string {
 	switch strings.TrimSpace(raw) {
 	case "on_demand":
 		return "on_demand"
+	case "backend_async":
+		// The backend-direct write path's per-session async refresh worker
+		// (async_transcript_refresher.go) — the projection work that used to
+		// run inline in HTTP handlers.
+		return "backend_async"
 	default:
 		return "unknown"
 	}
@@ -2312,7 +2317,7 @@ func transcriptRowMaterializationTriggerLabel(raw string) string {
 
 func transcriptRowMaterializationResultLabel(raw string) string {
 	switch strings.TrimSpace(raw) {
-	case "fresh", "backfilled", "failed", "timeout":
+	case "fresh", "backfilled", "refreshed", "failed", "timeout":
 		return strings.TrimSpace(raw)
 	default:
 		return "unknown"

--- a/backend-go/cmd/tank-operator/server.go
+++ b/backend-go/cmd/tank-operator/server.go
@@ -41,6 +41,11 @@ type appServer struct {
 	sessionEvents  store.SessionEventStore
 	transcriptRows store.SessionTranscriptRowStore
 	turns          store.SessionTurnStore
+	// transcriptRefresher is the per-session async projection worker for the
+	// backend-direct write path (async_transcript_refresher.go). Nil in
+	// degraded boots and test fixtures; persistBackendEvent then skips
+	// projection (on-read resync covers it) and wakes SSE inline.
+	transcriptRefresher *asyncTranscriptRefresher
 	avatars        avatarassets.Store
 	avatarImages   avatarassets.ImageStore
 	avatarUploads  avataruploads.Store


### PR DESCRIPTION
## Summary

PR 2a of the #1051 plan — the bounded half of "remove the O(session) projection cost," fixing finding 3 directly. `persistBackendEvent` ran a full `RefreshEvent` inline: on a background-task-heavy session that is a whole-session re-projection **inside the HTTP request**, which is how `POST .../interrupt` on session 815 exceeded 240 s during the incident recovery (`persist interrupt request: context canceled`).

- The durable contract — the `session_events` row — is written synchronously exactly as before. Only the derived transcript-row projection moves off the request, onto a per-session async worker mirroring the bus persister's dispatch shape (serial per session, batch-coalesced through the same `RefreshEventBatch` classification).
- **Refresh-then-wake ordering preserved**: the SSE wake fires after the projection completes, the same guarantee the bus persister provides — the two write paths now share one shape instead of the backend-direct path being the inline anomaly.
- A refresh failure still wakes (the reader's staleness check triggers the documented on-read `EnsureSession` resync) and is counted under the existing materialization metric with the new bounded `trigger="backend_async"` label.
- Stop/submit/answer/sweep handlers all stop paying projection cost inline; Stop on a bgtask-heavy session now responds in milliseconds.

The unbounded projection cost itself (the back-half rewrite into a checkpointed incremental fold) is PR 2b; its staged plan is recorded on #1051.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- **Transcript** ("`session_events` owns transcript entries"; rows are a server-owned projection; "SSE is a live follower of durable events"): the ledger write stays synchronous; only projection timing changes, to the same asynchrony the runner-produced majority of events has always had. `TestAsyncTranscriptRefresherWakesAfterRefresh` pins refresh-then-wake; `TestAsyncTranscriptRefresherCoalescesQueuedEvents` pins one projection pass per drain (not per event); `TestAsyncTranscriptRefresherWakesOnRefreshFailure` pins the resync-via-wake degraded path. Full suite green including all existing projection/materializer pins — output shape untouched.
- **Agent Runners** (Stop chain: "Stop publishes interrupt_turn and remains stopping until the durable turn.interrupted arrives"): the durable `turn.interrupt_requested` write is unchanged and synchronous; the handler no longer times out on large sessions, which during the incident recovery prevented Stop from being *requested* at all on the worst session. Race-clean (`-race` on the new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
