### PR TITLE
Align NATS callout token audience

### DIFF
--- a/backend-go/cmd/nats-auth-callout/callout.go
+++ b/backend-go/cmd/nats-auth-callout/callout.go
@@ -1,7 +1,8 @@
 // nats-auth-callout is the per-session NATS credential issuer
 // (tank-operator#1128). Session pods stop sharing one fleet-wide NATS token;
 // each pod authenticates with its projected ServiceAccount token (audience
-// auth.romaine.life — the same trust root as the MCP gateway) and receives a
+// https://auth.romaine.life — the same platform audience used by the
+// auth.romaine.life exchange path and MCP gateway) and receives a
 // NATS user JWT whose permissions cover exactly its own session's subjects:
 //
 //   - publish tank.session.<scope>.<sid>.events       (event ledger ingress)

--- a/backend-go/cmd/nats-auth-callout/main.go
+++ b/backend-go/cmd/nats-auth-callout/main.go
@@ -27,6 +27,11 @@ import (
 // requests when authorization.auth_callout is configured.
 const natsAuthCalloutSubject = "$SYS.REQ.USER.AUTH"
 
+// defaultTokenAudience is the platform service-account token audience used
+// by auth.romaine.life's exchange path. NATS auth intentionally validates the
+// same audience instead of inventing a parallel NATS-only audience.
+const defaultTokenAudience = "https://auth.romaine.life"
+
 var calloutAuthTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "tank_nats_auth_callout_total",
 	Help: "NATS auth-callout outcomes: session (per-session JWT issued), legacy (shared-token transition grant), denied_*, error.",
@@ -131,7 +136,7 @@ func main() {
 		account: natsGlobalAccount,
 		resolver: &k8sSessionResolver{
 			client:            client,
-			audience:          env("NATS_CALLOUT_TOKEN_AUDIENCE", "auth.romaine.life"),
+			audience:          env("NATS_CALLOUT_TOKEN_AUDIENCE", defaultTokenAudience),
 			sessionsNamespace: requiredEnv("NATS_CALLOUT_SESSIONS_NAMESPACE"),
 			serviceAccount:    env("NATS_CALLOUT_SESSION_SERVICE_ACCOUNT", "claude-session"),
 		},

--- a/backend-go/cmd/nats-auth-callout/main_test.go
+++ b/backend-go/cmd/nats-auth-callout/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestDefaultTokenAudienceMatchesPlatformAudience(t *testing.T) {
+	if got, want := defaultTokenAudience, "https://auth.romaine.life"; got != want {
+		t.Fatalf("defaultTokenAudience = %q, want %q", got, want)
+	}
+}

--- a/docs/features/agent-runners/capabilities.md
+++ b/docs/features/agent-runners/capabilities.md
@@ -632,8 +632,8 @@ Session pods must not share a fleet-wide NATS token. The NATS bus carries
 durable turn commands, interrupts, input replies, and runner-produced events; a
 shared token lets any compromised pod forge another session's command/event
 traffic. New GUI session pods authenticate to NATS through auth_callout using
-their projected `auth.romaine.life` audience service-account token, and receive
-permissions scoped to their own session subjects.
+their projected `https://auth.romaine.life` audience service-account token,
+and receive permissions scoped to their own session subjects.
 
 Affected contracts:
 - Agent Runners

--- a/docs/session-bus-auth.md
+++ b/docs/session-bus-auth.md
@@ -19,8 +19,9 @@ static `auth_users` entry to `$SYS.REQ.USER.AUTH`. The
 account nkey:
 
 - **Session pods** connect with `user=<storage key>`, `pass=<projected SA
-  token>` (audience `auth.romaine.life` — the MCP-gateway trust root). The
-  callout validates the token via audience-pinned `TokenReview`, takes the
+  token>` (audience `https://auth.romaine.life` — the same platform audience
+  used by auth.romaine.life's exchange path and the MCP gateway). The callout
+  validates the token via audience-pinned `TokenReview`, takes the
   **bound pod name from the token's claims**, reads the pod's
   orchestrator-written labels (`tank-operator/session-id`, `-scope`), and
   issues permissions for exactly that session:


### PR DESCRIPTION
## Summary
- align the NATS auth-callout TokenReview default audience with the existing platform service-account audience: `https://auth.romaine.life`
- keep session runner pods on the existing `/var/run/secrets/auth.romaine.life/token` path instead of adding a NATS-specific projected token
- update session-bus auth docs and add a regression test for the platform audience default

## Root Cause
New runner pods were already mounting the correct platform identity token at `/var/run/secrets/auth.romaine.life/token`. That projected token has audience `https://auth.romaine.life`, matching the identity-provider exchange path. The NATS auth-callout was validating `auth.romaine.life` by default instead, so Kubernetes TokenReview rejected the token before the callout could authorize the session. Runner logs showed `Authorization Violation`, and submitted turns stayed stuck.

## Feature Contracts
Affected contracts:
- [x] Agent Runners

Evidence:
- `backend-go/cmd/nats-auth-callout/main_test.go` pins the callout default audience to `https://auth.romaine.life`.
- `docs/session-bus-auth.md` and `docs/features/agent-runners/capabilities.md` now document that NATS uses the same platform audience, not a parallel NATS-only audience.
- `node scripts/check-removed-chat-runtime.mjs` passes.

## Tests
- `node scripts/check-removed-chat-runtime.mjs`
- `git diff --check origin/main...HEAD`
- PR CI: Go backend passed on the corrected branch.