### PR TITLE
Fix repo-cloner repo base JSON default

### DIFF
--- a/backend-go/internal/sessionmodel/sessionmodel_test.go
+++ b/backend-go/internal/sessionmodel/sessionmodel_test.go
@@ -391,6 +391,9 @@ func TestPodManifestSelectedReposAddsRepoClonerInitContainer(t *testing.T) {
 	if got, want := env["TANK_REPOS_JSON"], "[\"romaine-life/tank-operator\"]"; got != want {
 		t.Fatalf("TANK_REPOS_JSON = %v, want %q", got, want)
 	}
+	if got, want := env["TANK_REPO_BASES_JSON"], "{}"; got != want {
+		t.Fatalf("TANK_REPO_BASES_JSON = %v, want %q", got, want)
+	}
 	if got, want := env["TANK_OPERATOR_INTERNAL_URL"], "http://tank-operator.test"; got != want {
 		t.Fatalf("TANK_OPERATOR_INTERNAL_URL = %v, want %q", got, want)
 	}
@@ -462,6 +465,21 @@ func TestPodManifestRestrictedGitCapabilityWiresOptInEnv(t *testing.T) {
 	assertConfigMapMountSubPath(t, cloner, "/opt/tank/agent-pre-push-hook.sh", "agent-pre-push-hook.sh")
 	assertVolumeMount(t, cloner, "workspace")
 	assertVolumeMount(t, cloner, "auth-romaine-sa-token")
+}
+
+func TestRepoClonerAvoidsBraceDefaultExpansionForRepoBases(t *testing.T) {
+	script, err := os.ReadFile("../../../k8s/session-config/repo-cloner.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(script)
+	if strings.Contains(body, `REPO_BASES_JSON="${TANK_REPO_BASES_JSON:-{}}"`) {
+		t.Fatal("repo-cloner must not use ${TANK_REPO_BASES_JSON:-{}}; bash appends the closing brace and turns {} into {}}")
+	}
+	if !strings.Contains(body, `REPO_BASES_JSON="${TANK_REPO_BASES_JSON:-}"`) ||
+		!strings.Contains(body, `REPO_BASES_JSON="{}"`) {
+		t.Fatal("repo-cloner must normalize an unset TANK_REPO_BASES_JSON through an explicit {} assignment")
+	}
 }
 
 func TestPodManifestWithoutSelectedReposOmitsRepoCloner(t *testing.T) {

--- a/k8s/session-config/repo-cloner.sh
+++ b/k8s/session-config/repo-cloner.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 WORKSPACE="${WORKSPACE:-/workspace}"
 REPOS_JSON="${TANK_REPOS_JSON:-[]}"
-REPO_BASES_JSON="${TANK_REPO_BASES_JSON:-{}}"
+REPO_BASES_JSON="${TANK_REPO_BASES_JSON:-}"
+if [ -z "$REPO_BASES_JSON" ]; then
+  REPO_BASES_JSON="{}"
+fi
 AUTH_TOKEN_PATH="${AUTH_ROMAINE_TOKEN_PATH:-/var/run/secrets/auth.romaine.life/token}"
 AUTH_EXCHANGE_URL="${AUTH_ROMAINE_EXCHANGE_URL:-https://auth.romaine.life/api/auth/exchange/k8s}"
 MCP_GITHUB_URL="${MCP_GITHUB_URL:-http://mcp-github.mcp-github.svc:80}"


### PR DESCRIPTION
## Summary

- Fix repo-cloner's default handling for `TANK_REPO_BASES_JSON` so a configured `{}` value stays valid JSON instead of becoming `{}}` under bash parameter expansion.
- Add manifest/script regression coverage for the repo-base JSON env stamped into repo-cloner init containers.

## Feature Contracts

Affected contracts:
- [ ] Transcript
- [ ] Transcript Navigation
- [ ] App Chrome
- [ ] Session Bar
- [x] Session Lifecycle
- [ ] Agent Runners
- [ ] Auth And Streams
- [ ] Artifacts And Files
- [ ] Observability
- [ ] None

Evidence:
- Production incident evidence: session `1049` ledger had `user_message.created` + `turn.submitted` + `session.status: loading`, but no runner-produced events or terminal; Kubernetes showed `repo-cloner` init container `CrashLoopBackOff` with `jq: parse error: Unmatched '}' at line 1, column 3`.
- Reproduced the shell bug in the session image: `TANK_REPO_BASES_JSON={}` plus `${TANK_REPO_BASES_JSON:-{}}` expands to `{}}`.
- Patched live `tank-session-config` ConfigMap as incident containment so newly created sessions receive the fixed script while this PR runs through CI.
- Local checks: `git diff --check`; static repo-cloner guard; direct container probe confirming the fixed expansion keeps `{}` parseable by `jq`.
- Not run locally: `go test` and `helm template` because `go` and `helm` are not installed in this Windows shell. PR CI should be treated as the durable build/test gate.