### PR TITLE
sweep: 15-minute cadence for the stranded-turn scan (PG load fix)

### DIFF
--- a/backend-go/cmd/tank-operator/stranded_turn_sweep.go
+++ b/backend-go/cmd/tank-operator/stranded_turn_sweep.go
@@ -14,11 +14,17 @@ import (
 )
 
 const (
-	// strandedTurnSweepInterval mirrors the launch sweep: stranding is a rare
-	// durability gap, not a latency-sensitive path. The cost of a slow tick is
-	// only how long a stranded turn shows as submitted/streaming before it
-	// flips to failed.
-	strandedTurnSweepInterval = 60 * time.Second
+	// strandedTurnSweepInterval. Unlike the launch sweep's cheap lone-event
+	// probe, FindStrandedTurns scans the full 30-day turn.submitted window
+	// with three correlated subqueries — at the launch sweep's 60s cadence on
+	// both replicas it kept the B1ms instance pinned after the historical
+	// drain (sustained TankPgConnectionPollFailing / select_session_events
+	// P99, observed 2026-06-11 post-#1055). Stranding detection tolerates
+	// large latency by construction: candidates already sit ≥30 minutes
+	// behind the quiet-window floor, so a 15-minute cadence adds at most
+	// ~50% to time-to-terminal while cutting steady-state query load 15×
+	// per replica.
+	strandedTurnSweepInterval = 15 * time.Minute
 	// strandedTurnMinAgeSubmitted is the age floor for a never-claimed strand.
 	// A healthy runner claims a deliverable submit_turn within seconds (it is
 	// a queue pop), so thirty quiet minutes is many multiples of headroom. The


### PR DESCRIPTION
Found during live verification: the stranded-turn sweep inherited the launch sweep's 60s tick, but its query is far heavier (30-day window, three correlated subqueries). At 60s on both replicas it kept the B1ms pinned after the historical drain — sustained TankPgConnectionPollFailing + select_session_events P99 on the current prod pods. Candidates already sit >=30m behind the quiet-window floor, so 15-minute cadence adds at most ~50% to time-to-terminal while cutting steady-state load 15x per replica.

## Feature Contracts

Affected contracts:
- [x] Observability

Evidence:
- The firing TankPgConnectionPollFailing on both tank-operator-68b6456b76 pods is the reproduction; after deploy the poller failures and the post-drain select_session_events P99 should subside — will verify in Grafana. TestProcessStrandedTurnsWindowArguments and the sweep behavior tests pass unchanged (cadence is loop wiring, not sweep semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)