### PR TITLE
Use per-session NATS auth for runners

### DIFF
--- a/backend-go/cmd/antigravity-runner/main.go
+++ b/backend-go/cmd/antigravity-runner/main.go
@@ -128,6 +128,8 @@ type runnerConfig struct {
 	sessionStorageKey string
 	ownerEmail        string
 	natsURL           string
+	natsUser          string
+	natsPasswordFile  string
 	natsToken         string
 	natsStream        string
 	natsCommandStream string
@@ -1076,6 +1078,8 @@ func loadConfig() (runnerConfig, error) {
 		sessionStorageKey: storageKey,
 		ownerEmail:        strings.ToLower(strings.TrimSpace(os.Getenv("POD_OWNER_EMAIL"))),
 		natsURL:           firstNonEmpty(os.Getenv("NATS_URL"), "nats://tank-nats.nats.svc.cluster.local:4222"),
+		natsUser:          strings.TrimSpace(os.Getenv("NATS_USER")),
+		natsPasswordFile:  strings.TrimSpace(os.Getenv("NATS_PASSWORD_FILE")),
 		natsToken:         strings.TrimSpace(os.Getenv("NATS_TOKEN")),
 		natsStream:        sessionbus.StreamName(os.Getenv("NATS_STREAM")),
 		natsCommandStream: sessionbus.CommandStreamName(os.Getenv("NATS_COMMAND_STREAM")),
@@ -1126,10 +1130,33 @@ func connectNATS(cfg runnerConfig) (*nats.Conn, error) {
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(2 * time.Second),
 	}
+	if cfg.natsUser != "" || cfg.natsPasswordFile != "" {
+		if cfg.natsUser == "" || cfg.natsPasswordFile == "" {
+			return nil, errors.New("NATS_USER and NATS_PASSWORD_FILE must be set together")
+		}
+		password, err := readTrimmedFile(cfg.natsPasswordFile, "NATS_PASSWORD_FILE")
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, nats.UserInfo(cfg.natsUser, password))
+		return nats.Connect(cfg.natsURL, opts...)
+	}
 	if cfg.natsToken != "" {
 		opts = append(opts, nats.Token(cfg.natsToken))
 	}
 	return nats.Connect(cfg.natsURL, opts...)
+}
+
+func readTrimmedFile(path string, label string) (string, error) {
+	value, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("%s read failed: %w", label, err)
+	}
+	trimmed := strings.TrimSpace(string(value))
+	if trimmed == "" {
+		return "", fmt.Errorf("%s is empty", label)
+	}
+	return trimmed, nil
 }
 
 func runDataConsumer(ctx context.Context, js jetstream.JetStream, cfg runnerConfig, builder eventBuilder, publisher func(map[string]any) error, active *activeProcess, state *runnerState, ptmx *os.File) {

--- a/backend-go/cmd/antigravity-runner/main_test.go
+++ b/backend-go/cmd/antigravity-runner/main_test.go
@@ -477,6 +477,39 @@ func TestAgyArgsForConfigPassesSessionModel(t *testing.T) {
 	}
 }
 
+func TestLoadConfigReadsPerSessionNATSAuth(t *testing.T) {
+	t.Setenv("SESSION_ID", "17")
+	t.Setenv("TANK_SESSION_STORAGE_KEY", "slot-a:17")
+	t.Setenv("NATS_URL", "nats://tank-nats.nats.svc.cluster.local:4222")
+	t.Setenv("NATS_USER", "slot-a:17")
+	t.Setenv("NATS_PASSWORD_FILE", "/var/run/secrets/auth.romaine.life/token")
+	t.Setenv("NATS_TOKEN", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.natsUser, "slot-a:17"; got != want {
+		t.Fatalf("natsUser = %q, want %q", got, want)
+	}
+	if got, want := cfg.natsPasswordFile, "/var/run/secrets/auth.romaine.life/token"; got != want {
+		t.Fatalf("natsPasswordFile = %q, want %q", got, want)
+	}
+	if cfg.natsToken != "" {
+		t.Fatalf("natsToken = %q, want empty for per-session auth", cfg.natsToken)
+	}
+}
+
+func TestReadTrimmedFileRejectsEmptyNATSPasswordFile(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readTrimmedFile(tokenFile, "NATS_PASSWORD_FILE"); err == nil {
+		t.Fatal("readTrimmedFile accepted an empty projected token")
+	}
+}
+
 func TestReportRuntimeConfigPostsAppliedModel(t *testing.T) {
 	tokenFile := t.TempDir() + "/token"
 	if err := os.WriteFile(tokenFile, []byte("session-token\n"), 0o600); err != nil {

--- a/backend-go/internal/sessionmodel/sessionmodel.go
+++ b/backend-go/internal/sessionmodel/sessionmodel.go
@@ -1060,15 +1060,8 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			map[string]any{"name": "NATS_URL", "value": opts.NATSURL},
 			map[string]any{"name": "NATS_STREAM", "value": opts.NATSStream},
 			map[string]any{"name": "NATS_COMMAND_STREAM", "value": opts.NATSCommandStream},
-			map[string]any{
-				"name": "NATS_TOKEN",
-				"valueFrom": map[string]any{
-					"secretKeyRef": map[string]any{
-						"name": opts.NATSAuthSecret,
-						"key":  "token",
-					},
-				},
-			},
+			map[string]any{"name": "NATS_USER", "value": storageKey},
+			map[string]any{"name": "NATS_PASSWORD_FILE", "value": "/var/run/secrets/auth.romaine.life/token"},
 			map[string]any{"name": "TANK_OPERATOR_INTERNAL_URL", "value": opts.TankOperatorInternalURL},
 			map[string]any{"name": "TANK_OPERATOR_TOKEN_PATH", "value": "/var/run/secrets/tank-operator/token"},
 			map[string]any{"name": "WORKSPACE", "value": "/workspace"},
@@ -1204,15 +1197,8 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			map[string]any{"name": "NATS_URL", "value": opts.NATSURL},
 			map[string]any{"name": "NATS_STREAM", "value": opts.NATSStream},
 			map[string]any{"name": "NATS_COMMAND_STREAM", "value": opts.NATSCommandStream},
-			map[string]any{
-				"name": "NATS_TOKEN",
-				"valueFrom": map[string]any{
-					"secretKeyRef": map[string]any{
-						"name": opts.NATSAuthSecret,
-						"key":  "token",
-					},
-				},
-			},
+			map[string]any{"name": "NATS_USER", "value": storageKey},
+			map[string]any{"name": "NATS_PASSWORD_FILE", "value": "/var/run/secrets/auth.romaine.life/token"},
 			map[string]any{"name": "TANK_OPERATOR_INTERNAL_URL", "value": opts.TankOperatorInternalURL},
 			map[string]any{"name": "TANK_OPERATOR_TOKEN_PATH", "value": "/var/run/secrets/tank-operator/token"},
 			map[string]any{"name": "WORKSPACE", "value": "/workspace"},
@@ -1326,12 +1312,8 @@ func PodManifest(sessionID, owner, mode string, opts ManifestOptions) map[string
 			map[string]any{"name": "NATS_URL", "value": opts.NATSURL},
 			map[string]any{"name": "NATS_STREAM", "value": opts.NATSStream},
 			map[string]any{"name": "NATS_COMMAND_STREAM", "value": opts.NATSCommandStream},
-			map[string]any{
-				"name": "NATS_TOKEN",
-				"valueFrom": map[string]any{
-					"secretKeyRef": map[string]any{"name": opts.NATSAuthSecret, "key": "token"},
-				},
-			},
+			map[string]any{"name": "NATS_USER", "value": storageKey},
+			map[string]any{"name": "NATS_PASSWORD_FILE", "value": "/var/run/secrets/auth.romaine.life/token"},
 			map[string]any{"name": "TANK_OPERATOR_INTERNAL_URL", "value": opts.TankOperatorInternalURL},
 			map[string]any{"name": "TANK_OPERATOR_TOKEN_PATH", "value": "/var/run/secrets/tank-operator/token"},
 			map[string]any{"name": "WORKSPACE", "value": "/workspace"},

--- a/backend-go/internal/sessionmodel/sessionmodel_test.go
+++ b/backend-go/internal/sessionmodel/sessionmodel_test.go
@@ -622,12 +622,14 @@ func TestPodManifestSDKRunnersReceiveSessionBusEnv(t *testing.T) {
 			if got, want := env["TANK_SESSION_STORAGE_KEY"], "slot-a:12"; got != want {
 				t.Fatalf("TANK_SESSION_STORAGE_KEY = %v, want %q", got, want)
 			}
-			tokenRef := env["NATS_TOKEN"].(map[string]any)["secretKeyRef"].(map[string]any)
-			if got, want := tokenRef["name"], "tank-nats-auth"; got != want {
-				t.Fatalf("NATS_TOKEN secret name = %v, want %q", got, want)
+			if _, present := env["NATS_TOKEN"]; present {
+				t.Fatalf("runner env includes NATS_TOKEN; session pods must use per-session NATS auth")
 			}
-			if got, want := tokenRef["key"], "token"; got != want {
-				t.Fatalf("NATS_TOKEN secret key = %v, want %q", got, want)
+			if got, want := env["NATS_USER"], "slot-a:12"; got != want {
+				t.Fatalf("NATS_USER = %v, want %q", got, want)
+			}
+			if got, want := env["NATS_PASSWORD_FILE"], "/var/run/secrets/auth.romaine.life/token"; got != want {
+				t.Fatalf("NATS_PASSWORD_FILE = %v, want %q", got, want)
 			}
 			if got, want := env["TANK_OPERATOR_INTERNAL_URL"], "http://tank-operator.tank-operator.svc.cluster.local"; got != want {
 				t.Fatalf("TANK_OPERATOR_INTERNAL_URL = %v, want %q", got, want)

--- a/claude-runner/src/config.ts
+++ b/claude-runner/src/config.ts
@@ -8,6 +8,8 @@ export interface Config {
   sessionStorageKey: string;
   ownerEmail: string;
   natsURL: string;
+  natsUser?: string;
+  natsPasswordFile?: string;
   natsToken: string;
   natsStream: string;
   natsCommandStream: string;
@@ -33,6 +35,8 @@ export function loadConfig(): Config {
     sessionStorageKey: process.env.TANK_SESSION_STORAGE_KEY?.trim() || sessionId,
     ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
     natsURL,
+    natsUser: process.env.NATS_USER?.trim() || "",
+    natsPasswordFile: process.env.NATS_PASSWORD_FILE?.trim() || "",
     natsToken: process.env.NATS_TOKEN?.trim() || "",
     natsStream: process.env.NATS_STREAM?.trim() || "TANK_SESSION_BUS",
     natsCommandStream: process.env.NATS_COMMAND_STREAM?.trim() || "TANK_SESSION_COMMANDS",

--- a/claude-runner/src/sessionBus.test.ts
+++ b/claude-runner/src/sessionBus.test.ts
@@ -8,6 +8,9 @@
 // silence on our own graceful close), and the /healthz liveness signal.
 
 import { strict as assert } from "node:assert";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import { SharedSessionBus } from "../../runner-shared/sessionBus.js";
@@ -141,6 +144,45 @@ void test("connect hardens reconnection: unlimited attempts, waitOnFirstConnect"
   assert.equal(state.connectOptions?.waitOnFirstConnect, true);
   await stop();
   await bus.close();
+});
+
+void test("connect uses per-session user and projected token file authenticator", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tank-nats-auth-"));
+  const tokenPath = join(dir, "token");
+  await writeFile(tokenPath, "projected-token\n", { mode: 0o600 });
+  const { deps, state } = fakeDeps({ iterators: [blockingIterator([])] });
+  const cfg = {
+    ...busConfig(),
+    natsToken: "",
+    natsUser: "slot-a:63",
+    natsPasswordFile: tokenPath,
+  };
+  const bus = new SharedSessionBus(cfg as never, "claude", deps as never);
+  const stop = await bus.startCommandConsumer(async () => {}, undefined as never);
+  assert.equal(state.connectOptions?.token, undefined);
+  assert.equal(typeof state.connectOptions?.authenticator, "function");
+  const authenticator = state.connectOptions?.authenticator as () => AnyRecord;
+  assert.deepEqual(authenticator(), {
+    user: "slot-a:63",
+    pass: "projected-token",
+  });
+  await stop();
+  await bus.close();
+});
+
+void test("connect rejects partial per-session NATS auth config", async () => {
+  const { deps } = fakeDeps({ iterators: [blockingIterator([])] });
+  const cfg = {
+    ...busConfig(),
+    natsToken: "",
+    natsUser: "slot-a:63",
+    natsPasswordFile: "",
+  };
+  const bus = new SharedSessionBus(cfg as never, "claude", deps as never);
+  await assert.rejects(
+    () => bus.startCommandConsumer(async () => {}, undefined as never),
+    /NATS_USER and NATS_PASSWORD_FILE must be set together/,
+  );
 });
 
 void test("supervised consumer restarts after iterator death and redelivers", async () => {

--- a/codex-runner/src/config.ts
+++ b/codex-runner/src/config.ts
@@ -11,6 +11,8 @@ export interface Config {
   sessionStorageKey: string;
   ownerEmail: string;
   natsURL: string;
+  natsUser?: string;
+  natsPasswordFile?: string;
   natsToken: string;
   natsStream: string;
   natsCommandStream: string;
@@ -35,6 +37,8 @@ export function loadConfig(): Config {
     sessionStorageKey: process.env.TANK_SESSION_STORAGE_KEY?.trim() || sessionId,
     ownerEmail: (process.env.POD_OWNER_EMAIL ?? "").trim().toLowerCase(),
     natsURL,
+    natsUser: process.env.NATS_USER?.trim() || "",
+    natsPasswordFile: process.env.NATS_PASSWORD_FILE?.trim() || "",
     natsToken: process.env.NATS_TOKEN?.trim() || "",
     natsStream: process.env.NATS_STREAM?.trim() || "TANK_SESSION_BUS",
     natsCommandStream: process.env.NATS_COMMAND_STREAM?.trim() || "TANK_SESSION_COMMANDS",

--- a/docs/features/agent-runners/capabilities.md
+++ b/docs/features/agent-runners/capabilities.md
@@ -623,6 +623,56 @@ Pre-deploy session pods keep the mortal behavior until they are recycled
 contract). No wire shape changed: subjects, durable names, and consumer
 configs are identical, so old and new runners coexist freely.
 
+## Per-session NATS runner credentials
+
+Status: in progress (stage 3 implemented; stage 4 blocked on legacy-flatline)
+
+Intent:
+Session pods must not share a fleet-wide NATS token. The NATS bus carries
+durable turn commands, interrupts, input replies, and runner-produced events; a
+shared token lets any compromised pod forge another session's command/event
+traffic. New GUI session pods authenticate to NATS through auth_callout using
+their projected `auth.romaine.life` audience service-account token, and receive
+permissions scoped to their own session subjects.
+
+Affected contracts:
+- Agent Runners
+- Auth And Streams
+- Observability
+
+Contract impact:
+- Claude, Codex, and Antigravity runner sidecars receive
+  `NATS_USER=<session storage key>` and
+  `NATS_PASSWORD_FILE=/var/run/secrets/auth.romaine.life/token`; they no
+  longer mount `tank-nats-auth` as `NATS_TOKEN`.
+- The NATS auth-callout validates the projected token via TokenReview, reads
+  the orchestrator-written pod labels, equality-checks the claimed storage key,
+  and returns a NATS user JWT scoped to that session's event subject and command
+  consumers.
+- JavaScript runners use the NATS authenticator hook and read the projected
+  token file during auth, so reconnects can observe Kubernetes token rotation.
+  Antigravity's Go runner reads the projected token file at boot/connect and
+  relies on the existing permanent-close container restart path if auth is
+  later revoked.
+- Stage 4 is not optional: after
+  `tank_nats_auth_callout_total{result="legacy"}` stays flat for a full
+  pre-stage-3 pod-age window, remove `NATS_CALLOUT_LEGACY_TOKEN` and the
+  session-namespace `tank-nats-auth` ExternalSecret. Until then the legacy grant
+  exists only to avoid breaking live pre-stage-3 pods.
+
+Evidence:
+- Manifest: `backend-go/internal/sessionmodel/sessionmodel_test.go`
+  (`TestPodManifestSDKRunnersReceiveSessionBusEnv`) asserts runner sidecars get
+  `NATS_USER` / `NATS_PASSWORD_FILE` and no `NATS_TOKEN`.
+- JavaScript runner: `claude-runner/src/sessionBus.test.ts`
+  (`connect uses per-session user and projected token file authenticator`) pins
+  file-backed user/pass auth.
+- Antigravity runner: `backend-go/cmd/antigravity-runner/main_test.go`
+  (`TestLoadConfigReadsPerSessionNATSAuth`,
+  `TestReadTrimmedFileRejectsEmptyNATSPasswordFile`).
+- Migration guard: `scripts/check-removed-chat-runtime.mjs` blocks reintroducing
+  shared `NATS_TOKEN` injection into session runner envs.
+
 ## Runner correctness cluster (issue #1078)
 
 - **Status:** shipped

--- a/docs/session-bus-auth.md
+++ b/docs/session-bus-auth.md
@@ -64,10 +64,14 @@ safe.
    The orchestrator deployment simultaneously gains `NATS_USER`; session
    pods (legacy token) now authenticate THROUGH the callout's legacy grant.
    Watch `tank_nats_auth_callout_total{result="legacy"}` count the fleet.
-3. **Flip session credentials** — `sessionmodel.go` injects the storage key
-   + SA-token path instead of `NATS_TOKEN`; runners send user/pass. New
-   pods only (migration policy, pre-deploy-pod clause); old pods keep
-   working via the legacy grant for ≤7d (idle reaper bound).
+3. **Flip session credentials** — `sessionmodel.go` injects `NATS_USER`
+   (the storage key) + `NATS_PASSWORD_FILE` (the projected
+   auth.romaine.life-audience SA token path) instead of `NATS_TOKEN`;
+   runners send user/pass. JavaScript runners read the password file from
+   the NATS authenticator so reconnects see token rotation; Antigravity's
+   Go runner exits/restarts on permanent auth closure and reads the file on
+   boot. New pods only (migration policy, pre-deploy-pod clause); old pods
+   keep working via the legacy grant for ≤7d (idle reaper bound).
 4. **Drop the legacy grant** once `legacy` flatlines: remove
    `NATS_CALLOUT_LEGACY_TOKEN` from the callout deployment and delete the
    `tank-nats-auth` ExternalSecret from the sessions namespace. This is the

--- a/runner-shared/sessionBus.d.ts
+++ b/runner-shared/sessionBus.d.ts
@@ -9,6 +9,8 @@ export interface SessionBusConfig {
   sessionStorageKey?: string;
   ownerEmail: string;
   natsURL: string;
+  natsUser?: string;
+  natsPasswordFile?: string;
   natsToken?: string;
   natsStream: string;
   operatorInternalURL: string;

--- a/runner-shared/sessionBus.js
+++ b/runner-shared/sessionBus.js
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 
 export const SESSION_COMMAND_ACK_MS = parsePositiveInt(process.env.SESSION_COMMAND_ACK_MS, 120_000);
@@ -290,9 +291,10 @@ export class SharedSessionBus {
         if (this.nc && this.js && this.jsm) return;
         const servers = this.cfg.natsURL || process.env.NATS_URL;
         if (!servers) throw new Error("NATS_URL is required");
+        const auth = natsAuthOptions(this.cfg);
         this.nc = await this.deps.connect({
             servers,
-            token: this.cfg.natsToken || process.env.NATS_TOKEN,
+            ...auth,
             name: this.runnerID,
             // Reconnect FOREVER. The client default (10 attempts x 2s) made
             // every runner mortal: a NATS outage longer than ~25 seconds
@@ -446,6 +448,36 @@ export class SharedSessionBus {
             runtime: this.provider,
             written_at: typeof event.written_at === "string" ? event.written_at : new Date().toISOString(),
         };
+    }
+}
+
+function natsAuthOptions(cfg) {
+    const user = String(cfg.natsUser || process.env.NATS_USER || "").trim();
+    const passwordFile = String(cfg.natsPasswordFile || process.env.NATS_PASSWORD_FILE || "").trim();
+    if ((user && !passwordFile) || (!user && passwordFile)) {
+        throw new Error("NATS_USER and NATS_PASSWORD_FILE must be set together");
+    }
+    if (user && passwordFile) {
+        return {
+            authenticator: () => ({
+                user,
+                pass: readTrimmedFile(passwordFile, "NATS_PASSWORD_FILE"),
+            }),
+        };
+    }
+    const token = String(cfg.natsToken || process.env.NATS_TOKEN || "").trim();
+    if (token) return { token };
+    return {};
+}
+
+function readTrimmedFile(path, label) {
+    try {
+        const value = readFileSync(path, "utf8").trim();
+        if (!value) throw new Error(`${label} is empty`);
+        return value;
+    }
+    catch (err) {
+        throw new Error(`${label} read failed: ${errorText(err)}`);
     }
 }
 

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -350,6 +350,15 @@ const blocked = [
   { name: "removed INTERNAL_API_ALLOWED_SUBJECTS env var", pattern: /\bINTERNAL_API_ALLOWED_SUBJECTS\b/ },
   { name: "removed parseInternalSubjects helper", pattern: /\bparseInternalSubjects\b/ },
   { name: "removed internalAllowedSubjects field", pattern: /\binternalAllowedSubjects\b/ },
+  // tank-operator#1128 stage 3: GUI session runner sidecars authenticate
+  // to NATS through auth_callout with NATS_USER=<storage key> and
+  // NATS_PASSWORD_FILE=<projected auth.romaine.life SA token>. The shared
+  // tank-nats-auth token remains only for orchestrator/callout bootstrap and
+  // pre-stage-3 pods aging out through the callout's transition grant.
+  {
+    name: "removed shared NATS token injection into session runner env",
+    pattern: /(runnerEnv|codexRunnerEnv|antigravityRunnerEnv)[\s\S]{0,600}"name":\s*"NATS_TOKEN"/,
+  },
   // Turn-complete sound was per-pane (declared inside ChatPane in
   // App.tsx) before the cutover that moved it onto the always-on
   // /api/sessions/events SSE consumer. The per-pane shape was the


### PR DESCRIPTION
## Summary

- Finish #1128 stage 3 by removing shared `NATS_TOKEN` injection from GUI session runner sidecars.
- New Claude/Codex/Antigravity session pods authenticate to NATS with `NATS_USER=<session storage key>` and `NATS_PASSWORD_FILE=/var/run/secrets/auth.romaine.life/token` through the existing auth_callout path.
- Add runner tests, docs, capability ledger, and a migration guard so the shared-token runner env path cannot silently return.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [x] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- Agent Runners: `TestPodManifestSDKRunnersReceiveSessionBusEnv` now asserts runner sidecars receive `NATS_USER` / `NATS_PASSWORD_FILE` and no `NATS_TOKEN`; Claude shared-runner test pins file-backed NATS authenticator; Antigravity tests pin per-session auth config and empty projected-token rejection.
- Auth And Streams: session runner auth now uses the projected `auth.romaine.life` audience service-account token path instead of the fleet token; JS reconnect auth reads the file via the NATS authenticator hook so token rotation is observed on auth attempts.
- Observability: `docs/features/agent-runners/capabilities.md` records the capability and explicitly gates stage 4 on `tank_nats_auth_callout_total{result="legacy"}` flatlining; `scripts/check-removed-chat-runtime.mjs` blocks reintroducing shared `NATS_TOKEN` injection into session runner envs.
- Local checks run: `npm --prefix claude-runner run build && npm --prefix claude-runner test`; `npm --prefix codex-runner run build && npm --prefix codex-runner test`; `node scripts/check-removed-chat-runtime.mjs`.
- Local checks not run: Go tests and Helm render, because this Windows desktop environment has no `go` or `helm` executable on PATH. CI is expected to cover these before merge.
