### PR TITLE
Allow session runners to ACK NATS commands

### DIFF
--- a/backend-go/cmd/nats-auth-callout/callout.go
+++ b/backend-go/cmd/nats-auth-callout/callout.go
@@ -153,6 +153,7 @@ func (s *calloutService) sessionUserJWT(req *jwt.AuthorizationRequestClaims, sto
 			"$JS.API.CONSUMER.CREATE."+s.commandStream+"."+durable+".>",
 			"$JS.API.CONSUMER.INFO."+s.commandStream+"."+durable,
 			"$JS.API.CONSUMER.MSG.NEXT."+s.commandStream+"."+durable,
+			"$JS.ACK."+s.commandStream+"."+durable+".>",
 		)
 	}
 	uc.Permissions.Pub.Allow.Add(pub...)

--- a/backend-go/cmd/nats-auth-callout/callout_test.go
+++ b/backend-go/cmd/nats-auth-callout/callout_test.go
@@ -176,6 +176,9 @@ func TestSessionPodGetsOwnSubjectsOnly(t *testing.T) {
 	if err := nc.Publish("$JS.API.CONSUMER.MSG.NEXT."+defaultCommandStream+"."+durable, []byte("{}")); err != nil {
 		t.Fatalf("publish own consumer next: %v", err)
 	}
+	if err := nc.Publish("$JS.ACK."+defaultCommandStream+"."+durable+".1.2.3.4.5", []byte{}); err != nil {
+		t.Fatalf("publish own consumer ack: %v", err)
+	}
 	if violations := errs(); len(violations) != 0 {
 		t.Fatalf("own-session subjects must be allowed, got violations: %v", violations)
 	}
@@ -189,8 +192,11 @@ func TestSessionPodGetsOwnSubjectsOnly(t *testing.T) {
 	if err := nc.Publish("$JS.API.CONSUMER.MSG.NEXT."+defaultCommandStream+"."+other, []byte("{}")); err != nil {
 		t.Fatalf("publish queues locally even when denied: %v", err)
 	}
+	if err := nc.Publish("$JS.ACK."+defaultCommandStream+"."+other+".1.2.3.4.5", []byte{}); err != nil {
+		t.Fatalf("publish queues locally even when denied: %v", err)
+	}
 	violations := errs()
-	if len(violations) != 2 {
+	if len(violations) != 3 {
 		t.Fatalf("cross-session subjects must violate, got: %v", violations)
 	}
 	for _, v := range violations {


### PR DESCRIPTION
## Summary

- Allow per-session NATS auth-callout users to publish ACKs for their own JetStream command consumers.
- Keep ACK permissions scoped to each session/provider durable (`$JS.ACK.<stream>.<durable>.>`), not broad JetStream access.
- Extend the auth-callout permission test so own ACKs are allowed and another session's ACK subject is denied.

## Production evidence

After #1153 removed the legacy shared-token path, session runners authenticated successfully but could not ACK delivered commands. NATS server logs showed publish violations like:

- `$JS.ACK.TANK_SESSION_COMMANDS.codex_ZGVmYXVsdA_ODkw...` for `session-890`
- `$JS.ACK.TANK_SESSION_COMMANDS.claude_ZGVmYXVsdA_ODk1...` for `session-895`

The durable ledger showed submitted turns with zero child/progress events while each data consumer had `Outstanding Acks: 1`.

## Feature Contracts

Affected contracts:
- [x] Agent Runners
- [x] Auth And Streams
- [x] Observability

Evidence:
- `git diff --check`
- `node scripts/check-removed-chat-runtime.mjs`
- Added `TestSessionPodGetsOwnSubjectsOnly` coverage for own/cross-session `$JS.ACK` subjects.

Not run locally:
- `go test ./cmd/nats-auth-callout` because `go` is not installed in this desktop shell; PR CI must cover it.