### PR TITLE
Expose soft-deleted session recovery metadata

### DIFF
--- a/backend-go/cmd/tank-operator/handlers_debug_session_list.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_list.go
@@ -69,31 +69,47 @@ func (s *appServer) handleDebugSessionListState(w http.ResponseWriter, r *http.R
 	writeJSON(w, http.StatusOK, out)
 }
 
-// debugRowJSON is a compact, sidebar-relevant projection. Drops the
+// debugRowJSON is a compact, recovery-relevant projection. Drops the
 // activity_summary and test/rollout blobs to keep the response
-// scannable; the operator can re-query the registry directly for
-// those if needed.
+// scannable, but keeps the durable create-time run configuration so
+// an operator can recreate a soft-deleted session without direct
+// database credentials.
 func debugRowJSON(record sessionmodel.SessionRecord) map[string]any {
 	return map[string]any{
-		"id":               record.ID,
-		"mode":             record.Mode,
-		"pod_name":         record.PodName,
-		"name":             record.Name,
-		"visible":          record.Visible,
-		"status":           record.Status,
-		"requested_at":     record.RequestedAt,
-		"created_at":       record.CreatedAt,
-		"updated_at":       record.UpdatedAt,
-		"ready_at":         record.ReadyAt,
-		"terminating_at":   record.TerminatingAt,
-		"agent_avatar_id":  record.AgentAvatarID,
-		"system_avatar_id": record.SystemAvatarID,
-		"sidebar_position": record.SidebarPosition,
-		"row_version":      record.RowVersion,
-		"has_activity":     len(record.ActivitySummary) > 0,
-		"has_test_state":   record.TestState != nil,
-		"has_rollout":      record.RolloutState != nil,
+		"id":                    record.ID,
+		"mode":                  record.Mode,
+		"pod_name":              record.PodName,
+		"name":                  record.Name,
+		"visible":               record.Visible,
+		"status":                record.Status,
+		"requested_at":          record.RequestedAt,
+		"created_at":            record.CreatedAt,
+		"updated_at":            record.UpdatedAt,
+		"ready_at":              record.ReadyAt,
+		"terminating_at":        record.TerminatingAt,
+		"repos":                 nonNilStrings(record.Repos),
+		"capabilities":          nonNilStrings(record.Capabilities),
+		"model":                 record.Model,
+		"effort":                record.Effort,
+		"runtime_model":         record.RuntimeModel,
+		"runtime_effort":        record.RuntimeEffort,
+		"runtime_configured_at": record.RuntimeConfiguredAt,
+		"agent_avatar_id":       record.AgentAvatarID,
+		"system_avatar_id":      record.SystemAvatarID,
+		"sidebar_position":      record.SidebarPosition,
+		"row_version":           record.RowVersion,
+		"has_activity":          len(record.ActivitySummary) > 0,
+		"has_clone_state":       record.CloneState != nil,
+		"has_test_state":        record.TestState != nil,
+		"has_rollout":           record.RolloutState != nil,
 	}
+}
+
+func nonNilStrings(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
 }
 
 func sliceMap[T, R any](in []T, fn func(T) R) []R {

--- a/backend-go/cmd/tank-operator/handlers_debug_session_list_test.go
+++ b/backend-go/cmd/tank-operator/handlers_debug_session_list_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/romaine-life/tank-operator/backend-go/internal/auth"
+	"github.com/romaine-life/tank-operator/backend-go/internal/sessionmodel"
 )
 
 func TestDebugSessionListStateAdminGate(t *testing.T) {
@@ -48,4 +49,49 @@ func TestDebugSessionListStateAdminGate(t *testing.T) {
 			t.Fatalf("status = %d body = %s", resp.Code, resp.Body.String())
 		}
 	})
+}
+
+func TestDebugRowJSONCarriesRecoveryRunConfig(t *testing.T) {
+	row := debugRowJSON(sessionmodel.SessionRecord{
+		ID:                  "851",
+		Mode:                sessionmodel.CodexGUIMode,
+		PodName:             "session-851",
+		Name:                "Investigate NATS session freeze",
+		Visible:             false,
+		Status:              "Terminated",
+		Repos:               []string{"romaine-life/tank-operator"},
+		Capabilities:       []string{sessionmodel.SessionCapabilitySpireLensMCP},
+		Model:               "gpt-5.5",
+		Effort:              "xhigh",
+		RuntimeModel:        "gpt-5.5",
+		RuntimeEffort:       "xhigh",
+		RuntimeConfiguredAt: "2026-06-13T01:02:03Z",
+		CloneState:          map[string]any{"romaine-life/tank-operator": "ok"},
+	})
+
+	assertDebugRowField(t, row, "visible", false)
+	assertDebugRowField(t, row, "mode", sessionmodel.CodexGUIMode)
+	assertDebugRowField(t, row, "name", "Investigate NATS session freeze")
+	assertDebugRowField(t, row, "model", "gpt-5.5")
+	assertDebugRowField(t, row, "effort", "xhigh")
+	assertDebugRowField(t, row, "runtime_model", "gpt-5.5")
+	assertDebugRowField(t, row, "runtime_effort", "xhigh")
+	assertDebugRowField(t, row, "runtime_configured_at", "2026-06-13T01:02:03Z")
+	assertDebugRowField(t, row, "has_clone_state", true)
+
+	repos, ok := row["repos"].([]string)
+	if !ok || len(repos) != 1 || repos[0] != "romaine-life/tank-operator" {
+		t.Fatalf("repos = %#v, want selected repo slug", row["repos"])
+	}
+	capabilities, ok := row["capabilities"].([]string)
+	if !ok || len(capabilities) != 1 || capabilities[0] != sessionmodel.SessionCapabilitySpireLensMCP {
+		t.Fatalf("capabilities = %#v, want selected capability", row["capabilities"])
+	}
+}
+
+func assertDebugRowField(t *testing.T, row map[string]any, key string, want any) {
+	t.Helper()
+	if got := row[key]; got != want {
+		t.Fatalf("%s = %#v, want %#v", key, got, want)
+	}
 }

--- a/docs/features/session-lifecycle/capabilities.md
+++ b/docs/features/session-lifecycle/capabilities.md
@@ -3,6 +3,41 @@
 This ledger names session lifecycle behavior that crosses browser,
 orchestrator, database, and pod boundaries.
 
+## Soft-Deleted Session Recovery Metadata
+
+Status: in progress
+
+Intent:
+Let an admin or support agent recover the durable create-time shape of a
+soft-deleted session without direct Postgres credentials. Soft deletion is a
+sidebar tombstone, not a loss of registry metadata needed to understand or
+recreate the session.
+
+Affected contracts:
+- Session Lifecycle
+- Session Bar
+- Auth And Streams
+
+Contract impact:
+- Normal `/api/sessions` and `/api/sessions/{id}` continue to hide
+  `visible=false` rows because the product sidebar should not reopen deleted
+  sessions.
+- Admin-only `/api/debug/session-list-state` includes invisible rows for one
+  bounded owner/scope and carries the durable recreate inputs: `mode`, `name`,
+  `repos`, `capabilities`, `model`, and `effort`, plus runner-reported
+  `runtime_model`/`runtime_effort` for verification.
+- Recovery does not require browser devtools, raw database credentials, or a
+  second partial endpoint. The debug surface reads the same durable sessions
+  row that drives session-list catch-up and exposes only bounded row metadata,
+  not transcript contents or provider credentials.
+
+Evidence:
+- `backend-go/cmd/tank-operator/handlers_debug_session_list_test.go`
+  (`TestDebugRowJSONCarriesRecoveryRunConfig`) covers invisible-row recovery
+  metadata.
+- `backend-go/cmd/tank-operator/handlers_debug_session_list_test.go`
+  (`TestDebugSessionListStateAdminGate`) covers the admin/service-admin gate.
+
 ## Tank-Owned Session Run Options
 
 Status: complete


### PR DESCRIPTION
## Summary

- Extend the admin-only session-list debug row projection with soft-deleted session recovery metadata: repos, capabilities, model, effort, and runner-reported runtime config.
- Document the recovery metadata capability so future incident work does not require direct Postgres credentials for this case.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [x] Session Bar
- [x] Session Lifecycle
- [ ] Agent Runners
- [x] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- backend-go/cmd/tank-operator/handlers_debug_session_list_test.go::TestDebugRowJSONCarriesRecoveryRunConfig covers invisible-row recovery metadata on the admin debug projection.
- backend-go/cmd/tank-operator/handlers_debug_session_list_test.go::TestDebugSessionListStateAdminGate covers human admin and service-admin access to the debug surface.
- git diff --check HEAD passed locally.
- Local Go tooling was unavailable in this Windows shell (go/gofmt not on PATH), so Go test execution is left to PR CI.