### PR TITLE
projection: per-turn fold-memo partitioning + tx-riding turn numbers (#1051 follow-ups)

### DIFF
--- a/backend-go/cmd/tank-operator/transcript_fold_checkpoint.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_checkpoint.go
@@ -30,11 +30,15 @@ import (
 // Versioning: bump sessionFoldMemoVersion whenever the memo shape or the
 // projection semantics it snapshots change; a version mismatch on load is a
 // resync, never a best-effort read of stale state.
-const sessionFoldMemoVersion = 1
+const sessionFoldMemoVersion = 2
 
-// sessionFoldMemoMaxBytes caps the serialized memo. A session whose memo
-// outgrows it has the fold disabled durably (always batch-projected, exactly
-// the pre-fold behavior) and counted — never silently truncated.
+// sessionFoldMemoMaxBytes caps each serialized memo PART: the shared
+// session part and every per-turn entry blob individually. A session with a
+// part over the cap has the fold disabled durably (always batch-projected,
+// exactly the pre-fold behavior) and counted — never silently truncated.
+// Partitioning is what lets the incident-class sessions fold: their v1
+// single-blob memos exceeded the cap (disabled_size=16 on first deploy),
+// while their largest single turn fits comfortably.
 const sessionFoldMemoMaxBytes = 1_500_000
 
 type sessionFoldMemo struct {
@@ -57,10 +61,14 @@ type sessionFoldMemo struct {
 	WakeParents           map[string]string `json:"wake_parents,omitempty"`
 	ContinuationTurns     map[string]bool   `json:"continuation_turns,omitempty"`
 
-	// Turns holds pruned entries keyed by the turn the entry RENDERS under —
-	// wake/continuation entries are stored under their originating parent,
-	// matching the batch pipeline's fold-into-parent semantics.
-	Turns map[string]*turnFoldEntries `json:"turns,omitempty"`
+	// Turns holds pruned entries keyed by the entry's ORIGINAL turn. It is
+	// deliberately excluded from the session part's serialization: each
+	// turn's entry set persists as its own row
+	// (session_transcript_fold_turns), loaded per batch for exactly the
+	// turns the batch touches. TouchedTurns tracks which sets this in-memory
+	// fold pass modified, so the save writes only those.
+	Turns        map[string]*turnFoldEntries `json:"-"`
+	TouchedTurns map[string]bool             `json:"-"`
 }
 
 type turnFoldEntries struct {
@@ -116,6 +124,7 @@ func newSessionFoldMemo() *sessionFoldMemo {
 		WakeParents:           map[string]string{},
 		ContinuationTurns:     map[string]bool{},
 		Turns:                 map[string]*turnFoldEntries{},
+		TouchedTurns:          map[string]bool{},
 	}
 }
 
@@ -283,6 +292,7 @@ func (m *sessionFoldMemo) routeEntry(entry map[string]any, turnID string) (strin
 		m.Turns[turnID] = turn
 	}
 	turn.upsert(pruneFoldEntry(entry))
+	m.TouchedTurns[turnID] = true
 	return render, foldApplied
 }
 
@@ -522,15 +532,30 @@ func buildSessionFoldMemo(events []map[string]any) *sessionFoldMemo {
 	return memo
 }
 
-func marshalSessionFoldMemo(memo *sessionFoldMemo) ([]byte, bool) {
+// marshalSessionFoldMemo serializes the session part plus the given turn
+// sets (touched-only for fold saves; all for reseeds). fits=false when any
+// single part exceeds the cap.
+func marshalSessionFoldMemo(memo *sessionFoldMemo, turnIDs []string) ([]byte, map[string][]byte, bool) {
 	if memo == nil {
-		return nil, false
+		return nil, nil, false
 	}
 	raw, err := json.Marshal(memo)
 	if err != nil || len(raw) > sessionFoldMemoMaxBytes {
-		return nil, false
+		return nil, nil, false
 	}
-	return raw, true
+	turns := map[string][]byte{}
+	for _, turnID := range turnIDs {
+		set := memo.Turns[turnID]
+		if set == nil {
+			continue
+		}
+		blob, err := json.Marshal(set)
+		if err != nil || len(blob) > sessionFoldMemoMaxBytes {
+			return nil, nil, false
+		}
+		turns[turnID] = blob
+	}
+	return raw, turns, true
 }
 
 func unmarshalSessionFoldMemo(raw []byte) *sessionFoldMemo {
@@ -572,15 +597,55 @@ func unmarshalSessionFoldMemo(raw []byte) *sessionFoldMemo {
 	if memo.ContinuationTurns == nil {
 		memo.ContinuationTurns = map[string]bool{}
 	}
-	if memo.Turns == nil {
-		memo.Turns = map[string]*turnFoldEntries{}
+	memo.Turns = map[string]*turnFoldEntries{}
+	memo.TouchedTurns = map[string]bool{}
+	return &memo
+}
+
+// attachFoldTurnBlobs deserializes per-turn entry sets into a loaded memo.
+// A blob that fails to decode poisons the memo (returns false) — the caller
+// falls back to the reference path, which reseeds.
+func attachFoldTurnBlobs(memo *sessionFoldMemo, blobs map[string][]byte) bool {
+	for turnID, blob := range blobs {
+		var set turnFoldEntries
+		if err := json.Unmarshal(blob, &set); err != nil {
+			return false
+		}
+		if set.Entries == nil {
+			set.Entries = map[string]map[string]any{}
+		}
+		memo.Turns[turnID] = &set
 	}
-	for _, turn := range memo.Turns {
-		if turn != nil && turn.Entries == nil {
-			turn.Entries = map[string]map[string]any{}
+	return true
+}
+
+// foldTurnIDsToLoad computes the turn entry sets a batch needs: the batch's
+// own turns, their render parents, and — for any parent shell rebuild — every
+// wake child of those parents (the family closure mergeBackgroundWake needs).
+func (m *sessionFoldMemo) foldTurnIDsToLoad(events []map[string]any) []string {
+	need := map[string]bool{}
+	for _, event := range events {
+		turnID := transcriptString(event, "turn_id")
+		if turnID == "" {
+			continue
+		}
+		need[turnID] = true
+		if parent := m.WakeParents[turnID]; parent != "" {
+			need[parent] = true
 		}
 	}
-	return &memo
+	// Family closure: children of every needed parent.
+	for wakeID, parent := range m.WakeParents {
+		if need[parent] {
+			need[wakeID] = true
+		}
+	}
+	out := make([]string, 0, len(need))
+	for turnID := range need {
+		out = append(out, turnID)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // foldBatch applies a sorted batch of events to the memo. It returns the set

--- a/backend-go/cmd/tank-operator/transcript_fold_checkpoint_test.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_checkpoint_test.go
@@ -67,6 +67,7 @@ func (s *memoryFoldEventStore) ListBySessionTx(_ context.Context, _ pgx.Tx, _ st
 type memoryFoldRowsStore struct {
 	rows         map[string]map[string]any
 	foldMemo     []byte
+	foldTurns    map[string][]byte
 	foldDisabled bool
 	inTx         bool
 }
@@ -118,21 +119,44 @@ func (s *memoryFoldRowsStore) LoadFoldStateTx(context.Context, pgx.Tx, string) (
 	return s.foldMemo, s.foldDisabled, nil
 }
 
-func (s *memoryFoldRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx, _ string, memo []byte) error {
+func (s *memoryFoldRowsStore) LoadFoldTurnsTx(_ context.Context, _ pgx.Tx, _ string, turnIDs []string) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	for _, turnID := range turnIDs {
+		if blob, ok := s.foldTurns[turnID]; ok {
+			out[turnID] = blob
+		}
+	}
+	return out, nil
+}
+
+func (s *memoryFoldRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx, _ string, memo []byte, turns map[string][]byte) error {
 	s.foldMemo = append([]byte(nil), memo...)
+	if s.foldTurns == nil {
+		s.foldTurns = map[string][]byte{}
+	}
+	for turnID, blob := range turns {
+		s.foldTurns[turnID] = append([]byte(nil), blob...)
+	}
 	s.foldDisabled = false
 	return nil
+}
+
+func (s *memoryFoldRowsStore) ReplaceFoldStateTx(ctx context.Context, tx pgx.Tx, sessionID string, memo []byte, turns map[string][]byte) error {
+	s.foldTurns = map[string][]byte{}
+	return s.SaveFoldStateTx(ctx, tx, sessionID, memo, turns)
 }
 
 func (s *memoryFoldRowsStore) DeleteFoldStateTx(context.Context, pgx.Tx, string) error {
 	if !s.foldDisabled {
 		s.foldMemo = nil
+		s.foldTurns = nil
 	}
 	return nil
 }
 
 func (s *memoryFoldRowsStore) DisableFoldTx(context.Context, pgx.Tx, string) error {
 	s.foldMemo = nil
+	s.foldTurns = nil
 	s.foldDisabled = true
 	return nil
 }
@@ -290,13 +314,20 @@ func TestFoldCheckpointEquivalenceOverFixtures(t *testing.T) {
 func TestFoldMemoSerializationRoundTrip(t *testing.T) {
 	events := foldFixtureEvents(t, "slot1_session_161_events.json")
 	memo := buildSessionFoldMemo(events)
-	raw, ok := marshalSessionFoldMemo(memo)
+	allTurns := make([]string, 0, len(memo.Turns))
+	for turnID := range memo.Turns {
+		allTurns = append(allTurns, turnID)
+	}
+	raw, turnBlobs, ok := marshalSessionFoldMemo(memo, allTurns)
 	if !ok {
-		t.Fatalf("memo did not marshal within the size cap (len would exceed %d)", sessionFoldMemoMaxBytes)
+		t.Fatalf("memo did not marshal within the per-part size cap (%d)", sessionFoldMemoMaxBytes)
 	}
 	back := unmarshalSessionFoldMemo(raw)
 	if back == nil {
 		t.Fatalf("memo failed to unmarshal")
+	}
+	if !attachFoldTurnBlobs(back, turnBlobs) {
+		t.Fatalf("turn blobs failed to attach")
 	}
 	if back.LastOrderKey != memo.LastOrderKey {
 		t.Fatalf("LastOrderKey lost in round trip")

--- a/backend-go/cmd/tank-operator/transcript_fold_shadow.go
+++ b/backend-go/cmd/tank-operator/transcript_fold_shadow.go
@@ -64,7 +64,7 @@ func (m transcriptRowsMaterializer) shadowCompareFoldTx(
 		cursor = page.NextOrderKey
 	}
 	projection := projectTranscriptEvents(events)
-	if numbers, ok := m.turnNumbersForSession(ctx, sessionID); ok {
+	if numbers, ok := m.turnNumbersForSession(ctx, tx, sessionID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
 	reference := map[string]map[string]any{}

--- a/backend-go/cmd/tank-operator/transcript_rows_materializer.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer.go
@@ -29,7 +29,9 @@ type transcriptRowsMaterializationTxStore interface {
 	// Checkpointed-fold state (tank-operator#1051 B3), advanced in the same
 	// transaction as the row writes it describes.
 	LoadFoldStateTx(context.Context, pgx.Tx, string) ([]byte, bool, error)
-	SaveFoldStateTx(context.Context, pgx.Tx, string, []byte) error
+	LoadFoldTurnsTx(context.Context, pgx.Tx, string, []string) (map[string][]byte, error)
+	SaveFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string, memo []byte, turns map[string][]byte) error
+	ReplaceFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string, memo []byte, turns map[string][]byte) error
 	DeleteFoldStateTx(context.Context, pgx.Tx, string) error
 	DisableFoldTx(context.Context, pgx.Tx, string) error
 }
@@ -241,7 +243,7 @@ func (m transcriptRowsMaterializer) refreshSessionBatch(ctx context.Context, ses
 			}
 			projection := projectTranscriptEvents(turnEvents)
 			recordTranscriptProjectionInvariantViolations(sessionID, turnID, turnEvents, projection.Entries)
-			if numbers, ok := m.turnNumbersForTurn(ctx, sessionID, turnID); ok {
+			if numbers, ok := m.turnNumbersForTurn(ctx, tx, sessionID, turnID); ok {
 				stampTurnNumbers(sessionID, numbers, projection.Entries)
 			}
 			if err := txRows.ReplaceForTurnTx(ctx, tx, sessionID, turnID, projection.Entries); err != nil {
@@ -292,6 +294,17 @@ func (m transcriptRowsMaterializer) tryFoldBatchTx(
 	if memo == nil {
 		return false, nil
 	}
+	blobs, err := txRows.LoadFoldTurnsTx(ctx, tx, sessionID, memo.foldTurnIDsToLoad(events))
+	if err != nil {
+		slog.Warn("fold turn-set load failed; using reference projection",
+			"session_id", sessionID, "error", err)
+		recordTranscriptFold("load_error")
+		return false, nil
+	}
+	if !attachFoldTurnBlobs(memo, blobs) {
+		recordTranscriptFold("load_error")
+		return false, nil
+	}
 	// Turn-less events ride their own UpsertRows path and never touch
 	// shells; their presence alongside foldable events is fine, but they are
 	// handled by the caller, so only attempt the fold when every event in
@@ -320,7 +333,7 @@ func (m transcriptRowsMaterializer) tryFoldBatchTx(
 		if !emit {
 			continue
 		}
-		if numbers, ok := m.turnNumbersForTurn(ctx, sessionID, turnID); ok {
+		if numbers, ok := m.turnNumbersForTurn(ctx, tx, sessionID, turnID); ok {
 			stampTurnNumbers(sessionID, numbers, []map[string]any{row})
 		}
 		rows = append(rows, row)
@@ -330,14 +343,14 @@ func (m transcriptRowsMaterializer) tryFoldBatchTx(
 			return false, err
 		}
 	}
-	encoded, fits := marshalSessionFoldMemo(memo)
+	encoded, turnBlobs, fits := marshalSessionFoldMemo(memo, sortedFoldTurnIDs(memo.TouchedTurns))
 	if !fits {
-		// The rows just written are correct; only the memo outgrew its cap.
-		// Durably opt the session out so it batch-projects from here on.
+		// The rows just written are correct; only a memo part outgrew its
+		// cap. Durably opt the session out so it batch-projects from here on.
 		recordTranscriptFold("disabled_size")
 		return true, txRows.DisableFoldTx(ctx, tx, sessionID)
 	}
-	if err := txRows.SaveFoldStateTx(ctx, tx, sessionID, encoded); err != nil {
+	if err := txRows.SaveFoldStateTx(ctx, tx, sessionID, encoded, turnBlobs); err != nil {
 		return false, err
 	}
 	recordTranscriptFold("folded")
@@ -373,13 +386,17 @@ func (m transcriptRowsMaterializer) resyncSessionTx(
 		return err
 	}
 	memo := buildSessionFoldMemo(events)
-	encoded, fits := marshalSessionFoldMemo(memo)
+	allTurns := make([]string, 0, len(memo.Turns))
+	for turnID := range memo.Turns {
+		allTurns = append(allTurns, turnID)
+	}
+	encoded, turnBlobs, fits := marshalSessionFoldMemo(memo, allTurns)
 	if !fits {
 		recordTranscriptFold("disabled_size")
 		return rowsStore.DisableFoldTx(ctx, tx, sessionID)
 	}
 	recordTranscriptFold("reseeded")
-	return rowsStore.SaveFoldStateTx(ctx, tx, sessionID, encoded)
+	return rowsStore.ReplaceFoldStateTx(ctx, tx, sessionID, encoded, turnBlobs)
 }
 
 func (m transcriptRowsMaterializer) RefreshEvent(ctx context.Context, event map[string]any) error {
@@ -415,7 +432,7 @@ func (m transcriptRowsMaterializer) RefreshEvent(ctx context.Context, event map[
 	}
 	projection := projectTranscriptEvents(turnEvents)
 	recordTranscriptProjectionInvariantViolations(sessionID, turnID, turnEvents, projection.Entries)
-	if numbers, ok := m.turnNumbersForTurn(ctx, sessionID, turnID); ok {
+	if numbers, ok := m.turnNumbersForTurn(ctx, nil, sessionID, turnID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
 	return m.rows.ReplaceForTurn(ctx, sessionID, turnID, projection.Entries)
@@ -451,7 +468,7 @@ func (m transcriptRowsMaterializer) refreshEventTx(
 	}
 	projection := projectTranscriptEvents(turnEvents)
 	recordTranscriptProjectionInvariantViolations(sessionID, turnID, turnEvents, projection.Entries)
-	if numbers, ok := m.turnNumbersForTurn(ctx, sessionID, turnID); ok {
+	if numbers, ok := m.turnNumbersForTurn(ctx, tx, sessionID, turnID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
 	if err := rows.ReplaceForTurnTx(ctx, tx, sessionID, turnID, projection.Entries); err != nil {
@@ -570,7 +587,7 @@ func (m transcriptRowsMaterializer) refreshSession(ctx context.Context, sessionI
 	}
 	projection := projectTranscriptEvents(events)
 	recordTranscriptProjectionInvariantViolations(sessionID, "", events, projection.Entries)
-	if numbers, ok := m.turnNumbersForSession(ctx, sessionID); ok {
+	if numbers, ok := m.turnNumbersForSession(ctx, nil, sessionID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
 	if err := m.rows.ReplaceForSession(ctx, sessionID, projection.Entries); err != nil {
@@ -606,7 +623,7 @@ func (m transcriptRowsMaterializer) backfillSessionEventsTx(
 	}
 	projection := projectTranscriptEvents(events)
 	recordTranscriptProjectionInvariantViolations(sessionID, "", events, projection.Entries)
-	if numbers, ok := m.turnNumbersForSession(ctx, sessionID); ok {
+	if numbers, ok := m.turnNumbersForSession(ctx, tx, sessionID); ok {
 		stampTurnNumbers(sessionID, numbers, projection.Entries)
 	}
 	if err := rowsStore.ReplaceForSessionTx(ctx, tx, sessionID, projection.Entries); err != nil {
@@ -692,11 +709,11 @@ func turnNumberingActive(s store.SessionTurnStore) bool {
 // next event) rather than recording a false miss. ok is true with an empty map
 // only when the turn genuinely has no number yet, which the stamping pass then
 // records as a missing-number invariant violation.
-func (m transcriptRowsMaterializer) turnNumbersForTurn(ctx context.Context, sessionID, turnID string) (map[string]int64, bool) {
+func (m transcriptRowsMaterializer) turnNumbersForTurn(ctx context.Context, tx pgx.Tx, sessionID, turnID string) (map[string]int64, bool) {
 	if !turnNumberingActive(m.turns) || strings.TrimSpace(turnID) == "" {
 		return nil, false
 	}
-	number, ok, err := m.turns.TurnNumberForTurnID(ctx, sessionID, turnID)
+	number, ok, err := m.readTurnNumberForTurnID(ctx, tx, sessionID, turnID)
 	if err != nil {
 		slog.Warn("read durable turn number", "session_id", sessionID, "turn_id", turnID, "error", err)
 		return nil, false
@@ -710,16 +727,44 @@ func (m transcriptRowsMaterializer) turnNumbersForTurn(ctx context.Context, sess
 // turnNumbersForSession returns the whole-session {turn_id: number} map for the
 // session/backfill projection paths. ok follows the same contract as
 // turnNumbersForTurn.
-func (m transcriptRowsMaterializer) turnNumbersForSession(ctx context.Context, sessionID string) (map[string]int64, bool) {
+func (m transcriptRowsMaterializer) turnNumbersForSession(ctx context.Context, tx pgx.Tx, sessionID string) (map[string]int64, bool) {
 	if !turnNumberingActive(m.turns) {
 		return nil, false
 	}
-	numbers, err := m.turns.TurnNumbersForSession(ctx, sessionID)
+	numbers, err := m.readTurnNumbersForSession(ctx, tx, sessionID)
 	if err != nil {
 		slog.Warn("read durable turn numbers", "session_id", sessionID, "error", err)
 		return nil, false
 	}
 	return numbers, true
+}
+
+// sessionTurnTxReader is the optional in-transaction surface of the turn
+// store. Inside a materialization transaction the turn-number reads MUST ride
+// the transaction's connection: reading on the pool from inside an open
+// transaction is how the 2026-06-12 pool deadlock formed (every pool
+// connection held by the very transactions doing the acquiring — #1065).
+type sessionTurnTxReader interface {
+	TurnNumbersForSessionTx(ctx context.Context, tx pgx.Tx, tankSessionID string) (map[string]int64, error)
+	TurnNumberForTurnIDTx(ctx context.Context, tx pgx.Tx, tankSessionID, turnID string) (int64, bool, error)
+}
+
+func (m transcriptRowsMaterializer) readTurnNumbersForSession(ctx context.Context, tx pgx.Tx, sessionID string) (map[string]int64, error) {
+	if tx != nil {
+		if reader, ok := m.turns.(sessionTurnTxReader); ok {
+			return reader.TurnNumbersForSessionTx(ctx, tx, sessionID)
+		}
+	}
+	return m.turns.TurnNumbersForSession(ctx, sessionID)
+}
+
+func (m transcriptRowsMaterializer) readTurnNumberForTurnID(ctx context.Context, tx pgx.Tx, sessionID, turnID string) (int64, bool, error) {
+	if tx != nil {
+		if reader, ok := m.turns.(sessionTurnTxReader); ok {
+			return reader.TurnNumberForTurnIDTx(ctx, tx, sessionID, turnID)
+		}
+	}
+	return m.turns.TurnNumberForTurnID(ctx, sessionID, turnID)
 }
 
 // stampTurnNumbers sets turnNumber on every turn-tagged transcript row from

--- a/backend-go/cmd/tank-operator/transcript_rows_materializer_test.go
+++ b/backend-go/cmd/tank-operator/transcript_rows_materializer_test.go
@@ -92,7 +92,7 @@ func (s *lockingTranscriptRowsStore) LoadFoldStateTx(context.Context, pgx.Tx, st
 	return s.foldMemo, s.foldDisabled, nil
 }
 
-func (s *lockingTranscriptRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx, _ string, memo []byte) error {
+func (s *lockingTranscriptRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx, _ string, memo []byte, _ map[string][]byte) error {
 	if !s.lockHeld {
 		s.t.Fatal("SaveFoldStateTx called outside materialization lock")
 	}
@@ -100,6 +100,17 @@ func (s *lockingTranscriptRowsStore) SaveFoldStateTx(_ context.Context, _ pgx.Tx
 	s.foldDisabled = false
 	s.foldSaves++
 	return nil
+}
+
+func (s *lockingTranscriptRowsStore) ReplaceFoldStateTx(ctx context.Context, tx pgx.Tx, sessionID string, memo []byte, turns map[string][]byte) error {
+	return s.SaveFoldStateTx(ctx, tx, sessionID, memo, turns)
+}
+
+func (s *lockingTranscriptRowsStore) LoadFoldTurnsTx(context.Context, pgx.Tx, string, []string) (map[string][]byte, error) {
+	if !s.lockHeld {
+		s.t.Fatal("LoadFoldTurnsTx called outside materialization lock")
+	}
+	return map[string][]byte{}, nil
 }
 
 func (s *lockingTranscriptRowsStore) DeleteFoldStateTx(context.Context, pgx.Tx, string) error {

--- a/backend-go/internal/pgstore/migrations.go
+++ b/backend-go/internal/pgstore/migrations.go
@@ -1777,6 +1777,20 @@ var schemaMigrations = []migration{
 		disabled        boolean NOT NULL DEFAULT false,
 		updated_at      timestamptz NOT NULL DEFAULT now()
 	)`},
+
+	// Per-turn partition of the fold memo (tank-operator#1051 follow-up):
+	// the session row keeps the small shared context; each turn's pruned
+	// entry set lives in its own row so a fold batch loads and saves only
+	// the turns it touches, and the size cap applies per part — the
+	// monster sessions that exceeded the single-row cap (disabled_size=16
+	// on first deploy) fit comfortably partitioned.
+	{ID: "0145", SQL: `CREATE TABLE IF NOT EXISTS session_transcript_fold_turns (
+		tank_session_id text NOT NULL,
+		turn_id         text NOT NULL,
+		entries         jsonb NOT NULL,
+		updated_at      timestamptz NOT NULL DEFAULT now(),
+		PRIMARY KEY (tank_session_id, turn_id)
+	)`},
 }
 
 // migrationsAdvisoryLockKey is an arbitrary stable 64-bit value used to

--- a/backend-go/internal/store/session_transcript_rows.go
+++ b/backend-go/internal/store/session_transcript_rows.go
@@ -191,9 +191,11 @@ func (s *transcriptRowStore) needsBackfill(ctx context.Context, q transcriptRowQ
 	return version != transcriptRowBackfillVersion, nil
 }
 
-// LoadFoldStateTx reads the session's checkpointed fold memo and whether the
-// fold is durably disabled for this session. A missing row is (nil, false):
-// the fold seeds on the next session-scope re-projection.
+// LoadFoldStateTx reads the session's checkpointed fold memo (the shared
+// session part only — per-turn entry sets load separately via
+// LoadFoldTurnsTx) and whether the fold is durably disabled for this session.
+// A missing row is (nil, false): the fold seeds on the next session-scope
+// re-projection.
 func (s *transcriptRowStore) LoadFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string) ([]byte, bool, error) {
 	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
 	var memo []byte
@@ -212,22 +214,81 @@ func (s *transcriptRowStore) LoadFoldStateTx(ctx context.Context, tx pgx.Tx, tan
 	return memo, disabled, nil
 }
 
-func (s *transcriptRowStore) SaveFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string, memo []byte) error {
+// LoadFoldTurnsTx reads the per-turn entry-set blobs for exactly the turns a
+// fold batch touches. A turn with no row simply has no entries yet.
+func (s *transcriptRowStore) LoadFoldTurnsTx(ctx context.Context, tx pgx.Tx, tankSessionID string, turnIDs []string) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	if len(turnIDs) == 0 {
+		return out, nil
+	}
 	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
-	_, err := tx.Exec(ctx, `
+	rows, err := tx.Query(ctx, `
+		SELECT turn_id, entries
+		FROM session_transcript_fold_turns
+		WHERE tank_session_id = $1 AND turn_id = ANY($2::text[])
+	`, storageKey, turnIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var turnID string
+		var entries []byte
+		if err := rows.Scan(&turnID, &entries); err != nil {
+			return nil, err
+		}
+		out[turnID] = entries
+	}
+	return out, rows.Err()
+}
+
+// SaveFoldStateTx upserts the session part and exactly the touched turn
+// blobs — the per-batch write cost is O(touched turns), never O(session).
+func (s *transcriptRowStore) SaveFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string, memo []byte, turns map[string][]byte) error {
+	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	if _, err := tx.Exec(ctx, `
 		INSERT INTO session_transcript_fold_state (tank_session_id, memo, disabled, updated_at)
 		VALUES ($1, $2, false, now())
 		ON CONFLICT (tank_session_id) DO UPDATE
 		SET memo = EXCLUDED.memo, disabled = false, updated_at = now()
-	`, storageKey, memo)
-	return err
+	`, storageKey, memo); err != nil {
+		return err
+	}
+	for turnID, entries := range turns {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO session_transcript_fold_turns (tank_session_id, turn_id, entries, updated_at)
+			VALUES ($1, $2, $3, now())
+			ON CONFLICT (tank_session_id, turn_id) DO UPDATE
+			SET entries = EXCLUDED.entries, updated_at = now()
+		`, storageKey, turnID, entries); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReplaceFoldStateTx is the reseed write: the session part plus the COMPLETE
+// turn-blob set, with stale turn rows removed.
+func (s *transcriptRowStore) ReplaceFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string, memo []byte, turns map[string][]byte) error {
+	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM session_transcript_fold_turns WHERE tank_session_id = $1
+	`, storageKey); err != nil {
+		return err
+	}
+	return s.SaveFoldStateTx(ctx, tx, tankSessionID, memo, turns)
 }
 
 // DeleteFoldStateTx invalidates the memo: a turn-scope reference projection
 // makes it stale, and the next session-scope projection reseeds it. A
-// durably disabled row is preserved.
+// durably disabled session-part row is preserved.
 func (s *transcriptRowStore) DeleteFoldStateTx(ctx context.Context, tx pgx.Tx, tankSessionID string) error {
 	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM session_transcript_fold_turns WHERE tank_session_id = $1
+	`, storageKey); err != nil {
+		return err
+	}
 	_, err := tx.Exec(ctx, `
 		DELETE FROM session_transcript_fold_state
 		WHERE tank_session_id = $1 AND disabled = false

--- a/backend-go/internal/store/session_turns.go
+++ b/backend-go/internal/store/session_turns.go
@@ -88,18 +88,33 @@ func (s *sessionTurnStore) ResolveTurnNumber(ctx context.Context, tankSessionID 
 }
 
 func (s *sessionTurnStore) TurnNumberForTurnID(ctx context.Context, tankSessionID, turnID string) (int64, bool, error) {
+	return s.turnNumberForTurnID(ctx, s.pool, tankSessionID, turnID)
+}
+
+// TurnNumberForTurnIDTx is the in-transaction twin — see
+// TurnNumbersForSessionTx for why in-transaction callers must not read on
+// the pool.
+func (s *sessionTurnStore) TurnNumberForTurnIDTx(ctx context.Context, tx pgx.Tx, tankSessionID, turnID string) (int64, bool, error) {
+	return s.turnNumberForTurnID(ctx, tx, tankSessionID, turnID)
+}
+
+type sessionTurnRowQueryer interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func (s *sessionTurnStore) turnNumberForTurnID(ctx context.Context, q sessionTurnRowQueryer, tankSessionID, turnID string) (int64, bool, error) {
 	turnID = strings.TrimSpace(turnID)
 	if turnID == "" {
 		return 0, false, nil
 	}
 	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
-	const q = `
+	const query = `
 		SELECT turn_number
 		FROM session_turns
 		WHERE tank_session_id = $1 AND turn_id = $2
 	`
 	var number int64
-	if err := s.pool.QueryRow(ctx, q, storageKey, turnID).Scan(&number); err != nil {
+	if err := q.QueryRow(ctx, query, storageKey, turnID).Scan(&number); err != nil {
 		if err == pgx.ErrNoRows {
 			return 0, false, nil
 		}
@@ -109,13 +124,30 @@ func (s *sessionTurnStore) TurnNumberForTurnID(ctx context.Context, tankSessionI
 }
 
 func (s *sessionTurnStore) TurnNumbersForSession(ctx context.Context, tankSessionID string) (map[string]int64, error) {
+	return s.turnNumbersForSession(ctx, s.pool, tankSessionID)
+}
+
+// TurnNumbersForSessionTx is the in-transaction twin: callers already inside
+// a materialization transaction must read on the transaction's connection.
+// Reading on the pool from inside an open transaction is how the
+// 2026-06-12 pool deadlock formed (every pool connection held by the very
+// transactions doing the acquiring — see #1065).
+func (s *sessionTurnStore) TurnNumbersForSessionTx(ctx context.Context, tx pgx.Tx, tankSessionID string) (map[string]int64, error) {
+	return s.turnNumbersForSession(ctx, tx, tankSessionID)
+}
+
+type sessionTurnQueryer interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+func (s *sessionTurnStore) turnNumbersForSession(ctx context.Context, q sessionTurnQueryer, tankSessionID string) (map[string]int64, error) {
 	storageKey := sessionmodel.SessionStorageKey(s.scope, tankSessionID)
-	const q = `
+	const query = `
 		SELECT turn_id, turn_number
 		FROM session_turns
 		WHERE tank_session_id = $1
 	`
-	rows, err := s.pool.Query(ctx, q, storageKey)
+	rows, err := q.Query(ctx, query, storageKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes both follow-ups from #1051's closing summary in one coherent change.

**Partitioning**: session row keeps the shared context; each turn's pruned entry set persists as its own row (migration 0145). A fold batch loads/saves only the turns it touches (batch turns + render parents + wake-family closure); the size cap applies per part — the incident-class sessions whose v1 single-blob memos tripped disabled_size now fit, and the durable disabled flag self-heals on their next session resync. Memo version → 2 (v1 rows fail the gate and reseed).

**Tx-riding turn numbers**: stampTurnNumbers callers inside the materialization transaction read session_turns on the transaction's connection via an assertion seam — removing the in-transaction pool acquisition class behind the #1065 deadlock entirely.

## Feature Contracts

Affected contracts:
- [x] Transcript

Evidence:
- The fixture equivalence harness (byte-identical rows after every batch, fold engagement asserted) passes through the partitioned store with per-turn blobs crossing the real []byte boundary; round-trip + version-gate tests updated to the split shape; full backend suite + both migration guards green. Live acceptance post-deploy: disabled_size sessions reseed as v2 and fold (tank_transcript_fold_total{result=folded} > 0 on bgtask traffic) — will verify and note here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)