### PR TITLE
Revert premature NATS legacy grant cleanup

### DIFF
--- a/backend-go/cmd/nats-auth-callout/callout.go
+++ b/backend-go/cmd/nats-auth-callout/callout.go
@@ -16,14 +16,17 @@
 // orchestrator-written labels (tank-operator/session-id, -scope). A pod can
 // only ever get permissions for the session the orchestrator bound it to.
 //
-// The orchestrator itself is a static auth_users entry in the NATS server
-// config and never reaches this service — a callout outage therefore cannot
-// take down the command plane, only delay NEW session pods' connections
-// (JetStream redelivers).
+// Transition (#1128 staging): legacy pods that still present the shared
+// fleet token are granted unrestricted permissions here, preserving the
+// pre-callout behavior until they age out; the orchestrator itself is a
+// static auth_users entry in the NATS server config and never reaches this
+// service — a callout outage therefore cannot take down the command plane,
+// only delay NEW session pods' connections (JetStream redelivers).
 package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -53,6 +56,11 @@ type calloutService struct {
 	// runs everything in the global account.
 	account  string
 	resolver sessionResolver
+	// legacyToken, when non-empty, grants pre-#1128 unrestricted
+	// permissions to clients presenting the shared fleet token — the
+	// migration policy's pre-deploy-pod clause: existing pods hold that
+	// token until they age out.
+	legacyToken string
 	// commandStream is the WorkQueue stream carrying session commands.
 	commandStream string
 	// providers whose per-session durables a session pod may own. The
@@ -95,6 +103,23 @@ func (s *calloutService) Handle(ctx context.Context, requestJWT []byte) ([]byte,
 			return nil, fmt.Errorf("encode authorization response: %w", err)
 		}
 		return []byte(encoded), nil
+	}
+
+	// Transition arm: the shared fleet token, presented either via the
+	// dedicated token field (nats.Token / nats.js token:) or as a bare
+	// password, keeps unrestricted permissions until pre-#1128 pods age out.
+	presented := strings.TrimSpace(req.ConnectOptions.Token)
+	if presented == "" && strings.TrimSpace(req.ConnectOptions.Username) == "" {
+		presented = strings.TrimSpace(req.ConnectOptions.Password)
+	}
+	if s.legacyToken != "" && presented != "" &&
+		subtle.ConstantTimeCompare([]byte(presented), []byte(s.legacyToken)) == 1 {
+		userJWT, err := s.legacyUserJWT(req)
+		if err != nil {
+			return respond("", "legacy user issuance failed")
+		}
+		recordCalloutAuth("legacy")
+		return respond(userJWT, "")
 	}
 
 	saToken := strings.TrimSpace(req.ConnectOptions.Password)
@@ -158,6 +183,17 @@ func (s *calloutService) sessionUserJWT(req *jwt.AuthorizationRequestClaims, sto
 	uc.Permissions.Pub.Allow.Add(pub...)
 	// JS API replies and pull deliveries arrive on the client's inbox.
 	uc.Permissions.Sub.Allow.Add("_INBOX.>")
+	return uc.Encode(s.issuer)
+}
+
+// legacyUserJWT preserves pre-callout behavior for the shared fleet token.
+func (s *calloutService) legacyUserJWT(req *jwt.AuthorizationRequestClaims) (string, error) {
+	uc := jwt.NewUserClaims(req.UserNkey)
+	uc.Name = "legacy-shared-token"
+	uc.Audience = s.account
+	uc.Expires = s.now().Add(s.userTTL).Unix()
+	uc.Permissions.Pub.Allow.Add(">")
+	uc.Permissions.Sub.Allow.Add(">")
 	return uc.Encode(s.issuer)
 }
 

--- a/backend-go/cmd/nats-auth-callout/callout_test.go
+++ b/backend-go/cmd/nats-auth-callout/callout_test.go
@@ -42,7 +42,10 @@ func (s *stubResolver) SessionStorageKeyForPod(_ context.Context, podName string
 	return key, nil
 }
 
-const testCalloutPass = "callout-pw"
+const (
+	testLegacyToken = "legacy-fleet-token"
+	testCalloutPass = "callout-pw"
+)
 
 // startCalloutServer runs an embedded nats-server with auth_callout enabled
 // and the callout service subscribed — the REAL authorization path end to
@@ -123,6 +126,7 @@ func testService(t *testing.T) *calloutService {
 			tokens: map[string]string{"sa-token-864": "session-pod-864"},
 			pods:   map[string]string{"session-pod-864": "864"},
 		},
+		legacyToken:   testLegacyToken,
 		commandStream: defaultCommandStream,
 		providers:     defaultProviders,
 		userTTL:       time.Hour,
@@ -232,6 +236,33 @@ func TestSessionPodCannotSubscribeToOtherSubjects(t *testing.T) {
 	}
 }
 
+func TestLegacySharedTokenKeepsFullAccess(t *testing.T) {
+	svc := testService(t)
+	_, url := startCalloutServer(t, svc)
+
+	// Old pods present the fleet token via the token field (nats.Token /
+	// nats.js token:) with no username.
+	nc, err := nats.Connect(url, nats.Token(testLegacyToken))
+	if err != nil {
+		t.Fatalf("legacy pod connect: %v", err)
+	}
+	defer nc.Close()
+	errs := permissionErrors(t, nc)
+
+	if err := nc.Publish(sessionbus.SessionEventSubject("864"), []byte("{}")); err != nil {
+		t.Fatalf("legacy publish: %v", err)
+	}
+	if err := nc.Publish(sessionbus.SessionEventSubject("865"), []byte("{}")); err != nil {
+		t.Fatalf("legacy publish: %v", err)
+	}
+	if _, err := nc.SubscribeSync("tank.session.>"); err != nil {
+		t.Fatalf("legacy subscribe: %v", err)
+	}
+	if violations := errs(); len(violations) != 0 {
+		t.Fatalf("legacy token must keep pre-callout access, got: %v", violations)
+	}
+}
+
 func TestUnknownCredentialsAreRejected(t *testing.T) {
 	svc := testService(t)
 	_, url := startCalloutServer(t, svc)
@@ -239,8 +270,8 @@ func TestUnknownCredentialsAreRejected(t *testing.T) {
 	if _, err := nats.Connect(url, nats.UserInfo("864", "wrong-token")); err == nil {
 		t.Fatalf("bad SA token must be rejected at connect")
 	}
-	if _, err := nats.Connect(url, nats.Token("shared-fleet-token")); err == nil {
-		t.Fatalf("bare shared token must be rejected at connect")
+	if _, err := nats.Connect(url, nats.Token("not-the-fleet-token")); err == nil {
+		t.Fatalf("bad legacy token must be rejected at connect")
 	}
 	if _, err := nats.Connect(url); err == nil {
 		t.Fatalf("credential-less connect must be rejected")

--- a/backend-go/cmd/nats-auth-callout/main.go
+++ b/backend-go/cmd/nats-auth-callout/main.go
@@ -34,7 +34,7 @@ const defaultTokenAudience = "https://auth.romaine.life"
 
 var calloutAuthTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "tank_nats_auth_callout_total",
-	Help: "NATS auth-callout outcomes: session (per-session JWT issued), denied_*, error.",
+	Help: "NATS auth-callout outcomes: session (per-session JWT issued), legacy (shared-token transition grant), denied_*, error.",
 }, []string{"result"})
 
 func recordCalloutAuth(result string) {
@@ -140,6 +140,7 @@ func main() {
 			sessionsNamespace: requiredEnv("NATS_CALLOUT_SESSIONS_NAMESPACE"),
 			serviceAccount:    env("NATS_CALLOUT_SESSION_SERVICE_ACCOUNT", "claude-session"),
 		},
+		legacyToken:   strings.TrimSpace(os.Getenv("NATS_CALLOUT_LEGACY_TOKEN")),
 		commandStream: env("NATS_CALLOUT_COMMAND_STREAM", defaultCommandStream),
 		providers:     defaultProviders,
 		userTTL:       defaultUserTTL,
@@ -199,6 +200,7 @@ func main() {
 	slog.Info("nats auth callout serving",
 		"subject", natsAuthCalloutSubject,
 		"sessions_namespace", svc.resolver.(*k8sSessionResolver).sessionsNamespace,
+		"legacy_token_enabled", svc.legacyToken != "",
 		"metrics", metricsAddr,
 	)
 

--- a/backend-go/cmd/tank-operator/main.go
+++ b/backend-go/cmd/tank-operator/main.go
@@ -1041,8 +1041,9 @@ func buildSessionBus(scope string) *sessionbus.Bus {
 	defer cancel()
 	bus, err := sessionbus.Connect(ctx, sessionbus.Config{
 		URL: url,
-		// The orchestrator is an auth_callout-exempt named user; NATS_TOKEN
-		// carries that user's password, not a shared session-pod token.
+		// NATS_USER set = static user/password auth (#1128 stage 2: the
+		// orchestrator is an auth_callout-exempt named user; password is
+		// the same NATS_TOKEN value). Unset = legacy token auth.
 		User:              os.Getenv("NATS_USER"),
 		Token:             os.Getenv("NATS_TOKEN"),
 		Stream:            envDefault("NATS_STREAM", "TANK_SESSION_BUS"),

--- a/backend-go/internal/sessionbus/bus.go
+++ b/backend-go/internal/sessionbus/bus.go
@@ -19,10 +19,12 @@ import (
 type Config struct {
 	URL   string
 	Token string
-	// User authenticates the orchestrator as a static auth_users entry
-	// (password = Token), so it never routes through the NATS auth_callout.
-	// Token-only auth is retired; omit both fields only for unauthenticated
-	// local/test NATS servers.
+	// User, when set, switches authentication from the bare token to a
+	// static user/password pair (password = Token). This is stage 2 of
+	// tank-operator#1128: with authorization.auth_callout enabled on the
+	// server, the orchestrator must be a named auth_users entry so it never
+	// routes through the callout — token-only auth has no user name to
+	// exempt. Unset = pre-callout token auth, unchanged.
 	User string
 	// Stream is the legacy combined stream (events forever; command
 	// subjects only for pre-split session pods). CommandStream is the
@@ -313,7 +315,7 @@ func Connect(ctx context.Context, cfg Config) (*Bus, error) {
 		// password carried in Token.
 		opts = append(opts, nats.UserInfo(user, strings.TrimSpace(cfg.Token)))
 	} else if token := strings.TrimSpace(cfg.Token); token != "" {
-		return nil, fmt.Errorf("NATS token-only auth is retired; set NATS_USER for static user/password auth")
+		opts = append(opts, nats.Token(token))
 	}
 	nc, err := nats.Connect(url, opts...)
 	if err != nil {

--- a/backend-go/internal/sessionbus/bus_test.go
+++ b/backend-go/internal/sessionbus/bus_test.go
@@ -122,16 +122,6 @@ func (m *recordingMetrics) RecordPersistBatchSize(n int) {
 	defer m.mu.Unlock()
 	m.batchSizes = append(m.batchSizes, n)
 }
-
-func TestConnectRejectsTokenOnlyAuth(t *testing.T) {
-	_, err := Connect(context.Background(), Config{
-		URL:   "nats://127.0.0.1:1",
-		Token: "shared-token",
-	})
-	if err == nil || !strings.Contains(err.Error(), "token-only auth is retired") {
-		t.Fatalf("Connect token-only auth error = %v, want retired auth error", err)
-	}
-}
 func (m *recordingMetrics) RecordProcessedEventAge(seconds float64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/docs/features/agent-runners/capabilities.md
+++ b/docs/features/agent-runners/capabilities.md
@@ -625,7 +625,9 @@ configs are identical, so old and new runners coexist freely.
 
 ## Per-session NATS runner credentials
 
-Status: shipped
+Status: in progress (stage 3 implemented + deployed; stage 4 blocked on
+legacy-flatline, now observable via the `tank-nats-auth-callout` PodMonitor and
+the `TankNatsAuthCalloutLegacyTokenInUse` alert)
 
 Intent:
 Session pods must not share a fleet-wide NATS token. The NATS bus carries
@@ -654,10 +656,15 @@ Contract impact:
   Antigravity's Go runner reads the projected token file at boot/connect and
   relies on the existing permanent-close container restart path if auth is
   later revoked.
-- The migration is closed: the callout has no shared-token authorization
-  branch, no legacy-token env, and no session-namespace `tank-nats-auth`
-  ExternalSecret. The remaining `tank-nats-auth` Secret is the orchestrator
-  namespace's static password for `NATS_USER=tank-operator`.
+- Stage 4 is not optional: after
+  `tank_nats_auth_callout_total{result="legacy"}` stays flat for a full
+  pre-stage-3 pod-age window, remove `NATS_CALLOUT_LEGACY_TOKEN` and the
+  session-namespace `tank-nats-auth` ExternalSecret. Until then the legacy grant
+  exists only to avoid breaking live pre-stage-3 pods. That gate is now
+  measurable: the callout is scraped by the `tank-nats-auth-callout` PodMonitor
+  and `TankNatsAuthCalloutLegacyTokenInUse` fires while any client still
+  presents the shared token. Before this the callout exposed the counter but
+  nothing scraped it, so the gate could not be evaluated.
 
 Evidence:
 - Manifest: `backend-go/internal/sessionmodel/sessionmodel_test.go`
@@ -673,8 +680,10 @@ Evidence:
   shared `NATS_TOKEN` injection into session runner envs.
 - Observability: the callout exposes `tank_nats_auth_callout_total{result}` on
   `:9100`, scraped by the `tank-nats-auth-callout` PodMonitor in
-  `k8s/templates/observability.yaml`. `TankNatsAuthCalloutDenials` pages the
-  #1148 new-pod auth-failure class (`denied_*`/`error`).
+  `k8s/templates/observability.yaml`. `TankNatsAuthCalloutLegacyTokenInUse`
+  makes the stage-4 `result="legacy"` flatline gate observable, and
+  `TankNatsAuthCalloutDenials` pages the #1148 new-pod auth-failure class
+  (`denied_*`/`error`).
 
 ## Runner correctness cluster (issue #1078)
 

--- a/docs/session-bus-auth.md
+++ b/docs/session-bus-auth.md
@@ -32,6 +32,10 @@ account nkey:
   - subscribe `_INBOX.>`
   The claimed username is only ever checked for equality with the pod's
   label binding — identity comes from the cluster, not the client.
+- **Legacy pods** (pre-flip session images) present the shared fleet token;
+  the callout grants them the old unrestricted permissions until they age
+  out (`NATS_CALLOUT_LEGACY_TOKEN`, wired to the same `tank-nats-auth`
+  secret). Removing that env is the final security flip.
 - **The orchestrator and the callout itself** are static `auth_users` in
   the NATS server config and never route through the callout — a callout
   outage cannot take down the command plane. Existing connections keep
@@ -40,10 +44,13 @@ account nkey:
   connect late".
 
 Outcomes are counted in `tank_nats_auth_callout_total{result}`:
-`session` / `denied_*` / `error`. The callout has no Service (it answers
-NATS, not HTTP), so the counter is scraped by the `tank-nats-auth-callout`
-PodMonitor in `k8s/templates/observability.yaml`; `TankNatsAuthCalloutDenials`
-surfaces the `denied_*`/`error` new-pod auth-failure class.
+`session` / `legacy` / `denied_*` / `error`. `legacy` hitting zero for a
+full pod-age window is the signal that stage 4 (drop the legacy grant) is
+safe. The callout has no Service (it answers NATS, not HTTP), so the counter
+is scraped by the `tank-nats-auth-callout` PodMonitor in
+`k8s/templates/observability.yaml`; `TankNatsAuthCalloutLegacyTokenInUse`
+surfaces the stage-4 gate and `TankNatsAuthCalloutDenials` surfaces the
+`denied_*`/`error` new-pod auth-failure class.
 
 ## Staged rollout
 
@@ -60,24 +67,24 @@ surfaces the `denied_*`/`error` new-pod auth-failure class.
    password = the existing fleet token value) + `auth_callout { issuer:
    <account public key>, auth_users: [tank-operator, nats-auth-callout] }`.
    The orchestrator deployment simultaneously gains `NATS_USER`; session
-   pods created before stage 3 used the old shared token and had to be
-   recycled before the final cleanup.
+   pods (legacy token) now authenticate THROUGH the callout's legacy grant.
+   Watch `tank_nats_auth_callout_total{result="legacy"}` count the fleet.
 3. **Flip session credentials** — `sessionmodel.go` injects `NATS_USER`
    (the storage key) + `NATS_PASSWORD_FILE` (the projected
    auth.romaine.life-audience SA token path) instead of `NATS_TOKEN`;
    runners send user/pass. JavaScript runners read the password file from
    the NATS authenticator so reconnects see token rotation; Antigravity's
    Go runner exits/restarts on permanent auth closure and reads the file on
-   boot.
-4. **Drop the legacy grant** — completed after stage 3: the callout has no
-   shared-token branch, the callout deployment has no legacy-token env, and
-   the chart no longer renders a
-   session-namespace `tank-nats-auth` ExternalSecret. The remaining
-   `tank-nats-auth` Secret in the orchestrator namespace is only the static
-   password for `NATS_USER=tank-operator`.
+   boot. New pods only (migration policy, pre-deploy-pod clause); old pods
+   keep working via the legacy grant for ≤7d (idle reaper bound).
+4. **Drop the legacy grant** once `legacy` flatlines: remove
+   `NATS_CALLOUT_LEGACY_TOKEN` from the callout deployment and delete the
+   `tank-nats-auth` ExternalSecret from the sessions namespace. This is the
+   point where forging another session's events stops being possible.
 
 Rollback at any stage: stage 2 reverts to `authorization.token` (one config
-sync). The subject and durable shapes the callout grants are pinned against
+sync); stages 3–4 revert by re-adding the env/secret. The subject and
+durable shapes the callout grants are pinned against
 `internal/sessionbus` + `runner-shared/sessionBus.js` by
 `TestSessionDurableNamesMirrorRunnerShared` and the embedded-server
 permission tests in `cmd/nats-auth-callout`.

--- a/k8s/templates/externalsecret-nats.yaml
+++ b/k8s/templates/externalsecret-nats.yaml
@@ -22,3 +22,28 @@ spec:
         metadataPolicy: None
         nullBytePolicy: Ignore
 {{- end }}
+---
+{{- if eq (include "tank-operator.renderWarm" .) "true" }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.sessionBus.authSecret }}
+  namespace: {{ include "tank-operator.sessionsNamespace" . }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.storeName }}
+    kind: {{ .Values.externalSecret.storeKind }}
+  target:
+    name: {{ .Values.sessionBus.authSecret }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef:
+        key: {{ .Values.sessionBus.tokenKvKey }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+{{- end }}

--- a/k8s/templates/nats-auth-callout.yaml
+++ b/k8s/templates/nats-auth-callout.yaml
@@ -2,17 +2,24 @@
 Per-session NATS credential issuer (tank-operator#1128).
 
 Session pods authenticate to NATS with their projected SA token (audience
-https://auth.romaine.life) instead of the shared fleet token; this service answers
+auth.romaine.life) instead of the shared fleet token; this service answers
 the NATS server's $SYS.REQ.USER.AUTH callout with a user JWT scoped to the
 pod's own session subjects. Identity is the pod's orchestrator-written
 labels, fetched via TokenReview (bound-pod claim) + pods/get — never the
 client's claimed username.
 
-The NATS server routes non-static clients through authorization.auth_callout
-pointing at this issuer's account key. The orchestrator and this callout are
-static auth_users, so a callout outage cannot take down the command plane:
-existing connections keep their authorization, and a NEW pod's connect just
-retries (maxReconnectAttempts -1; JetStream redelivers).
+Gated off by default: flipping natsCallout.enabled only deploys the issuer;
+nothing routes through it until infra-bootstrap's NATS chart turns on
+authorization.auth_callout pointing at this issuer's account key. Staging
+(issue #1128): 1) deploy this, 2) flip the NATS server config (orchestrator
+becomes a static auth_user; legacy fleet token grants full access THROUGH
+this callout), 3) flip sessionmodel to inject SA-token credentials (new
+pods only, per the migration policy's pre-deploy-pod clause), 4) once
+pre-flip pods age out, remove the legacy grant + session-namespace token
+secret. A callout outage cannot take down the command plane: the
+orchestrator never routes through it, existing connections keep their
+authorization, and a NEW pod's connect just retries (maxReconnectAttempts
+-1; JetStream redelivers).
 
 Test slots never render this (isTestEnv excluded): slot NATS runs tokenless
 single-tenant.
@@ -150,6 +157,12 @@ spec:
                 secretKeyRef:
                   name: tank-nats-callout
                   key: issuer-seed
+            - name: NATS_CALLOUT_LEGACY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sessionBus.authSecret }}
+                  key: token
+                  optional: true
             - name: NATS_CALLOUT_SESSIONS_NAMESPACE
               value: {{ include "tank-operator.sessionsNamespace" . }}
             - name: NATS_CALLOUT_SESSION_SERVICE_ACCOUNT

--- a/k8s/templates/observability.yaml
+++ b/k8s/templates/observability.yaml
@@ -127,8 +127,9 @@ spec:
 # #1128). It exposes tank_nats_auth_callout_total on :9100 but has no
 # Service — it speaks NATS ($SYS.REQ.USER.AUTH), not HTTP, so there is
 # nothing for a ServiceMonitor to select; scrape the pods directly.
-# Without this, every new-pod auth FAILURE (result=denied_*/error — the
-# #1148 "Authorization Violation" class that wedges submitted turns) is
+# Without this, the stage-4 gate metric (result="legacy" flatline) and
+# every new-pod auth FAILURE (result=denied_*/error — the #1148
+# "Authorization Violation" class that wedges submitted turns) are
 # invisible to Prometheus. Gated to non-test envs because test slots run
 # tokenless single-tenant NATS and never render the callout. Two replicas;
 # the counter is per-pod, so the alerts below sum() across pods.
@@ -1393,6 +1394,34 @@ spec:
               Confirm tank_nats_auth_callout_total{result="session"} is
               still incrementing (healthy pods) and grep the affected
               session pod's runner logs for NATS "Authorization Violation".
+
+        # Stage-4 gate signal (#1128). The callout grants the legacy
+        # unrestricted permission set to any client still presenting the
+        # shared fleet token (NATS_CALLOUT_LEGACY_TOKEN). Expected ONLY for
+        # pre-stage-3 session pods that have not yet aged out (idle reaper
+        # bound ≤7d). This is the migration audit checklist's required
+        # "the old path is being used again" counter: while it fires,
+        # deleting the legacy grant would strand those live pods, so stage 4
+        # (remove NATS_CALLOUT_LEGACY_TOKEN + the sessions-namespace
+        # tank-nats-auth ExternalSecret) MUST NOT ship. Diagnostic only.
+        - alert: TankNatsAuthCalloutLegacyTokenInUse
+          expr: sum(rate(tank_nats_auth_callout_total{result="legacy"}[1h])) > 0
+          for: 5m
+          labels:
+            severity: info
+          annotations:
+            summary: "NATS auth-callout is still granting the legacy shared fleet token"
+            runbook: |
+              A client authenticated to NATS with the shared fleet token and
+              the callout issued the legacy unrestricted grant. Expected only
+              for pre-stage-3 session pods that have not yet aged out (idle
+              reaper bound ≤7d after the stage-3 session-image flip). This is
+              the #1128 stage-4 gate: when this stays at zero for a full
+              pre-stage-3 pod-age window, the legacy grant is safe to remove
+              (docs/session-bus-auth.md → Staged rollout step 4); until then
+              removing it strands live pods. Identify the lingering pods via
+              NATS connz (user="legacy-shared-token") in the nats namespace.
+              Does not page.
 
     - name: tank-operator.api-proxy
       rules:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -319,13 +319,10 @@ sessionBus:
   # stream`). R=3 requires the infra-bootstrap NATS chart to also run
   # cluster.replicas: 3; both must move together.
   streamReplicas: 3
-  # Static password Secret for the orchestrator's NATS auth_users entry.
-  # Session pods do not mount this; they authenticate through auth_callout
-  # with projected auth.romaine.life service-account tokens.
   authSecret: tank-nats-auth
   tokenKvKey: tank-nats-token
-  # Static NATS user for the orchestrator. Must match infra-bootstrap's
-  # NATS authorization.users entry.
+  # 1128 stage 2: set to "tank-operator" together with infra-bootstrap's
+  # NATS authorization.users flip. Empty = legacy bare-token auth.
   user: tank-operator
   monitorURLs:
     - http://tank-nats-0.tank-nats-headless.nats.svc.cluster.local:8222
@@ -334,7 +331,8 @@ sessionBus:
   # NATS lives in its own namespace, deployed by infra-bootstrap's nats
   # chart. tank-operator chart no longer owns the NATS sub-chart; the
   # ExternalSecret template in k8s/templates/externalsecret-nats.yaml
-  # provisions only the orchestrator static-user password Secret.
+  # still provisions the auth token Secret in the orchestrator and
+  # sessions namespaces so clients can connect.
   url: nats://tank-nats.nats.svc.cluster.local:4222
 
 clusterMaintenance:

--- a/scripts/check-removed-chat-runtime.mjs
+++ b/scripts/check-removed-chat-runtime.mjs
@@ -353,18 +353,11 @@ const blocked = [
   // tank-operator#1128 stage 3: GUI session runner sidecars authenticate
   // to NATS through auth_callout with NATS_USER=<storage key> and
   // NATS_PASSWORD_FILE=<projected auth.romaine.life SA token>. The shared
-  // tank-nats-auth remains only as the orchestrator static-user password.
+  // tank-nats-auth token remains only for orchestrator/callout bootstrap and
+  // pre-stage-3 pods aging out through the callout's transition grant.
   {
     name: "removed shared NATS token injection into session runner env",
     pattern: /(runnerEnv|codexRunnerEnv|antigravityRunnerEnv)[\s\S]{0,600}"name":\s*"NATS_TOKEN"/,
-  },
-  {
-    name: "removed NATS callout shared-token grant env",
-    pattern: /\bNATS_CALLOUT_LEGACY_TOKEN\b/,
-  },
-  {
-    name: "removed NATS callout unrestricted shared-token user",
-    pattern: /\blegacy-shared-token\b/,
   },
   // Turn-complete sound was per-pane (declared inside ChatPane in
   // App.tsx) before the cutover that moved it onto the always-on


### PR DESCRIPTION
## Summary

- Revert #1151 so the NATS auth-callout transition grant is available again while stale test-slot deployments are still running pre-migration token-only images.
- Restore the session-namespace `tank-nats-auth` ExternalSecret rendering, `NATS_CALLOUT_LEGACY_TOKEN`, legacy callout metrics/alerting, and token-only sessionbus behavior that #1151 removed.
- Keep the per-session runner auth migration and the #1148 `https://auth.romaine.life` audience fix intact.

## Why

Live NATS connz after #1151 still showed legacy-token clients in slot resources:

- `tank-operator-slot-1/tank-operator-5984769b6d-9bjns` using `NATS_TOKEN` only
- `tank-operator-slot-7/tank-operator-7d47c495fb-*` using `NATS_TOKEN` only
- `tank-operator-slot-7-sessions/session-11` and `session-12` using runner `NATS_TOKEN` only

Current production replacement sessions 890-897 are on `NATS_USER=<session>` plus `NATS_PASSWORD_FILE=/var/run/secrets/auth.romaine.life/token`, so this is containment for stale slot clients rather than a rollback of the new production auth path.

## Feature Contracts

Affected contracts:
- [x] Agent Runners
- [x] Auth And Streams
- [x] Observability

Evidence:
- Live NATS `connz?auth=true` showed legacy clients only in `tank-operator-slot-1`, `tank-operator-slot-7`, and `tank-operator-slot-7-sessions`; production `tank-operator-sessions` runners use per-session auth.
- `kubectl -n tank-operator-sessions get pods -o json` confirmed production runner env uses `NATS_USER` + `NATS_PASSWORD_FILE`, not `NATS_TOKEN`.
- `git diff --check HEAD~1..HEAD`
- `node scripts/check-removed-chat-runtime.mjs`

Not run locally:
- `go test ./cmd/nats-auth-callout ./internal/sessionbus` because `go` is not installed in this desktop shell; PR CI must cover it.