### PR TITLE
Use named NATS user for orchestrator

### DIFF
--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -323,7 +323,7 @@ sessionBus:
   tokenKvKey: tank-nats-token
   # 1128 stage 2: set to "tank-operator" together with infra-bootstrap's
   # NATS authorization.users flip. Empty = legacy bare-token auth.
-  user: ""
+  user: tank-operator
   monitorURLs:
     - http://tank-nats-0.tank-nats-headless.nats.svc.cluster.local:8222
     - http://tank-nats-1.tank-nats-headless.nats.svc.cluster.local:8222


### PR DESCRIPTION
## Summary

- Complete the #1128 stage-2 chart flip for the orchestrator by setting `sessionBus.user: tank-operator`.
- The backend already supports `NATS_USER` as static user/password auth with `NATS_TOKEN` as the password; this moves orchestrator connections out of the auth_callout legacy-token path and into the `auth_users` exemption configured in NATS.
- Does not change NATS server config and does not affect session pods.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [ ] Session Lifecycle
- [x] Agent Runners
- [x] Auth And Streams
- [ ] Artifacts And Files
- [x] Observability
- [ ] None

Evidence:
- Agent Runners/Auth And Streams: `backend-go/internal/sessionbus.Config.User` and `buildSessionBus` already route non-empty `NATS_USER` to `nats.UserInfo(user, NATS_TOKEN)`; this chart value renders that env as `tank-operator`, matching the NATS `auth_users` exemption deployed in infra-bootstrap.
- Observability: live NATS `connz` before this PR showed `tank-operator` connections still counted as `legacy-shared-token`; after deploy, `connz` should show the orchestrator as `tank-operator`, leaving only pre-stage-3 session pods/slot pods on the transition grant.
- Local checks run: `node scripts/check-removed-chat-runtime.mjs`, `git diff --check`.
- Local checks not run: `helm template`, because this Windows desktop environment has no `helm` executable on PATH. CI must render/check the chart before merge.
