### PR TITLE
projection: sampled production shadow-compare for the checkpointed fold (#1051 B5)

### DIFF
--- a/backend-go/cmd/tank-operator/observability.go
+++ b/backend-go/cmd/tank-operator/observability.go
@@ -2411,6 +2411,28 @@ func recordTranscriptFoldDuration(d time.Duration) {
 	transcriptFoldDurationSeconds.Observe(d.Seconds())
 }
 
+// Production shadow-compare of the checkpointed fold (#1051 B5): sampled
+// folded batches re-derive their written shells from the reference
+// projection. divergence means the fold wrote rows the reference disagrees
+// with — auto-healed in the same transaction, but the class must page:
+// TankTranscriptFoldShadowDivergence.
+var transcriptFoldShadowTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tank_transcript_fold_shadow_total",
+		Help: "Sampled fold-vs-reference shadow comparisons, labeled by bounded result (match, divergence).",
+	},
+	[]string{"result"},
+)
+
+func recordTranscriptFoldShadow(result string) {
+	switch result {
+	case "match", "divergence":
+	default:
+		result = "other"
+	}
+	transcriptFoldShadowTotal.WithLabelValues(result).Inc()
+}
+
 // recordTurnActivityPages observes the page count and total event count of a
 // turn-activity projection so long-turn frequency (the pagination trigger) is
 // visible without high-cardinality labels.

--- a/backend-go/cmd/tank-operator/transcript_fold_shadow.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_shadow.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+	"sync/atomic"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/romaine-life/tank-operator/backend-go/internal/store"
+)
+
+// transcriptFoldShadowSampleEvery is the sampling stride for the production
+// shadow-compare: one in every N successfully folded batches also runs the
+// full reference projection and diffs the fold-written shells. The shadow
+// read is O(session) — the very cost the fold removes — so it stays sampled;
+// at 1-in-50 a flood session pays roughly 2% of the pre-fold read load for a
+// continuous production equivalence net. A var (not const) so the harness can
+// run at stride 1.
+var transcriptFoldShadowSampleEvery uint64 = 50
+
+var transcriptFoldShadowCounter atomic.Uint64
+
+func transcriptFoldShadowDue() bool {
+	every := transcriptFoldShadowSampleEvery
+	if every == 0 {
+		return false
+	}
+	return transcriptFoldShadowCounter.Add(1)%every == 0
+}
+
+// shadowCompareFoldTx re-derives the rows the fold just wrote from a full
+// reference projection of the session ledger and diffs them. A match is
+// counted; a divergence is counted, logged with the offending row ids, and
+// healed in the same transaction by the reference re-projection (which also
+// reseeds the memo) — so a fold defect costs one wrong-rows window of zero:
+// the transaction that wrote them also corrects them.
+func (m transcriptRowsMaterializer) shadowCompareFoldTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	txEvents transcriptEventsTxStore,
+	txRows transcriptRowsMaterializationTxStore,
+	sessionID string,
+	foldRows []map[string]any,
+) error {
+	if len(foldRows) == 0 {
+		recordTranscriptFoldShadow("match")
+		return nil
+	}
+	var events []map[string]any
+	cursor := ""
+	for {
+		page, err := txEvents.ListBySessionTx(ctx, tx, sessionID, store.SessionEventCursor{
+			AfterOrderKey: cursor,
+		}, 1000)
+		if err != nil {
+			return err
+		}
+		events = append(events, page.Events...)
+		if page.FoundNewest || len(page.Events) == 0 || page.NextOrderKey == "" || page.NextOrderKey == cursor {
+			break
+		}
+		cursor = page.NextOrderKey
+	}
+	projection := projectTranscriptEvents(events)
+	if numbers, ok := m.turnNumbersForSession(ctx, sessionID); ok {
+		stampTurnNumbers(sessionID, numbers, projection.Entries)
+	}
+	reference := map[string]map[string]any{}
+	for _, entry := range projection.Entries {
+		if id := transcriptMapString(entry, "id"); id != "" {
+			reference[id] = entry
+		}
+	}
+	var diverged []string
+	for _, row := range foldRows {
+		id := transcriptMapString(row, "id")
+		want, ok := reference[id]
+		if !ok || !reflect.DeepEqual(row, want) {
+			diverged = append(diverged, id)
+		}
+	}
+	if len(diverged) == 0 {
+		recordTranscriptFoldShadow("match")
+		return nil
+	}
+	recordTranscriptFoldShadow("divergence")
+	slog.Error("transcript fold shadow divergence — healing via reference re-projection",
+		"session_id", sessionID,
+		"rows", diverged,
+	)
+	return m.resyncSessionTx(ctx, tx, txEvents, txRows, sessionID)
+}

--- a/backend-go/cmd/tank-operator/transcript_fold_shadow_test.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_shadow_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/romaine-life/tank-operator/backend-go/internal/store"
+)
+
+// TestFoldShadowCompareMatchesAtFullSampling replays the background-task
+// fixture with the shadow sampling at stride 1: every folded batch also runs
+// the reference projection and diffs. The harness asserts the shadow engaged,
+// matched every time, and never reported a divergence — the production net
+// agreeing with the offline equivalence proof.
+func TestFoldShadowCompareMatchesAtFullSampling(t *testing.T) {
+	prior := transcriptFoldShadowSampleEvery
+	transcriptFoldShadowSampleEvery = 1
+	defer func() { transcriptFoldShadowSampleEvery = prior }()
+
+	matchBefore := testutil.ToFloat64(transcriptFoldShadowTotal.WithLabelValues("match"))
+	divergenceBefore := testutil.ToFloat64(transcriptFoldShadowTotal.WithLabelValues("divergence"))
+
+	events := foldFixtureEvents(t, "slot1_session_161_events.json")
+	rows := newMemoryFoldRowsStore()
+	eventsStore := &memoryFoldEventStore{}
+	m := transcriptRowsMaterializer{events: eventsStore, rows: rows, turns: store.StubSessionTurnStore{}}
+
+	const batchSize = 7
+	for start := 0; start < len(events); start += batchSize {
+		end := min(start+batchSize, len(events))
+		batch := events[start:end]
+		eventsStore.append(batch...)
+		if start == 0 {
+			if _, err := m.BackfillSession(context.Background(), transcriptMaterializerSessionID(batch[0])); err != nil {
+				t.Fatalf("seed backfill: %v", err)
+			}
+		}
+		if err := m.RefreshEventBatch(context.Background(), batch); err != nil {
+			t.Fatalf("RefreshEventBatch at %d: %v", start, err)
+		}
+	}
+
+	if got := testutil.ToFloat64(transcriptFoldShadowTotal.WithLabelValues("match")) - matchBefore; got == 0 {
+		t.Fatalf("shadow compare never engaged at stride 1")
+	}
+	if got := testutil.ToFloat64(transcriptFoldShadowTotal.WithLabelValues("divergence")) - divergenceBefore; got != 0 {
+		t.Fatalf("shadow compare reported %v divergences on equivalent paths", got)
+	}
+}
+
+// TestFoldShadowCompareHealsDivergence pins the divergence path: a fold row
+// that disagrees with the reference is counted, and the heal (reference
+// re-projection in the same transaction) replaces the wrong rows and reseeds
+// the memo.
+func TestFoldShadowCompareHealsDivergence(t *testing.T) {
+	divergenceBefore := testutil.ToFloat64(transcriptFoldShadowTotal.WithLabelValues("divergence"))
+
+	events := foldFixtureEvents(t, "slot1_session_159_events.json")
+	rows := newMemoryFoldRowsStore()
+	eventsStore := &memoryFoldEventStore{}
+	eventsStore.append(events...)
+	m := transcriptRowsMaterializer{events: eventsStore, rows: rows, turns: store.StubSessionTurnStore{}}
+
+	sessionID := transcriptMaterializerSessionID(events[0])
+	// A row the reference projection cannot contain.
+	tampered := map[string]any{
+		"id":       "turn-activity-tampered",
+		"kind":     "turn_activity",
+		"turnId":   "turn-tampered",
+		"orderKey": "zzz",
+	}
+	if err := m.shadowCompareFoldTx(context.Background(), nil, eventsStore, rows, sessionID, []map[string]any{tampered}); err != nil {
+		t.Fatalf("shadowCompareFoldTx: %v", err)
+	}
+	if got := testutil.ToFloat64(transcriptFoldShadowTotal.WithLabelValues("divergence")) - divergenceBefore; got != 1 {
+		t.Fatalf("divergence counter delta = %v, want 1", got)
+	}
+	// The heal ran the reference projection: the row store now equals ground
+	// truth and the memo is reseeded.
+	want := groundTruthRows(eventsStore.all())
+	if diff := diffRowSets(rows.rows, want); diff != "" {
+		t.Fatalf("heal did not converge rows to reference:\n%s", diff)
+	}
+	if len(rows.foldMemo) == 0 && !rows.foldDisabled {
+		t.Fatalf("heal did not reseed the fold memo")
+	}
+}

--- a/backend-go/cmd/tank-operator/transcript_rows_materializer.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer.go
@@ -315,6 +315,20 @@ func (m transcriptRowsMaterializer) tryFoldBatchTx(
 	}
 	recordTranscriptFold("folded")
 	recordTranscriptFoldDuration(time.Since(started))
+	// Production shadow-compare (tank-operator#1051 B5): on a sampled
+	// fraction of folded batches, re-derive the written shells from a full
+	// reference projection and diff. A divergence is counted, paged
+	// (TankTranscriptFoldShadowDivergence), and healed in this same
+	// transaction by the reference re-projection — the user never sees the
+	// wrong rows beyond this batch. The fixture harness proves equivalence
+	// for known shapes; the shadow is the net for shapes production invents.
+	if transcriptFoldShadowDue() {
+		if txEvents, ok := m.events.(transcriptEventsTxStore); ok {
+			if err := m.shadowCompareFoldTx(ctx, tx, txEvents, txRows, sessionID, rows); err != nil {
+				return false, err
+			}
+		}
+	}
 	return true, nil
 }
 

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -861,6 +861,33 @@ spec:
               persister ack floor"), then assess which sessions lost
               events via the per-session order_key continuity.
 
+        # Checkpointed-fold shadow divergence. Sampled folded batches
+        # re-derive their written shells from the reference projection;
+        # a divergence means the fold wrote rows the reference disagrees
+        # with. It is auto-healed in the same transaction (the reference
+        # re-projection overwrites and reseeds), so users never keep the
+        # wrong rows — but the defect class must page, because every
+        # unsampled fold batch with the same shape went uncorrected
+        # until its next resync.
+        - alert: TankTranscriptFoldShadowDivergence
+          expr: sum(increase(tank_transcript_fold_shadow_total{result="divergence"}[1h])) > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: "checkpointed-fold shadow compare diverged from the reference projection"
+            runbook: |
+              The slog.Error "transcript fold shadow divergence" names the
+              session and row ids. Reproduce by replaying that session's
+              ledger through TestFoldCheckpointEquivalenceOverFixtures-style
+              prefix replay (capture the ledger via
+              GET /api/debug/session-event-ledger, add it as a fixture).
+              Mitigate immediately by disabling the fold for the affected
+              session (UPDATE session_transcript_fold_state SET memo=NULL,
+              disabled=true WHERE tank_session_id='<id>') or fleet-wide by
+              deleting all fold state — the reference pipeline is the
+              always-correct fallback-free path and serves every read
+              shape on its own.
+
         # Stranded-turn sweep activity. The sweep is the command-plane
         # four-outcome backstop: it terminals turns whose submit_turn
         # command or runner died silently. Each swept turn is a real


### PR DESCRIPTION
Final stage of the #1051 plan. One in every 50 folded batches re-derives its written shells from the reference projection and diffs, inside the same transaction: a divergence is counted, paged, and healed on the spot by the reference re-projection (which also reseeds the memo) — the offline fixture harness proves equivalence for known shapes; the shadow is the net for shapes production invents. Runbook covers per-session and fleet-wide fold disable (the reference pipeline serves every read shape on its own).

## Feature Contracts

Affected contracts:
- [x] Transcript
- [x] Observability

Evidence:
- **Transcript**: TestFoldShadowCompareMatchesAtFullSampling replays the background-task incident fixture with EVERY batch shadowed (stride 1) — shadow engages, matches only, zero divergences. TestFoldShadowCompareHealsDivergence pins the divergence path end to end: counter increment, heal converges the row store to reference ground truth, memo reseeded.
- **Observability**: tank_transcript_fold_shadow_total{result} + TankTranscriptFoldShadowDivergence (critical — auto-healed per occurrence, but every unsampled batch with the same shape went uncorrected until its next resync, so the class pages). Runbook names the slog line, the fixture-replay reproduction path via GET /api/debug/session-event-ledger, and the disable levers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)