### PR TITLE
docs: capability ledger entries for the #1051 pipeline behaviors

### DIFF
--- a/docs/features/agent-runners/capabilities.md
+++ b/docs/features/agent-runners/capabilities.md
@@ -475,3 +475,31 @@ Evidence:
 - Metrics: `tank_runner_provider_api_retry_total{error}` and
   `tank_runner_provider_rate_limit_decision_total{decision="retry_stall_failed"}`.
 - Docs: `docs/observability.md` runner-metrics taxonomy.
+
+## Stranded-turn sweep (command-plane four-outcome backstop)
+
+Status: shipped (2026-06-11, tank-operator#1051 PR 4)
+
+Intent:
+A durably submitted turn whose submit_turn command or runner dies has no
+other terminal writer; before the sweep such turns sat as permanent
+"submitted"/"streaming" ghosts (five sessions in the 2026-06-11 incident,
+plus 53 historical strands spanning 30 days drained on first deploy). The
+sweep terminals them with durable turn.command_failed once the whole session
+has been silent past the stranding floors (30m never-claimed / 2h mid-turn),
+never re-driving the command. Continuation strands (background-task wakes,
+scheduled wakeups, agent continuations) carry the
+stranded_continuation_swept away-error reason so the sidebar rings the
+summon bell; ordinary user turns fail plainly with resubmit guidance.
+
+Affected contracts:
+- Agent Runners ("a durable *_requested event MUST be followed by exactly one
+  durable terminal; silent strandings are a counted bug class")
+- Observability (tank_stranded_turn_swept_total, TankStrandedTurnsSwept — the
+  alert is about WHY commands die; the terminal is the recovery)
+
+Retirement note:
+Scan cadence is 15 minutes because FindStrandedTurns is a heavy 30-day window
+scan; if the candidate query ever becomes incremental, the cadence can drop.
+The quiet-session predicate is the false-positive guard — do not relax it to
+catch strands faster.

--- a/docs/features/transcript/capabilities.md
+++ b/docs/features/transcript/capabilities.md
@@ -784,3 +784,38 @@ Evidence:
 - Frontend: `frontend/src/turnCostEstimateUi.test.ts` guards that the composer
   renders the restored `run-cost-estimate` context/cost chip while visible
   transcript usage messages stay retired.
+
+## Durable transcript pipeline: persister dispatch, reconciler, async backend refresh
+
+Status: shipped (2026-06-11, tank-operator#1051 PRs 1/2a)
+
+Intent:
+The session-bus persister is the sole bus-to-Postgres writer for transcript
+events, and its health is the product: when it stalls, every session freezes
+at once while runners keep working invisibly (the 2026-06-11 incident). Three
+named behaviors keep that pipeline trustworthy:
+
+- Per-session dispatch with batch coalescing: one durable consumer feeds
+  per-session serial queues over a bounded worker pool; a flood session
+  saturates one worker, and N queued events for one turn cost one projection
+  pass (RefreshEventBatch).
+- MAX_DELIVERIES advisory repair + startup reconciler: an event that exhausts
+  redelivery is re-persisted out of band or counted as lost
+  (tank_session_event_persist_exhausted_total); on boot the reconciler
+  replays the ack-floor window and repairs holes idempotently (146 events
+  recovered on first deploy).
+- Async backend refresh: backend-direct writers (submit, interrupt, sweeps)
+  persist the ledger row synchronously but run the transcript-row projection
+  on a per-session async worker with refresh-then-wake ordering, unifying
+  both write paths and keeping projection cost out of HTTP handlers.
+
+Affected contracts:
+- Transcript (session_events ownership; SSE as live follower of durable rows)
+- Observability (persister lag gauges read JetStream consumer state so the
+  signal survives the persister itself failing; TankSessionEventPersisterBacklog,
+  TankSessionEventPersistExhausted, TankSessionEventStreamTruncated)
+
+Retirement note:
+The full-batch projection (projectTranscriptEvents) is the reference
+implementation and the explicit resync path; the in-flight checkpointed-fold
+stages (#1051 B2-B5) change its cost profile, never its ownership.


### PR DESCRIPTION
Doc-only. Adds the capability-ledger entries CLAUDE.md requires for named behavior shipped in the #1051 series: the durable transcript pipeline behaviors (per-session dispatch + coalescing, advisory repair + startup reconciler, async backend refresh) in the Transcript ledger, and the stranded-turn sweep in the Agent Runners ledger, each with contract references and retirement notes.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Agent Runners

Evidence:
- Ledger-only change; the named behaviors' own tests/alerts are evidenced on #1052/#1055/#1056. Entries follow the existing ledger template (Status / Intent / Affected contracts / Retirement note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)