### PR TITLE
projection: cap concurrent session resyncs at one per pod (B1ms wedge fix)

### DIFF
--- a/backend-go/cmd/tank-operator/transcript_rows_materializer.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer.go
@@ -332,6 +332,17 @@ func (m transcriptRowsMaterializer) tryFoldBatchTx(
 	return true, nil
 }
 
+// sessionResyncSlots caps CONCURRENT session-scope re-projections per pod.
+// The per-session worker isolation that keeps one session from starving
+// another also means N cold sessions (post-deploy, no fold memos yet) can
+// start N full-ledger reads simultaneously — five parallel multi-thousand-row
+// reads wedged the B1ms instance outright on the 2026-06-12 post-#1051
+// deploys: every Postgres caller timed out and the persister made zero
+// progress. One heavy read at a time is proven fine on this instance class;
+// queued workers wait here while flood-class folds (no ledger read) continue
+// unimpeded on other sessions.
+var sessionResyncSlots = make(chan struct{}, 1)
+
 // resyncSessionTx is the reference projection: re-project the whole session
 // and reseed the fold memo from the same events, in the same transaction.
 func (m transcriptRowsMaterializer) resyncSessionTx(
@@ -341,6 +352,12 @@ func (m transcriptRowsMaterializer) resyncSessionTx(
 	rowsStore transcriptRowsMaterializationTxStore,
 	sessionID string,
 ) error {
+	select {
+	case sessionResyncSlots <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	defer func() { <-sessionResyncSlots }()
 	events, err := m.backfillSessionEventsTx(ctx, tx, eventsStore, rowsStore, sessionID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Live finding from the B-series deploys: post-deploy cold start (no fold memos yet) let all five big sessions start full-ledger re-projections simultaneously — five parallel multi-thousand-row reads wedged the B1ms (all Postgres callers timing out, persister frozen at pending=1893). A 1-slot semaphore serializes session-scope re-projections per pod; queued workers wait while flood-class folds (no ledger read) continue on other sessions. Single heavy reads are proven fine on this instance class — it was the multiplication by worker count that killed it.

## Feature Contracts

Affected contracts:
- [x] Transcript

Evidence:
- Semantics unchanged (the semaphore is transparent to projection output): full fold/equivalence/materializer suites green. Live acceptance: after this deploys, the frozen pending=1893 backlog must drain serially — will verify and note here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)