### PR TITLE
store: skip-and-count retired-shape ledger rows on read (#1051 B5 hardening)

### DIFF
--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -1027,7 +1027,7 @@ func (StubSessionEventStore) CountUserMessages(_ context.Context, _ string) (int
 
 // sessionEventReadRejectedTotal counts stored ledger rows the CURRENT schema
 // cannot validate — overwhelmingly retired event types from old sessions
-// (e.g. tool.approval_requested). The read path skips such rows instead of
+// (event types the schema has since retired). The read path skips such rows instead of
 // failing the whole session's projection: before this, one retired-type row
 // made a session permanently un-projectable (the session-288 resync failures
 // during the tank-operator#1051 recovery). The WRITE path still hard-rejects

--- a/backend-go/internal/store/session_events.go
+++ b/backend-go/internal/store/session_events.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/romaine-life/tank-operator/backend-go/internal/conversation"
 	"github.com/romaine-life/tank-operator/backend-go/internal/sessionmodel"
@@ -360,19 +363,14 @@ func (s *postgresSessionEventStore) listBySession(ctx context.Context, qx sessio
 		if err := rows.Scan(&payload); err != nil {
 			return SessionEventPage{}, err
 		}
-		var doc map[string]any
-		if err := json.Unmarshal(payload, &doc); err != nil {
-			return SessionEventPage{}, fmt.Errorf("session-events doc is not JSON: %w", err)
+		// Producer regressions are caught and alerted at the WRITE path;
+		// a stored row the current schema rejects (a retired event type
+		// from an old session) is skipped + counted rather than poisoning
+		// the whole session's reads — see decodeStoredSessionEvent.
+		doc, ok := decodeStoredSessionEvent(payload, tankSessionID)
+		if !ok {
+			continue
 		}
-		if err := conversation.ValidateEventMap(doc); err != nil {
-			// Per docs/migration-policy.md, the read path no longer silently
-			// filters malformed docs. The producer-side cutover (runner
-			// dispatch contract, persister schema-terminal NAK) guarantees
-			// only Tank events land in storage. A failure here means one of
-			// those guarantees regressed — surface it.
-			return SessionEventPage{}, fmt.Errorf("session-events doc rejected by schema: %w", err)
-		}
-		doc["tank_session_id"] = tankSessionID
 		out = append(out, doc)
 	}
 	if err := rows.Err(); err != nil {
@@ -433,14 +431,14 @@ func (s *postgresSessionEventStore) eventsForTurn(ctx context.Context, qx sessio
 		if err := rows.Scan(&payload); err != nil {
 			return SessionEventPage{}, err
 		}
-		var doc map[string]any
-		if err := json.Unmarshal(payload, &doc); err != nil {
-			return SessionEventPage{}, fmt.Errorf("session-events doc is not JSON: %w", err)
+		// Producer regressions are caught and alerted at the WRITE path;
+		// a stored row the current schema rejects (a retired event type
+		// from an old session) is skipped + counted rather than poisoning
+		// the whole session's reads — see decodeStoredSessionEvent.
+		doc, ok := decodeStoredSessionEvent(payload, tankSessionID)
+		if !ok {
+			continue
 		}
-		if err := conversation.ValidateEventMap(doc); err != nil {
-			return SessionEventPage{}, fmt.Errorf("session-events doc rejected by schema: %w", err)
-		}
-		doc["tank_session_id"] = tankSessionID
 		out = append(out, doc)
 	}
 	if err := rows.Err(); err != nil {
@@ -523,14 +521,13 @@ func (s *postgresSessionEventStore) FindTurnTerminal(ctx context.Context, tankSe
 	if err != nil {
 		return nil, err
 	}
-	var doc map[string]any
-	if err := json.Unmarshal(payload, &doc); err != nil {
-		return nil, fmt.Errorf("session-events doc is not JSON: %w", err)
+	// A terminal row the current schema rejects (legacy shape) cannot be
+	// interpreted by current code: treat as no usable terminal, counted
+	// by decodeStoredSessionEvent.
+	doc, ok := decodeStoredSessionEvent(payload, tankSessionID)
+	if !ok {
+		return nil, nil
 	}
-	if err := conversation.ValidateEventMap(doc); err != nil {
-		return nil, fmt.Errorf("session-events doc rejected by schema: %w", err)
-	}
-	doc["tank_session_id"] = tankSessionID
 	return doc, nil
 }
 
@@ -721,14 +718,14 @@ func (s *postgresSessionEventStore) LatestLifecycleEvents(ctx context.Context, t
 		if err := rows.Scan(&payload); err != nil {
 			return nil, err
 		}
-		var doc map[string]any
-		if err := json.Unmarshal(payload, &doc); err != nil {
-			return nil, fmt.Errorf("session-events doc is not JSON: %w", err)
+		// Producer regressions are caught and alerted at the WRITE path;
+		// a stored row the current schema rejects (a retired event type
+		// from an old session) is skipped + counted rather than poisoning
+		// the whole session's reads — see decodeStoredSessionEvent.
+		doc, ok := decodeStoredSessionEvent(payload, tankSessionID)
+		if !ok {
+			continue
 		}
-		if err := conversation.ValidateEventMap(doc); err != nil {
-			return nil, fmt.Errorf("session-events doc rejected by schema: %w", err)
-		}
-		doc["tank_session_id"] = tankSessionID
 		out = append(out, doc)
 	}
 	if err := rows.Err(); err != nil {
@@ -851,14 +848,14 @@ func (s *postgresSessionEventStore) ShellTaskEvents(ctx context.Context, tankSes
 		if err := rows.Scan(&payload); err != nil {
 			return nil, err
 		}
-		var doc map[string]any
-		if err := json.Unmarshal(payload, &doc); err != nil {
-			return nil, fmt.Errorf("session-events doc is not JSON: %w", err)
+		// Producer regressions are caught and alerted at the WRITE path;
+		// a stored row the current schema rejects (a retired event type
+		// from an old session) is skipped + counted rather than poisoning
+		// the whole session's reads — see decodeStoredSessionEvent.
+		doc, ok := decodeStoredSessionEvent(payload, tankSessionID)
+		if !ok {
+			continue
 		}
-		if err := conversation.ValidateEventMap(doc); err != nil {
-			return nil, fmt.Errorf("session-events doc rejected by schema: %w", err)
-		}
-		doc["tank_session_id"] = tankSessionID
 		out = append(out, doc)
 	}
 	if err := rows.Err(); err != nil {
@@ -1026,6 +1023,48 @@ func (StubSessionEventStore) ShellTaskEvents(_ context.Context, _ string) ([]map
 
 func (StubSessionEventStore) CountUserMessages(_ context.Context, _ string) (int64, error) {
 	return 0, nil
+}
+
+// sessionEventReadRejectedTotal counts stored ledger rows the CURRENT schema
+// cannot validate — overwhelmingly retired event types from old sessions
+// (e.g. tool.approval_requested). The read path skips such rows instead of
+// failing the whole session's projection: before this, one retired-type row
+// made a session permanently un-projectable (the session-288 resync failures
+// during the tank-operator#1051 recovery). The WRITE path still hard-rejects
+// invalid docs — producer regressions are caught there, counted by
+// tank_session_event_persist_schema_rejected_total and alerted; this counter
+// is the read-side visibility, expected nonzero only when ancient sessions
+// are read.
+var sessionEventReadRejectedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tank_session_event_read_rejected_total",
+		Help: "Stored session_events rows skipped on read because the current schema rejects them, labeled by bounded reason (invalid_json, schema_rejected).",
+	},
+	[]string{"reason"},
+)
+
+// decodeStoredSessionEvent unmarshals and validates one stored ledger row.
+// ok=false means the row is unusable under the current schema and the caller
+// must skip it (counted + logged); the ledger row itself stays untouched.
+func decodeStoredSessionEvent(payload []byte, tankSessionID string) (map[string]any, bool) {
+	var doc map[string]any
+	if err := json.Unmarshal(payload, &doc); err != nil {
+		sessionEventReadRejectedTotal.WithLabelValues("invalid_json").Inc()
+		slog.Warn("session-events row skipped on read: not JSON",
+			"tank_session_id", tankSessionID, "error", err)
+		return nil, false
+	}
+	if err := conversation.ValidateEventMap(doc); err != nil {
+		sessionEventReadRejectedTotal.WithLabelValues("schema_rejected").Inc()
+		slog.Warn("session-events row skipped on read: rejected by current schema",
+			"tank_session_id", tankSessionID,
+			"event_id", stringField(doc, "event_id"),
+			"event_type", stringField(doc, "type"),
+			"error", err)
+		return nil, false
+	}
+	doc["tank_session_id"] = tankSessionID
+	return doc, true
 }
 
 func cloneSessionEventMap(input map[string]any) map[string]any {

--- a/backend-go/internal/store/session_events_read_skip_test.go
+++ b/backend-go/internal/store/session_events_read_skip_test.go
@@ -40,9 +40,9 @@ func TestDecodeStoredSessionEventSkipsRetiredShapes(t *testing.T) {
 
 	before := testutil.ToFloat64(sessionEventReadRejectedTotal.WithLabelValues("schema_rejected"))
 	retired := []byte(`{
-		"id": "turn-1:tool.approval_requested:x",
-		"event_id": "turn-1:tool.approval_requested:x",
-		"type": "tool.approval_requested",
+		"id": "turn-1:legacy.retired_event:x",
+		"event_id": "turn-1:legacy.retired_event:x",
+		"type": "legacy.retired_event",
 		"actor": "tool",
 		"source": "claude",
 		"session_id": "288",

--- a/backend-go/internal/store/session_events_read_skip_test.go
+++ b/backend-go/internal/store/session_events_read_skip_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestDecodeStoredSessionEventSkipsRetiredShapes pins the read-side contract:
+// a stored ledger row the current schema rejects (a retired event type from
+// an old session) is skipped and counted instead of poisoning the whole
+// session's reads — before this, one such row made a session permanently
+// un-projectable (the session-288 resync failures during the
+// tank-operator#1051 recovery). The write path still hard-rejects invalid
+// docs; this is read-side tolerance for history only.
+func TestDecodeStoredSessionEventSkipsRetiredShapes(t *testing.T) {
+	valid := []byte(`{
+		"id": "turn-1:item.completed:x",
+		"event_id": "turn-1:item.completed:x",
+		"type": "item.completed",
+		"actor": "tool",
+		"source": "claude",
+		"session_id": "63",
+		"turn_id": "turn-1",
+		"timeline_id": "turn-1:item:x",
+		"order_key": "001",
+		"created_at": "2026-06-11T00:00:00Z",
+		"written_at": "2026-06-11T00:00:00Z",
+		"producer": {"name": "claude-runner"},
+		"visibility": "durable",
+		"payload": {"kind": "command_execution"}
+	}`)
+	doc, ok := decodeStoredSessionEvent(valid, "63")
+	if !ok {
+		t.Fatalf("valid doc must decode")
+	}
+	if doc["tank_session_id"] != "63" {
+		t.Fatalf("decoded doc missing tank_session_id stamp")
+	}
+
+	before := testutil.ToFloat64(sessionEventReadRejectedTotal.WithLabelValues("schema_rejected"))
+	retired := []byte(`{
+		"id": "turn-1:tool.approval_requested:x",
+		"event_id": "turn-1:tool.approval_requested:x",
+		"type": "tool.approval_requested",
+		"actor": "tool",
+		"source": "claude",
+		"session_id": "288",
+		"turn_id": "turn-1",
+		"order_key": "001",
+		"created_at": "2026-05-28T00:00:00Z"
+	}`)
+	if _, ok := decodeStoredSessionEvent(retired, "288"); ok {
+		t.Fatalf("retired event type must not decode")
+	}
+	if after := testutil.ToFloat64(sessionEventReadRejectedTotal.WithLabelValues("schema_rejected")); after-before != 1 {
+		t.Fatalf("schema_rejected counter delta = %v, want 1", after-before)
+	}
+
+	jsonBefore := testutil.ToFloat64(sessionEventReadRejectedTotal.WithLabelValues("invalid_json"))
+	if _, ok := decodeStoredSessionEvent([]byte("{not json"), "288"); ok {
+		t.Fatalf("invalid json must not decode")
+	}
+	if after := testutil.ToFloat64(sessionEventReadRejectedTotal.WithLabelValues("invalid_json")); after-jsonBefore != 1 {
+		t.Fatalf("invalid_json counter delta = %v, want 1", after-jsonBefore)
+	}
+}


### PR DESCRIPTION
B5 hardening from the #1051 plan. The read path validated every stored row against the CURRENT schema and failed the whole read on any historical row with a retired event type — one such row made a session permanently un-projectable (the session-288 resync failures during the incident recovery). Reads now skip-and-count (tank_session_event_read_rejected_total{reason}) with a warn naming the event id. Read-side tolerance for history only: the write path still hard-rejects, and producer regressions stay alerted via the persist-side counter.

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Observability

Evidence:
- **Transcript**: a session with retired-type history becomes projectable again; current-shape rows decode identically (TestDecodeStoredSessionEventSkipsRetiredShapes pins valid-decode, retired-skip + count, invalid-json-skip + count). Full store + cmd suites green.
- **Observability**: the new counter is the read-side visibility, expected nonzero only when ancient sessions are read; the runbook story for producer regressions remains the persist-side schema-rejected alert. Will verify post-deploy that session 288's resync failures (backend_async result=failed) stop recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)