### PR TITLE
projection: checkpointed fold — flood events stop reading the ledger (#1051 B2+B3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 backend-go/antigravity-runner
+backend-go/tank-operator.exe

--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -2376,6 +2376,41 @@ func recordTurnNumberMissing(phase string) {
 	turnNumberMissingTotal.WithLabelValues(turnNumberMissingPhaseLabel(phase)).Inc()
 }
 
+// Checkpointed transcript fold (tank-operator#1051 B2+B3). result tells the
+// story per batch attempt: folded (fast path), reseeded (session re-projection
+// rebuilt the memo), invalidated (turn-scope reference projection made the
+// memo stale), resync (a structure-class event sent the batch to the
+// reference path), disabled / disabled_size (session durably opted out),
+// load_error (fold state unreadable; reference path used).
+var transcriptFoldTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tank_transcript_fold_total",
+		Help: "Checkpointed transcript-fold batch outcomes, labeled by bounded result.",
+	},
+	[]string{"result"},
+)
+
+var transcriptFoldDurationSeconds = promauto.NewHistogram(
+	prometheus.HistogramOpts{
+		Name:    "tank_transcript_fold_duration_seconds",
+		Help:    "Wall time of successful checkpointed-fold batch applications (load excluded, save included).",
+		Buckets: []float64{.001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+	},
+)
+
+func recordTranscriptFold(result string) {
+	switch result {
+	case "folded", "reseeded", "invalidated", "resync", "disabled", "disabled_size", "load_error":
+	default:
+		result = "other"
+	}
+	transcriptFoldTotal.WithLabelValues(result).Inc()
+}
+
+func recordTranscriptFoldDuration(d time.Duration) {
+	transcriptFoldDurationSeconds.Observe(d.Seconds())
+}
+
 // recordTurnActivityPages observes the page count and total event count of a
 // turn-activity projection so long-turn frequency (the pagination trigger) is
 // visible without high-cardinality labels.

--- a/backend-go/cmd/tank-operator/transcript_fold_checkpoint.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_checkpoint.go
@@ -1,0 +1,624 @@
+package main
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// sessionFoldMemo is stages B2+B3 of the checkpointed-projector plan
+// (tank-operator#1051): the bounded fold state that lets the persister apply
+// a flood-class event to the transcript-row projection without re-reading the
+// session ledger. The memo is durable (session_transcript_fold_state, loaded
+// and saved inside the same materialization transaction as the row writes),
+// and deliberately conservative: any event the fold cannot handle with full
+// confidence reports needsResync, and the batch pipeline — which remains the
+// reference implementation, never a retired path — re-projects the session
+// and reseeds the memo.
+//
+// What the memo retains is bounded by construction:
+//   - OPEN items only (an item leaves the memo when it reaches a terminal
+//     status; a later touch of an evicted id forces a resync);
+//   - background tasks and turn usages/terminals, bounded by count;
+//   - per-turn PRUNED entries: only the ~20 fields the shell summary math
+//     and membership predicates read (turnFoldEntryFields) — tool payloads,
+//     message bodies, and reasoning text never enter the memo. Shell rows are
+//     rebuilt from these via the same B1 fold finishes and
+//     buildTurnActivityShellRow the batch pipeline uses, so the summary math
+//     has exactly one implementation.
+//
+// Versioning: bump sessionFoldMemoVersion whenever the memo shape or the
+// projection semantics it snapshots change; a version mismatch on load is a
+// resync, never a best-effort read of stale state.
+const sessionFoldMemoVersion = 1
+
+// sessionFoldMemoMaxBytes caps the serialized memo. A session whose memo
+// outgrows it has the fold disabled durably (always batch-projected, exactly
+// the pre-fold behavior) and counted — never silently truncated.
+const sessionFoldMemoMaxBytes = 1_500_000
+
+type sessionFoldMemo struct {
+	Version      int    `json:"version"`
+	LastOrderKey string `json:"last_order_key"`
+	RunStatus    string `json:"run_status"`
+	ActiveTurnID string `json:"active_turn_id"`
+
+	OpenItems    map[string]*projectionItem `json:"open_items,omitempty"`
+	EvictedItems map[string]bool            `json:"evicted_items,omitempty"`
+
+	Tasks           []*projectionBackgroundTask `json:"tasks,omitempty"`
+	TaskProviderIDs map[string]bool             `json:"task_provider_ids,omitempty"`
+
+	TurnUsages    map[string]turnUsageProjection    `json:"turn_usages,omitempty"`
+	TurnTerminals map[string]turnTerminalProjection `json:"turn_terminals,omitempty"`
+
+	BackgroundWakeTurns   map[string]bool   `json:"background_wake_turns,omitempty"`
+	BackgroundWakeTaskIDs map[string]string `json:"background_wake_task_ids,omitempty"`
+	WakeParents           map[string]string `json:"wake_parents,omitempty"`
+	ContinuationTurns     map[string]bool   `json:"continuation_turns,omitempty"`
+
+	// Turns holds pruned entries keyed by the turn the entry RENDERS under —
+	// wake/continuation entries are stored under their originating parent,
+	// matching the batch pipeline's fold-into-parent semantics.
+	Turns map[string]*turnFoldEntries `json:"turns,omitempty"`
+}
+
+type turnFoldEntries struct {
+	Order   []string                  `json:"order"`
+	Entries map[string]map[string]any `json:"entries"`
+}
+
+// turnFoldEntryFields is the exact field set the shell derivation reads:
+// every membership predicate (isProjectedUserMessage, isProjectionWakePrompt,
+// isProjectionTurnProgress, isProjectionAwaitingInputEntry,
+// isProjectionTerminalMetaEntry, isProjectedAssistantMessage), the summary
+// math in turnActivitySummaryMap, the anchor lookups in
+// buildTurnActivityShellRow, and the terminal annotations. Pruning to this
+// set is what keeps the memo small; if shell derivation grows a new field,
+// add it here — the equivalence harness fails loudly if this set goes stale.
+var turnFoldEntryFields = []string{
+	"id", "kind", "metaKind", "role", "turnId", "backendTurnId",
+	"orderKey", "time", "startedAt", "completedAt", "updatedAt",
+	"toolStatus", "taskStatus", "severity", "sessionStatus",
+	"progressStatus", "wakePrompt", "sourceEventId",
+	"turnUsage", "usageObservation",
+	"turnTerminalStatus", "turnTerminalAt", "turnTerminalEventId", "turnTerminalOrderKey",
+	"activityEndOrderKey", "awaitingInput",
+}
+
+func pruneFoldEntry(entry map[string]any) map[string]any {
+	out := make(map[string]any, len(turnFoldEntryFields)+1)
+	for _, field := range turnFoldEntryFields {
+		if v, ok := entry[field]; ok {
+			out[field] = v
+		}
+	}
+	// meta.severity feeds errorCount; the rest of meta is presentation.
+	if meta := transcriptMap(entry, "meta"); meta != nil {
+		if severity, ok := meta["severity"]; ok {
+			out["meta"] = map[string]any{"severity": severity}
+		}
+	}
+	return out
+}
+
+func newSessionFoldMemo() *sessionFoldMemo {
+	return &sessionFoldMemo{
+		Version:               sessionFoldMemoVersion,
+		RunStatus:             "ready",
+		OpenItems:             map[string]*projectionItem{},
+		EvictedItems:          map[string]bool{},
+		TaskProviderIDs:       map[string]bool{},
+		TurnUsages:            map[string]turnUsageProjection{},
+		TurnTerminals:         map[string]turnTerminalProjection{},
+		BackgroundWakeTurns:   map[string]bool{},
+		BackgroundWakeTaskIDs: map[string]string{},
+		WakeParents:           map[string]string{},
+		ContinuationTurns:     map[string]bool{},
+		Turns:                 map[string]*turnFoldEntries{},
+	}
+}
+
+// foldEventOutcome is the per-event verdict. Anything but foldApplied or
+// foldNoop means the batch must take the reference (re-projection) path.
+type foldEventOutcome int
+
+const (
+	foldApplied foldEventOutcome = iota
+	foldNoop
+	foldNeedsResync
+)
+
+// foldEvent applies one just-persisted event to the memo. It returns the turn
+// whose shell row changed (the RENDER turn — a wake-turn event reports its
+// originating parent) or needsResync when the event is outside the fold's
+// confident envelope: turn lifecycle boundaries, terminals, questions/answers,
+// messages, compaction, session status, new/exiting background tasks, wake
+// boundaries, revisions of evicted items — every structure-class event. The
+// flood classes (item.*, turn.usage, shell_task.updated on a known running
+// task) are the fold's whole purpose: they were >90% of the #1051 incident
+// session's ledger.
+func (m *sessionFoldMemo) foldEvent(event map[string]any) (string, foldEventOutcome) {
+	if m == nil || event == nil {
+		return "", foldNeedsResync
+	}
+	eventType := transcriptString(event, "type")
+	switch eventType {
+	case "item.started", "item.completed", "item.failed":
+		return m.foldItemEvent(event)
+	case "turn.usage":
+		return m.foldTurnUsageEvent(event)
+	case "shell_task.updated":
+		return m.foldShellTaskUpdate(event)
+	default:
+		return "", foldNeedsResync
+	}
+}
+
+func (m *sessionFoldMemo) foldItemEvent(event map[string]any) (string, foldEventOutcome) {
+	if projectionIsCodexUserMessageEcho(event) {
+		return "", foldNoop
+	}
+	id := transcriptString(event, "timeline_id")
+	turnID := transcriptString(event, "turn_id")
+	if id == "" || turnID == "" {
+		return "", foldNoop
+	}
+	if m.EvictedItems[id] {
+		// A revision of an item the memo no longer holds: the merged item
+		// state cannot be reconstructed without the ledger. Resync.
+		return "", foldNeedsResync
+	}
+	// Replay the event through the real apply() on a scratch state seeded
+	// with the item's prior revision, so merge semantics (payload union,
+	// terminal-status preservation, timing fields) have one implementation.
+	scratch := newProjectionState()
+	if existing := m.OpenItems[id]; existing != nil {
+		item := *existing
+		scratch.items = []*projectionItem{&item}
+		scratch.itemIndex[id] = 0
+	}
+	scratch.apply(event)
+	idx, ok := scratch.itemIndex[id]
+	if !ok || idx >= len(scratch.items) {
+		return "", foldNoop
+	}
+	item := scratch.items[idx]
+	if isTerminalProjectionItemStatus(item.Status) {
+		delete(m.OpenItems, id)
+		m.EvictedItems[id] = true
+	} else {
+		m.OpenItems[id] = item
+	}
+	if item.ProviderItemID != "" && m.TaskProviderIDs[item.ProviderItemID] {
+		// Background-task echo items never become flat entries; the task's
+		// own shell_task.* lifecycle renders them.
+		return "", foldNoop
+	}
+	entry := projectProjectionItem(item)
+	if entry == nil {
+		return "", foldNoop
+	}
+	return m.routeEntry(entry, turnID)
+}
+
+func (m *sessionFoldMemo) foldTurnUsageEvent(event map[string]any) (string, foldEventOutcome) {
+	turnID := transcriptString(event, "turn_id")
+	if turnID == "" || transcriptPayloadValue(event, "usage") == nil {
+		return "", foldNoop
+	}
+	scratch := newProjectionState()
+	if existing, ok := m.TurnUsages[turnID]; ok {
+		scratch.turnUsages[turnID] = existing
+	}
+	scratch.apply(event)
+	usage, ok := scratch.turnUsages[turnID]
+	if !ok {
+		return "", foldNoop
+	}
+	m.TurnUsages[turnID] = usage
+	return m.routeEntry(projectTurnUsage(usage), turnID)
+}
+
+func (m *sessionFoldMemo) foldShellTaskUpdate(event map[string]any) (string, foldEventOutcome) {
+	id := transcriptString(event, "timeline_id")
+	turnID := transcriptString(event, "turn_id")
+	if id == "" || turnID == "" {
+		return "", foldNoop
+	}
+	existingIdx := -1
+	for i, task := range m.Tasks {
+		if task != nil && task.ID == id {
+			existingIdx = i
+			break
+		}
+	}
+	if existingIdx < 0 {
+		// First sight of a task on an update (its started event predates the
+		// memo, or producers disagree on ids): structure change, resync.
+		return "", foldNeedsResync
+	}
+	scratch := newProjectionState()
+	seeded := *m.Tasks[existingIdx]
+	scratch.backgroundTasks = []*projectionBackgroundTask{&seeded}
+	scratch.backgroundIndex[id] = 0
+	scratch.apply(event)
+	idx, ok := scratch.backgroundIndex[id]
+	if !ok || idx >= len(scratch.backgroundTasks) {
+		return "", foldNoop
+	}
+	task := scratch.backgroundTasks[idx]
+	if isTerminalProjectionBackgroundStatus(task.Status) {
+		// A task reaching a terminal through an update changes parked /
+		// continuation structure — the batch pipeline owns that transition.
+		return "", foldNeedsResync
+	}
+	m.Tasks[existingIdx] = task
+	return m.routeEntry(projectProjectionBackgroundTask(task), task.TurnID)
+}
+
+// routeEntry annotates and upserts the pruned entry under its ORIGINAL turn —
+// wake content stays in the wake turn's set, exactly as the batch pipeline
+// keeps per-turn bodies separate and merges them at shell-build time. The
+// returned id is the RENDER turn (the wake's originating parent) so callers
+// know whose shell to rebuild.
+func (m *sessionFoldMemo) routeEntry(entry map[string]any, turnID string) (string, foldEventOutcome) {
+	if entry == nil {
+		return "", foldNoop
+	}
+	entry = annotateProjectionTerminal(entry, m.TurnTerminals)
+	render := turnID
+	if isBackgroundWakeTurnID(turnID) || m.BackgroundWakeTurns[turnID] {
+		parent := m.WakeParents[turnID]
+		if parent == "" {
+			// Wake turn with no established parent edge: the batch pipeline
+			// owns parent resolution.
+			return "", foldNeedsResync
+		}
+		render = parent
+	}
+	turn := m.Turns[turnID]
+	if turn == nil {
+		turn = &turnFoldEntries{Entries: map[string]map[string]any{}}
+		m.Turns[turnID] = turn
+	}
+	turn.upsert(pruneFoldEntry(entry))
+	return render, foldApplied
+}
+
+// upsert keeps Order sorted by orderKey (ties keep arrival order), mirroring
+// the batch pipeline's orderKey-sorted flat list and the orderKey-sorted
+// wake-body merge. A revision that changes the entry's orderKey — an item
+// completing re-keys it to the completion event's position — re-sorts the
+// entry, exactly as the batch pipeline's full re-sort would.
+func (t *turnFoldEntries) upsert(entry map[string]any) {
+	id := transcriptMapString(entry, "id")
+	if id == "" {
+		return
+	}
+	key := transcriptMapString(entry, "orderKey")
+	if prior, seen := t.Entries[id]; seen {
+		if transcriptMapString(prior, "orderKey") == key {
+			t.Entries[id] = entry
+			return
+		}
+		for i, existingID := range t.Order {
+			if existingID == id {
+				t.Order = append(t.Order[:i], t.Order[i+1:]...)
+				break
+			}
+		}
+	}
+	t.Entries[id] = entry
+	pos := len(t.Order)
+	for i, existingID := range t.Order {
+		if transcriptMapString(t.Entries[existingID], "orderKey") > key {
+			pos = i
+			break
+		}
+	}
+	t.Order = append(t.Order, "")
+	copy(t.Order[pos+1:], t.Order[pos:])
+	t.Order[pos] = id
+}
+
+func (t *turnFoldEntries) ordered() []map[string]any {
+	out := make([]map[string]any, 0, len(t.Order))
+	for _, id := range t.Order {
+		if entry := t.Entries[id]; entry != nil {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// bodyForTurn derives one turn's activity body in its own mode, exactly as
+// the batch pipeline does before any wake merging.
+func (m *sessionFoldMemo) bodyForTurn(turnID string) (turnActivityBody, bool) {
+	turn := m.Turns[turnID]
+	if turn == nil {
+		return turnActivityBody{}, false
+	}
+	fold := newTurnShellFold(turnID)
+	for _, entry := range turn.ordered() {
+		fold.upsertEntry(entry)
+	}
+	if terminal, hasTerminal := m.TurnTerminals[turnID]; hasTerminal {
+		return fold.finishTerminal(terminal, m.BackgroundWakeTurns[turnID], m.ContinuationTurns[turnID])
+	}
+	if body, ok := fold.finishAwaitingInputHandoff(); ok {
+		return body, true
+	}
+	if turnID == m.ActiveTurnID {
+		return fold.finishActive(m.RunStatus)
+	}
+	return turnActivityBody{}, false
+}
+
+// shellRowForTurn rebuilds the durable turn_activity row for one RENDER turn
+// from the memo: per-member bodies (the turn plus every wake turn parented to
+// it) are derived in their own modes and merged through the same
+// mergeBackgroundWakeActivityBodies the batch pipeline uses, then the row is
+// built by the shared builder. ok=false with foldOK=true means the turn
+// currently emits no shell (the emission gate) — the fold never deletes a
+// previously-emitted shell, because fold-class events only add content.
+// foldOK=false means the merged result includes an entry that escapes
+// compaction (a promoted final answer): such rows carry full content the
+// pruned memo deliberately does not hold, so the event class must resync.
+func (m *sessionFoldMemo) shellRowForTurn(turnID string) (row map[string]any, ok bool, foldOK bool) {
+	if m.BackgroundWakeTurns[turnID] && m.WakeParents[turnID] != "" {
+		// Folded wake turns never surface their own shell.
+		return nil, false, true
+	}
+	bodies := map[string]turnActivityBody{}
+	memberParents := map[string]string{}
+	if body, has := m.bodyForTurn(turnID); has {
+		bodies[turnID] = body
+	}
+	for wakeID, parent := range m.WakeParents {
+		if parent != turnID {
+			continue
+		}
+		if body, has := m.bodyForTurn(wakeID); has {
+			bodies[wakeID] = body
+			memberParents[wakeID] = parent
+		}
+	}
+	if len(bodies) == 0 {
+		return nil, false, true
+	}
+	merged := mergeBackgroundWakeActivityBodies(bodies, memberParents)
+	body, has := merged[turnID]
+	if !has {
+		return nil, false, true
+	}
+	// Every merged entry must be inside the compacted set (shell content) —
+	// an escaping entry is a promoted row whose full content the pruned memo
+	// does not hold.
+	compacted := map[string]bool{}
+	for _, id := range body.CompactedEntryIDs {
+		compacted[id] = true
+	}
+	for _, entry := range body.Entries {
+		id := transcriptMapString(entry, "id")
+		if id == "" || compacted[id] || isProjectionAwaitingInputEntry(entry) {
+			continue
+		}
+		return nil, false, false
+	}
+	parentBody := bodies[turnID]
+	parentEntries := parentBody.Entries
+	// Emission gate, mirroring compactProjectedTranscript: the gate runs on
+	// the parent's OWN body, exactly as the batch pipeline gates shells
+	// before the wake fold rewrites them. The turn-progress probe reads the
+	// memo's full entry set — progress chips are anchors, not body entries.
+	var progressProbe []map[string]any
+	if turn := m.Turns[turnID]; turn != nil {
+		progressProbe = turn.ordered()
+	}
+	active := parentBody.Summary["active"] == true
+	activeProgressOnly := active && len(parentBody.CompactedEntryIDs) == 0 && foldEntriesHaveTurnProgress(progressProbe)
+	activeNeedsInput := active && parentBody.Status == "needs_input"
+	handoff := parentBody.Summary["awaitingInputHandoff"] == true
+	if len(parentBody.CompactedEntryIDs) == 0 && !activeProgressOnly && !activeNeedsInput && !handoff {
+		return nil, false, true
+	}
+	if m.ContinuationTurns[turnID] {
+		parentBody.Summary["continuation"] = true
+	}
+	// Build the parent-only row first (anchoring, top-level usage fields),
+	// then let the SAME refreshFoldedParentShells the batch pipeline uses
+	// rewrite it with the merged body — preserved fields and all.
+	shellRow := buildTurnActivityShellRow(parentBody, parentEntries)
+	if len(memberParents) > 0 {
+		shellRow = refreshFoldedParentShells([]map[string]any{shellRow}, merged, memberParents)[0]
+	}
+	return shellRow, true, true
+}
+
+func foldEntriesHaveTurnProgress(entries []map[string]any) bool {
+	for _, entry := range entries {
+		if isProjectionTurnProgress(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildSessionFoldMemo seeds the memo from a full ledger replay — the resync
+// half of the contract. It runs the same apply loop and flat projection the
+// batch pipeline runs, then snapshots the bounded context and routes pruned
+// entries to their render turns exactly as foldEvent does.
+func buildSessionFoldMemo(events []map[string]any) *sessionFoldMemo {
+	memo := newSessionFoldMemo()
+	state := newProjectionState()
+	ordered := orderedTranscriptEvents(events)
+	for _, event := range ordered {
+		state.apply(event)
+	}
+	state.continuationTurns = state.backgroundTaskContinuationTurns()
+	state.backgroundWakeParents = state.backgroundTaskWakeParentTurns()
+
+	memo.RunStatus = state.runStatus
+	memo.ActiveTurnID = state.activeTurnID
+	for id, idx := range state.itemIndex {
+		if idx >= len(state.items) || state.items[idx] == nil {
+			continue
+		}
+		item := *state.items[idx]
+		if isTerminalProjectionItemStatus(item.Status) {
+			memo.EvictedItems[id] = true
+		} else {
+			memo.OpenItems[id] = &item
+		}
+	}
+	for _, task := range state.backgroundTasks {
+		if task == nil {
+			continue
+		}
+		copied := *task
+		memo.Tasks = append(memo.Tasks, &copied)
+	}
+	for providerID := range state.backgroundProviderItemIDs() {
+		memo.TaskProviderIDs[providerID] = true
+	}
+	for turnID, usage := range state.turnUsages {
+		memo.TurnUsages[turnID] = usage
+	}
+	for turnID, terminal := range state.turnTerminals {
+		memo.TurnTerminals[turnID] = terminal
+	}
+	for turnID := range state.backgroundWakeTurns {
+		memo.BackgroundWakeTurns[turnID] = true
+	}
+	for turnID, taskID := range state.backgroundWakeTaskIDs {
+		memo.BackgroundWakeTaskIDs[turnID] = taskID
+	}
+	for wakeID, parent := range state.backgroundWakeParents {
+		memo.WakeParents[wakeID] = parent
+	}
+	for turnID := range state.continuationTurns {
+		memo.ContinuationTurns[turnID] = true
+	}
+
+	flat := state.projectFlatEntries()
+	assignSessionStatusOwnership(flat)
+	flat = dropOrphanSessionLifecycle(flat)
+	for _, entry := range flat {
+		turnID := transcriptMapString(entry, "turnId")
+		if turnID == "" {
+			continue
+		}
+		turn := memo.Turns[turnID]
+		if turn == nil {
+			turn = &turnFoldEntries{Entries: map[string]map[string]any{}}
+			memo.Turns[turnID] = turn
+		}
+		turn.upsert(pruneFoldEntry(entry))
+	}
+	if len(ordered) > 0 {
+		memo.LastOrderKey = transcriptString(ordered[len(ordered)-1], "order_key")
+	}
+	return memo
+}
+
+func marshalSessionFoldMemo(memo *sessionFoldMemo) ([]byte, bool) {
+	if memo == nil {
+		return nil, false
+	}
+	raw, err := json.Marshal(memo)
+	if err != nil || len(raw) > sessionFoldMemoMaxBytes {
+		return nil, false
+	}
+	return raw, true
+}
+
+func unmarshalSessionFoldMemo(raw []byte) *sessionFoldMemo {
+	if len(raw) == 0 {
+		return nil
+	}
+	var memo sessionFoldMemo
+	if err := json.Unmarshal(raw, &memo); err != nil {
+		return nil
+	}
+	if memo.Version != sessionFoldMemoVersion {
+		return nil
+	}
+	// Maps elided by omitempty must come back usable.
+	if memo.OpenItems == nil {
+		memo.OpenItems = map[string]*projectionItem{}
+	}
+	if memo.EvictedItems == nil {
+		memo.EvictedItems = map[string]bool{}
+	}
+	if memo.TaskProviderIDs == nil {
+		memo.TaskProviderIDs = map[string]bool{}
+	}
+	if memo.TurnUsages == nil {
+		memo.TurnUsages = map[string]turnUsageProjection{}
+	}
+	if memo.TurnTerminals == nil {
+		memo.TurnTerminals = map[string]turnTerminalProjection{}
+	}
+	if memo.BackgroundWakeTurns == nil {
+		memo.BackgroundWakeTurns = map[string]bool{}
+	}
+	if memo.BackgroundWakeTaskIDs == nil {
+		memo.BackgroundWakeTaskIDs = map[string]string{}
+	}
+	if memo.WakeParents == nil {
+		memo.WakeParents = map[string]string{}
+	}
+	if memo.ContinuationTurns == nil {
+		memo.ContinuationTurns = map[string]bool{}
+	}
+	if memo.Turns == nil {
+		memo.Turns = map[string]*turnFoldEntries{}
+	}
+	for _, turn := range memo.Turns {
+		if turn != nil && turn.Entries == nil {
+			turn.Entries = map[string]map[string]any{}
+		}
+	}
+	return &memo
+}
+
+// foldBatch applies a sorted batch of events to the memo. It returns the set
+// of changed render turns when every event folded; any resync-class event
+// aborts the whole batch to the reference path (one session re-projection
+// covers everything, matching the pre-fold coalescing behavior).
+func (m *sessionFoldMemo) foldBatch(events []map[string]any) (map[string]bool, bool) {
+	changed := map[string]bool{}
+	for _, event := range orderedTranscriptEvents(events) {
+		orderKey := transcriptString(event, "order_key")
+		if orderKey != "" && m.LastOrderKey != "" && orderKey <= m.LastOrderKey {
+			// Already folded (reconciler replay, duplicate delivery): the
+			// upsert-by-id semantics make re-folding idempotent, but skipping
+			// avoids resurrecting evicted items as resyncs.
+			continue
+		}
+		turnID, outcome := m.foldEvent(event)
+		switch outcome {
+		case foldNeedsResync:
+			return nil, false
+		case foldApplied:
+			changed[turnID] = true
+		}
+		if orderKey > m.LastOrderKey {
+			m.LastOrderKey = orderKey
+		}
+	}
+	return changed, true
+}
+
+// sortedFoldTurnIDs gives deterministic write order for changed shells.
+func sortedFoldTurnIDs(changed map[string]bool) []string {
+	out := make([]string, 0, len(changed))
+	for turnID := range changed {
+		if strings.TrimSpace(turnID) != "" {
+			out = append(out, turnID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend-go/cmd/tank-operator/transcript_fold_checkpoint_test.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_checkpoint_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/romaine-life/tank-operator/backend-go/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory tx stores: faithful stand-ins for the Postgres row/event stores so
+// the equivalence harness can drive the REAL RefreshEventBatch wiring —
+// including fold-state load/save through []byte serialization, exactly the
+// shape the durable checkpoint takes in production.
+// ---------------------------------------------------------------------------
+
+type memoryFoldEventStore struct {
+	store.StubSessionEventStore
+	events []map[string]any
+}
+
+func (s *memoryFoldEventStore) append(events ...map[string]any) {
+	s.events = append(s.events, events...)
+	sort.SliceStable(s.events, func(i, j int) bool {
+		return transcriptString(s.events[i], "order_key") < transcriptString(s.events[j], "order_key")
+	})
+}
+
+func (s *memoryFoldEventStore) all() []map[string]any {
+	return append([]map[string]any(nil), s.events...)
+}
+
+func (s *memoryFoldEventStore) EventsForTurnAfterTx(_ context.Context, _ pgx.Tx, _ string, turnID, afterOrderKey string, _ int) (store.SessionEventPage, error) {
+	var out []map[string]any
+	for _, event := range s.events {
+		if transcriptString(event, "turn_id") != turnID {
+			continue
+		}
+		if afterOrderKey != "" && transcriptString(event, "order_key") <= afterOrderKey {
+			continue
+		}
+		out = append(out, event)
+	}
+	return store.SessionEventPage{Events: out, FoundOldest: true, FoundNewest: true}, nil
+}
+
+func (s *memoryFoldEventStore) ListBySessionTx(_ context.Context, _ pgx.Tx, _ string, cursor store.SessionEventCursor, _ int) (store.SessionEventPage, error) {
+	var out []map[string]any
+	for _, event := range s.events {
+		if cursor.AfterOrderKey != "" && transcriptString(event, "order_key") <= cursor.AfterOrderKey {
+			continue
+		}
+		out = append(out, event)
+	}
+	return store.SessionEventPage{Events: out, FoundOldest: true, FoundNewest: true}, nil
+}
+
+type memoryFoldRowsStore struct {
+	rows         map[string]map[string]any
+	foldMemo     []byte
+	foldDisabled bool
+	inTx         bool
+}
+
+func newMemoryFoldRowsStore() *memoryFoldRowsStore {
+	return &memoryFoldRowsStore{rows: map[string]map[string]any{}}
+}
+
+func (s *memoryFoldRowsStore) WithTranscriptMaterializationTx(ctx context.Context, _ string, fn func(context.Context, pgx.Tx) error) error {
+	s.inTx = true
+	defer func() { s.inTx = false }()
+	return fn(ctx, nil)
+}
+
+func (s *memoryFoldRowsStore) upsert(entries []map[string]any) {
+	for _, entry := range entries {
+		if id := transcriptMapString(entry, "id"); id != "" {
+			s.rows[id] = entry
+		}
+	}
+}
+
+func (s *memoryFoldRowsStore) ReplaceForTurnTx(_ context.Context, _ pgx.Tx, _ string, turnID string, entries []map[string]any) error {
+	for id, row := range s.rows {
+		if transcriptMapString(row, "turnId") == turnID {
+			delete(s.rows, id)
+		}
+	}
+	s.upsert(entries)
+	return nil
+}
+
+func (s *memoryFoldRowsStore) ReplaceForSessionTx(_ context.Context, _ pgx.Tx, _ string, entries []map[string]any) error {
+	s.rows = map[string]map[string]any{}
+	s.upsert(entries)
+	return nil
+}
+
+func (s *memoryFoldRowsStore) UpsertRowsTx(_ context.Context, _ pgx.Tx, _ string, entries []map[string]any) error {
+	s.upsert(entries)
+	return nil
+}
+
+func (s *memoryFoldRowsStore) NeedsBackfillTx(context.Context, pgx.Tx, string) (bool, error) {
+	return true, nil
+}
+
+func (s *memoryFoldRowsStore) LoadFoldStateTx(context.Context, pgx.Tx, string) ([]byte, bool, error) {
+	return s.foldMemo, s.foldDisabled, nil
+}
+
+func (s *memoryFoldRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx, _ string, memo []byte) error {
+	s.foldMemo = append([]byte(nil), memo...)
+	s.foldDisabled = false
+	return nil
+}
+
+func (s *memoryFoldRowsStore) DeleteFoldStateTx(context.Context, pgx.Tx, string) error {
+	if !s.foldDisabled {
+		s.foldMemo = nil
+	}
+	return nil
+}
+
+func (s *memoryFoldRowsStore) DisableFoldTx(context.Context, pgx.Tx, string) error {
+	s.foldMemo = nil
+	s.foldDisabled = true
+	return nil
+}
+
+// Non-tx SessionTranscriptRowStore surface — RefreshEventBatch type-asserts
+// the tx interfaces, but the materializer struct field needs the base one.
+func (s *memoryFoldRowsStore) ReplaceForTurn(ctx context.Context, sessionID, turnID string, entries []map[string]any) error {
+	return s.ReplaceForTurnTx(ctx, nil, sessionID, turnID, entries)
+}
+func (s *memoryFoldRowsStore) ReplaceForSession(ctx context.Context, sessionID string, entries []map[string]any) error {
+	return s.ReplaceForSessionTx(ctx, nil, sessionID, entries)
+}
+func (s *memoryFoldRowsStore) UpsertRows(ctx context.Context, sessionID string, entries []map[string]any) error {
+	return s.UpsertRowsTx(ctx, nil, sessionID, entries)
+}
+func (s *memoryFoldRowsStore) ListChangedAfterOrderKey(context.Context, string, string, int) (store.TranscriptRowDeltaPage, error) {
+	return store.TranscriptRowDeltaPage{}, nil
+}
+func (s *memoryFoldRowsStore) ListLatest(context.Context, string, int) (store.TranscriptRowPage, error) {
+	return store.TranscriptRowPage{}, nil
+}
+func (s *memoryFoldRowsStore) ListOldest(context.Context, string, int) (store.TranscriptRowPage, error) {
+	return store.TranscriptRowPage{}, nil
+}
+func (s *memoryFoldRowsStore) ListBefore(context.Context, string, string, int) (store.TranscriptRowPage, error) {
+	return store.TranscriptRowPage{}, nil
+}
+func (s *memoryFoldRowsStore) ListAround(context.Context, string, string, int, int) (store.TranscriptRowPage, error) {
+	return store.TranscriptRowPage{}, nil
+}
+func (s *memoryFoldRowsStore) ResolveCursorForTimelineID(context.Context, string, string) (string, error) {
+	return "", nil
+}
+func (s *memoryFoldRowsStore) NeedsBackfill(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+// ---------------------------------------------------------------------------
+// The equivalence harness: replay each #1051 incident fixture through the
+// real RefreshEventBatch in batches, and after EVERY batch require the row
+// store to be byte-identical to a from-scratch batch projection of the same
+// prefix. This is the acceptance gate for the checkpointed fold: any
+// divergence between the fold fast path and the reference pipeline — summary
+// math, membership, ordering, wake folding, promotion — fails here with the
+// offending row named.
+// ---------------------------------------------------------------------------
+
+func foldFixtureEvents(t *testing.T, name string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var events []map[string]any
+	if err := json.Unmarshal(raw, &events); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return events
+}
+
+func groundTruthRows(events []map[string]any) map[string]map[string]any {
+	projection := projectTranscriptEvents(events)
+	out := make(map[string]map[string]any, len(projection.Entries))
+	for _, entry := range projection.Entries {
+		if id := transcriptMapString(entry, "id"); id != "" {
+			out[id] = entry
+		}
+	}
+	return out
+}
+
+func diffRowSets(got, want map[string]map[string]any) string {
+	var problems []string
+	for id, wantRow := range want {
+		gotRow, ok := got[id]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("missing row %s", id))
+			continue
+		}
+		if !reflect.DeepEqual(gotRow, wantRow) {
+			gotJSON, _ := json.Marshal(gotRow)
+			wantJSON, _ := json.Marshal(wantRow)
+			problems = append(problems, fmt.Sprintf("row %s diverged:\n  got:  %s\n  want: %s", id, gotJSON, wantJSON))
+		}
+	}
+	for id := range got {
+		if _, ok := want[id]; !ok {
+			problems = append(problems, fmt.Sprintf("extra row %s", id))
+		}
+	}
+	if len(problems) == 0 {
+		return ""
+	}
+	sort.Strings(problems)
+	if len(problems) > 6 {
+		problems = append(problems[:6], fmt.Sprintf("... and %d more", len(problems)-6))
+	}
+	return strings.Join(problems, "\n")
+}
+
+func TestFoldCheckpointEquivalenceOverFixtures(t *testing.T) {
+	fixtures := []string{
+		"slot1_session_159_events.json",
+		"slot1_session_160_events.json",
+		"slot1_session_161_events.json",
+	}
+	for _, fixture := range fixtures {
+		for _, batchSize := range []int{1, 7, 64} {
+			t.Run(fmt.Sprintf("%s/batch=%d", fixture, batchSize), func(t *testing.T) {
+				events := foldFixtureEvents(t, fixture)
+				rows := newMemoryFoldRowsStore()
+				eventsStore := &memoryFoldEventStore{}
+				m := transcriptRowsMaterializer{events: eventsStore, rows: rows, turns: store.StubSessionTurnStore{}}
+
+				// Seed the memo the way production does on first read: an
+				// on-demand backfill. From here the fold engages for every
+				// flood-class batch and reseeds/invalidates per the wiring.
+				foldedBefore := testutil.ToFloat64(transcriptFoldTotal.WithLabelValues("folded"))
+
+				for start := 0; start < len(events); start += batchSize {
+					end := min(start+batchSize, len(events))
+					batch := events[start:end]
+					eventsStore.append(batch...)
+					if start == 0 {
+						if _, err := m.BackfillSession(context.Background(), transcriptMaterializerSessionID(batch[0])); err != nil {
+							t.Fatalf("seed backfill: %v", err)
+						}
+					}
+					if err := m.RefreshEventBatch(context.Background(), batch); err != nil {
+						t.Fatalf("RefreshEventBatch at %d: %v", start, err)
+					}
+					want := groundTruthRows(eventsStore.all())
+					if diff := diffRowSets(rows.rows, want); diff != "" {
+						t.Fatalf("rows diverged from reference after batch ending at %d:\n%s", end, diff)
+					}
+				}
+
+				foldedAfter := testutil.ToFloat64(transcriptFoldTotal.WithLabelValues("folded"))
+				// Engagement guard: at granular batch sizes the
+				// background-task fixture must exercise the fold fast path;
+				// without this, a regression that quietly routes everything
+				// to the reference pipeline would still pass the equality
+				// checks. Wide batches (64) legitimately resync almost every
+				// window — they nearly always contain a structure event.
+				if fixture == "slot1_session_161_events.json" && batchSize <= 7 && foldedAfter == foldedBefore {
+					t.Fatalf("the fold fast path never engaged on the background-task fixture — the harness is not exercising the checkpointed path")
+				}
+			})
+		}
+	}
+}
+
+// TestFoldMemoSerializationRoundTrip pins that a memo survives the durable
+// []byte round trip with its maps usable and version honored.
+func TestFoldMemoSerializationRoundTrip(t *testing.T) {
+	events := foldFixtureEvents(t, "slot1_session_161_events.json")
+	memo := buildSessionFoldMemo(events)
+	raw, ok := marshalSessionFoldMemo(memo)
+	if !ok {
+		t.Fatalf("memo did not marshal within the size cap (len would exceed %d)", sessionFoldMemoMaxBytes)
+	}
+	back := unmarshalSessionFoldMemo(raw)
+	if back == nil {
+		t.Fatalf("memo failed to unmarshal")
+	}
+	if back.LastOrderKey != memo.LastOrderKey {
+		t.Fatalf("LastOrderKey lost in round trip")
+	}
+	if len(back.Turns) != len(memo.Turns) {
+		t.Fatalf("turn count changed in round trip: %d != %d", len(back.Turns), len(memo.Turns))
+	}
+	// Version gate: stale shapes never load.
+	var generic map[string]any
+	_ = json.Unmarshal(raw, &generic)
+	generic["version"] = sessionFoldMemoVersion + 1
+	stale, _ := json.Marshal(generic)
+	if unmarshalSessionFoldMemo(stale) != nil {
+		t.Fatalf("stale memo version must not load")
+	}
+}

--- a/backend-go/cmd/tank-operator/transcript_projection.go
+++ b/backend-go/cmd/tank-operator/transcript_projection.go
@@ -1562,49 +1562,57 @@ func compactProjectedTranscript(entries []map[string]any, activeTurnID string, r
 			if continuationTurns[activity.TurnID] {
 				activity.Summary["continuation"] = true
 			}
-			shellOrderKey := transcriptMapString(activity.Summary, "startOrderKey")
-			shellStartedAt := transcriptMapString(activity.Summary, "startedAt")
-			if umKey := turnUserMessageOrderKey(entries, activity.TurnID); umKey != "" && shellOrderKey <= umKey {
-				// Folded session-startup lifecycle carries order keys that predate
-				// the turn's message. The transcript row store positions a
-				// turn_activity row by activity.startOrderKey (its row cursor is
-				// startOrderKey+id), so anchor the shell's start to the turn's first
-				// real event after the message (turn.submitted/started). The
-				// lifecycle stays inside the body; only the shell's placement and
-				// reported start move to the turn's own start — never above the
-				// message it belongs to.
-				if anchor := turnFirstEntryAfter(entries, activity.TurnID, umKey); anchor != nil {
-					shellOrderKey = transcriptMapString(anchor, "orderKey")
-					activity.Summary["startOrderKey"] = shellOrderKey
-					if t := transcriptMapString(anchor, "time"); t != "" {
-						shellStartedAt = t
-						activity.Summary["startedAt"] = t
-					}
-				}
-			}
-			shell := map[string]any{
-				"id":            "turn-activity-" + activity.TurnID,
-				"kind":          "turn_activity",
-				"turnId":        activity.TurnID,
-				"time":          shellStartedAt,
-				"orderKey":      shellOrderKey,
-				"activity":      activity.Summary,
-				"activityIds":   activity.CompactedEntryIDs,
-				"sourceEventId": transcriptMapString(activity.Summary, "sourceEventId"),
-			}
-			if turnUsage := activity.Summary["turnUsage"]; turnUsage != nil {
-				shell["turnUsage"] = turnUsage
-			}
-			if usageObservation := activity.Summary["usageObservation"]; usageObservation != nil {
-				shell["usageObservation"] = usageObservation
-			}
-			out = append(out, shell)
+			out = append(out, buildTurnActivityShellRow(activity, entries))
 		}
 		if !compactedIndexes[idx] {
 			out = append(out, entry)
 		}
 	}
 	return transcriptProjection{Entries: out, ActivityBodies: bodies}
+}
+
+// buildTurnActivityShellRow builds the durable turn_activity row for one
+// turn's body. turnEntries supplies the user-message anchor lookup — entries
+// of other turns are ignored, so callers may pass the whole flat list (batch
+// pipeline) or just this turn's entries (checkpointed fold).
+func buildTurnActivityShellRow(activity turnActivityBody, turnEntries []map[string]any) map[string]any {
+	shellOrderKey := transcriptMapString(activity.Summary, "startOrderKey")
+	shellStartedAt := transcriptMapString(activity.Summary, "startedAt")
+	if umKey := turnUserMessageOrderKey(turnEntries, activity.TurnID); umKey != "" && shellOrderKey <= umKey {
+		// Folded session-startup lifecycle carries order keys that predate
+		// the turn's message. The transcript row store positions a
+		// turn_activity row by activity.startOrderKey (its row cursor is
+		// startOrderKey+id), so anchor the shell's start to the turn's first
+		// real event after the message (turn.submitted/started). The
+		// lifecycle stays inside the body; only the shell's placement and
+		// reported start move to the turn's own start — never above the
+		// message it belongs to.
+		if anchor := turnFirstEntryAfter(turnEntries, activity.TurnID, umKey); anchor != nil {
+			shellOrderKey = transcriptMapString(anchor, "orderKey")
+			activity.Summary["startOrderKey"] = shellOrderKey
+			if t := transcriptMapString(anchor, "time"); t != "" {
+				shellStartedAt = t
+				activity.Summary["startedAt"] = t
+			}
+		}
+	}
+	shell := map[string]any{
+		"id":            "turn-activity-" + activity.TurnID,
+		"kind":          "turn_activity",
+		"turnId":        activity.TurnID,
+		"time":          shellStartedAt,
+		"orderKey":      shellOrderKey,
+		"activity":      activity.Summary,
+		"activityIds":   activity.CompactedEntryIDs,
+		"sourceEventId": transcriptMapString(activity.Summary, "sourceEventId"),
+	}
+	if turnUsage := activity.Summary["turnUsage"]; turnUsage != nil {
+		shell["turnUsage"] = turnUsage
+	}
+	if usageObservation := activity.Summary["usageObservation"]; usageObservation != nil {
+		shell["usageObservation"] = usageObservation
+	}
+	return shell
 }
 
 func foldBackgroundWakeContinuationActivities(projection transcriptProjection, wakeParents map[string]string) transcriptProjection {

--- a/backend-go/cmd/tank-operator/transcript_rows_materializer.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer.go
@@ -26,6 +26,12 @@ type transcriptRowsMaterializationTxStore interface {
 	ReplaceForSessionTx(context.Context, pgx.Tx, string, []map[string]any) error
 	UpsertRowsTx(context.Context, pgx.Tx, string, []map[string]any) error
 	NeedsBackfillTx(context.Context, pgx.Tx, string) (bool, error)
+	// Checkpointed-fold state (tank-operator#1051 B3), advanced in the same
+	// transaction as the row writes it describes.
+	LoadFoldStateTx(context.Context, pgx.Tx, string) ([]byte, bool, error)
+	SaveFoldStateTx(context.Context, pgx.Tx, string, []byte) error
+	DeleteFoldStateTx(context.Context, pgx.Tx, string) error
+	DisableFoldTx(context.Context, pgx.Tx, string) error
 }
 
 type transcriptEventsTxStore interface {
@@ -37,8 +43,9 @@ type transcriptEventsTxStore interface {
 // paging the turn-scoped cursor to exhaustion. The materializer folds the
 // COMPLETE turn so the stored turn-activity shell's terminal/active status can
 // never be a casualty of a bounded read — the bug that made a finished long
-// turn render as perpetually active. (Bounded-cost incremental re-projection of
-// only the live page is the named follow-up; correctness comes first.)
+// turn render as perpetually active. This full read is the REFERENCE path:
+// flood-class events take the checkpointed fold
+// (transcript_fold_checkpoint.go) and never reach it.
 func readAllTurnEventsTx(ctx context.Context, events transcriptEventsTxStore, tx pgx.Tx, sessionID, turnID string) ([]map[string]any, error) {
 	var all []map[string]any
 	cursor := ""
@@ -144,7 +151,17 @@ func (m transcriptRowsMaterializer) refreshSessionBatch(ctx context.Context, ses
 	var turnOrder []string
 	seenTurn := map[string]bool{}
 	for _, event := range events {
-		if transcriptString(event, "type") == "turn.input_answered" {
+		switch transcriptString(event, "type") {
+		case "turn.input_answered":
+			sessionScope = true
+		case "shell_task.started", "shell_task.updated", "shell_task.exited":
+			// Background-task lifecycle changes the wake forest, and a turn
+			// that has absorbed wake content cannot be correctly re-projected
+			// turn-scope: the per-turn read can't see the wake turns' folded
+			// entries, so a per-turn replace would silently shed the merge.
+			// (The checkpointed fold above handles flood-class shell_task
+			// updates without this escalation; this is the REFERENCE path's
+			// conservative rule.)
 			sessionScope = true
 		}
 		turnID := transcriptString(event, "turn_id")
@@ -158,11 +175,24 @@ func (m transcriptRowsMaterializer) refreshSessionBatch(ctx context.Context, ses
 		}
 	}
 	return txRows.WithTranscriptMaterializationTx(ctx, sessionID, func(ctx context.Context, tx pgx.Tx) error {
+		// Checkpointed fold (tank-operator#1051 B2+B3): when the session has
+		// a live memo and every event in the batch is flood-class, advance
+		// the memo and rewrite only the changed shell rows — no ledger read
+		// at all. The fold's own classifier rejects structure-class events
+		// (terminals, boundaries, new/exiting tasks, answers), so it gets
+		// first try unconditionally; anything outside its confident envelope
+		// falls through to the reference projection below, which reseeds or
+		// invalidates the memo. sessionScope only steers the reference path.
+		if len(turnOrder) > 0 && len(noTurn) == 0 {
+			if done, err := m.tryFoldBatchTx(ctx, tx, txRows, sessionID, events); done || err != nil {
+				return err
+			}
+		}
 		if sessionScope {
 			// The session re-projection reads the whole ledger, so it
 			// already covers every turn-less and per-turn event in the
 			// batch.
-			return m.backfillSessionTx(ctx, tx, txEvents, txRows, sessionID)
+			return m.resyncSessionTx(ctx, tx, txEvents, txRows, sessionID)
 		}
 		for _, event := range noTurn {
 			projection := projectTranscriptEvents([]map[string]any{event})
@@ -171,15 +201,16 @@ func (m transcriptRowsMaterializer) refreshSessionBatch(ctx context.Context, ses
 				return err
 			}
 		}
+		invalidatedMemo := false
 		for _, turnID := range turnOrder {
 			turnEvents, err := readAllTurnEventsTx(ctx, txEvents, tx, sessionID, turnID)
 			if err != nil {
 				return err
 			}
-			if turnEventsContainBackgroundWake(turnEvents) {
+			if turnEventsContainBackgroundWake(turnEvents) || turnEventsContainShellTask(turnEvents) {
 				// One session re-projection covers the remaining turns
 				// in the batch too.
-				return m.backfillSessionTx(ctx, tx, txEvents, txRows, sessionID)
+				return m.resyncSessionTx(ctx, tx, txEvents, txRows, sessionID)
 			}
 			projection := projectTranscriptEvents(turnEvents)
 			recordTranscriptProjectionInvariantViolations(sessionID, turnID, turnEvents, projection.Entries)
@@ -189,9 +220,125 @@ func (m transcriptRowsMaterializer) refreshSessionBatch(ctx context.Context, ses
 			if err := txRows.ReplaceForTurnTx(ctx, tx, sessionID, turnID, projection.Entries); err != nil {
 				return err
 			}
+			if !invalidatedMemo {
+				// A turn-scope reference projection changes rows the memo
+				// doesn't know about. Invalidate rather than rebuild: a
+				// rebuild needs a full session read, which is exactly the
+				// cost a turn-scope batch exists to avoid. The next
+				// session-scope projection reseeds the memo.
+				invalidatedMemo = true
+				recordTranscriptFold("invalidated")
+				if err := txRows.DeleteFoldStateTx(ctx, tx, sessionID); err != nil {
+					return err
+				}
+			}
 		}
 		return nil
 	})
+}
+
+// tryFoldBatchTx attempts the checkpointed-fold fast path. done=true means
+// the batch is fully handled (rows written, memo saved). done=false means the
+// caller must run the reference projection; the memo, if any, is left intact
+// for the reference path to invalidate or reseed.
+func (m transcriptRowsMaterializer) tryFoldBatchTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	txRows transcriptRowsMaterializationTxStore,
+	sessionID string,
+	events []map[string]any,
+) (bool, error) {
+	raw, disabled, err := txRows.LoadFoldStateTx(ctx, tx, sessionID)
+	if err != nil {
+		// The fold is an optimization; a state-read failure must not block
+		// the durable projection. The reference path still runs.
+		slog.Warn("fold state load failed; using reference projection",
+			"session_id", sessionID, "error", err)
+		recordTranscriptFold("load_error")
+		return false, nil
+	}
+	if disabled {
+		recordTranscriptFold("disabled")
+		return false, nil
+	}
+	memo := unmarshalSessionFoldMemo(raw)
+	if memo == nil {
+		return false, nil
+	}
+	// Turn-less events ride their own UpsertRows path and never touch
+	// shells; their presence alongside foldable events is fine, but they are
+	// handled by the caller, so only attempt the fold when every event in
+	// the batch carries a turn.
+	for _, event := range events {
+		if transcriptString(event, "turn_id") == "" {
+			return false, nil
+		}
+	}
+	started := time.Now()
+	changed, ok := memo.foldBatch(events)
+	if !ok {
+		recordTranscriptFold("resync")
+		return false, nil
+	}
+	// Build every changed shell BEFORE writing anything: a turn whose merged
+	// body includes a promotion-class entry sends the whole batch to the
+	// reference path, and at that point no fold writes may have landed.
+	var rows []map[string]any
+	for _, turnID := range sortedFoldTurnIDs(changed) {
+		row, emit, foldOK := memo.shellRowForTurn(turnID)
+		if !foldOK {
+			recordTranscriptFold("resync")
+			return false, nil
+		}
+		if !emit {
+			continue
+		}
+		if numbers, ok := m.turnNumbersForTurn(ctx, sessionID, turnID); ok {
+			stampTurnNumbers(sessionID, numbers, []map[string]any{row})
+		}
+		rows = append(rows, row)
+	}
+	for _, row := range rows {
+		if err := txRows.UpsertRowsTx(ctx, tx, sessionID, []map[string]any{row}); err != nil {
+			return false, err
+		}
+	}
+	encoded, fits := marshalSessionFoldMemo(memo)
+	if !fits {
+		// The rows just written are correct; only the memo outgrew its cap.
+		// Durably opt the session out so it batch-projects from here on.
+		recordTranscriptFold("disabled_size")
+		return true, txRows.DisableFoldTx(ctx, tx, sessionID)
+	}
+	if err := txRows.SaveFoldStateTx(ctx, tx, sessionID, encoded); err != nil {
+		return false, err
+	}
+	recordTranscriptFold("folded")
+	recordTranscriptFoldDuration(time.Since(started))
+	return true, nil
+}
+
+// resyncSessionTx is the reference projection: re-project the whole session
+// and reseed the fold memo from the same events, in the same transaction.
+func (m transcriptRowsMaterializer) resyncSessionTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	eventsStore transcriptEventsTxStore,
+	rowsStore transcriptRowsMaterializationTxStore,
+	sessionID string,
+) error {
+	events, err := m.backfillSessionEventsTx(ctx, tx, eventsStore, rowsStore, sessionID)
+	if err != nil {
+		return err
+	}
+	memo := buildSessionFoldMemo(events)
+	encoded, fits := marshalSessionFoldMemo(memo)
+	if !fits {
+		recordTranscriptFold("disabled_size")
+		return rowsStore.DisableFoldTx(ctx, tx, sessionID)
+	}
+	recordTranscriptFold("reseeded")
+	return rowsStore.SaveFoldStateTx(ctx, tx, sessionID, encoded)
 }
 
 func (m transcriptRowsMaterializer) RefreshEvent(ctx context.Context, event map[string]any) error {
@@ -247,27 +394,51 @@ func (m transcriptRowsMaterializer) refreshEventTx(
 		recordTranscriptProjectionInvariantViolations(sessionID, "", []map[string]any{event}, projection.Entries)
 		return rows.UpsertRowsTx(ctx, tx, sessionID, projection.Entries)
 	}
-	if transcriptString(event, "type") == "turn.input_answered" {
-		return m.backfillSessionTx(ctx, tx, events, rows, sessionID)
+	switch transcriptString(event, "type") {
+	case "turn.input_answered", "shell_task.started", "shell_task.updated", "shell_task.exited":
+		// Cross-turn structure: answers backpatch earlier turns, and
+		// background-task lifecycle changes the wake forest a per-turn
+		// replace cannot see (it would shed a parent's folded wake content).
+		return m.resyncSessionTx(ctx, tx, events, rows, sessionID)
 	}
 	turnEvents, err := readAllTurnEventsTx(ctx, events, tx, sessionID, turnID)
 	if err != nil {
 		return err
 	}
-	if turnEventsContainBackgroundWake(turnEvents) {
-		return m.backfillSessionTx(ctx, tx, events, rows, sessionID)
+	if turnEventsContainBackgroundWake(turnEvents) || turnEventsContainShellTask(turnEvents) {
+		return m.resyncSessionTx(ctx, tx, events, rows, sessionID)
 	}
 	projection := projectTranscriptEvents(turnEvents)
 	recordTranscriptProjectionInvariantViolations(sessionID, turnID, turnEvents, projection.Entries)
 	if numbers, ok := m.turnNumbersForTurn(ctx, sessionID, turnID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
-	return rows.ReplaceForTurnTx(ctx, tx, sessionID, turnID, projection.Entries)
+	if err := rows.ReplaceForTurnTx(ctx, tx, sessionID, turnID, projection.Entries); err != nil {
+		return err
+	}
+	// A turn-scope reference projection changed rows the fold memo doesn't
+	// know about; invalidate it (the next session-scope projection reseeds).
+	return rows.DeleteFoldStateTx(ctx, tx, sessionID)
 }
 
 func turnEventsContainBackgroundWake(events []map[string]any) bool {
 	for _, event := range events {
 		if isBackgroundTaskWakeTurnEvent(event) {
+			return true
+		}
+	}
+	return false
+}
+
+// turnEventsContainShellTask reports whether the turn started background
+// work. Such a turn may have wake turns folded into its shell, and a
+// turn-scope replace cannot see those wake turns' entries — re-projecting it
+// turn-scope would silently shed the merge, so callers escalate to a session
+// re-projection.
+func turnEventsContainShellTask(events []map[string]any) bool {
+	for _, event := range events {
+		switch transcriptString(event, "type") {
+		case "shell_task.started", "shell_task.updated", "shell_task.exited":
 			return true
 		}
 	}
@@ -321,7 +492,7 @@ func (m transcriptRowsMaterializer) BackfillSession(ctx context.Context, session
 				if err != nil || !needed {
 					return err
 				}
-				if err := m.backfillSessionTx(ctx, tx, txEvents, txRows, sessionID); err != nil {
+				if err := m.resyncSessionTx(ctx, tx, txEvents, txRows, sessionID); err != nil {
 					return err
 				}
 				backfilled = true
@@ -367,13 +538,16 @@ func (m transcriptRowsMaterializer) refreshSession(ctx context.Context, sessionI
 	return nil
 }
 
-func (m transcriptRowsMaterializer) backfillSessionTx(
+// backfillSessionEventsTx re-projects the whole session and returns the
+// events it read, so resyncSessionTx can reseed the fold memo from the same
+// ledger snapshot without a second read.
+func (m transcriptRowsMaterializer) backfillSessionEventsTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	eventsStore transcriptEventsTxStore,
 	rowsStore transcriptRowsMaterializationTxStore,
 	sessionID string,
-) error {
+) ([]map[string]any, error) {
 	var events []map[string]any
 	cursor := ""
 	for {
@@ -381,7 +555,7 @@ func (m transcriptRowsMaterializer) backfillSessionTx(
 			AfterOrderKey: cursor,
 		}, 1000)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		events = append(events, page.Events...)
 		if page.FoundNewest || len(page.Events) == 0 || page.NextOrderKey == "" || page.NextOrderKey == cursor {
@@ -394,7 +568,10 @@ func (m transcriptRowsMaterializer) backfillSessionTx(
 	if numbers, ok := m.turnNumbersForSession(ctx, sessionID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
-	return rowsStore.ReplaceForSessionTx(ctx, tx, sessionID, projection.Entries)
+	if err := rowsStore.ReplaceForSessionTx(ctx, tx, sessionID, projection.Entries); err != nil {
+		return nil, err
+	}
+	return events, nil
 }
 
 func transcriptRowMaterializationFailureResult(ctx context.Context, err error) string {

--- a/backend-go/cmd/tank-operator/transcript_rows_materializer_test.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer_test.go
@@ -79,6 +79,47 @@ type lockingTranscriptRowsStore struct {
 	replaceTurnTxCalls    int
 	replacedTurnIDs       []string
 	replaceSessionTxCalls int
+	foldMemo              []byte
+	foldDisabled          bool
+	foldSaves             int
+	foldDeletes           int
+}
+
+func (s *lockingTranscriptRowsStore) LoadFoldStateTx(context.Context, pgx.Tx, string) ([]byte, bool, error) {
+	if !s.lockHeld {
+		s.t.Fatal("LoadFoldStateTx called outside materialization lock")
+	}
+	return s.foldMemo, s.foldDisabled, nil
+}
+
+func (s *lockingTranscriptRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx, _ string, memo []byte) error {
+	if !s.lockHeld {
+		s.t.Fatal("SaveFoldStateTx called outside materialization lock")
+	}
+	s.foldMemo = memo
+	s.foldDisabled = false
+	s.foldSaves++
+	return nil
+}
+
+func (s *lockingTranscriptRowsStore) DeleteFoldStateTx(context.Context, pgx.Tx, string) error {
+	if !s.lockHeld {
+		s.t.Fatal("DeleteFoldStateTx called outside materialization lock")
+	}
+	if !s.foldDisabled {
+		s.foldMemo = nil
+	}
+	s.foldDeletes++
+	return nil
+}
+
+func (s *lockingTranscriptRowsStore) DisableFoldTx(context.Context, pgx.Tx, string) error {
+	if !s.lockHeld {
+		s.t.Fatal("DisableFoldTx called outside materialization lock")
+	}
+	s.foldMemo = nil
+	s.foldDisabled = true
+	return nil
 }
 
 func (s *lockingTranscriptRowsStore) WithTranscriptMaterializationTx(ctx context.Context, _ string, fn func(context.Context, pgx.Tx) error) error {

--- a/backend-go/internal/pgstore/migrations.go
+++ b/backend-go/internal/pgstore/migrations.go
@@ -1764,6 +1764,19 @@ var schemaMigrations = []migration{
 	// session booted from without reading a live pod.
 	{ID: "0143", SQL: `ALTER TABLE sessions
 		ADD COLUMN IF NOT EXISTS session_image text NOT NULL DEFAULT ''`},
+
+	// Checkpointed transcript-fold state (tank-operator#1051 B3): the bounded
+	// per-session fold memo the persister advances per flood-class event
+	// instead of re-reading the session ledger. memo=NULL with disabled=true
+	// durably opts a session out (memo over the size cap); a missing row just
+	// means the fold seeds on the next session-scope re-projection. Owned by
+	// backend-go/cmd/tank-operator/transcript_fold_checkpoint.go.
+	{ID: "0144", SQL: `CREATE TABLE IF NOT EXISTS session_transcript_fold_state (
+		tank_session_id text PRIMARY KEY,
+		memo            jsonb,
+		disabled        boolean NOT NULL DEFAULT false,
+		updated_at      timestamptz NOT NULL DEFAULT now()
+	)`},
 }
 
 // migrationsAdvisoryLockKey is an arbitrary stable 64-bit value used to

--- a/backend-go/internal/store/session_transcript_rows.go
+++ b/backend-go/internal/store/session_transcript_rows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -188,6 +189,64 @@ func (s *transcriptRowStore) needsBackfill(ctx context.Context, q transcriptRowQ
 		return false, err
 	}
 	return version != transcriptRowBackfillVersion, nil
+}
+
+// LoadFoldStateTx reads the session's checkpointed fold memo and whether the
+// fold is durably disabled for this session. A missing row is (nil, false):
+// the fold seeds on the next session-scope re-projection.
+func (s *transcriptRowStore) LoadFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string) ([]byte, bool, error) {
+	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	var memo []byte
+	var disabled bool
+	err := tx.QueryRow(ctx, `
+		SELECT memo, disabled
+		FROM session_transcript_fold_state
+		WHERE tank_session_id = $1
+	`, storageKey).Scan(&memo, &disabled)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return memo, disabled, nil
+}
+
+func (s *transcriptRowStore) SaveFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string, memo []byte) error {
+	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	_, err := tx.Exec(ctx, `
+		INSERT INTO session_transcript_fold_state (tank_session_id, memo, disabled, updated_at)
+		VALUES ($1, $2, false, now())
+		ON CONFLICT (tank_session_id) DO UPDATE
+		SET memo = EXCLUDED.memo, disabled = false, updated_at = now()
+	`, storageKey, memo)
+	return err
+}
+
+// DeleteFoldStateTx invalidates the memo: a turn-scope reference projection
+// makes it stale, and the next session-scope projection reseeds it. A
+// durably disabled row is preserved.
+func (s *transcriptRowStore) DeleteFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string) error {
+	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	_, err := tx.Exec(ctx, `
+		DELETE FROM session_transcript_fold_state
+		WHERE tank_session_id = $1 AND disabled = false
+	`, storageKey)
+	return err
+}
+
+// DisableFoldTx durably opts the session out of the checkpointed fold (memo
+// over the size cap). The session batch-projects from then on — exactly the
+// pre-fold behavior — and the row pins the decision.
+func (s *transcriptRowStore) DisableFoldTx(ctx context.Context, tx pgx.Tx, tankSessionID string) error {
+	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	_, err := tx.Exec(ctx, `
+		INSERT INTO session_transcript_fold_state (tank_session_id, memo, disabled, updated_at)
+		VALUES ($1, NULL, true, now())
+		ON CONFLICT (tank_session_id) DO UPDATE
+		SET memo = NULL, disabled = true, updated_at = now()
+	`, storageKey)
+	return err
 }
 
 func (s *transcriptRowStore) lockTranscriptMaterializationTx(ctx context.Context, tx pgx.Tx, storageKey string) error {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,6 +60,18 @@ All metric names are prefixed `tank_`. The full namespace:
   queues), and `_processed_event_age_seconds` (how far behind users'
   transcripts are). Per-session detail lives in
   `GET /api/debug/persister`, never in labels.
+- `tank_transcript_fold_total{result}` + `tank_transcript_fold_duration_seconds`
+  — the checkpointed transcript fold (tank-operator#1051 B2+B3): per-batch
+  outcomes of the persist-path projection. `folded` is the fast path (no
+  ledger read); `reseeded` and `invalidated` are memo lifecycle around the
+  reference projection; `resync` means a structure-class event correctly sent
+  the batch to the reference path; `disabled`/`disabled_size` mark sessions
+  durably opted out (memo over the size cap — always batch-projected, the
+  pre-fold behavior); `load_error` means fold state was unreadable and the
+  reference path covered. A sustained zero `folded` rate on a busy
+  background-task session means the fast path stopped engaging. The
+  fixture-replay equivalence harness
+  (`TestFoldCheckpointEquivalenceOverFixtures`) is the correctness gate.
 - `tank_stranded_turn_swept_total{result}` — the command-plane
   four-outcome backstop (tank-operator#1051 PR 4): dispatched turns whose
   submit_turn command or runner died silently, swept to a durable


### PR DESCRIPTION
## Summary

Stages **B2+B3** of the #1051 plan — the core of the checkpointed projector. Flood-class events (`item.*`, `turn.usage`, `shell_task.updated` on known running tasks — >90% of the incident session's ledger) now advance a **durable per-session fold memo** and rewrite only the changed `turn_activity` shell rows, with **no ledger read at all**. Everything else stays on the reference (full re-projection) pipeline, which reseeds the memo on session-scope passes and invalidates it on turn-scope ones.

Design points:
- **One summary implementation.** The memo stores *pruned* entries (only the fields the shell math and membership predicates read; tool payloads and message bodies never enter it), and shells rebuild through the same B1 fold finishes, `mergeBackgroundWakeActivityBodies`, `refreshFoldedParentShells`, and `buildTurnActivityShellRow` the batch pipeline uses. There is no second renderer to drift.
- **Conservative envelope.** Structure-class events (boundaries, terminals, questions/answers, compaction, task start/exit, unestablished wake parents, revisions of evicted items) and any merged body whose entry escapes compaction (a promoted final answer needs full content the memo doesn't hold) abort to the reference path *before any fold write lands*.
- **Durable, versioned memo** (`session_transcript_fold_state`, migration 0144), advanced in the same materialization transaction as the rows under the existing advisory lock. Over the size cap, the session is durably opted out — always batch-projected, exactly the pre-fold behavior, counted.

The harness also exposed a **pre-existing staleness bug in the reference path**: a turn-scope replace of a turn that started background work sheds its folded wake content until the next session resync (`got progressNoteCount=1, want 2` on the incident fixtures). Fixed by escalating `shell_task.*` batches and task-starting turns to session scope.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- **Transcript** (rows are a server-owned projection of the durable ledger; one projection semantics): the acceptance gate is `TestFoldCheckpointEquivalenceOverFixtures` — it replays all three #1051 incident fixtures (including the 5,671-event background-task museum) at batch sizes 1/7/64 through the real `RefreshEventBatch` wiring with the memo crossing a real `[]byte` serialization boundary, and requires the row store to be **byte-identical to a from-scratch batch projection after every single batch**, plus asserts the fast path actually engages (a regression that silently routes everything to the reference path fails the harness, not just slows down). During development the harness caught and drove out three real divergence classes — wake bodies must merge per-turn rather than re-route into the parent's finish; revisions that re-key an entry must re-sort it; promotion-class entries must resync — which is the harness doing exactly what the plan built it for. `TestFoldMemoSerializationRoundTrip` pins the durable round trip and the version gate. Full backend suite + race detector green; migration guard clean.
- **Observability**: `tank_transcript_fold_total{result}` + duration histogram, documented in docs/observability.md with the read of each result label. B5 (sampled production shadow-compare with divergence alert) is the next stage per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
